### PR TITLE
Add MCP server with 14 tools for SDL understanding, authoring, and inspection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "sse-starlette>=2.0.0",
     "asyncssh>=2.17.0",
+    "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -30,6 +31,7 @@ dev = [
 
 [project.scripts]
 aces = "aces.cli.main:app"
+aces-mcp = "aces.mcp.__main__:server.run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aces"]

--- a/src/aces/mcp/__init__.py
+++ b/src/aces/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""ACES SDL MCP Server.
+
+A Model Context Protocol server that exposes tools for understanding,
+authoring, and validating ACES Scenario Description Language (SDL)
+scenarios.  Designed to be used by AI agents with no prior SDL knowledge.
+"""

--- a/src/aces/mcp/__main__.py
+++ b/src/aces/mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point: ``python -m aces.mcp``."""
+
+from aces.mcp.server import create_server
+
+server = create_server()
+server.run()

--- a/src/aces/mcp/server.py
+++ b/src/aces/mcp/server.py
@@ -1,0 +1,42 @@
+"""ACES SDL MCP Server — tools for understanding, authoring, and validating SDL scenarios.
+
+Launch via:
+    python -m aces.mcp
+    # or
+    aces mcp serve
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from aces.mcp.tools.reference import register as register_reference_tools
+from aces.mcp.tools.authoring import register as register_authoring_tools
+from aces.mcp.tools.inspection import register as register_inspection_tools
+
+_INSTRUCTIONS = """\
+You are connected to the ACES SDL (Scenario Description Language) server.
+
+The SDL is a YAML-based language for specifying cyber-range scenarios — \
+who (entities, accounts, agents), what (nodes, features, vulnerabilities, \
+content), when (scripts, stories, events), and declarative experiment \
+semantics (objectives, scoring, conditions, relationships, workflows, \
+variables).
+
+Start with `sdl_overview` to orient yourself, then use \
+`sdl_section_reference` for any section you need to understand. \
+Use `sdl_get_example` to see real-world annotated scenarios. \
+Use `sdl_validate` to check any SDL YAML you write.\
+"""
+
+
+def create_server() -> FastMCP:
+    """Build and return the configured MCP server instance."""
+    mcp = FastMCP(
+        name="aces-sdl",
+        instructions=_INSTRUCTIONS,
+    )
+    register_reference_tools(mcp)
+    register_authoring_tools(mcp)
+    register_inspection_tools(mcp)
+    return mcp

--- a/src/aces/mcp/tools/authoring.py
+++ b/src/aces/mcp/tools/authoring.py
@@ -1,0 +1,598 @@
+"""SDL authoring tools — validate, scaffold, and instantiate scenarios.
+
+These tools let agents write SDL from scratch, check it for errors,
+build up scenarios incrementally, and instantiate parameterized
+scenarios with concrete values.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    """Register SDL authoring tools on the MCP server."""
+
+    @mcp.tool(
+        name="sdl_validate",
+        description=(
+            "Parse and validate SDL YAML content.  Returns either a success "
+            "confirmation (with advisories if any) or a structured list of "
+            "every error found — parse errors, structural errors, and semantic "
+            "validation errors.  All errors are collected before reporting so "
+            "you see every issue at once.\n\n"
+            "Pass the full YAML scenario text as `sdl_content`.  Optionally "
+            "set `structural_only=true` to skip semantic cross-reference "
+            "checks (useful for work-in-progress fragments that aren't "
+            "complete yet)."
+        ),
+    )
+    def sdl_validate(
+        sdl_content: str,
+        structural_only: bool = False,
+    ) -> str:
+        from aces.core.sdl import (
+            SDLParseError,
+            SDLValidationError,
+            parse_sdl,
+        )
+
+        try:
+            scenario = parse_sdl(
+                sdl_content,
+                skip_semantic_validation=structural_only,
+            )
+        except SDLParseError as exc:
+            return (
+                "PARSE ERROR — the YAML could not be loaded or the "
+                "structure does not match the SDL schema.\n\n"
+                f"Details:\n{exc.details}"
+            )
+        except SDLValidationError as exc:
+            header = (
+                f"VALIDATION ERRORS — {len(exc.errors)} semantic "
+                f"issue{'s' if len(exc.errors) != 1 else ''} found.\n\n"
+            )
+            bullets = "\n".join(f"  - {e}" for e in exc.errors)
+            return header + bullets
+
+        # Success path
+        parts = [f"VALID — scenario '{scenario.name}' parsed successfully."]
+
+        # Summary
+        section_counts = _section_summary(scenario)
+        if section_counts:
+            parts.append("\nSections populated:")
+            for sec, count in section_counts:
+                parts.append(f"  {sec}: {count} element{'s' if count != 1 else ''}")
+
+        if scenario.advisories:
+            parts.append(f"\nAdvisories ({len(scenario.advisories)}):")
+            for adv in scenario.advisories:
+                parts.append(f"  - {adv}")
+
+        if structural_only:
+            parts.append(
+                "\nNote: semantic validation was skipped. Run without "
+                "`structural_only` for full cross-reference checking."
+            )
+
+        return "\n".join(parts)
+
+    @mcp.tool(
+        name="sdl_validate_section",
+        description=(
+            "Validate a single SDL section fragment by wrapping it in a "
+            "minimal scenario context.  Useful when you are building a "
+            "scenario piece by piece and want to check one section's syntax "
+            "before assembling the whole document.\n\n"
+            "Pass the section name (e.g. 'nodes', 'features') and the YAML "
+            "content for that section.  Optionally provide `context_yaml` — "
+            "additional SDL YAML sections needed to satisfy cross-references "
+            "(e.g. nodes referenced by infrastructure).  Structural "
+            "validation is always performed; semantic validation runs only "
+            "when `context_yaml` is provided."
+        ),
+    )
+    def sdl_validate_section(
+        section: str,
+        section_yaml: str,
+        context_yaml: str = "",
+    ) -> str:
+        import yaml as _yaml
+
+        from aces.core.sdl import SDLParseError, SDLValidationError, parse_sdl
+
+        section = section.strip().lower().replace("-", "_")
+        valid_sections = {
+            "nodes", "infrastructure", "features", "conditions",
+            "vulnerabilities", "metrics", "evaluations", "tlos", "goals",
+            "entities", "injects", "events", "scripts", "stories",
+            "content", "accounts", "relationships", "agents", "objectives",
+            "workflows", "variables",
+        }
+        if section not in valid_sections:
+            return (
+                f"Unknown section '{section}'. "
+                f"Valid sections: {', '.join(sorted(valid_sections))}"
+            )
+
+        # Build a minimal valid wrapper
+        try:
+            section_data = _yaml.safe_load(section_yaml)
+        except _yaml.YAMLError as exc:
+            return f"YAML ERROR in section content:\n{exc}"
+
+        wrapper: dict = {"name": "__mcp_validation_fragment"}
+        if context_yaml:
+            try:
+                ctx = _yaml.safe_load(context_yaml)
+                if isinstance(ctx, dict):
+                    wrapper.update(ctx)
+            except _yaml.YAMLError as exc:
+                return f"YAML ERROR in context_yaml:\n{exc}"
+
+        wrapper[section] = section_data
+        combined = _yaml.dump(wrapper, default_flow_style=False, sort_keys=False)
+
+        skip_semantic = not bool(context_yaml)
+        try:
+            parse_sdl(combined, skip_semantic_validation=skip_semantic)
+        except SDLParseError as exc:
+            return f"PARSE ERROR in '{section}' section:\n{exc.details}"
+        except SDLValidationError as exc:
+            header = f"VALIDATION ERRORS in '{section}' section ({len(exc.errors)}):\n"
+            bullets = "\n".join(f"  - {e}" for e in exc.errors)
+            return header + bullets
+
+        mode = "structural" if skip_semantic else "structural + semantic"
+        return f"VALID — '{section}' section passes {mode} validation."
+
+    @mcp.tool(
+        name="sdl_scaffold",
+        description=(
+            "Generate a starter SDL scenario skeleton.  Choose a complexity "
+            "level: 'minimal' (topology + features only), 'standard' "
+            "(adds scoring, entities, accounts), or 'full' (all 21 sections "
+            "with placeholder structure).  Optionally provide a scenario name "
+            "and description.  The output is valid SDL YAML you can edit."
+        ),
+    )
+    def sdl_scaffold(
+        complexity: str = "standard",
+        scenario_name: str = "my-scenario",
+        description: str = "A new SDL scenario",
+    ) -> str:
+        key = complexity.lower().strip()
+        if key not in ("minimal", "standard", "full"):
+            return "Invalid complexity. Choose: 'minimal', 'standard', or 'full'."
+
+        if key == "minimal":
+            return _SCAFFOLD_MINIMAL.format(name=scenario_name, desc=description)
+        if key == "standard":
+            return _SCAFFOLD_STANDARD.format(name=scenario_name, desc=description)
+        return _SCAFFOLD_FULL.format(name=scenario_name, desc=description)
+
+    @mcp.tool(
+        name="sdl_instantiate",
+        description=(
+            "Instantiate a parameterized SDL scenario by substituting "
+            "concrete values for ${var} placeholders.  Pass the SDL YAML and "
+            "a JSON-formatted dictionary of parameter values.  Returns the "
+            "fully resolved scenario summary or detailed errors if "
+            "instantiation fails."
+        ),
+    )
+    def sdl_instantiate(
+        sdl_content: str,
+        parameters_json: str = "{}",
+    ) -> str:
+        import json
+
+        from aces.core.sdl import (
+            SDLInstantiationError,
+            SDLParseError,
+            SDLValidationError,
+            instantiate_scenario,
+            parse_sdl,
+        )
+
+        try:
+            params = json.loads(parameters_json)
+        except json.JSONDecodeError as exc:
+            return f"Invalid JSON in parameters_json: {exc}"
+        if not isinstance(params, dict):
+            return "parameters_json must be a JSON object (dictionary)."
+
+        try:
+            scenario = parse_sdl(sdl_content)
+        except SDLParseError as exc:
+            return f"PARSE ERROR:\n{exc.details}"
+        except SDLValidationError as exc:
+            bullets = "\n".join(f"  - {e}" for e in exc.errors)
+            return f"VALIDATION ERRORS:\n{bullets}"
+
+        try:
+            concrete = instantiate_scenario(scenario, parameters=params)
+        except SDLInstantiationError as exc:
+            bullets = "\n".join(f"  - {e}" for e in exc.errors)
+            return f"INSTANTIATION ERRORS ({len(exc.errors)}):\n{bullets}"
+
+        parts = [
+            f"INSTANTIATED — scenario '{concrete.name}' fully resolved.",
+            f"Parameters used: {concrete.instantiation_parameters}",
+        ]
+        section_counts = _section_summary(concrete)
+        if section_counts:
+            parts.append("\nSections:")
+            for sec, count in section_counts:
+                parts.append(f"  {sec}: {count}")
+        return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SECTION_FIELDS = [
+    "nodes", "infrastructure", "features", "conditions", "vulnerabilities",
+    "metrics", "evaluations", "tlos", "goals", "entities", "injects",
+    "events", "scripts", "stories", "content", "accounts", "relationships",
+    "agents", "objectives", "workflows", "variables",
+]
+
+
+def _section_summary(scenario: object) -> list[tuple[str, int]]:
+    """Return (section_name, element_count) for non-empty sections."""
+    counts: list[tuple[str, int]] = []
+    for field in _SECTION_FIELDS:
+        data = getattr(scenario, field, None)
+        if data:
+            counts.append((field, len(data)))
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Scaffold templates
+# ---------------------------------------------------------------------------
+
+_SCAFFOLD_MINIMAL = """\
+name: {name}
+description: {desc}
+
+nodes:
+  net-switch:
+    type: Switch
+    description: Main network
+
+  server-01:
+    type: VM
+    os: linux
+    resources: {{ram: 2 GiB, cpu: 1}}
+    features: [my-service]
+    services:
+      - {{port: 443, name: https}}
+
+infrastructure:
+  net-switch:
+    count: 1
+    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  server-01:
+    count: 1
+    links: [net-switch]
+
+features:
+  my-service: {{type: Service, source: my-package}}
+"""
+
+_SCAFFOLD_STANDARD = """\
+name: {name}
+description: {desc}
+
+nodes:
+  corp-net:
+    type: Switch
+    description: Corporate network
+
+  web-server:
+    type: VM
+    os: linux
+    resources: {{ram: 4 GiB, cpu: 2}}
+    features: {{web-app: web-admin}}
+    conditions: {{web-healthy: web-admin}}
+    services:
+      - {{port: 443, name: https}}
+    roles:
+      web-admin: www-data
+
+  db-server:
+    type: VM
+    os: linux
+    resources: {{ram: 4 GiB, cpu: 2}}
+    features: {{database: dba}}
+    services:
+      - {{port: 5432, name: postgres}}
+    roles:
+      dba: postgres
+
+infrastructure:
+  corp-net:
+    count: 1
+    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  web-server:
+    count: 1
+    links: [corp-net]
+  db-server:
+    count: 1
+    links: [corp-net]
+
+features:
+  web-app: {{type: Service, source: my-webapp}}
+  database: {{type: Service, source: postgresql-16}}
+
+conditions:
+  web-healthy:
+    command: "curl -sf https://localhost/ || exit 1"
+    interval: 15
+
+vulnerabilities:
+  sqli:
+    name: SQL Injection
+    description: SQL injection in login form
+    technical: true
+    class: CWE-89
+
+metrics:
+  web-uptime:
+    type: CONDITIONAL
+    max-score: 100
+    condition: web-healthy
+
+evaluations:
+  availability:
+    metrics: [web-uptime]
+    min-score: 75
+
+tlos:
+  defend-web:
+    name: Defend the web application
+    evaluation: availability
+
+goals:
+  exercise-goal:
+    tlos: [defend-web]
+
+entities:
+  blue-team:
+    name: Blue Team
+    role: Blue
+    tlos: [defend-web]
+  red-team:
+    name: Red Team
+    role: Red
+
+accounts:
+  web-admin-account:
+    username: webadmin
+    node: web-server
+    password_strength: strong
+  db-admin-account:
+    username: dbadmin
+    node: db-server
+    password_strength: medium
+
+relationships:
+  web-to-db:
+    type: connects_to
+    source: web-app
+    target: database
+    properties: {{protocol: tcp, port: "5432"}}
+"""
+
+_SCAFFOLD_FULL = """\
+name: {name}
+description: {desc}
+
+# --- Parameterization ---
+variables:
+  exercise_speed:
+    type: number
+    default: 1.0
+    description: Story playback speed multiplier
+  admin_password_strength:
+    type: string
+    default: strong
+    allowed_values: [weak, medium, strong]
+
+# --- Topology ---
+nodes:
+  corp-net:
+    type: Switch
+    description: Corporate network
+
+  web-server:
+    type: VM
+    os: linux
+    resources: {{ram: 4 GiB, cpu: 2}}
+    features: {{web-app: web-admin}}
+    conditions: {{web-healthy: web-admin}}
+    vulnerabilities: [sqli]
+    services:
+      - {{port: 443, name: https}}
+    roles:
+      web-admin:
+        username: www-data
+        entities: [blue-team.web-ops]
+
+  db-server:
+    type: VM
+    os: linux
+    resources: {{ram: 4 GiB, cpu: 2}}
+    features: {{database: dba}}
+    services:
+      - {{port: 5432, name: postgres}}
+    roles:
+      dba: postgres
+    asset_value:
+      confidentiality: high
+      integrity: high
+
+infrastructure:
+  corp-net:
+    count: 1
+    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  web-server:
+    count: 1
+    links: [corp-net]
+  db-server:
+    count: 1
+    links: [corp-net]
+
+# --- Software ---
+features:
+  web-app: {{type: Service, source: my-webapp}}
+  database: {{type: Service, source: postgresql-16}}
+
+conditions:
+  web-healthy:
+    command: "curl -sf https://localhost/ || exit 1"
+    interval: 15
+
+vulnerabilities:
+  sqli:
+    name: SQL Injection
+    description: SQL injection in application
+    technical: true
+    class: CWE-89
+
+# --- Scoring Pipeline ---
+metrics:
+  web-uptime:
+    type: CONDITIONAL
+    max-score: 100
+    condition: web-healthy
+  report-quality:
+    type: MANUAL
+    max-score: 50
+
+evaluations:
+  overall:
+    metrics: [web-uptime, report-quality]
+    min-score: 75
+
+tlos:
+  defend-web:
+    name: Defend the web application
+    evaluation: overall
+
+goals:
+  exercise-goal:
+    tlos: [defend-web]
+
+# --- Teams ---
+entities:
+  blue-team:
+    name: Blue Team
+    role: Blue
+    tlos: [defend-web]
+    entities:
+      web-ops: {{name: Web Operations}}
+  red-team:
+    name: Red Team
+    role: Red
+
+# --- Orchestration ---
+injects:
+  attack-brief:
+    source: attack-briefing-doc
+    from_entity: red-team
+    to_entities: [blue-team]
+
+events:
+  attack-start:
+    injects: [attack-brief]
+
+scripts:
+  main-timeline:
+    start-time: 0
+    end-time: 4 hour
+    speed: ${{exercise_speed}}
+    events:
+      attack-start: 30 min
+
+stories:
+  exercise:
+    speed: ${{exercise_speed}}
+    scripts: [main-timeline]
+
+# --- Content ---
+content:
+  seed-data:
+    type: dataset
+    target: db-server
+    format: sql
+    source: seed-data-pkg
+
+# --- Accounts ---
+accounts:
+  web-admin-account:
+    username: webadmin
+    node: web-server
+    password_strength: ${{admin_password_strength}}
+  db-admin-account:
+    username: dbadmin
+    node: db-server
+    password_strength: medium
+
+# --- Relationships ---
+relationships:
+  web-to-db:
+    type: connects_to
+    source: web-app
+    target: database
+    properties: {{protocol: tcp, port: "5432"}}
+
+# --- Agents ---
+agents:
+  red-agent:
+    entity: red-team
+    actions: [Scan, Exploit]
+    initial_knowledge:
+      hosts: [web-server]
+      subnets: [corp-net]
+      services: [https]
+
+# --- Objectives ---
+objectives:
+  red-access:
+    agent: red-agent
+    actions: [Scan, Exploit]
+    targets: [web-server, sqli]
+    success:
+      conditions: [web-healthy]
+    window:
+      stories: [exercise]
+  blue-defend:
+    entity: blue-team
+    success:
+      goals: [exercise-goal]
+    depends_on: [red-access]
+
+# --- Workflows ---
+workflows:
+  exercise-flow:
+    start: run-attack
+    steps:
+      run-attack:
+        type: objective
+        objective: red-access
+        on-success: run-defense
+      run-defense:
+        type: objective
+        objective: blue-defend
+        on-success: done
+      done:
+        type: end
+"""

--- a/src/aces/mcp/tools/authoring.py
+++ b/src/aces/mcp/tools/authoring.py
@@ -7,9 +7,12 @@ scenarios with concrete values.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from mcp.server.fastmcp import FastMCP
+
+# Maximum input size to prevent resource exhaustion via YAML bombs or
+# extremely large payloads.  64 KiB accommodates the largest bundled
+# example (~750 lines / ~25 KiB) with generous headroom.
+_MAX_INPUT_BYTES = 64 * 1024
 
 
 def register(mcp: FastMCP) -> None:
@@ -33,6 +36,9 @@ def register(mcp: FastMCP) -> None:
         sdl_content: str,
         structural_only: bool = False,
     ) -> str:
+        if len(sdl_content.encode("utf-8", errors="replace")) > _MAX_INPUT_BYTES:
+            return f"INPUT TOO LARGE — limit is {_MAX_INPUT_BYTES} bytes."
+
         from aces.core.sdl import (
             SDLParseError,
             SDLValidationError,
@@ -101,6 +107,12 @@ def register(mcp: FastMCP) -> None:
         section_yaml: str,
         context_yaml: str = "",
     ) -> str:
+        combined_size = len(section_yaml.encode("utf-8", errors="replace")) + len(
+            context_yaml.encode("utf-8", errors="replace")
+        )
+        if combined_size > _MAX_INPUT_BYTES:
+            return f"INPUT TOO LARGE — limit is {_MAX_INPUT_BYTES} bytes."
+
         import yaml as _yaml
 
         from aces.core.sdl import SDLParseError, SDLValidationError, parse_sdl
@@ -125,7 +137,7 @@ def register(mcp: FastMCP) -> None:
         except _yaml.YAMLError as exc:
             return f"YAML ERROR in section content:\n{exc}"
 
-        wrapper: dict = {"name": "__mcp_validation_fragment"}
+        wrapper: dict = {}
         if context_yaml:
             try:
                 ctx = _yaml.safe_load(context_yaml)
@@ -134,6 +146,9 @@ def register(mcp: FastMCP) -> None:
             except _yaml.YAMLError as exc:
                 return f"YAML ERROR in context_yaml:\n{exc}"
 
+        # Force a safe synthetic name — always last so context_yaml cannot
+        # override it and cause confusing error messages.
+        wrapper["name"] = "__mcp_validation_fragment"
         wrapper[section] = section_data
         combined = _yaml.dump(wrapper, default_flow_style=False, sort_keys=False)
 
@@ -169,11 +184,19 @@ def register(mcp: FastMCP) -> None:
         if key not in ("minimal", "standard", "full"):
             return "Invalid complexity. Choose: 'minimal', 'standard', or 'full'."
 
-        if key == "minimal":
-            return _SCAFFOLD_MINIMAL.format(name=scenario_name, desc=description)
-        if key == "standard":
-            return _SCAFFOLD_STANDARD.format(name=scenario_name, desc=description)
-        return _SCAFFOLD_FULL.format(name=scenario_name, desc=description)
+        templates = {
+            "minimal": _SCAFFOLD_MINIMAL,
+            "standard": _SCAFFOLD_STANDARD,
+            "full": _SCAFFOLD_FULL,
+        }
+        # Use Template-style substitution instead of str.format() to
+        # avoid crashes or unexpected behaviour when user-provided
+        # scenario_name/description contain { or } characters.
+        return (
+            templates[key]
+            .replace("{name}", scenario_name)
+            .replace("{desc}", description)
+        )
 
     @mcp.tool(
         name="sdl_instantiate",
@@ -189,6 +212,12 @@ def register(mcp: FastMCP) -> None:
         sdl_content: str,
         parameters_json: str = "{}",
     ) -> str:
+        combined_size = len(sdl_content.encode("utf-8", errors="replace")) + len(
+            parameters_json.encode("utf-8", errors="replace")
+        )
+        if combined_size > _MAX_INPUT_BYTES:
+            return f"INPUT TOO LARGE — limit is {_MAX_INPUT_BYTES} bytes."
+
         import json
 
         from aces.core.sdl import (
@@ -270,21 +299,21 @@ nodes:
   server-01:
     type: VM
     os: linux
-    resources: {{ram: 2 GiB, cpu: 1}}
+    resources: {ram: 2 GiB, cpu: 1}
     features: [my-service]
     services:
-      - {{port: 443, name: https}}
+      - {port: 443, name: https}
 
 infrastructure:
   net-switch:
     count: 1
-    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+    properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}
   server-01:
     count: 1
     links: [net-switch]
 
 features:
-  my-service: {{type: Service, source: my-package}}
+  my-service: {type: Service, source: my-package}
 """
 
 _SCAFFOLD_STANDARD = """\
@@ -299,28 +328,28 @@ nodes:
   web-server:
     type: VM
     os: linux
-    resources: {{ram: 4 GiB, cpu: 2}}
-    features: {{web-app: web-admin}}
-    conditions: {{web-healthy: web-admin}}
+    resources: {ram: 4 GiB, cpu: 2}
+    features: {web-app: web-admin}
+    conditions: {web-healthy: web-admin}
     services:
-      - {{port: 443, name: https}}
+      - {port: 443, name: https}
     roles:
       web-admin: www-data
 
   db-server:
     type: VM
     os: linux
-    resources: {{ram: 4 GiB, cpu: 2}}
-    features: {{database: dba}}
+    resources: {ram: 4 GiB, cpu: 2}
+    features: {database: dba}
     services:
-      - {{port: 5432, name: postgres}}
+      - {port: 5432, name: postgres}
     roles:
       dba: postgres
 
 infrastructure:
   corp-net:
     count: 1
-    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+    properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}
   web-server:
     count: 1
     links: [corp-net]
@@ -329,8 +358,8 @@ infrastructure:
     links: [corp-net]
 
 features:
-  web-app: {{type: Service, source: my-webapp}}
-  database: {{type: Service, source: postgresql-16}}
+  web-app: {type: Service, source: my-webapp}
+  database: {type: Service, source: postgresql-16}
 
 conditions:
   web-healthy:
@@ -388,7 +417,7 @@ relationships:
     type: connects_to
     source: web-app
     target: database
-    properties: {{protocol: tcp, port: "5432"}}
+    properties: {protocol: tcp, port: "5432"}
 """
 
 _SCAFFOLD_FULL = """\
@@ -415,12 +444,12 @@ nodes:
   web-server:
     type: VM
     os: linux
-    resources: {{ram: 4 GiB, cpu: 2}}
-    features: {{web-app: web-admin}}
-    conditions: {{web-healthy: web-admin}}
+    resources: {ram: 4 GiB, cpu: 2}
+    features: {web-app: web-admin}
+    conditions: {web-healthy: web-admin}
     vulnerabilities: [sqli]
     services:
-      - {{port: 443, name: https}}
+      - {port: 443, name: https}
     roles:
       web-admin:
         username: www-data
@@ -429,10 +458,10 @@ nodes:
   db-server:
     type: VM
     os: linux
-    resources: {{ram: 4 GiB, cpu: 2}}
-    features: {{database: dba}}
+    resources: {ram: 4 GiB, cpu: 2}
+    features: {database: dba}
     services:
-      - {{port: 5432, name: postgres}}
+      - {port: 5432, name: postgres}
     roles:
       dba: postgres
     asset_value:
@@ -442,7 +471,7 @@ nodes:
 infrastructure:
   corp-net:
     count: 1
-    properties: {{cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+    properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}
   web-server:
     count: 1
     links: [corp-net]
@@ -452,8 +481,8 @@ infrastructure:
 
 # --- Software ---
 features:
-  web-app: {{type: Service, source: my-webapp}}
-  database: {{type: Service, source: postgresql-16}}
+  web-app: {type: Service, source: my-webapp}
+  database: {type: Service, source: postgresql-16}
 
 conditions:
   web-healthy:
@@ -498,7 +527,7 @@ entities:
     role: Blue
     tlos: [defend-web]
     entities:
-      web-ops: {{name: Web Operations}}
+      web-ops: {name: Web Operations}
   red-team:
     name: Red Team
     role: Red
@@ -518,13 +547,13 @@ scripts:
   main-timeline:
     start-time: 0
     end-time: 4 hour
-    speed: ${{exercise_speed}}
+    speed: ${exercise_speed}
     events:
       attack-start: 30 min
 
 stories:
   exercise:
-    speed: ${{exercise_speed}}
+    speed: ${exercise_speed}
     scripts: [main-timeline]
 
 # --- Content ---
@@ -540,7 +569,7 @@ accounts:
   web-admin-account:
     username: webadmin
     node: web-server
-    password_strength: ${{admin_password_strength}}
+    password_strength: ${admin_password_strength}
   db-admin-account:
     username: dbadmin
     node: db-server
@@ -552,7 +581,7 @@ relationships:
     type: connects_to
     source: web-app
     target: database
-    properties: {{protocol: tcp, port: "5432"}}
+    properties: {protocol: tcp, port: "5432"}
 
 # --- Agents ---
 agents:

--- a/src/aces/mcp/tools/inspection.py
+++ b/src/aces/mcp/tools/inspection.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
+_MAX_INPUT_BYTES = 64 * 1024
+
 
 def register(mcp: FastMCP) -> None:
     """Register SDL inspection/query tools on the MCP server."""
@@ -116,6 +118,9 @@ _SECTION_FIELDS = [
 
 def _parse_or_error(sdl_content: str):
     """Attempt to parse SDL, returning a Scenario or an error string."""
+    if len(sdl_content.encode("utf-8", errors="replace")) > _MAX_INPUT_BYTES:
+        return f"INPUT TOO LARGE — limit is {_MAX_INPUT_BYTES} bytes."
+
     from aces.core.sdl import SDLParseError, SDLValidationError, parse_sdl
 
     try:
@@ -196,15 +201,23 @@ def _build_summary(scenario) -> str:
     return "\n".join(lines)
 
 
-def _format_entities(entities: dict, lines: list[str], indent: int) -> None:
+_MAX_RECURSION_DEPTH = 20
+
+
+def _format_entities(
+    entities: dict, lines: list[str], indent: int, depth: int = 0
+) -> None:
     """Recursively format entity hierarchy."""
+    if depth > _MAX_RECURSION_DEPTH:
+        lines.append(" " * indent + "(truncated — max depth reached)")
+        return
     prefix = " " * indent
     for name, entity in entities.items():
         role_str = f" ({entity.role.value})" if entity.role and hasattr(entity.role, 'value') else ""
         display = entity.name or name
         lines.append(f"{prefix}{name}: {display}{role_str}")
         if entity.entities:
-            _format_entities(entity.entities, lines, indent + 2)
+            _format_entities(entity.entities, lines, indent + 2, depth + 1)
 
 
 def _list_elements(scenario, section_filter: str) -> str:
@@ -238,15 +251,20 @@ def _list_elements(scenario, section_filter: str) -> str:
     return "\n".join(lines)
 
 
+_SECTION_FIELDS_SET = frozenset(_SECTION_FIELDS)
+
+
 def _get_element_detail(scenario, name: str) -> str:
     """Get detailed info about a named element."""
     # Try qualified ref first (e.g. "nodes.web-server")
     if "." in name:
         parts = name.split(".", 1)
         section_name, element_name = parts[0], parts[1]
-        data = getattr(scenario, section_name, None)
-        if isinstance(data, dict) and element_name in data:
-            return _format_element(section_name, element_name, data[element_name])
+        # Only access known SDL section attributes — never arbitrary attrs.
+        if section_name in _SECTION_FIELDS_SET:
+            data = getattr(scenario, section_name, None)
+            if isinstance(data, dict) and element_name in data:
+                return _format_element(section_name, element_name, data[element_name])
 
     # Search all sections for bare name
     matches: list[tuple[str, str, object]] = []
@@ -301,15 +319,17 @@ def _format_element(section: str, name: str, obj: object) -> str:
     return "\n".join(lines)
 
 
-def _format_value(value: object, indent: int = 4) -> str:
+def _format_value(value: object, indent: int = 4, depth: int = 0) -> str:
     """Format a value for display, handling nested structures."""
+    if depth > _MAX_RECURSION_DEPTH:
+        return "(...)"
     if isinstance(value, dict):
         if not value:
             return "{}"
         parts = []
         prefix = " " * indent
         for k, v in value.items():
-            parts.append(f"{prefix}{k}: {_format_value(v, indent + 2)}")
+            parts.append(f"{prefix}{k}: {_format_value(v, indent + 2, depth + 1)}")
         return "\n" + "\n".join(parts)
     if isinstance(value, list):
         if not value:
@@ -319,7 +339,7 @@ def _format_value(value: object, indent: int = 4) -> str:
         parts = []
         prefix = " " * indent
         for v in value:
-            parts.append(f"{prefix}- {_format_value(v, indent + 2)}")
+            parts.append(f"{prefix}- {_format_value(v, indent + 2, depth + 1)}")
         return "\n" + "\n".join(parts)
     if hasattr(value, "value"):
         return str(value.value)

--- a/src/aces/mcp/tools/inspection.py
+++ b/src/aces/mcp/tools/inspection.py
@@ -1,0 +1,591 @@
+"""SDL inspection tools — analyze, query, and summarize parsed scenarios.
+
+These tools work on SDL YAML that has already been written.  They let
+agents understand the structure of a scenario, look up individual
+elements, trace cross-references, and get high-level summaries.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    """Register SDL inspection/query tools on the MCP server."""
+
+    @mcp.tool(
+        name="sdl_summarize",
+        description=(
+            "Parse an SDL YAML scenario and return a structured summary: "
+            "scenario name/description, which sections are populated, element "
+            "counts, variables defined, entities hierarchy, and high-level "
+            "topology stats (VM count, switch count, network links).  "
+            "Useful for getting a quick understanding of an existing scenario."
+        ),
+    )
+    def sdl_summarize(sdl_content: str) -> str:
+        scenario = _parse_or_error(sdl_content)
+        if isinstance(scenario, str):
+            return scenario
+        return _build_summary(scenario)
+
+    @mcp.tool(
+        name="sdl_list_elements",
+        description=(
+            "List all named elements in a parsed SDL scenario, optionally "
+            "filtered by section.  Returns element names grouped by section.  "
+            "Pass `section` to filter (e.g. 'nodes', 'accounts').  "
+            "Pass `section='all'` or omit it to list everything."
+        ),
+    )
+    def sdl_list_elements(
+        sdl_content: str,
+        section: str = "all",
+    ) -> str:
+        scenario = _parse_or_error(sdl_content)
+        if isinstance(scenario, str):
+            return scenario
+        return _list_elements(scenario, section.lower().strip())
+
+    @mcp.tool(
+        name="sdl_get_element",
+        description=(
+            "Get detailed information about a specific named element in a "
+            "scenario.  Use a bare name like 'web-server' or a qualified "
+            "ref like 'nodes.web-server'.  Returns all fields, references "
+            "to/from this element, and related context."
+        ),
+    )
+    def sdl_get_element(
+        sdl_content: str,
+        element_name: str,
+    ) -> str:
+        scenario = _parse_or_error(sdl_content)
+        if isinstance(scenario, str):
+            return scenario
+        return _get_element_detail(scenario, element_name.strip())
+
+    @mcp.tool(
+        name="sdl_check_references",
+        description=(
+            "Analyze cross-references in a scenario.  For a given element "
+            "name, shows what it references (outgoing) and what references "
+            "it (incoming).  Helps understand dependency chains and "
+            "connectivity.  If no element_name is given, returns a full "
+            "reference graph summary."
+        ),
+    )
+    def sdl_check_references(
+        sdl_content: str,
+        element_name: str = "",
+    ) -> str:
+        scenario = _parse_or_error(sdl_content)
+        if isinstance(scenario, str):
+            return scenario
+        if element_name.strip():
+            return _element_references(scenario, element_name.strip())
+        return _full_reference_graph(scenario)
+
+    @mcp.tool(
+        name="sdl_diagram",
+        description=(
+            "Generate an ASCII topology diagram of the scenario's network "
+            "layout showing switches, VMs connected to each switch, and "
+            "inter-node dependencies.  Useful for visualizing the scenario "
+            "structure."
+        ),
+    )
+    def sdl_diagram(sdl_content: str) -> str:
+        scenario = _parse_or_error(sdl_content)
+        if isinstance(scenario, str):
+            return scenario
+        return _build_diagram(scenario)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_SECTION_FIELDS = [
+    "nodes", "infrastructure", "features", "conditions", "vulnerabilities",
+    "metrics", "evaluations", "tlos", "goals", "entities", "injects",
+    "events", "scripts", "stories", "content", "accounts", "relationships",
+    "agents", "objectives", "workflows", "variables",
+]
+
+
+def _parse_or_error(sdl_content: str):
+    """Attempt to parse SDL, returning a Scenario or an error string."""
+    from aces.core.sdl import SDLParseError, SDLValidationError, parse_sdl
+
+    try:
+        return parse_sdl(sdl_content, skip_semantic_validation=True)
+    except SDLParseError as exc:
+        return f"PARSE ERROR:\n{exc.details}"
+    except SDLValidationError as exc:
+        # Shouldn't happen with skip_semantic_validation=True, but be safe
+        bullets = "\n".join(f"  - {e}" for e in exc.errors)
+        return f"VALIDATION ERRORS:\n{bullets}"
+
+
+def _build_summary(scenario) -> str:
+    """Build a human-readable summary of a scenario."""
+    from aces.core.sdl.entities import flatten_entities
+    from aces.core.sdl.nodes import NodeType
+
+    lines = [
+        f"Scenario: {scenario.name}",
+    ]
+    if scenario.description:
+        lines.append(f"Description: {scenario.description.strip()}")
+    if scenario.version != "*":
+        lines.append(f"Version: {scenario.version}")
+
+    # Section counts
+    lines.append("\n--- Sections ---")
+    total_elements = 0
+    for field in _SECTION_FIELDS:
+        data = getattr(scenario, field, None)
+        if data:
+            count = len(data)
+            total_elements += count
+            lines.append(f"  {field}: {count}")
+    lines.append(f"  (total named elements: {total_elements})")
+
+    # Topology stats
+    vm_count = 0
+    switch_count = 0
+    for node in scenario.nodes.values():
+        if node.type == NodeType.VM:
+            vm_count += 1
+        elif node.type == NodeType.SWITCH:
+            switch_count += 1
+    if scenario.nodes:
+        lines.append(f"\n--- Topology ---")
+        lines.append(f"  VMs: {vm_count}")
+        lines.append(f"  Switches: {switch_count}")
+
+    # Variables
+    if scenario.variables:
+        lines.append(f"\n--- Variables ---")
+        for var_name, var in scenario.variables.items():
+            default_str = f" (default: {var.default})" if var.default is not None else ""
+            req = " [required]" if var.required else ""
+            lines.append(f"  ${{{var_name}}}: {var.type.value}{default_str}{req}")
+
+    # Entities hierarchy
+    if scenario.entities:
+        lines.append(f"\n--- Entities ---")
+        _format_entities(scenario.entities, lines, indent=2)
+
+    # Objectives summary
+    if scenario.objectives:
+        lines.append(f"\n--- Objectives ---")
+        for obj_name, obj in scenario.objectives.items():
+            actor = obj.agent or obj.entity
+            deps = f" (depends: {', '.join(obj.depends_on)})" if obj.depends_on else ""
+            lines.append(f"  {obj_name}: actor={actor}{deps}")
+
+    # Workflows summary
+    if scenario.workflows:
+        lines.append(f"\n--- Workflows ---")
+        for wf_name, wf in scenario.workflows.items():
+            step_count = len(wf.steps) if wf.steps else 0
+            lines.append(f"  {wf_name}: {step_count} steps, start={wf.start}")
+
+    return "\n".join(lines)
+
+
+def _format_entities(entities: dict, lines: list[str], indent: int) -> None:
+    """Recursively format entity hierarchy."""
+    prefix = " " * indent
+    for name, entity in entities.items():
+        role_str = f" ({entity.role.value})" if entity.role and hasattr(entity.role, 'value') else ""
+        display = entity.name or name
+        lines.append(f"{prefix}{name}: {display}{role_str}")
+        if entity.entities:
+            _format_entities(entity.entities, lines, indent + 2)
+
+
+def _list_elements(scenario, section_filter: str) -> str:
+    """List named elements, optionally filtered by section."""
+    from aces.core.sdl.entities import flatten_entities
+
+    lines: list[str] = []
+    for field in _SECTION_FIELDS:
+        if section_filter not in ("all", "") and field != section_filter:
+            continue
+        data = getattr(scenario, field, None)
+        if not data:
+            continue
+        lines.append(f"\n{field}:")
+        for name in data:
+            lines.append(f"  - {name}")
+        # Special: show nested entities
+        if field == "entities":
+            flat = flatten_entities(data)
+            nested = [n for n in flat if "." in n]
+            if nested:
+                lines.append("  (nested entities):")
+                for n in nested:
+                    lines.append(f"    - {n}")
+
+    if not lines:
+        if section_filter not in ("all", ""):
+            return f"Section '{section_filter}' is empty or does not exist."
+        return "Scenario has no named elements."
+
+    return "\n".join(lines)
+
+
+def _get_element_detail(scenario, name: str) -> str:
+    """Get detailed info about a named element."""
+    # Try qualified ref first (e.g. "nodes.web-server")
+    if "." in name:
+        parts = name.split(".", 1)
+        section_name, element_name = parts[0], parts[1]
+        data = getattr(scenario, section_name, None)
+        if isinstance(data, dict) and element_name in data:
+            return _format_element(section_name, element_name, data[element_name])
+
+    # Search all sections for bare name
+    matches: list[tuple[str, str, object]] = []
+    for field in _SECTION_FIELDS:
+        data = getattr(scenario, field, None)
+        if not data:
+            continue
+        if name in data:
+            matches.append((field, name, data[name]))
+
+    if not matches:
+        # Try nested entity names
+        from aces.core.sdl.entities import flatten_entities
+        if scenario.entities:
+            flat = flatten_entities(scenario.entities)
+            if name in flat:
+                return _format_element("entities", name, flat[name])
+
+        return (
+            f"Element '{name}' not found. "
+            "Use `sdl_list_elements` to see all available elements, "
+            "or try a qualified ref like 'nodes.my-node'."
+        )
+
+    if len(matches) == 1:
+        section, ename, obj = matches[0]
+        return _format_element(section, ename, obj)
+
+    # Ambiguous
+    lines = [f"Ambiguous name '{name}' found in multiple sections:"]
+    for section, ename, _ in matches:
+        lines.append(f"  - {section}.{ename}")
+    lines.append("Use a qualified ref to disambiguate.")
+    return "\n".join(lines)
+
+
+def _format_element(section: str, name: str, obj: object) -> str:
+    """Format a single element's details as readable text."""
+    lines = [f"{section}.{name}"]
+
+    if hasattr(obj, "model_dump"):
+        data = obj.model_dump(exclude_defaults=True, exclude_none=True)
+        for key, value in data.items():
+            if isinstance(value, dict) and not value:
+                continue
+            if isinstance(value, list) and not value:
+                continue
+            lines.append(f"  {key}: {_format_value(value)}")
+    else:
+        lines.append(f"  {obj!r}")
+
+    return "\n".join(lines)
+
+
+def _format_value(value: object, indent: int = 4) -> str:
+    """Format a value for display, handling nested structures."""
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+        parts = []
+        prefix = " " * indent
+        for k, v in value.items():
+            parts.append(f"{prefix}{k}: {_format_value(v, indent + 2)}")
+        return "\n" + "\n".join(parts)
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        if all(isinstance(v, str) for v in value):
+            return f"[{', '.join(str(v) for v in value)}]"
+        parts = []
+        prefix = " " * indent
+        for v in value:
+            parts.append(f"{prefix}- {_format_value(v, indent + 2)}")
+        return "\n" + "\n".join(parts)
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def _element_references(scenario, name: str) -> str:
+    """Show what an element references and what references it."""
+    outgoing: list[str] = []
+    incoming: list[str] = []
+
+    ref_map = _build_reference_map(scenario)
+    for (src_section, src_name), targets in ref_map.items():
+        src_key = f"{src_section}.{src_name}"
+        for tgt in targets:
+            if src_name == name or src_key == name:
+                outgoing.append(tgt)
+            if tgt == name or tgt.endswith(f".{name}"):
+                incoming.append(src_key)
+
+    lines = [f"References for '{name}':"]
+
+    if outgoing:
+        lines.append(f"\n  Outgoing ({len(outgoing)}):")
+        for ref in sorted(set(outgoing)):
+            lines.append(f"    -> {ref}")
+    else:
+        lines.append("\n  No outgoing references found.")
+
+    if incoming:
+        lines.append(f"\n  Incoming ({len(incoming)}):")
+        for ref in sorted(set(incoming)):
+            lines.append(f"    <- {ref}")
+    else:
+        lines.append("\n  No incoming references found.")
+
+    return "\n".join(lines)
+
+
+def _full_reference_graph(scenario) -> str:
+    """Build a summary of all cross-references in the scenario."""
+    ref_map = _build_reference_map(scenario)
+    if not ref_map:
+        return "No cross-references found in this scenario."
+
+    lines = ["Cross-reference graph:"]
+    for (src_section, src_name), targets in sorted(ref_map.items()):
+        if targets:
+            targets_str = ", ".join(sorted(targets))
+            lines.append(f"  {src_section}.{src_name} -> {targets_str}")
+
+    return "\n".join(lines)
+
+
+def _build_reference_map(scenario) -> dict[tuple[str, str], list[str]]:
+    """Extract cross-section references from a scenario.
+
+    Returns a dict mapping (section, element_name) -> list of referenced names.
+    This is a best-effort extraction covering the most important references.
+    """
+    refs: dict[tuple[str, str], list[str]] = {}
+
+    # Nodes -> features, conditions, vulnerabilities
+    for name, node in scenario.nodes.items():
+        targets: list[str] = []
+        if node.features:
+            targets.extend(node.features.keys())
+        if node.conditions:
+            targets.extend(node.conditions.keys())
+        if node.vulnerabilities:
+            targets.extend(node.vulnerabilities)
+        if targets:
+            refs[("nodes", name)] = targets
+
+    # Infrastructure -> nodes, links, dependencies
+    for name, infra in scenario.infrastructure.items():
+        targets = []
+        if infra.links:
+            targets.extend(infra.links)
+        if infra.dependencies:
+            targets.extend(infra.dependencies)
+        if targets:
+            refs[("infrastructure", name)] = targets
+
+    # Features -> dependencies
+    for name, feat in scenario.features.items():
+        if feat.dependencies:
+            refs[("features", name)] = list(feat.dependencies)
+
+    # Metrics -> conditions
+    for name, metric in scenario.metrics.items():
+        if metric.condition:
+            refs[("metrics", name)] = [metric.condition]
+
+    # Evaluations -> metrics
+    for name, ev in scenario.evaluations.items():
+        if ev.metrics:
+            refs[("evaluations", name)] = list(ev.metrics)
+
+    # TLOs -> evaluations
+    for name, tlo in scenario.tlos.items():
+        refs[("tlos", name)] = [tlo.evaluation]
+
+    # Goals -> TLOs
+    for name, goal in scenario.goals.items():
+        if goal.tlos:
+            refs[("goals", name)] = list(goal.tlos)
+
+    # Events -> conditions, injects
+    for name, event in scenario.events.items():
+        targets = []
+        if event.conditions:
+            targets.extend(event.conditions)
+        if event.injects:
+            targets.extend(event.injects)
+        if targets:
+            refs[("events", name)] = targets
+
+    # Scripts -> events
+    for name, script in scenario.scripts.items():
+        if script.events:
+            refs[("scripts", name)] = list(script.events.keys())
+
+    # Stories -> scripts
+    for name, story in scenario.stories.items():
+        if story.scripts:
+            refs[("stories", name)] = list(story.scripts)
+
+    # Relationships -> source, target
+    for name, rel in scenario.relationships.items():
+        targets = []
+        if rel.source:
+            targets.append(rel.source)
+        if rel.target:
+            targets.append(rel.target)
+        if targets:
+            refs[("relationships", name)] = targets
+
+    # Accounts -> node
+    for name, acct in scenario.accounts.items():
+        if acct.node:
+            refs[("accounts", name)] = [acct.node]
+
+    # Content -> target
+    for name, content in scenario.content.items():
+        if content.target:
+            refs[("content", name)] = [content.target]
+
+    # Agents -> entity, accounts, etc.
+    for name, agent in scenario.agents.items():
+        targets = []
+        if agent.entity:
+            targets.append(agent.entity)
+        if agent.starting_accounts:
+            targets.extend(agent.starting_accounts)
+        if targets:
+            refs[("agents", name)] = targets
+
+    # Objectives -> agent/entity, targets, success refs, deps
+    for name, obj in scenario.objectives.items():
+        targets = []
+        if obj.agent:
+            targets.append(obj.agent)
+        if obj.entity:
+            targets.append(obj.entity)
+        if obj.targets:
+            targets.extend(obj.targets)
+        if obj.depends_on:
+            targets.extend(obj.depends_on)
+        if obj.success:
+            targets.extend(obj.success.conditions)
+            targets.extend(obj.success.metrics)
+            targets.extend(obj.success.evaluations)
+            targets.extend(obj.success.tlos)
+            targets.extend(obj.success.goals)
+        if targets:
+            refs[("objectives", name)] = targets
+
+    # Injects -> entities
+    for name, inject in scenario.injects.items():
+        targets = []
+        if inject.from_entity:
+            targets.append(inject.from_entity)
+        if inject.to_entities:
+            targets.extend(inject.to_entities)
+        if targets:
+            refs[("injects", name)] = targets
+
+    return refs
+
+
+def _build_diagram(scenario) -> str:
+    """Build an ASCII topology diagram."""
+    from aces.core.sdl.nodes import NodeType
+
+    lines = [f"Topology: {scenario.name}", "=" * 40]
+
+    # Group VMs by their connected switches
+    switch_to_vms: dict[str, list[str]] = {}
+    unlinked_vms: list[str] = []
+
+    switches = [
+        name for name, node in scenario.nodes.items()
+        if node.type == NodeType.SWITCH
+    ]
+    vms = [
+        name for name, node in scenario.nodes.items()
+        if node.type == NodeType.VM
+    ]
+
+    for sw in switches:
+        switch_to_vms[sw] = []
+
+    for vm_name in vms:
+        infra = scenario.infrastructure.get(vm_name)
+        if infra and infra.links:
+            for link in infra.links:
+                if link in switch_to_vms:
+                    switch_to_vms[link].append(vm_name)
+        else:
+            unlinked_vms.append(vm_name)
+
+    # Render each switch and its connected VMs
+    for sw_name in switches:
+        connected = switch_to_vms.get(sw_name, [])
+        sw_infra = scenario.infrastructure.get(sw_name)
+        cidr = ""
+        if sw_infra and sw_infra.properties:
+            props = sw_infra.properties
+            if hasattr(props, "cidr") and props.cidr:
+                cidr = f" ({props.cidr})"
+            elif isinstance(props, list) and props:
+                pass  # complex properties
+
+        sw_node = scenario.nodes.get(sw_name)
+        desc = ""
+        if sw_node and sw_node.description:
+            desc = f" - {sw_node.description}"
+
+        lines.append(f"\n[{sw_name}]{cidr}{desc}")
+        if connected:
+            for i, vm in enumerate(connected):
+                connector = "├── " if i < len(connected) - 1 else "└── "
+                vm_node = scenario.nodes.get(vm)
+                svc_info = ""
+                if vm_node and vm_node.services:
+                    svc_names = [s.name for s in vm_node.services if s.name]
+                    if svc_names:
+                        svc_info = f"  [{', '.join(svc_names)}]"
+                lines.append(f"  {connector}{vm}{svc_info}")
+        else:
+            lines.append("  (no VMs connected)")
+
+    if unlinked_vms:
+        lines.append(f"\n[unlinked VMs]")
+        for vm in unlinked_vms:
+            lines.append(f"  └── {vm}")
+
+    # Show infrastructure dependencies
+    deps_found = False
+    for name, infra in scenario.infrastructure.items():
+        if infra.dependencies:
+            if not deps_found:
+                lines.append(f"\n--- Dependencies ---")
+                deps_found = True
+            for dep in infra.dependencies:
+                lines.append(f"  {name} --> {dep}")
+
+    return "\n".join(lines)

--- a/src/aces/mcp/tools/reference.py
+++ b/src/aces/mcp/tools/reference.py
@@ -1,0 +1,472 @@
+"""SDL reference and learning tools.
+
+These tools teach agents about the SDL from scratch — no prior knowledge
+required.  They expose the language overview, per-section documentation,
+and annotated real-world examples.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+# ---------------------------------------------------------------------------
+# Docs / examples on disk
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]  # src/aces/mcp/tools -> repo root
+_DOCS_DIR = _REPO_ROOT / "docs" / "sdl"
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+
+def _read_doc(name: str) -> str:
+    path = _DOCS_DIR / name
+    if not path.exists():
+        return f"Documentation file not found: {name}"
+    return path.read_text()
+
+
+def _read_example(name: str) -> str:
+    path = _EXAMPLES_DIR / name
+    if not path.exists():
+        return f"Example file not found: {name}"
+    return path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Section-level reference snippets
+# ---------------------------------------------------------------------------
+
+# Maps each section name to the heading anchor used in sections.md so we
+# can extract just the relevant portion.
+_SECTION_NAMES: dict[str, str] = {
+    "nodes": "Nodes",
+    "infrastructure": "Infrastructure",
+    "features": "Features",
+    "conditions": "Conditions",
+    "vulnerabilities": "Vulnerabilities",
+    "metrics": "Scoring Pipeline: Metrics, Evaluations, TLOs, Goals",
+    "evaluations": "Scoring Pipeline: Metrics, Evaluations, TLOs, Goals",
+    "tlos": "Scoring Pipeline: Metrics, Evaluations, TLOs, Goals",
+    "goals": "Scoring Pipeline: Metrics, Evaluations, TLOs, Goals",
+    "scoring": "Scoring Pipeline: Metrics, Evaluations, TLOs, Goals",
+    "entities": "Entities",
+    "injects": "Orchestration: Injects, Events, Scripts, Stories",
+    "events": "Orchestration: Injects, Events, Scripts, Stories",
+    "scripts": "Orchestration: Injects, Events, Scripts, Stories",
+    "stories": "Orchestration: Injects, Events, Scripts, Stories",
+    "orchestration": "Orchestration: Injects, Events, Scripts, Stories",
+    "content": "Content",
+    "accounts": "Accounts",
+    "relationships": "Relationships",
+    "agents": "Agents",
+    "objectives": "Objectives",
+    "workflows": "Workflows",
+    "variables": "Variables",
+}
+
+
+def _extract_section(doc_text: str, heading: str) -> str:
+    """Extract a single ## section from the sections.md document."""
+    marker = f"## {heading}\n"
+    start = doc_text.find(marker)
+    if start == -1:
+        return f"Section '{heading}' not found in reference docs."
+    # Find end: next ## heading or end of file
+    next_h2 = doc_text.find("\n## ", start + len(marker))
+    if next_h2 == -1:
+        return doc_text[start:]
+    return doc_text[start:next_h2].rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Tool registrations
+# ---------------------------------------------------------------------------
+
+
+def register(mcp: FastMCP) -> None:
+    """Register SDL reference/learning tools on the MCP server."""
+
+    @mcp.tool(
+        name="sdl_overview",
+        description=(
+            "Get a comprehensive overview of the ACES Scenario Description "
+            "Language (SDL). Returns what the SDL is, its 21 sections, how "
+            "parsing/validation works, the variable system, and a complete "
+            "minimal example. Start here if you have never seen the SDL before."
+        ),
+    )
+    def sdl_overview() -> str:
+        return _OVERVIEW_TEXT
+
+    @mcp.tool(
+        name="sdl_section_reference",
+        description=(
+            "Get detailed documentation for a specific SDL section including "
+            "its schema, fields, YAML examples, shorthands, and validation "
+            "rules.  Valid section names: nodes, infrastructure, features, "
+            "conditions, vulnerabilities, scoring (metrics+evaluations+tlos+"
+            "goals), entities, orchestration (injects+events+scripts+stories), "
+            "content, accounts, relationships, agents, objectives, workflows, "
+            "variables.  You can also pass the individual section name like "
+            "'metrics' or 'events'."
+        ),
+    )
+    def sdl_section_reference(section: str) -> str:
+        key = section.lower().strip()
+        if key not in _SECTION_NAMES:
+            valid = sorted(set(_SECTION_NAMES.keys()))
+            return (
+                f"Unknown section '{section}'. "
+                f"Valid names: {', '.join(valid)}"
+            )
+        heading = _SECTION_NAMES[key]
+        doc_text = _read_doc("sections.md")
+        extracted = _extract_section(doc_text, heading)
+
+        # Append relevant validation rules
+        validation_text = _read_doc("validation.md")
+        verify_tag = f"verify_{key}"
+        # Try to find the matching validation pass description
+        val_lines: list[str] = []
+        for line in validation_text.splitlines():
+            if verify_tag in line.lower().replace("-", "_"):
+                val_lines.append(line)
+        if val_lines:
+            extracted += "\n\n### Validation Rules\n\n" + "\n".join(val_lines)
+
+        return extracted
+
+    @mcp.tool(
+        name="sdl_get_example",
+        description=(
+            "Get a complete, real-world annotated SDL scenario example. "
+            "Available examples: 'hospital' (hospital ransomware exercise, "
+            "~750 lines, uses all 21 sections), 'satcom' (satellite supply-chain "
+            "exercise, ~750 lines), 'port' (port authority OT exercise, ~680 lines), "
+            "'minimal' (a small annotated pentest-lab example to learn the basics). "
+            "Use 'hospital' for a comprehensive reference of all SDL features."
+        ),
+    )
+    def sdl_get_example(
+        name: str,
+    ) -> str:
+        key = name.lower().strip()
+        if key in ("hospital", "hospital-ransomware", "ransomware"):
+            return _read_example("hospital-ransomware-surgery-day.sdl.yaml")
+        if key in ("satcom", "satellite", "supply-chain", "release-poisoning"):
+            return _read_example("satcom-release-poisoning.sdl.yaml")
+        if key in ("port", "port-authority", "ot", "surge"):
+            return _read_example("port-authority-surge-response.sdl.yaml")
+        if key in ("minimal", "simple", "small", "pentest", "lab"):
+            return _MINIMAL_EXAMPLE
+        return (
+            f"Unknown example '{name}'. "
+            "Available: 'hospital', 'satcom', 'port', 'minimal'"
+        )
+
+    @mcp.tool(
+        name="sdl_parser_reference",
+        description=(
+            "Get documentation about SDL parser behavior: key normalization "
+            "(case-insensitive fields), shorthand expansion rules, the variable "
+            "system (${var} syntax), OCR duration grammar (e.g. '1h 30min'), "
+            "and the parse/validate pipeline stages."
+        ),
+    )
+    def sdl_parser_reference() -> str:
+        return _read_doc("parser.md")
+
+    @mcp.tool(
+        name="sdl_validation_reference",
+        description=(
+            "Get documentation about SDL semantic validation: all 22 named "
+            "validation passes, cross-reference resolution rules, error "
+            "reporting, advisories, and how ambiguous references are handled."
+        ),
+    )
+    def sdl_validation_reference() -> str:
+        return _read_doc("validation.md")
+
+
+# ---------------------------------------------------------------------------
+# Static content
+# ---------------------------------------------------------------------------
+
+_MINIMAL_EXAMPLE = """\
+# Minimal SDL Example: Pentest Lab
+# This demonstrates the core SDL structure with a small, self-contained scenario.
+
+name: simple-pentest-lab
+description: Web app with SQL injection targeting a database
+
+# --- Topology: nodes define VMs and network switches ---
+nodes:
+  lab-net:
+    type: Switch                         # pure connectivity, no OS/resources
+    description: Lab network
+
+  webapp:
+    type: VM
+    os: linux
+    resources: {ram: 2 GiB, cpu: 1}      # human-readable RAM
+    features: [flask-app]                 # list shorthand for feature bindings
+    services:
+      - {port: 8080, name: http}          # exposed network service
+    vulnerabilities: [sqli]
+
+  database:
+    type: VM
+    os: linux
+    resources: {ram: 1 GiB, cpu: 1}
+    features: [postgres]
+    services:
+      - {port: 5432, name: postgresql}
+    asset_value:
+      confidentiality: high               # CIA triad classification
+
+# --- Deployment: how many of each, which networks, IPs ---
+infrastructure:
+  lab-net:
+    count: 1
+    properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}
+  webapp:
+    count: 1
+    links: [lab-net]                       # connected to lab-net switch
+  database:
+    count: 1
+    links: [lab-net]
+
+# --- Software deployed onto VMs ---
+features:
+  flask-app: {type: Service, source: vulnerable-flask-app}
+  postgres: {type: Service, source: postgresql-16}
+
+# --- Security weaknesses ---
+vulnerabilities:
+  sqli:
+    name: SQL Injection
+    description: SQLi in login form allows auth bypass
+    technical: true
+    class: CWE-89                          # must be CWE-\\d+ format
+
+# --- Typed edges between elements ---
+relationships:
+  app-to-db:
+    type: connects_to                      # authenticates_with, trusts, federates_with,
+    source: flask-app                      #   connects_to, depends_on, manages, replicates_to
+    target: postgres
+    properties: {protocol: tcp, port: "5432"}
+
+# --- User accounts ---
+accounts:
+  db-admin:
+    username: admin
+    node: database                         # must reference a VM node
+    password_strength: weak                # weak, medium, strong, none
+
+# --- Health checks ---
+conditions:
+  web-alive:
+    command: "curl -sf http://localhost:8080/ || exit 1"
+    interval: 15
+
+# --- Scoring pipeline: conditions -> metrics -> evaluations -> TLOs -> goals ---
+metrics:
+  uptime:
+    type: CONDITIONAL
+    max-score: 100
+    condition: web-alive
+
+evaluations:
+  basic-eval:
+    metrics: [uptime]
+    min-score: 75                          # shorthand for {percentage: 75}
+
+tlos:
+  web-defense:
+    name: Defend the web application
+    evaluation: basic-eval
+
+goals:
+  pass:
+    tlos: [web-defense]
+
+# --- Teams / people ---
+entities:
+  blue-team:
+    name: Blue Team
+    role: Blue                             # Blue, Red, White, Green
+    tlos: [web-defense]
+  red-team:
+    name: Red Team
+    role: Red
+
+# --- Parameterization (${var} syntax, resolved at instantiation, not parse time) ---
+variables:
+  lab_cidr:
+    type: string
+    default: "10.0.0.0/24"
+    description: Lab network CIDR block
+"""
+
+_OVERVIEW_TEXT = """\
+# ACES Scenario Description Language (SDL) Overview
+
+## What is the SDL?
+
+The ACES SDL is a **YAML-based, backend-agnostic specification language** for \
+describing cyber range scenarios and experiments. It defines *what a scenario \
+means* — not how to deploy it. Backend implementations realize SDL \
+specifications through runtime contracts.
+
+It descends from the Open Cyber Range (OCR) SDL and extends it with 7 \
+additional sections for richer experiment semantics.
+
+## The 21 Sections
+
+A scenario is a YAML document with a required `name` and up to 21 optional \
+sections, organized into four concerns:
+
+### Topology & Software (5 sections)
+| Section | Purpose |
+|---------|---------|
+| `nodes` | VMs and network switches — the compute/network topology |
+| `infrastructure` | Deployment: counts, links, dependencies, IPs, CIDRs, ACLs |
+| `features` | Software (Service/Configuration/Artifact) deployed to VMs |
+| `conditions` | Health checks (command+interval or library source) |
+| `vulnerabilities` | CWE-classified weaknesses |
+
+### Scoring Pipeline (4 sections)
+| Section | Purpose |
+|---------|---------|
+| `metrics` | Scoring criteria: CONDITIONAL (automated) or MANUAL |
+| `evaluations` | Metric groups with pass/fail thresholds |
+| `tlos` | Training Learning Objectives linked to evaluations |
+| `goals` | High-level goals composed of TLOs |
+
+Flow: `conditions -> metrics -> evaluations -> TLOs -> goals`
+
+### Exercise Orchestration (4 sections)
+| Section | Purpose |
+|---------|---------|
+| `entities` | Teams, organizations, people (recursive hierarchy) |
+| `injects` | Actions between entities |
+| `events` | Triggered actions combining conditions + injects |
+| `scripts` | Timed event sequences with human-readable durations |
+| `stories` | Top-level orchestration grouping scripts |
+
+### Extended Experiment Semantics (7 sections)
+| Section | Purpose |
+|---------|---------|
+| `content` | Data placed into systems (files, datasets, emails) |
+| `accounts` | User accounts on nodes |
+| `relationships` | Typed directed edges (auth, trust, federation, etc.) |
+| `agents` | Autonomous participants with actions/knowledge/scope |
+| `objectives` | Declarative tasks: actor + targets + success + window |
+| `workflows` | Branching/parallel control graphs over objectives |
+| `variables` | Parameterization via `${var_name}` syntax |
+
+### Top-level Composition Fields
+- `name` (required), `version`, `description`
+- `module` — publishable module descriptor
+- `imports` — module imports (`local:`, `oci:`, `locked:`)
+
+## Key Concepts
+
+### Variables
+- `${var_name}` placeholders in field values (NOT in mapping keys)
+- Preserved as literal strings during parsing; resolved at instantiation
+- Types: string, integer, boolean, number
+- Can have defaults, allowed_values, required flag
+
+### Shorthand Expansion
+The parser auto-expands common patterns:
+- `source: "pkg"` → `{name: "pkg", version: "*"}`
+- `infrastructure: {node: 3}` → `{node: {count: 3}}`
+- `roles: {admin: "user"}` → `{admin: {username: "user"}}`
+- `min-score: 50` → `{percentage: 50}`
+- `features: [nginx, php]` → `{nginx: "", php: ""}`
+
+### Key Normalization
+- Field keys are case-insensitive: `Name` → `name`, `Min-Score` → `min_score`
+- User-defined names (node names, feature names, etc.) are preserved as-is
+
+### Cross-Reference System
+- Named elements can be referenced by bare name when unambiguous: `webapp`
+- Qualified refs when disambiguation needed: `nodes.webapp`, `features.nginx`
+- Nested entities use dot-notation: `blue-team.alice`
+- Named services: `nodes.<node>.services.<service_name>`
+- Named ACLs: `infrastructure.<infra>.acls.<acl_name>`
+
+### Validation Pipeline
+1. YAML parsing (`yaml.safe_load()`)
+2. Key normalization
+3. Shorthand expansion
+4. Pydantic structural validation
+5. 22-pass semantic validation (cross-references, cycles, IP/CIDR, etc.)
+All errors collected before reporting — authors see every issue at once.
+
+### Duration Grammar
+Script/event times accept: `1h 30min`, `2 days`, `1m+30`, `500ms`
+Units: y, mon, w, d, h, m/min, s/sec, ms, us, ns
+
+## Quick Example
+
+```yaml
+name: simple-lab
+description: Basic web app scenario
+
+nodes:
+  net: {type: Switch}
+  web: {type: VM, os: linux, resources: {ram: 2 GiB, cpu: 1}, features: [app]}
+  db:  {type: VM, os: linux, resources: {ram: 1 GiB, cpu: 1}, features: [postgres]}
+
+infrastructure:
+  net: {count: 1, properties: {cidr: 10.0.0.0/24}}
+  web: {count: 1, links: [net]}
+  db:  {count: 1, links: [net]}
+
+features:
+  app:      {type: Service, source: flask-app}
+  postgres: {type: Service, source: postgresql-16}
+
+vulnerabilities:
+  sqli: {name: SQL Injection, technical: true, class: CWE-89}
+
+relationships:
+  app-to-db: {type: connects_to, source: app, target: postgres}
+```
+
+## Python API
+
+```python
+from aces.core.sdl import parse_sdl, parse_sdl_file, instantiate_scenario
+
+# Parse from string or file
+scenario = parse_sdl(yaml_string)
+scenario = parse_sdl_file(Path("scenario.yaml"))
+
+# Structural only (skip cross-reference checks)
+scenario = parse_sdl(yaml_string, skip_semantic_validation=True)
+
+# Instantiate with concrete variable values
+concrete = instantiate_scenario(scenario, parameters={"domain": "corp.local"})
+
+# Check non-fatal advisories
+for advisory in scenario.advisories:
+    print(advisory)
+```
+
+## Error Types
+- `SDLParseError` — YAML syntax or structural issues
+- `SDLValidationError` — semantic issues (has `.errors` list with ALL issues)
+- `SDLInstantiationError` — variable binding failures
+
+Use `sdl_section_reference` to learn about any specific section in detail.
+Use `sdl_get_example` to see complete real-world scenarios.
+Use `sdl_validate` to check your SDL YAML.
+"""

--- a/src/aces/mcp/tools/reference.py
+++ b/src/aces/mcp/tools/reference.py
@@ -7,22 +7,29 @@ and annotated real-world examples.
 
 from __future__ import annotations
 
-import importlib.resources
 from pathlib import Path
-from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
 # ---------------------------------------------------------------------------
-# Docs / examples on disk
+# Docs / examples on disk — allowlisted filenames only
 # ---------------------------------------------------------------------------
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]  # src/aces/mcp/tools -> repo root
 _DOCS_DIR = _REPO_ROOT / "docs" / "sdl"
 _EXAMPLES_DIR = _REPO_ROOT / "examples"
 
+_ALLOWED_DOCS = frozenset({"sections.md", "parser.md", "validation.md"})
+_ALLOWED_EXAMPLES = frozenset({
+    "hospital-ransomware-surgery-day.sdl.yaml",
+    "satcom-release-poisoning.sdl.yaml",
+    "port-authority-surge-response.sdl.yaml",
+})
+
 
 def _read_doc(name: str) -> str:
+    if name not in _ALLOWED_DOCS:
+        return f"Documentation file not available: {name}"
     path = _DOCS_DIR / name
     if not path.exists():
         return f"Documentation file not found: {name}"
@@ -30,6 +37,8 @@ def _read_doc(name: str) -> str:
 
 
 def _read_example(name: str) -> str:
+    if name not in _ALLOWED_EXAMPLES:
+        return f"Example file not available: {name}"
     path = _EXAMPLES_DIR / name
     if not path.exists():
         return f"Example file not found: {name}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -534,3 +534,73 @@ class TestServerConstruction:
         server = create_server()
         assert server.instructions
         assert "SDL" in server.instructions
+
+
+# ---------------------------------------------------------------------------
+# Security regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurity:
+    """Regression tests for security hardening."""
+
+    def test_scaffold_with_braces_in_name(self, server):
+        """Format string injection: braces in user input must not crash."""
+        text = _call(
+            server,
+            "sdl_scaffold",
+            {
+                "complexity": "minimal",
+                "scenario_name": "test{oops}",
+                "description": "desc with {curly} braces",
+            },
+        )
+        assert "test{oops}" in text
+        assert "{curly}" in text
+        # Should still be valid YAML (name: test{oops} is a valid YAML string)
+        assert "name: test{oops}" in text
+
+    def test_get_element_private_attr_access(self, server):
+        """Qualified ref must not access private/dunder attributes."""
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": MINIMAL_SDL, "element_name": "_advisories.anything"},
+        )
+        assert "not found" in text.lower()
+
+    def test_get_element_dunder_access(self, server):
+        """Qualified ref must not access __class__ or similar."""
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": MINIMAL_SDL, "element_name": "__class__.foo"},
+        )
+        assert "not found" in text.lower()
+
+    def test_validate_oversized_input_rejected(self, server):
+        """Extremely large input must be rejected."""
+        huge = "name: x\nnodes:\n" + "  n{i}: {{type: Switch}}\n" * 10_000
+        text = _call(server, "sdl_validate", {"sdl_content": huge})
+        assert "INPUT TOO LARGE" in text
+
+    def test_summarize_oversized_input_rejected(self, server):
+        """Inspection tools also enforce size limits."""
+        huge = "name: x\n" + "x" * (65 * 1024)
+        text = _call(server, "sdl_summarize", {"sdl_content": huge})
+        assert "INPUT TOO LARGE" in text
+
+    def test_validate_section_context_cannot_override_name(self, server):
+        """context_yaml must not be able to hijack the wrapper name."""
+        text = _call(
+            server,
+            "sdl_validate_section",
+            {
+                "section": "nodes",
+                "section_yaml": "sw:\n  type: Switch",
+                "context_yaml": "name: hijacked",
+            },
+        )
+        # Should succeed validation — name should still be the safe internal one
+        assert "VALID" in text or "VALIDATION" in text
+        assert "hijacked" not in text

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,536 @@
+"""Tests for the ACES SDL MCP server tools.
+
+Verifies that all 14 tools produce correct results across
+reference, authoring, and inspection categories.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from aces.mcp.server import create_server
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def server():
+    return create_server()
+
+
+def _text(result) -> str:
+    """Extract text from the MCP tool result tuple."""
+    content_list = result[0]
+    return content_list[0].text
+
+
+def _call(server, tool: str, args: dict | None = None) -> str:
+    """Synchronously call a tool and return its text."""
+    return asyncio.get_event_loop().run_until_complete(
+        _async_call(server, tool, args or {})
+    )
+
+
+async def _async_call(server, tool: str, args: dict) -> str:
+    result = await server.call_tool(tool, args)
+    return _text(result)
+
+
+# ---------------------------------------------------------------------------
+# Valid SDL fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_SDL = """\
+name: test-scenario
+nodes:
+  net: {type: Switch}
+  web: {type: VM, os: linux, resources: {ram: 2 GiB, cpu: 1}}
+infrastructure:
+  net: {count: 1, properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  web: {count: 1, links: [net]}
+"""
+
+FULL_SDL = """\
+name: mcp-test
+description: Test scenario with many sections
+
+variables:
+  speed:
+    type: number
+    default: 1.0
+
+nodes:
+  corp-net: {type: Switch}
+  web: {type: VM, os: linux, resources: {ram: 2 GiB, cpu: 1}, features: {app: admin}, roles: {admin: www}, conditions: {alive: admin}}
+  db:  {type: VM, os: linux, resources: {ram: 1 GiB, cpu: 1}, features: {pg: dba}, roles: {dba: postgres}, services: [{port: 5432, name: pg-port}]}
+
+infrastructure:
+  corp-net: {count: 1, properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  web: {count: 1, links: [corp-net]}
+  db:  {count: 1, links: [corp-net]}
+
+features:
+  app: {type: Service, source: my-app}
+  pg:  {type: Service, source: postgresql}
+
+conditions:
+  alive:
+    command: "curl -sf http://localhost/ || exit 1"
+    interval: 15
+
+vulnerabilities:
+  sqli: {name: SQL Injection, description: "SQLi in login", technical: true, class: CWE-89}
+
+metrics:
+  uptime: {type: CONDITIONAL, max-score: 100, condition: alive}
+
+evaluations:
+  basic: {metrics: [uptime], min-score: 50}
+
+tlos:
+  web-defense: {name: Defend web, evaluation: basic}
+
+goals:
+  pass: {tlos: [web-defense]}
+
+entities:
+  blue-team:
+    name: Blue
+    role: Blue
+    tlos: [web-defense]
+    entities:
+      alice: {name: Alice}
+  red-team:
+    name: Red
+    role: Red
+
+injects:
+  brief: {source: brief-doc, from_entity: red-team, to_entities: [blue-team]}
+
+events:
+  attack: {injects: [brief]}
+
+scripts:
+  timeline:
+    start-time: 0
+    end-time: 2 hour
+    speed: "${speed}"
+    events:
+      attack: 30 min
+
+stories:
+  exercise:
+    speed: "${speed}"
+    scripts: [timeline]
+
+content:
+  seed: {type: dataset, target: db, format: sql, source: seed-pkg}
+
+accounts:
+  admin-acct: {username: admin, node: web, password_strength: strong}
+
+relationships:
+  web-to-db: {type: connects_to, source: app, target: pg}
+
+agents:
+  red-agent:
+    entity: red-team
+    actions: [Scan]
+    initial_knowledge:
+      hosts: [web]
+      subnets: [corp-net]
+      services: [pg-port]
+
+objectives:
+  red-access:
+    agent: red-agent
+    actions: [Scan]
+    targets: [web]
+    success: {conditions: [alive]}
+    window: {stories: [exercise]}
+
+workflows:
+  flow:
+    start: do-it
+    steps:
+      do-it: {type: objective, objective: red-access, on-success: done}
+      done: {type: end}
+"""
+
+
+INVALID_SDL = """\
+name: broken
+nodes:
+  web:
+    type: VM
+    os: linux
+    features: {ghost-feature: admin}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Reference tools
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceTools:
+    def test_sdl_overview_returns_content(self, server):
+        text = _call(server, "sdl_overview")
+        assert "SDL" in text
+        assert "21" in text or "sections" in text.lower()
+        assert "nodes" in text
+
+    def test_sdl_section_reference_valid(self, server):
+        text = _call(server, "sdl_section_reference", {"section": "nodes"})
+        assert "Nodes" in text
+        assert "Switch" in text
+        assert "VM" in text
+
+    def test_sdl_section_reference_scoring(self, server):
+        text = _call(server, "sdl_section_reference", {"section": "scoring"})
+        assert "Metrics" in text or "metrics" in text
+        assert "Evaluations" in text or "evaluations" in text
+
+    def test_sdl_section_reference_invalid(self, server):
+        text = _call(server, "sdl_section_reference", {"section": "nonexistent"})
+        assert "Unknown section" in text
+
+    def test_sdl_get_example_minimal(self, server):
+        text = _call(server, "sdl_get_example", {"name": "minimal"})
+        assert "name:" in text
+        assert "nodes:" in text
+
+    def test_sdl_get_example_hospital(self, server):
+        text = _call(server, "sdl_get_example", {"name": "hospital"})
+        assert "hospital-ransomware" in text
+        assert "objectives:" in text
+
+    def test_sdl_get_example_invalid(self, server):
+        text = _call(server, "sdl_get_example", {"name": "nonexistent"})
+        assert "Unknown example" in text
+
+    def test_sdl_parser_reference(self, server):
+        text = _call(server, "sdl_parser_reference")
+        assert "normalization" in text.lower() or "Normalization" in text
+
+    def test_sdl_validation_reference(self, server):
+        text = _call(server, "sdl_validation_reference")
+        assert "22" in text or "validation" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Authoring tools
+# ---------------------------------------------------------------------------
+
+
+class TestAuthoringTools:
+    def test_validate_valid_sdl(self, server):
+        text = _call(server, "sdl_validate", {"sdl_content": MINIMAL_SDL})
+        assert text.startswith("VALID")
+
+    def test_validate_full_sdl(self, server):
+        text = _call(server, "sdl_validate", {"sdl_content": FULL_SDL})
+        assert text.startswith("VALID")
+        assert "nodes: 3" in text
+        assert "objectives: 1" in text
+
+    def test_validate_invalid_sdl(self, server):
+        text = _call(server, "sdl_validate", {"sdl_content": INVALID_SDL})
+        assert "VALIDATION ERRORS" in text
+        assert "ghost-feature" in text
+
+    def test_validate_yaml_error(self, server):
+        text = _call(server, "sdl_validate", {"sdl_content": "{{not yaml"})
+        assert "PARSE ERROR" in text
+
+    def test_validate_structural_only(self, server):
+        text = _call(
+            server,
+            "sdl_validate",
+            {"sdl_content": INVALID_SDL, "structural_only": True},
+        )
+        # With structural_only, the cross-reference error should not appear
+        assert "VALID" in text or "semantic validation was skipped" in text
+
+    def test_validate_section_valid(self, server):
+        text = _call(
+            server,
+            "sdl_validate_section",
+            {
+                "section": "nodes",
+                "section_yaml": "myvm:\n  type: VM\n  os: linux\n  resources: {ram: 2 GiB, cpu: 1}",
+            },
+        )
+        assert "VALID" in text
+
+    def test_validate_section_invalid_yaml(self, server):
+        text = _call(
+            server,
+            "sdl_validate_section",
+            {"section": "nodes", "section_yaml": "{{not yaml"},
+        )
+        assert "YAML ERROR" in text
+
+    def test_validate_section_bad_section(self, server):
+        text = _call(
+            server,
+            "sdl_validate_section",
+            {"section": "nope", "section_yaml": "x: 1"},
+        )
+        assert "Unknown section" in text
+
+    def test_scaffold_minimal(self, server):
+        text = _call(server, "sdl_scaffold", {"complexity": "minimal"})
+        assert "name:" in text
+        assert "nodes:" in text
+        # Should be valid SDL
+        validation = _call(server, "sdl_validate", {"sdl_content": text})
+        assert validation.startswith("VALID")
+
+    def test_scaffold_standard(self, server):
+        text = _call(server, "sdl_scaffold", {"complexity": "standard"})
+        assert "entities:" in text
+        assert "accounts:" in text
+        validation = _call(server, "sdl_validate", {"sdl_content": text})
+        assert validation.startswith("VALID")
+
+    def test_scaffold_full(self, server):
+        text = _call(server, "sdl_scaffold", {"complexity": "full"})
+        assert "workflows:" in text
+        assert "objectives:" in text
+        assert "variables:" in text
+        validation = _call(server, "sdl_validate", {"sdl_content": text})
+        assert validation.startswith("VALID")
+
+    def test_scaffold_invalid_complexity(self, server):
+        text = _call(server, "sdl_scaffold", {"complexity": "ultra"})
+        assert "Invalid complexity" in text
+
+    def test_instantiate(self, server):
+        sdl = """\
+name: param-test
+variables:
+  greeting:
+    type: string
+    default: hello
+"""
+        text = _call(
+            server,
+            "sdl_instantiate",
+            {"sdl_content": sdl, "parameters_json": '{"greeting": "hi"}'},
+        )
+        assert "INSTANTIATED" in text
+
+    def test_instantiate_bad_json(self, server):
+        text = _call(
+            server,
+            "sdl_instantiate",
+            {"sdl_content": "name: x", "parameters_json": "{bad"},
+        )
+        assert "Invalid JSON" in text
+
+
+# ---------------------------------------------------------------------------
+# Inspection tools
+# ---------------------------------------------------------------------------
+
+
+class TestInspectionTools:
+    def test_summarize(self, server):
+        text = _call(server, "sdl_summarize", {"sdl_content": FULL_SDL})
+        assert "mcp-test" in text
+        assert "VMs:" in text
+        assert "Switches:" in text
+        assert "${speed}" in text
+
+    def test_summarize_entities(self, server):
+        text = _call(server, "sdl_summarize", {"sdl_content": FULL_SDL})
+        assert "blue-team" in text
+        assert "Entities" in text
+
+    def test_list_elements_all(self, server):
+        text = _call(
+            server, "sdl_list_elements", {"sdl_content": FULL_SDL, "section": "all"}
+        )
+        assert "nodes:" in text
+        assert "web" in text
+        assert "features:" in text
+
+    def test_list_elements_filtered(self, server):
+        text = _call(
+            server,
+            "sdl_list_elements",
+            {"sdl_content": FULL_SDL, "section": "accounts"},
+        )
+        assert "admin-acct" in text
+        # Should NOT list nodes
+        assert "\nnodes:" not in text
+
+    def test_list_elements_nested_entities(self, server):
+        text = _call(
+            server,
+            "sdl_list_elements",
+            {"sdl_content": FULL_SDL, "section": "entities"},
+        )
+        assert "blue-team" in text
+        assert "blue-team.alice" in text
+
+    def test_get_element_qualified(self, server):
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": FULL_SDL, "element_name": "nodes.web"},
+        )
+        assert "nodes.web" in text
+        assert "vm" in text.lower()
+
+    def test_get_element_unique_bare(self, server):
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": FULL_SDL, "element_name": "sqli"},
+        )
+        assert "SQL Injection" in text
+
+    def test_get_element_ambiguous(self, server):
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": MINIMAL_SDL, "element_name": "web"},
+        )
+        # 'web' is in both nodes and infrastructure
+        assert "Ambiguous" in text
+
+    def test_get_element_not_found(self, server):
+        text = _call(
+            server,
+            "sdl_get_element",
+            {"sdl_content": MINIMAL_SDL, "element_name": "nonexistent"},
+        )
+        assert "not found" in text.lower()
+
+    def test_check_references_element(self, server):
+        text = _call(
+            server,
+            "sdl_check_references",
+            {"sdl_content": FULL_SDL, "element_name": "app"},
+        )
+        assert "Outgoing" in text or "Incoming" in text
+
+    def test_check_references_full_graph(self, server):
+        text = _call(
+            server,
+            "sdl_check_references",
+            {"sdl_content": FULL_SDL},
+        )
+        assert "Cross-reference graph" in text
+        assert "->" in text
+
+    def test_diagram(self, server):
+        text = _call(server, "sdl_diagram", {"sdl_content": FULL_SDL})
+        assert "Topology" in text
+        assert "corp-net" in text
+        assert "web" in text
+
+    def test_diagram_shows_services(self, server):
+        text = _call(server, "sdl_diagram", {"sdl_content": FULL_SDL})
+        assert "pg-port" in text
+
+    def test_diagram_shows_dependencies(self, server):
+        sdl_with_deps = """\
+name: dep-test
+nodes:
+  sw: {type: Switch}
+  a: {type: VM, os: linux, resources: {ram: 1 GiB, cpu: 1}}
+  b: {type: VM, os: linux, resources: {ram: 1 GiB, cpu: 1}}
+infrastructure:
+  sw: {count: 1, properties: {cidr: 10.0.0.0/24, gateway: 10.0.0.1}}
+  a: {count: 1, links: [sw]}
+  b: {count: 1, links: [sw], dependencies: [a]}
+"""
+        text = _call(server, "sdl_diagram", {"sdl_content": sdl_with_deps})
+        assert "Dependencies" in text
+        assert "b --> a" in text
+
+
+# ---------------------------------------------------------------------------
+# Example scenario validation
+# ---------------------------------------------------------------------------
+
+
+class TestExampleScenarios:
+    """Validate that all bundled examples pass through the MCP tools."""
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "hospital-ransomware-surgery-day.sdl.yaml",
+            "satcom-release-poisoning.sdl.yaml",
+            "port-authority-surge-response.sdl.yaml",
+        ],
+    )
+    def test_example_validates(self, server, filename):
+        path = EXAMPLES_DIR / filename
+        if not path.exists():
+            pytest.skip(f"Example not found: {filename}")
+        sdl = path.read_text()
+        text = _call(server, "sdl_validate", {"sdl_content": sdl})
+        assert text.startswith("VALID"), f"{filename} failed: {text[:200]}"
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "hospital-ransomware-surgery-day.sdl.yaml",
+            "satcom-release-poisoning.sdl.yaml",
+            "port-authority-surge-response.sdl.yaml",
+        ],
+    )
+    def test_example_summarizes(self, server, filename):
+        path = EXAMPLES_DIR / filename
+        if not path.exists():
+            pytest.skip(f"Example not found: {filename}")
+        sdl = path.read_text()
+        text = _call(server, "sdl_summarize", {"sdl_content": sdl})
+        assert "Scenario:" in text
+        assert "VMs:" in text
+
+
+# ---------------------------------------------------------------------------
+# Server construction
+# ---------------------------------------------------------------------------
+
+
+class TestServerConstruction:
+    def test_server_has_all_tools(self):
+        server = create_server()
+        tool_names = [t.name for t in server._tool_manager._tools.values()]
+        expected = {
+            "sdl_overview",
+            "sdl_section_reference",
+            "sdl_get_example",
+            "sdl_parser_reference",
+            "sdl_validation_reference",
+            "sdl_validate",
+            "sdl_validate_section",
+            "sdl_scaffold",
+            "sdl_instantiate",
+            "sdl_summarize",
+            "sdl_list_elements",
+            "sdl_get_element",
+            "sdl_check_references",
+            "sdl_diagram",
+        }
+        assert set(tool_names) == expected
+
+    def test_server_has_instructions(self):
+        server = create_server()
+        assert server.instructions
+        assert "SDL" in server.instructions


### PR DESCRIPTION
Implements a Model Context Protocol server at src/aces/mcp/ that gives
AI agents everything they need to learn, write, and validate SDL scenarios
without prior knowledge of the language.

Tools are organized into three categories:

Reference (5 tools) — for agents learning the SDL:
  - sdl_overview: comprehensive language orientation
  - sdl_section_reference: detailed docs for any of the 21 sections
  - sdl_get_example: annotated real-world scenarios (hospital, satcom, port, minimal)
  - sdl_parser_reference: normalization, shorthands, variable syntax, durations
  - sdl_validation_reference: 22 semantic validation passes

Authoring (4 tools) — for building scenarios:
  - sdl_validate: full parse + validate with all errors collected
  - sdl_validate_section: check a single section fragment in isolation
  - sdl_scaffold: generate starter skeletons (minimal/standard/full)
  - sdl_instantiate: resolve ${var} placeholders with concrete values

Inspection (5 tools) — for analyzing existing scenarios:
  - sdl_summarize: stats, topology, variables, entities, objectives
  - sdl_list_elements: named elements by section with nested entity support
  - sdl_get_element: detailed view of any element (bare or qualified ref)
  - sdl_check_references: trace incoming/outgoing cross-references
  - sdl_diagram: ASCII network topology with services and dependencies

Includes 45 tests covering all tools, all three scaffold templates
(verified to produce valid SDL), and all three example scenarios.

https://claude.ai/code/session_01LRws6rafi7ibqLpF9GnDsr