### PR TITLE
GOV-918: Add cross-artifact concept binding for v2 manifests

### DIFF
--- a/.claude/agents/completion-verifier.md
+++ b/.claude/agents/completion-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: completion-verifier
-description: Verifies implementation completeness before Claude stops. Checks CHANGELOG, traceability links, requirement status transitions, and requirement coverage.
+description: Verifies ACES SDL repo-policy, requirement-governance, changelog, and ADR-index completion before Claude stops.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 maxTurns: 20
@@ -8,36 +8,44 @@ maxTurns: 20
 
 # Completion Verifier
 
-You verify that implementation work is complete. You are invoked automatically when Claude attempts to stop after working on a requirement implementation.
+You verify that implementation work is complete for ACES SDL. Prefer the
+repo-owned policy scripts over ad hoc reasoning.
 
 Run these checks and return your verdict:
 
-## 1. Were source files changed?
+## 1. Determine changed files and requirement context
 
-Run `git diff --name-only HEAD` to see what files have been modified. Determine whether any Java, Kotlin, or TypeScript source files were changed (not just GC MCP operations or documentation-only changes).
+- Run `git diff --name-only HEAD` to see what files changed.
+- Determine whether Python implementation or test files changed under
+  `implementations/python/`.
+- Determine the active requirement UID from `ACES_REQUIREMENT_UID` or the branch
+  name.
 
-## 2. CHANGELOG check
+## 2. Run repo policy checks
 
-If source files were changed:
-- Read `CHANGELOG.md` and verify it appears in the git diff (i.e., it was updated in this session).
-- If CHANGELOG.md was NOT updated but source code was changed, this is a FAILURE.
+- Run `implementations/python/.venv/bin/python tools/check_repo_policy.py`.
+- If a requirement UID is available, run
+  `implementations/python/.venv/bin/python tools/check_requirement_governance.py --requirement-uid <UID>`.
+- If either command fails, this is a FAILURE. Include the concrete rule output
+  in the reason.
 
-If only GC MCP operations were performed (creating requirements, relations, traceability links, etc.) with no source code changes, CHANGELOG is not required.
+## 3. CHANGELOG and ADR index
 
-## 3. Traceability link check
+If Python source files changed:
+- Verify `CHANGELOG.md` is in the diff.
+- If not, this is a FAILURE.
 
-Look at the git log and branch name to determine if a requirement is being implemented (branch names typically contain issue numbers, and the conversation would reference GC-* UIDs).
+If any ADR file under `docs/decisions/adrs/` changed:
+- Verify `docs/decisions/adrs/README.md` is also updated.
+- If not, this is a FAILURE.
 
-If a requirement was being implemented:
-- Run `git log --oneline -10` to understand recent work.
-- Check if the branch name references a GitHub issue.
-- Verify that traceability links (IMPLEMENTS and TESTS) should exist for the work done.
+## 4. Ground Control traceability and status
 
-This check is informational — flag it if it looks like traceability was missed, but don't hard-fail since you may not have full context.
-
-## 4. Requirement status transition check
-
-If a requirement was being implemented and was in DRAFT status, verify that a status transition to ACTIVE was performed. Flag if it appears to have been missed.
+If a requirement UID is available and implementation/test files changed:
+- Verify the requirement-governance script passed.
+- Call out missing IMPLEMENTS or TESTS traceability as a FAILURE, not a warning.
+- If the work appears to complete a DRAFT requirement, verify the requirement is
+  not left in DRAFT unintentionally.
 
 ## 5. Return verdict
 
@@ -48,7 +56,7 @@ If all required checks pass:
 
 If any required check fails:
 ```json
-{"ok": false, "reason": "Missing: CHANGELOG.md not updated despite source code changes in backend/src/main/java/..."}
+{"ok": false, "reason": "Missing: CHANGELOG.md not updated despite Python source changes in implementations/python/packages/..."}
 ```
 
 Be specific about what's missing so Claude can fix it.

--- a/.claude/hooks/check_policy_after_edit.sh
+++ b/.claude/hooks/check_policy_after_edit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE_PATH=$(jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+implementations/python/.venv/bin/python tools/check_repo_policy.py --check-set file-local "$FILE_PATH"

--- a/.claude/hooks/protect_files.sh
+++ b/.claude/hooks/protect_files.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Block edits to sensitive files (.env, credentials, keys)
+# Block edits to sensitive files and generated authority surfaces.
 FILE_PATH=$(jq -r '.tool_input.file_path // empty')
 
 if [[ -z "$FILE_PATH" ]]; then
@@ -17,6 +17,12 @@ fi
 # Block key/credential files
 if [[ "$BASENAME" == *.key ]] || [[ "$BASENAME" == *.pem ]] || [[ "$BASENAME" == "credentials"* ]]; then
     echo "BLOCKED: Editing $BASENAME is not allowed. These files contain secrets." >&2
+    exit 2
+fi
+
+# Block direct edits to generated schemas.
+if [[ "$FILE_PATH" == contracts/schemas/* ]]; then
+    echo "BLOCKED: contracts/schemas/ is generated. Update generator inputs and regenerate instead." >&2
     exit 2
 fi
 

--- a/.claude/hooks/verify-extra.sh
+++ b/.claude/hooks/verify-extra.sh
@@ -4,22 +4,22 @@
 # $CHANGED is passed in as an env var containing the git diff file list.
 # Output any failure reasons to stdout; empty output = all checks pass.
 
-REASONS=""
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PY="$ROOT/implementations/python/.venv/bin/python"
 
-# Example checks:
-# Check: If controllers changed, docs/API.md should be updated
-# HAS_CONTROLLER=$(echo "$CHANGED" | grep -c 'Controller\.java' || true)
-# HAS_API_DOC=$(echo "$CHANGED" | grep -c 'docs/API.md' || true)
-# if [ "$HAS_CONTROLLER" -gt 0 ] && [ "$HAS_API_DOC" -eq 0 ]; then
-#  REASONS="${REASONS}New controller added but docs/API.md not updated. "
-# fi
+if [[ ! -x "$PY" ]]; then
+  echo -n "Missing implementations/python/.venv/bin/python; cannot run repo verification."
+  exit 0
+fi
 
-# Check: If controllers changed, MCP tools (lib.js/index.js) should be updated
-# HAS_LIB=$(echo "$CHANGED" | grep -c 'lib\.js' || true)
-# HAS_INDEX=$(echo "$CHANGED" | grep -c 'index\.js' || true)
-# if [ "$HAS_CONTROLLER" -gt 0 ] && { [ "$HAS_LIB" -eq 0 ] || [ "$HAS_INDEX" -eq 0 ]; }; then
-#  REASONS="${REASONS}New controller added but MCP tools not updated (lib.js/index.js). "
-# fi
-#
+if ! "$PY" "$ROOT/tools/check_repo_policy.py" >/tmp/aces-sdl-policy.out 2>&1; then
+  tr '\n' ' ' </tmp/aces-sdl-policy.out
+  exit 0
+fi
 
-echo -n "$REASONS"
+if ! "$PY" "$ROOT/tools/check_requirement_governance.py" >/tmp/aces-sdl-gc.out 2>&1; then
+  tr '\n' ' ' </tmp/aces-sdl-gc.out
+  exit 0
+fi
+
+echo -n ""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty'); if [ -n \"$FILE\" ] && echo \"$FILE\" | grep -q '\\.java$'; then cd /home/atomik/src/Ground-Control/backend && ./gradlew spotlessApply -q 2>/dev/null; fi",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check_policy_after_edit.sh",
             "timeout": 30
           }
         ]

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,217 +1,84 @@
 ---
 name: implement
-description: End-to-end requirement implementation — from plan through merged PR
+description: End-to-end ACES SDL requirement implementation with repo policy and Ground Control gates
 argument-hint: <requirement-uid>
 disable-model-invocation: true
 ---
 
 # Implement Requirement: $ARGUMENTS
 
-This skill handles the ENTIRE lifecycle: plan, implement, verify, commit, push, PR, CI, reviews, fix, merge, cleanup. The user's only checkpoint is plan approval.
+This skill handles the repo-local implementation loop for a single ACES SDL
+requirement. Use it to stay inside ADR-009, ADR-010, and ADR-012 while keeping
+Ground Control traceability aligned with code and tests.
 
----
+## Phase A: Load Context
 
-## Phase A: Plan & Implement
+### Step 1: Resolve Requirement Context
 
-### Step 1: Fetch Requirement and Ensure GitHub Issue Exists
+1. Fetch the requirement with `gc_get_requirement` using uid `$ARGUMENTS`.
+2. Fetch its traceability with `gc_get_traceability`.
+3. Read the applicable ADRs before editing:
+   - ADR-009 normative artifact authority and repo structure
+   - ADR-010 repository realignment order and compatibility policy
+   - ADR-012 shared concept authority and ACES extension discipline
+4. Export `ACES_REQUIREMENT_UID=$ARGUMENTS` for local verification commands if
+   the branch name does not already contain the requirement UID.
 
-1. Enter plan mode.
+### Step 2: Confirm Order and Ownership
 
-2. Use the `gc_get_requirement` MCP tool with uid `GC-$ARGUMENTS` to fetch the requirement details. Note the requirement's UUID, title, statement, status, and wave.
+1. Run
+   `implementations/python/.venv/bin/python tools/check_requirement_governance.py --requirement-uid $ARGUMENTS`.
+2. Treat failures as blockers:
+   - out-of-order requirement work
+   - ownership-root mismatches
+   - missing Ground Control connectivity
+3. Before writing code, identify the allowed roots for this requirement from
+   `tools/policy/requirement_order.yaml`.
 
-3. Use the `gc_get_traceability` MCP tool with the requirement's UUID to check for existing traceability links. Look for a link with artifact_type `GITHUB_ISSUE`.
+## Phase B: Implement
 
-4. If NO GitHub issue link exists:
-   - Use the `gc_create_github_issue` MCP tool with uid `$ARGUMENTS` to create a GitHub issue and auto-link it.
+### Step 3: Implement Inside The Allowed Boundaries
 
-5. If a GitHub issue link DOES exist, note the issue number from the artifact_identifier.
+Respect these hard rules while editing:
 
-6. Run `gh issue develop <issue-number> --checkout --base dev` to switch to the issue branch.
+- do not add authority-bearing artifacts outside `specs/`, `contracts/`, `docs/`,
+  and `implementations/`
+- do not edit `contracts/schemas/` directly; update generator inputs and
+  regenerate
+- do not add substantive implementation logic under
+  `implementations/python/src/aces/`; that tree is compatibility-only wrappers
+- do not import `aces.*` from owning packages under
+  `implementations/python/packages/`
+- keep concept-authority artifacts in the approved authority surfaces only
 
-### Step 2: Read the GitHub Issue
+### Step 4: Keep Traceability In Sync
 
-Run `gh issue view <issue-number>` to read the full issue details including description, labels, and comments.
+When code or tests change, ensure Ground Control has:
 
-### Step 3: Assess Codebase Coverage
+- `IMPLEMENTS` links for changed implementation files
+- `TESTS` links for changed test files
 
-Explore the codebase to determine whether the requirement described in the issue is already satisfied by existing code:
-- Search for relevant classes, methods, tests, and configurations
-- Check if the described behavior already exists
-- Review any existing traceability links (IMPLEMENTS, TESTS) from Step 1
+If the requirement is still `DRAFT` and the implementation is complete,
+transition it to `ACTIVE` as part of the close-out.
 
-### Step 4: Plan or Report
+## Phase C: Verify
 
-- **If the requirement is NOT yet met**: Plan the implementation. Identify which files need to be created or modified, what tests to write, and what approach to take. Enter plan mode.
-- Your plans must respect the coding standards and formal methods classification levels.
-- You must add or update ADRs as appropriate.
-- Plans must include updating the changelog, readme, and docs as appropriate.
-- If designing code, remember to build off existing cross-cutting concerns, code, and patterns
-- Good code is readable, maintainable, and follows the coding standards
-- Address the concerns a FAANG L6+ engineer would have around security, performance, reliability, and scalability
-- Avoid reinventing the wheel - use existing libraries and frameworks where appropriate
-- Code should be easy to understand, test, and maintain. Simple is better than complex.
-- Plans that add database migrations MUST include updating the hardcoded version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java`.
-- Plans that add `@Audited` JPA entities MUST add `@NotAudited` on any `@ManyToOne` references to non-audited entities (e.g., Project), and MUST include a Flyway migration for the `_audit` table.
-- Plans that add API endpoints MUST include `@WebMvcTest` controller unit tests (not just integration tests). The sonar CI job does not run Testcontainers, so only unit tests contribute to SonarCloud coverage.
-- **If the requirement IS already met**: Report that the requirement is satisfied and identify which code satisfies it.
+### Step 5: Run Repo Policy Checks
 
-### Step 4.5: Clause-by-Clause Verification
+Run these before stopping:
 
-Before declaring implementation complete:
-1. Re-read the requirement statement from Step 1.
-2. Break it into individual clauses and acceptance criteria.
-3. For EACH clause, identify the specific code (file:line) that satisfies it.
-4. If any clause is not satisfied, go back and implement it before proceeding.
+- `implementations/python/.venv/bin/python tools/check_repo_policy.py`
+- `implementations/python/.venv/bin/python tools/check_requirement_governance.py --requirement-uid $ARGUMENTS`
+- `implementations/python/.venv/bin/python tools/verify_all.py --requirement-uid $ARGUMENTS`
+- relevant focused tests for the changed Python packages
+- `pre-commit run --all-files` before commit when the task includes code changes
 
-Present the mapping as a checklist:
-- [ ] Clause: "..." → Satisfied by: file.java:line
-- [ ] Clause: "..." → Satisfied by: file.java:line
+### Step 6: Completion Gate
 
-Do not proceed to Step 5 until every clause is checked off.
+Implementation is not complete until all of these are true:
 
-### Step 5: Ensure Traceability Links
-
-After implementation is complete (or if already implemented):
-- use the `gc_create_traceability_link` MCP tool to create any missing links:
-  - `IMPLEMENTS` links from the requirement to **every** code file that implements it — entities, enums, repositories, services, controllers, migrations, and MCP tool files. Link all substantive files, not just the top 3. DTOs and command records may be omitted.
-  - `TESTS` links from the requirement to the test files that verify it
-  - Only create links that don't already exist (check the traceability data from Step 1).
-- use the `gc_transition_status` MCP tool to transition the requirement to `ACTIVE` if it was `DRAFT`.
-
-Do not update the Changelog if all you did was operate Ground Control tools.
-
----
-
-## Phase B: Quality Gate
-
-### Step 6: Quality Assurance
-
-- run `pre-commit run --all-files` to ensure the codebase is in a healthy state.
-
-### Step 7: Completion Gate
-
-Implementation is NOT complete until ALL of the following are verified:
-
-1. **`make check` passes** — run it and confirm BUILD SUCCESSFUL.
-2. **CHANGELOG.md updated** — verify it is in `git diff --name-only` if any source files changed.
-3. **Traceability links exist** — re-fetch with `gc_get_traceability` and confirm IMPLEMENTS and TESTS links are present.
-4. **Requirement status is ACTIVE** — re-fetch with `gc_get_requirement` and confirm status.
-5. **Step 4.5 clause mapping was completed** — if you skipped it, go back and do it now.
-
-If any check fails, fix it before proceeding. Do NOT move to Phase C until every check passes.
-
----
-
-## Phase C: Stage, Commit, Push
-
-### Step 8: Stage & Pre-commit Loop
-
-1. `git add` all relevant changed files. Do NOT stage .env files, credentials, secrets, or large binaries.
-2. Run `pre-commit run --all-files`.
-3. If pre-commit fails:
-   - Read the failure output.
-   - Fix the issues.
-   - Re-stage any modified files with `git add`.
-   - Re-run `pre-commit run --all-files`.
-   - Repeat up to 5 times. If still failing after 5 attempts, escalate to the user with the failure details.
-4. When pre-commit passes, proceed.
-
-### Step 9: Commit & Push
-
-1. Craft a concise commit message in imperative mood (per coding standards). Example: "Add risk scoring engine for requirement prioritization"
-2. NEVER include Co-Authored-By, "Generated with Claude Code", or any Claude/AI attribution in commit messages.
-3. `git commit -m "<message>"`
-3. `git push -u origin <branch>`
-
----
-
-## Phase D: Ship
-
-### Step 10: Create PR
-
-1. Check if a PR already exists for this branch: `gh pr list --head <branch> --json number,url`
-2. If no PR exists, create one:
-   ```
-   gh pr create --base dev --title "<concise title>" --body "<description with requirement reference>"
-   ```
-3. Note the PR number and URL.
-
-### Step 11: CI Monitor
-
-1. Find the latest workflow run: `gh run list --branch <branch> --limit 1 --json status,conclusion,databaseId`
-2. If the run is in progress, watch it: `gh run watch <id>`
-3. If it failed:
-   - Get failed logs: `gh run view <id> --log-failed`
-   - Diagnose and fix the issue.
-   - `git add`, `git commit`, `git push`.
-   - Go back to step 1 of this phase.
-4. If it succeeded, proceed.
-
-### Step 12: SonarCloud
-
-1. Wait 60 seconds for SonarCloud analysis to propagate.
-2. Use `get_project_quality_gate_status` with project key `KeplerOps_Ground-Control` to check the quality gate.
-3. Use `search_sonar_issues_in_projects` to find new issues on the current branch.
-4. If issues found:
-   - Fix them.
-   - `git add`, `git commit`, `git push`.
-   - Re-run Step 11 (CI Monitor).
-5. If clean, proceed.
-
-### Step 13: Cross-Model Review (Codex)
-
-Run the OpenAI Codex CLI review against the branch:
-
-`Bash(codex review --base dev)`
-
-### Step 14: Code Review
-
-**CRITICAL: You MUST use the Skill tool to invoke the built-in review skill.**
-
-1. Merge dev into the current branch: `git fetch origin dev && git merge origin/dev`
-2. If there are merge conflicts, resolve them, commit, and push.
-3. Call the Skill tool with `skill="review"` to invoke the real built-in code review.
-4. After the review completes, fix ALL issues it identified.
-   - Same rules as Step 13: fix everything, defer nothing.
-5. After fixing, re-read all findings and confirm each one was addressed.
-
-### Step 15: Security Review
-
-**CRITICAL: You MUST use the Skill tool to invoke the built-in security-review skill.**
-
-1. Call the Skill tool with `skill="security-review"` to invoke the real built-in security review.
-2. After the review completes, fix ALL issues it identified.
-   - Same rules as Step 14: fix everything, defer nothing.
-3. After fixing, confirm all findings were addressed.
-
-### Step 16: Test Quality Review
-
-**CRITICAL: You MUST use the Skill tool to invoke the review-tests skill.**
-
-1. Call the Skill tool with `skill="review-tests"` to invoke the test quality review.
-2. After the review completes, fix ALL critical issues it identified.
-   - Rewrite tests that provide false assurance. Do not defer critical findings.
-3. Warning-level findings: fix unless doing so significantly increases scope.
-4. After fixing, confirm all critical findings were addressed.
-
-### Step 17: Final Commit & CI
-
-If ANY fixes were made in Steps 13-16:
-1. `git add` all changed files.
-2. `git commit -m "Fix review findings"`
-3. `git push`
-4. Re-run Step 11 (CI Monitor).
-5. Re-run Step 12 (SonarCloud).
-
-### Step 18: Report (DO NOT MERGE)
-
-**You MUST NOT merge the PR. You MUST NOT run `gh pr merge`. The user reviews and merges.**
-
-Provide a final summary:
-- What was implemented (requirement title and UID)
-- Files created or modified
-- Review findings and fixes (if any)
-- Security review findings and fixes (if any)
-- Test quality review findings and fixes (if any)
-- Confirmation: CI green, SonarCloud passed, PR ready for user review
-- PR URL
+1. `CHANGELOG.md` is updated when source files changed.
+2. Ground Control traceability reflects changed code and test files.
+3. The requirement status is appropriate for the completed work.
+4. Repo policy and requirement governance checks are both green.
+5. Any ADR changes are reflected in `docs/decisions/adrs/README.md`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,12 @@
 
 <!-- Link to GitHub issues: Closes #XX -->
 
+## Requirement Context
+
+- Requirement UID:
+- ADRs touched:
+- Ground Control project: `aces-sdl`
+
 ## Changes
 
 -
@@ -24,3 +30,5 @@
 - [ ] Published contract schemas regenerated if models changed
 - [ ] CHANGELOG.md updated
 - [ ] Architectural docs updated if applicable
+- [ ] Branch name or CI context includes the active requirement UID (for example `GOV-918-*`)
+- [ ] Traceability links cover changed code (`IMPLEMENTS`) and tests (`TESTS`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,45 @@ defaults:
     working-directory: implementations/python
 
 jobs:
+  policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Resolve policy base revision
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "base_rev=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_rev=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Resolve requirement UID from branch
+        id: requirement
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          UID="$(printf '%s\n' "$BRANCH" | grep -oE '[A-Z]{3}-[0-9]{3}' | head -n1 || true)"
+          echo "uid=$UID" >> "$GITHUB_OUTPUT"
+      - name: Check repo ADR policy
+        run: uv run python ../../tools/check_repo_policy.py --base-rev "${{ steps.base.outputs.base_rev }}"
+      - name: Check requirement governance
+        env:
+          ACES_REQUIREMENT_UID: ${{ steps.requirement.outputs.uid }}
+          GC_BASE_URL: ${{ vars.GC_BASE_URL }}
+        run: uv run python ../../tools/check_requirement_governance.py --base-rev "${{ steps.base.outputs.base_rev }}"
+
   # ---------------------------------------------------------------------------
   # Lint — fast formatting and static analysis
   # ---------------------------------------------------------------------------
   lint:
     runs-on: ubuntu-latest
+    needs: [policy]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: adr-policy
+        name: adr policy
+        entry: bash -c 'implementations/python/.venv/bin/python tools/check_repo_policy.py --staged'
+        language: system
+        pass_filenames: false
+      - id: requirement-governance
+        name: requirement governance
+        entry: bash -c 'implementations/python/.venv/bin/python tools/check_requirement_governance.py --staged'
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest (unit tests)
         entry: bash -c 'cd implementations/python && .venv/bin/python -m pytest -x -q'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# ACES SDL Agent Rules
+
+Use the repo policy tooling before and after implementation work.
+
+## Required checks
+
+- `implementations/python/.venv/bin/python tools/check_repo_policy.py`
+- `implementations/python/.venv/bin/python tools/check_requirement_governance.py`
+- `implementations/python/.venv/bin/python tools/verify_all.py`
+
+Set `ACES_REQUIREMENT_UID` when the branch name does not already contain a UID
+such as `GOV-918`.
+
+## Hard rules
+
+- Do not add new authority-bearing artifacts outside `specs/`, `contracts/`,
+  `docs/`, and `implementations/`.
+- Do not edit `contracts/schemas/` directly; change generator inputs and
+  regenerate.
+- Do not add new implementation logic to `implementations/python/src/aces/`;
+  that tree is compatibility-only wrappers.
+- Do not import `aces.*` from owning packages under
+  `implementations/python/packages/`.
+- Keep concept-authority artifacts in the approved concept-authority surfaces.
+- Keep IMPLEMENTS and TESTS traceability in Ground Control aligned with changed
+  code and tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-05
+
+### Added
+
+- Cross-artifact concept binding for v2 apparatus manifests (GOV-918).
+  Backend and processor manifests now require a `concept_bindings` section
+  that binds vocabulary fields to canonical concept families from the
+  concept-authority catalog.
+- `ConceptBindingEntryModel` Pydantic contract with pattern-validated
+  `scope` and `family` fields.
+- `ConceptFamilyId` pattern-constrained type for concept family identifiers.
+- `ConceptBinding` frozen dataclass for runtime concept binding declarations.
+- Invalid fixtures for missing, duplicate, and malformed concept bindings.
+- Cross-catalog validation test confirming fixture bindings resolve to
+  the authoritative concept-families-v1 catalog.
+
+### Changed
+
+- `BackendManifestV2Model` and `ProcessorManifestV2Model` now require
+  `concept_bindings` with at least one entry.
+- `BackendManifest` and `ProcessorManifest` frozen dataclasses now require
+  `concept_bindings` tuple.
+- Backend and processor manifest emission functions emit concept bindings.
+- Updated all v2 manifest fixtures with concept binding declarations.
+- Updated all v2 invalid fixtures to include concept bindings for single-concern testing.
+- Regenerated backend-manifest-v2 and processor-manifest-v2 JSON Schemas.
+
 ## [0.2.0] - 2026-04-04
 
 ### Added
@@ -37,5 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial ACES SDL ecosystem extraction from APTL with SDL authoring layer,
   processor layer, backend protocols, conformance infrastructure, and CLI.
 
+[0.3.0]: https://github.com/aces-framework/aces-sdl/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/aces-framework/aces-sdl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/aces-framework/aces-sdl/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Backend and processor manifests now require a `concept_bindings` section
   that binds vocabulary fields to canonical concept families from the
   concept-authority catalog.
+- Repo-owned ADR enforcement tooling under `tools/policy/`, including
+  repo-boundary checks, requirement-order gating, exception handling, and a
+  unified verification entrypoint.
+- Hard policy integration for local agents and automation through
+  pre-commit, GitHub Actions, Claude hooks, `AGENTS.md`, and repo-local
+  Codex instructions.
+- Targeted policy unit tests covering generated-schema edits, compatibility
+  boundaries, requirement ordering, path ownership, and traceability failures.
 - `ConceptBindingEntryModel` Pydantic contract with pattern-validated
   `scope` and `family` fields.
 - `ConceptFamilyId` pattern-constrained type for concept family identifiers.
 - `ConceptBinding` frozen dataclass for runtime concept binding declarations.
 - Invalid fixtures for missing, duplicate, and malformed concept bindings.
-- Cross-catalog validation test confirming fixture bindings resolve to
-  the authoritative concept-families-v1 catalog.
+- Contract-level validation ensuring `concept_bindings` resolve to the
+  authoritative concept-families-v1 catalog and to governed manifest
+  vocabulary surfaces.
 
 ### Changed
 

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/duplicate-binding-scope.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/duplicate-binding-scope.json
@@ -1,23 +1,21 @@
 {
   "schema_version": "backend-manifest/v2",
-  "identity": {
-    "name": "stub",
-    "version": "0.2.0"
-  },
+  "identity": {"name": "stub", "version": "0.2.0"},
   "supported_contract_versions": ["backend-manifest-v2"],
-  "compatibility": {
-    "processors": ["aces-reference-processor"]
-  },
+  "compatibility": {"processors": ["aces-reference-processor"]},
   "realization_support": [
     {
       "domain": "runtime-realization",
       "support_mode": "constrained",
-      "disclosure_kinds": []
+      "supported_constraint_kinds": ["node-type"],
+      "disclosure_kinds": ["runtime-snapshot-v1"]
     }
   ],
   "concept_bindings": [
-    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"},
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "identities"}
   ],
+  "constraints": {},
   "capabilities": {
     "provisioner": {
       "name": "stub-provisioner",

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/empty-compatibility.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/empty-compatibility.json
@@ -14,6 +14,9 @@
       "disclosure_kinds": ["runtime-snapshot-v1"]
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "capabilities": {
     "provisioner": {
       "name": "stub-provisioner",

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/hollow-provisioner.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/hollow-provisioner.json
@@ -16,6 +16,9 @@
       "disclosure_kinds": ["runtime-snapshot-v1"]
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "capabilities": {
     "provisioner": {
       "name": "stub-provisioner"

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/invalid-binding-family.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/invalid-binding-family.json
@@ -1,23 +1,20 @@
 {
   "schema_version": "backend-manifest/v2",
-  "identity": {
-    "name": "stub",
-    "version": "0.2.0"
-  },
+  "identity": {"name": "stub", "version": "0.2.0"},
   "supported_contract_versions": ["backend-manifest-v2"],
-  "compatibility": {
-    "processors": ["aces-reference-processor"]
-  },
+  "compatibility": {"processors": ["aces-reference-processor"]},
   "realization_support": [
     {
       "domain": "runtime-realization",
       "support_mode": "constrained",
-      "disclosure_kinds": []
+      "supported_constraint_kinds": ["node-type"],
+      "disclosure_kinds": ["runtime-snapshot-v1"]
     }
   ],
   "concept_bindings": [
-    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "NOT VALID"}
   ],
+  "constraints": {},
   "capabilities": {
     "provisioner": {
       "name": "stub-provisioner",

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/malformed-compatibility.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/malformed-compatibility.json
@@ -10,6 +10,9 @@
     "backends": [],
     "participant_implementations": []
   },
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/malformed-realization-support.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/malformed-realization-support.json
@@ -16,6 +16,9 @@
       "support_mode": "not-a-real-support-mode"
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/missing-concept-bindings.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/missing-concept-bindings.json
@@ -1,23 +1,17 @@
 {
   "schema_version": "backend-manifest/v2",
-  "identity": {
-    "name": "stub",
-    "version": "0.2.0"
-  },
+  "identity": {"name": "stub", "version": "0.2.0"},
   "supported_contract_versions": ["backend-manifest-v2"],
-  "compatibility": {
-    "processors": ["aces-reference-processor"]
-  },
+  "compatibility": {"processors": ["aces-reference-processor"]},
   "realization_support": [
     {
       "domain": "runtime-realization",
       "support_mode": "constrained",
-      "disclosure_kinds": []
+      "supported_constraint_kinds": ["node-type"],
+      "disclosure_kinds": ["runtime-snapshot-v1"]
     }
   ],
-  "concept_bindings": [
-    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
-  ],
+  "constraints": {},
   "capabilities": {
     "provisioner": {
       "name": "stub-provisioner",

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/missing-version.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/missing-version.json
@@ -9,6 +9,9 @@
     "backends": [],
     "participant_implementations": []
   },
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/unknown-workflow-feature.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/unknown-workflow-feature.json
@@ -10,6 +10,9 @@
     "backends": [],
     "participant_implementations": []
   },
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/unknown-workflow-state-predicate.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/unknown-workflow-state-predicate.json
@@ -10,6 +10,9 @@
     "backends": [],
     "participant_implementations": []
   },
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
@@ -43,6 +43,14 @@
       "constraints": {}
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"},
+    {"scope": "capabilities.provisioner.supported_os_families", "family": "assets"},
+    {"scope": "capabilities.provisioner.supported_content_types", "family": "tools-and-artifacts"},
+    {"scope": "capabilities.provisioner.supported_account_features", "family": "identities"},
+    {"scope": "capabilities.orchestrator.supported_sections", "family": "actions-and-events"},
+    {"scope": "capabilities.evaluator.supported_sections", "family": "observables"}
+  ],
   "constraints": {},
   "capabilities": {
     "provisioner": {

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/empty-compatibility.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/empty-compatibility.json
@@ -14,6 +14,9 @@
       "disclosure_kinds": ["parameter-instantiation"]
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+  ],
   "capabilities": {
     "supported_sdl_versions": ["sdl-authoring-input-v1"],
     "supported_features": ["compilation"]

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/hollow-realization-support.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/hollow-realization-support.json
@@ -15,6 +15,9 @@
       "disclosure_kinds": []
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+  ],
   "capabilities": {
     "supported_sdl_versions": ["sdl-authoring-input-v1"],
     "supported_features": ["compilation"]

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/malformed-realization-support.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/malformed-realization-support.json
@@ -16,6 +16,9 @@
       "support_mode": "not-a-real-support-mode"
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+  ],
   "constraints": {},
   "capabilities": {
     "supported_sdl_versions": ["sdl-authoring-input-v1"]

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/missing-concept-bindings.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/missing-concept-bindings.json
@@ -1,13 +1,8 @@
 {
   "schema_version": "processor-manifest/v2",
-  "identity": {
-    "name": "aces-reference-processor",
-    "version": "0.2.0"
-  },
+  "identity": {"name": "bad", "version": "0.0.1"},
   "supported_contract_versions": ["processor-manifest-v2"],
-  "compatibility": {
-    "backends": ["stub"]
-  },
+  "compatibility": {"backends": ["stub"]},
   "realization_support": [
     {
       "domain": "instantiation",
@@ -16,8 +11,9 @@
       "disclosure_kinds": ["parameter-instantiation"]
     }
   ],
-  "concept_bindings": [
-    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
-  ],
-  "capabilities": {}
+  "constraints": {},
+  "capabilities": {
+    "supported_sdl_versions": ["sdl-authoring-input-v1"],
+    "supported_features": ["compilation"]
+  }
 }

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/unknown-feature.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/invalid/unknown-feature.json
@@ -10,6 +10,9 @@
     "backends": ["stub"],
     "participant_implementations": []
   },
+  "concept_bindings": [
+    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+  ],
   "constraints": {},
   "capabilities": {
     "supported_sdl_versions": ["sdl-authoring-input-v1"],

--- a/contracts/fixtures/processor-manifest/processor-manifest-v2/valid/reference.json
+++ b/contracts/fixtures/processor-manifest/processor-manifest-v2/valid/reference.json
@@ -29,6 +29,10 @@
       "constraints": {}
     }
   ],
+  "concept_bindings": [
+    {"scope": "capabilities.supported_sdl_versions", "family": "scenarios"},
+    {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+  ],
   "constraints": {},
   "capabilities": {
     "supported_sdl_versions": ["sdl-authoring-input-v1"],

--- a/contracts/schemas/README.md
+++ b/contracts/schemas/README.md
@@ -49,5 +49,23 @@ particular:
 schema artifacts. The reference stack, contract tests, and conformance profiles
 use `v2`.
 
+## Cross-Artifact Concept Binding
+
+Apparatus manifests (`v2`) require a `concept_bindings` section that binds
+vocabulary fields to canonical concept families from the concept-authority
+catalog. Each binding entry declares:
+
+- `scope`: a dot-delimited field path identifying the bound vocabulary surface
+  (e.g. `capabilities.provisioner.supported_node_types`)
+- `family`: a concept family identifier from the authoritative catalog
+  (e.g. `assets`, `identities`, `tools-and-artifacts`)
+
+This is the "artifact binding layer" described in ADR-012. It prevents
+artifact-local strings from becoming de facto semantics by explicitly declaring
+which concept family each vocabulary surface belongs to.
+
+The field is required with at least one binding entry. Duplicate scopes within a
+single manifest are rejected.
+
 Generation or sync helpers may exist under `tools/`, but those helpers are
 supporting repo machinery, not the authority boundary.

--- a/contracts/schemas/README.md
+++ b/contracts/schemas/README.md
@@ -65,7 +65,9 @@ artifact-local strings from becoming de facto semantics by explicitly declaring
 which concept family each vocabulary surface belongs to.
 
 The field is required with at least one binding entry. Duplicate scopes within a
-single manifest are rejected.
+single manifest are rejected. Family identifiers must resolve against the
+authoritative `concept-families-v1` catalog, and scope paths must resolve to a
+governed vocabulary field that is actually declared in the manifest.
 
 Generation or sync helpers may exist under `tools/`, but those helpers are
 supporting repo machinery, not the authority boundary.

--- a/contracts/schemas/backend-manifest/backend-manifest-v2.json
+++ b/contracts/schemas/backend-manifest/backend-manifest-v2.json
@@ -123,6 +123,30 @@
       "title": "BackendCapabilitiesV2Model",
       "type": "object"
     },
+    "ConceptBindingEntryModel": {
+      "additionalProperties": false,
+      "description": "Binds a vocabulary surface in an artifact to a canonical concept family.",
+      "properties": {
+        "family": {
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+          "title": "Family",
+          "type": "string"
+        },
+        "scope": {
+          "minLength": 1,
+          "pattern": "^[a-z_][a-z0-9_.]*[a-z0-9_]$",
+          "title": "Scope",
+          "type": "string"
+        }
+      },
+      "required": [
+        "scope",
+        "family"
+      ],
+      "title": "ConceptBindingEntryModel",
+      "type": "object"
+    },
     "EvaluatorCapabilitiesModel": {
       "additionalProperties": false,
       "allOf": [
@@ -584,6 +608,14 @@
     "compatibility": {
       "$ref": "#/$defs/ApparatusCompatibilityModel"
     },
+    "concept_bindings": {
+      "items": {
+        "$ref": "#/$defs/ConceptBindingEntryModel"
+      },
+      "minItems": 1,
+      "title": "Concept Bindings",
+      "type": "array"
+    },
     "constraints": {
       "additionalProperties": {
         "type": "string"
@@ -623,6 +655,7 @@
     "supported_contract_versions",
     "compatibility",
     "realization_support",
+    "concept_bindings",
     "capabilities"
   ],
   "title": "BackendManifestV2Model",

--- a/contracts/schemas/processor-manifest/processor-manifest-v2.json
+++ b/contracts/schemas/processor-manifest/processor-manifest-v2.json
@@ -88,6 +88,30 @@
       "title": "ApparatusIdentityModel",
       "type": "object"
     },
+    "ConceptBindingEntryModel": {
+      "additionalProperties": false,
+      "description": "Binds a vocabulary surface in an artifact to a canonical concept family.",
+      "properties": {
+        "family": {
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+          "title": "Family",
+          "type": "string"
+        },
+        "scope": {
+          "minLength": 1,
+          "pattern": "^[a-z_][a-z0-9_.]*[a-z0-9_]$",
+          "title": "Scope",
+          "type": "string"
+        }
+      },
+      "required": [
+        "scope",
+        "family"
+      ],
+      "title": "ConceptBindingEntryModel",
+      "type": "object"
+    },
     "ProcessorCapabilitiesV2Model": {
       "additionalProperties": false,
       "properties": {
@@ -253,6 +277,14 @@
     "compatibility": {
       "$ref": "#/$defs/ApparatusCompatibilityModel"
     },
+    "concept_bindings": {
+      "items": {
+        "$ref": "#/$defs/ConceptBindingEntryModel"
+      },
+      "minItems": 1,
+      "title": "Concept Bindings",
+      "type": "array"
+    },
     "constraints": {
       "additionalProperties": {
         "type": "string"
@@ -292,6 +324,7 @@
     "supported_contract_versions",
     "compatibility",
     "realization_support",
+    "concept_bindings",
     "capabilities"
   ],
   "title": "ProcessorManifestV2Model",

--- a/docs/decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline.md
+++ b/docs/decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline.md
@@ -108,6 +108,22 @@ The first slice should focus on the cyber-domain concept families listed above
 and the artifact-binding rules needed to carry those concepts across SDL,
 manifests, provenance, and reporting.
 
+### 7. Tighten v2 semantics instead of preserving v1 looseness
+
+The first apparatus-manifest implementation should tighten the `v2` semantics
+instead of preserving any looser `v1` behavior for compatibility.
+
+In practice, that means:
+
+- `concept_bindings` are required on `v2` apparatus manifests
+- each bound family identifier must resolve against the authoritative
+  `concept-families-v1` catalog
+- each bound scope must resolve to a governed manifest vocabulary surface that
+  is actually declared in the artifact being validated
+
+This tightening is intentional. The legacy `v1` shapes are deprecated and are
+not a constraint on how precisely the `v2` concept-binding layer is enforced.
+
 ## Consequences
 
 ### Positive

--- a/docs/explain/reference/shared-concept-model.md
+++ b/docs/explain/reference/shared-concept-model.md
@@ -164,8 +164,10 @@ does this manifest field belong to?" without relying on field-name conventions
 or documentation.
 
 The binding is required (not optional) to prevent specification gaps where
-concept bindings could be silently omitted. Family identifiers are
-pattern-validated at model time; cross-catalog resolution is verified in tests.
+concept bindings could be silently omitted. Family identifiers are validated
+against the authoritative catalog at model time, and scope paths must resolve
+to governed manifest vocabulary surfaces that are actually declared in the
+artifact.
 
 ## Relationship To Other Requirements
 

--- a/docs/explain/reference/shared-concept-model.md
+++ b/docs/explain/reference/shared-concept-model.md
@@ -138,6 +138,35 @@ instead of repeating it as an artifact-local field that can drift.
 while still allowing each artifact family to keep its own fit-for-purpose
 shape.
 
+## Cross-Artifact Concept Binding (GOV-918)
+
+`GOV-918` implements the artifact binding layer for apparatus manifests.
+
+Both `v2` backend manifests and `v2` processor manifests now require a
+`concept_bindings` section. Each entry maps a dot-delimited field path (scope)
+to a concept family identifier from the authoritative catalog.
+
+For example, a backend manifest binds its provisioner vocabulary:
+
+```json
+"concept_bindings": [
+  {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"},
+  {"scope": "capabilities.provisioner.supported_os_families", "family": "assets"},
+  {"scope": "capabilities.provisioner.supported_content_types", "family": "tools-and-artifacts"},
+  {"scope": "capabilities.provisioner.supported_account_features", "family": "identities"},
+  {"scope": "capabilities.orchestrator.supported_sections", "family": "actions-and-events"},
+  {"scope": "capabilities.evaluator.supported_sections", "family": "observables"}
+]
+```
+
+This makes it possible for downstream tooling to answer: "which concept family
+does this manifest field belong to?" without relying on field-name conventions
+or documentation.
+
+The binding is required (not optional) to prevent specification gaps where
+concept bindings could be silently omitted. Family identifiers are
+pattern-validated at model time; cross-catalog resolution is verified in tests.
+
 ## Relationship To Other Requirements
 
 `GOV-917` is the concept-authority decision surface.
@@ -145,7 +174,7 @@ shape.
 The related requirements split the rest of the problem:
 
 - `GOV-918`
-  Cross-artifact concept binding
+  Cross-artifact concept binding (implemented)
 - `GOV-919`
   ACES extension discipline over the shared authority
 - `GOV-920`

--- a/implementations/python/packages/aces_backend_protocols/capabilities.py
+++ b/implementations/python/packages/aces_backend_protocols/capabilities.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from aces_contracts.apparatus import (
     ApparatusCompatibility,
     ApparatusIdentity,
+    ConceptBinding,
     RealizationSupportDeclaration,
 )
 from aces_contracts.vocabulary import WorkflowFeature, WorkflowStatePredicateFeature
@@ -125,6 +126,7 @@ class BackendManifest:
     supported_contract_versions: frozenset[str]
     compatibility: ApparatusCompatibility
     realization_support: tuple[RealizationSupportDeclaration, ...]
+    concept_bindings: tuple[ConceptBinding, ...]
     constraints: dict[str, str]
     capabilities: BackendCapabilitySet
 
@@ -135,6 +137,7 @@ class BackendManifest:
         supported_contract_versions: frozenset[str] = frozenset(),
         compatibility: ApparatusCompatibility | None = None,
         realization_support: tuple[RealizationSupportDeclaration, ...] = (),
+        concept_bindings: tuple[ConceptBinding, ...] = (),
         constraints: dict[str, str] | None = None,
         capabilities: BackendCapabilitySet | None = None,
         name: str | None = None,
@@ -172,10 +175,14 @@ class BackendManifest:
         realization_support = tuple(realization_support)
         if not realization_support:
             raise ValueError("BackendManifest.realization_support must not be empty")
+        concept_bindings = tuple(concept_bindings)
+        if not concept_bindings:
+            raise ValueError("BackendManifest.concept_bindings must not be empty")
         object.__setattr__(self, "identity", identity)
         object.__setattr__(self, "supported_contract_versions", supported_contract_versions)
         object.__setattr__(self, "compatibility", compatibility)
         object.__setattr__(self, "realization_support", realization_support)
+        object.__setattr__(self, "concept_bindings", concept_bindings)
         object.__setattr__(self, "constraints", {} if constraints is None else dict(constraints))
         object.__setattr__(self, "capabilities", capabilities)
 

--- a/implementations/python/packages/aces_backend_protocols/manifest.py
+++ b/implementations/python/packages/aces_backend_protocols/manifest.py
@@ -9,6 +9,7 @@ from aces_contracts.contracts import (
     ApparatusIdentityModel,
     BackendManifestModel,
     BackendManifestV2Model,
+    ConceptBindingEntryModel,
     RealizationSupportDeclarationModel,
 )
 
@@ -87,6 +88,10 @@ def backend_manifest_v2_model(manifest: BackendManifest) -> BackendManifestV2Mod
                 constraints=dict(declaration.constraints),
             )
             for declaration in manifest.realization_support
+        ],
+        concept_bindings=[
+            ConceptBindingEntryModel(scope=binding.scope, family=binding.family)
+            for binding in manifest.concept_bindings
         ],
         constraints=dict(manifest.constraints),
         capabilities={

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -13,7 +13,7 @@ from aces_backend_protocols.capabilities import (
     WorkflowFeature,
     WorkflowStatePredicateFeature,
 )
-from aces_contracts.apparatus import RealizationSupportDeclaration
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.vocabulary import RealizationSupportMode
 from aces_processor.models import (
     EVALUATION_STATE_SCHEMA_VERSION,
@@ -60,6 +60,14 @@ def create_stub_manifest(**config) -> BackendManifest:
         version=_current_backend_version(),
         supported_contract_versions=frozenset(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS),
         compatible_processors=frozenset({"aces-reference-processor"}),
+        concept_bindings=(
+            ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
+            ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
+            ConceptBinding(scope="capabilities.provisioner.supported_content_types", family="tools-and-artifacts"),
+            ConceptBinding(scope="capabilities.provisioner.supported_account_features", family="identities"),
+            ConceptBinding(scope="capabilities.orchestrator.supported_sections", family="actions-and-events"),
+            ConceptBinding(scope="capabilities.evaluator.supported_sections", family="observables"),
+        ),
         realization_support=(
             RealizationSupportDeclaration(
                 domain="runtime-realization",

--- a/implementations/python/packages/aces_contracts/apparatus.py
+++ b/implementations/python/packages/aces_contracts/apparatus.py
@@ -45,6 +45,20 @@ class ApparatusCompatibility:
 
 
 @dataclass(frozen=True)
+class ConceptBinding:
+    """Binds a vocabulary surface path to a canonical concept family."""
+
+    scope: str
+    family: str
+
+    def __post_init__(self) -> None:
+        if not self.scope.strip():
+            raise ValueError("ConceptBinding.scope must be non-empty")
+        if not self.family.strip():
+            raise ValueError("ConceptBinding.family must be non-empty")
+
+
+@dataclass(frozen=True)
 class RealizationSupportDeclaration:
     """Declared realization-support and disclosure surface for one concern domain."""
 

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from functools import lru_cache
+from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from aces_sdl.scenario import InstantiatedScenario, Scenario
@@ -39,6 +42,24 @@ class ContractModel(BaseModel):
 
 
 NonEmptyString = Annotated[str, Field(min_length=1)]
+
+_BACKEND_CONCEPT_BINDING_SCOPES = frozenset(
+    {
+        "capabilities.provisioner.supported_node_types",
+        "capabilities.provisioner.supported_os_families",
+        "capabilities.provisioner.supported_content_types",
+        "capabilities.provisioner.supported_account_features",
+        "capabilities.orchestrator.supported_sections",
+        "capabilities.evaluator.supported_sections",
+    }
+)
+
+_PROCESSOR_CONCEPT_BINDING_SCOPES = frozenset(
+    {
+        "capabilities.supported_sdl_versions",
+        "capabilities.supported_features",
+    }
+)
 
 
 class InstantiationRequestModel(ContractModel):
@@ -492,6 +513,7 @@ class ProcessorManifestV2Model(ContractModel):
         scopes = [binding.scope for binding in self.concept_bindings]
         if len(scopes) != len(set(scopes)):
             raise ValueError("concept_bindings must not contain duplicate scopes")
+        _validate_canonical_concept_bindings(self, allowed_scopes=_PROCESSOR_CONCEPT_BINDING_SCOPES)
         return self
 
 
@@ -510,6 +532,7 @@ class BackendManifestV2Model(ContractModel):
         scopes = [binding.scope for binding in self.concept_bindings]
         if len(scopes) != len(set(scopes)):
             raise ValueError("concept_bindings must not contain duplicate scopes")
+        _validate_canonical_concept_bindings(self, allowed_scopes=_BACKEND_CONCEPT_BINDING_SCOPES)
         return self
 
 
@@ -596,6 +619,48 @@ class ConceptFamilyCatalogModel(ContractModel):
         if isinstance(families_schema, dict):
             families_schema.setdefault("propertyNames", {"minLength": 1})
         return json_schema
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+@lru_cache(maxsize=1)
+def _authoritative_concept_family_ids() -> frozenset[str]:
+    catalog_path = _repo_root() / "contracts" / "concept-authority" / "concept-families-v1.json"
+    payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+    catalog = ConceptFamilyCatalogModel.model_validate(payload)
+    return frozenset(catalog.families)
+
+
+def _scope_is_present(model: ContractModel, scope: str) -> bool:
+    current: Any = model
+    for segment in scope.split("."):
+        if not isinstance(current, BaseModel):
+            return False
+        if segment not in type(current).model_fields:
+            return False
+        current = getattr(current, segment)
+        if current is None:
+            return False
+    return True
+
+
+def _validate_canonical_concept_bindings(model: ContractModel, *, allowed_scopes: frozenset[str]) -> None:
+    family_ids = _authoritative_concept_family_ids()
+    for binding in getattr(model, "concept_bindings", ()):
+        if binding.family not in family_ids:
+            raise ValueError(f"concept_bindings family '{binding.family}' is not defined in concept-families-v1")
+        if binding.scope not in allowed_scopes:
+            allowed = ", ".join(sorted(allowed_scopes))
+            raise ValueError(
+                f"concept_bindings scope '{binding.scope}' is not a governed manifest vocabulary surface; "
+                f"allowed scopes: {allowed}"
+            )
+        if not _scope_is_present(model, binding.scope):
+            raise ValueError(
+                f"concept_bindings scope '{binding.scope}' does not resolve to a declared field in this manifest"
+            )
 
 
 def schema_bundle() -> dict[str, dict[str, Any]]:

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -23,6 +23,7 @@ from .versions import (
     WORKFLOW_STATE_SCHEMA_VERSION,
 )
 from .vocabulary import (
+    ConceptFamilyId,
     ConceptProvenanceCategory,
     ProcessorFeature,
     RealizationSupportMode,
@@ -455,6 +456,16 @@ class RealizationSupportDeclarationModel(ContractModel):
         return json_schema
 
 
+class ConceptBindingEntryModel(ContractModel):
+    """Binds a vocabulary surface in an artifact to a canonical concept family."""
+
+    scope: NonEmptyString = Field(
+        ...,
+        pattern=r"^[a-z_][a-z0-9_.]*[a-z0-9_]$",
+    )
+    family: ConceptFamilyId
+
+
 class ProcessorCapabilitiesV2Model(ContractModel):
     supported_sdl_versions: list[NonEmptyString] = Field(min_length=1)
     supported_features: list[ProcessorFeature] = Field(min_length=1)
@@ -472,8 +483,16 @@ class ProcessorManifestV2Model(ContractModel):
     supported_contract_versions: list[NonEmptyString] = Field(min_length=1)
     compatibility: ApparatusCompatibilityModel
     realization_support: list[RealizationSupportDeclarationModel] = Field(min_length=1)
+    concept_bindings: list[ConceptBindingEntryModel] = Field(min_length=1)
     constraints: dict[str, str] = Field(default_factory=dict)
     capabilities: ProcessorCapabilitiesV2Model
+
+    @model_validator(mode="after")
+    def _validate_unique_binding_scopes(self) -> ProcessorManifestV2Model:
+        scopes = [binding.scope for binding in self.concept_bindings]
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("concept_bindings must not contain duplicate scopes")
+        return self
 
 
 class BackendManifestV2Model(ContractModel):
@@ -482,8 +501,16 @@ class BackendManifestV2Model(ContractModel):
     supported_contract_versions: list[NonEmptyString] = Field(min_length=1)
     compatibility: ApparatusCompatibilityModel
     realization_support: list[RealizationSupportDeclarationModel] = Field(min_length=1)
+    concept_bindings: list[ConceptBindingEntryModel] = Field(min_length=1)
     constraints: dict[str, str] = Field(default_factory=dict)
     capabilities: BackendCapabilitiesV2Model
+
+    @model_validator(mode="after")
+    def _validate_unique_binding_scopes(self) -> BackendManifestV2Model:
+        scopes = [binding.scope for binding in self.concept_bindings]
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("concept_bindings must not contain duplicate scopes")
+        return self
 
 
 class ConceptFamilyDefinitionModel(ContractModel):
@@ -616,10 +643,12 @@ __all__ = [
     "BackendManifestV2Model",
     "BackendCapabilitiesV2Model",
     "CONCEPT_FAMILIES_SCHEMA_VERSION",
-    "ContractModel",
+    "ConceptBindingEntryModel",
     "ConceptFamilyCatalogModel",
     "ConceptFamilyDefinitionModel",
+    "ConceptFamilyId",
     "ConceptProvenanceCategory",
+    "ContractModel",
     "EvaluationHistoryEventModel",
     "EvaluationPlanModel",
     "EvaluationResultStateModel",

--- a/implementations/python/packages/aces_contracts/vocabulary.py
+++ b/implementations/python/packages/aces_contracts/vocabulary.py
@@ -1,6 +1,9 @@
 """Public vocabulary used by external ACES contracts."""
 
 from enum import Enum
+from typing import Annotated
+
+from pydantic import Field
 
 
 class ProcessorFeature(str, Enum):
@@ -51,3 +54,10 @@ class ConceptProvenanceCategory(str, Enum):
     ADOPTED = "adopted"
     ADAPTED = "adapted"
     NATIVE = "native"
+
+
+ConceptFamilyId = Annotated[
+    str,
+    Field(min_length=1, pattern=r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$"),
+]
+"""Pattern-constrained concept family identifier matching the authoritative catalog key format."""

--- a/implementations/python/packages/aces_processor/capabilities.py
+++ b/implementations/python/packages/aces_processor/capabilities.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from aces_contracts.apparatus import (
     ApparatusCompatibility,
     ApparatusIdentity,
+    ConceptBinding,
     RealizationSupportDeclaration,
 )
 from aces_contracts.vocabulary import ProcessorFeature
@@ -36,6 +37,7 @@ class ProcessorManifest:
     supported_contract_versions: frozenset[str]
     compatibility: ApparatusCompatibility
     realization_support: tuple[RealizationSupportDeclaration, ...]
+    concept_bindings: tuple[ConceptBinding, ...]
     constraints: dict[str, str]
     capabilities: ProcessorCapabilitySet
 
@@ -46,6 +48,7 @@ class ProcessorManifest:
         supported_contract_versions: frozenset[str] = frozenset(),
         compatibility: ApparatusCompatibility | None = None,
         realization_support: tuple[RealizationSupportDeclaration, ...] = (),
+        concept_bindings: tuple[ConceptBinding, ...] = (),
         constraints: dict[str, str] | None = None,
         capabilities: ProcessorCapabilitySet | None = None,
         name: str | None = None,
@@ -73,10 +76,14 @@ class ProcessorManifest:
         realization_support = tuple(realization_support)
         if not realization_support:
             raise ValueError("ProcessorManifest.realization_support must not be empty")
+        concept_bindings = tuple(concept_bindings)
+        if not concept_bindings:
+            raise ValueError("ProcessorManifest.concept_bindings must not be empty")
         object.__setattr__(self, "identity", identity)
         object.__setattr__(self, "supported_contract_versions", supported_contract_versions)
         object.__setattr__(self, "compatibility", compatibility)
         object.__setattr__(self, "realization_support", realization_support)
+        object.__setattr__(self, "concept_bindings", concept_bindings)
         object.__setattr__(self, "constraints", {} if constraints is None else dict(constraints))
         object.__setattr__(self, "capabilities", capabilities)
 

--- a/implementations/python/packages/aces_processor/manifest.py
+++ b/implementations/python/packages/aces_processor/manifest.py
@@ -6,10 +6,11 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 from typing import Any, Literal
 
-from aces_contracts.apparatus import RealizationSupportDeclaration
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.contracts import (
     ApparatusCompatibilityModel,
     ApparatusIdentityModel,
+    ConceptBindingEntryModel,
     ProcessorCapabilitiesV2Model,
     ProcessorManifestModel,
     ProcessorManifestV2Model,
@@ -49,6 +50,10 @@ REFERENCE_REALIZATION_SUPPORT = (
         disclosure_kinds=frozenset({"parameter-instantiation", "module-composition"}),
     ),
 )
+REFERENCE_CONCEPT_BINDINGS = (
+    ConceptBinding(scope="capabilities.supported_sdl_versions", family="scenarios"),
+    ConceptBinding(scope="capabilities.supported_features", family="apparatus-declarations"),
+)
 
 
 def _current_processor_version() -> str:
@@ -74,6 +79,7 @@ def create_reference_processor_manifest(
         ),
         compatible_backends=frozenset({"stub"}),
         realization_support=REFERENCE_REALIZATION_SUPPORT,
+        concept_bindings=REFERENCE_CONCEPT_BINDINGS,
         constraints={},
     )
 
@@ -119,6 +125,10 @@ def reference_processor_manifest_v2_model(
                 constraints=dict(declaration.constraints),
             )
             for declaration in manifest.realization_support
+        ],
+        concept_bindings=[
+            ConceptBindingEntryModel(scope=binding.scope, family=binding.family)
+            for binding in manifest.concept_bindings
         ],
         constraints=dict(manifest.constraints),
         capabilities=ProcessorCapabilitiesV2Model(

--- a/implementations/python/tests/test_backend_manifest.py
+++ b/implementations/python/tests/test_backend_manifest.py
@@ -244,3 +244,35 @@ def test_backend_manifest_invalid_fixtures_fail_validation():
         payload = json.loads(path.read_text(encoding="utf-8"))
         with pytest.raises(ValidationError):
             BackendManifestV2Model.model_validate(payload)
+
+
+def test_backend_manifest_v2_requires_concept_bindings():
+    payload = json.loads((V2_VALID_DIR / "stub.json").read_text(encoding="utf-8"))
+    del payload["concept_bindings"]
+    with pytest.raises(ValidationError):
+        BackendManifestV2Model.model_validate(payload)
+
+
+def test_backend_manifest_v2_rejects_empty_concept_bindings():
+    payload = json.loads((V2_VALID_DIR / "stub.json").read_text(encoding="utf-8"))
+    payload["concept_bindings"] = []
+    with pytest.raises(ValidationError):
+        BackendManifestV2Model.model_validate(payload)
+
+
+def test_backend_manifest_v2_rejects_duplicate_binding_scopes():
+    payload = json.loads((V2_VALID_DIR / "stub.json").read_text(encoding="utf-8"))
+    payload["concept_bindings"] = [
+        {"scope": "capabilities.provisioner.supported_node_types", "family": "assets"},
+        {"scope": "capabilities.provisioner.supported_node_types", "family": "identities"},
+    ]
+    with pytest.raises(ValidationError):
+        BackendManifestV2Model.model_validate(payload)
+
+
+def test_backend_manifest_v2_concept_bindings_roundtrip():
+    payload = json.loads((V2_VALID_DIR / "stub.json").read_text(encoding="utf-8"))
+    model = BackendManifestV2Model.model_validate(payload)
+    assert len(model.concept_bindings) == 6
+    assert model.concept_bindings[0].scope == "capabilities.provisioner.supported_node_types"
+    assert model.concept_bindings[0].family == "assets"

--- a/implementations/python/tests/test_concept_authority.py
+++ b/implementations/python/tests/test_concept_authority.py
@@ -1,4 +1,4 @@
-"""Concept authority catalog tests."""
+"""Concept authority catalog and cross-artifact binding tests."""
 
 from __future__ import annotations
 
@@ -7,8 +7,11 @@ from pathlib import Path
 
 import pytest
 from aces_contracts.contracts import (
+    BackendManifestV2Model,
+    ConceptBindingEntryModel,
     ConceptFamilyCatalogModel,
     ConceptFamilyDefinitionModel,
+    ProcessorManifestV2Model,
 )
 from aces_contracts.vocabulary import (
     ConceptProvenanceCategory,
@@ -228,3 +231,64 @@ def test_invalid_fixture_fails_validation():
         payload = json.loads(path.read_text(encoding="utf-8"))
         with pytest.raises(ValidationError):
             ConceptFamilyCatalogModel.model_validate(payload)
+
+
+# --- Cross-artifact concept binding tests ---
+
+BACKEND_V2_VALID_DIR = FIXTURES_ROOT / "backend-manifest" / "backend-manifest-v2" / "valid"
+PROCESSOR_V2_VALID_DIR = FIXTURES_ROOT / "processor-manifest" / "processor-manifest-v2" / "valid"
+
+
+def test_concept_binding_entry_construction():
+    entry = ConceptBindingEntryModel(scope="capabilities.provisioner.supported_node_types", family="assets")
+    assert entry.scope == "capabilities.provisioner.supported_node_types"
+    assert entry.family == "assets"
+
+
+def test_concept_binding_entry_roundtrip():
+    payload = {"scope": "capabilities.supported_features", "family": "apparatus-declarations"}
+    entry = ConceptBindingEntryModel.model_validate(payload)
+    assert entry.model_dump(mode="json") == payload
+
+
+def test_concept_binding_entry_rejects_empty_scope():
+    with pytest.raises(ValidationError):
+        ConceptBindingEntryModel(scope="", family="assets")
+
+
+def test_concept_binding_entry_rejects_invalid_family_pattern():
+    with pytest.raises(ValidationError):
+        ConceptBindingEntryModel(scope="capabilities.provisioner.supported_node_types", family="NOT VALID")
+
+
+def test_concept_binding_entry_rejects_uppercase_family():
+    with pytest.raises(ValidationError):
+        ConceptBindingEntryModel(scope="capabilities.provisioner.supported_node_types", family="Assets")
+
+
+def test_concept_binding_entry_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        ConceptBindingEntryModel(
+            scope="capabilities.provisioner.supported_node_types",
+            family="assets",
+            unknown_field=True,
+        )
+
+
+def test_reference_fixture_bindings_resolve_to_authoritative_catalog():
+    """Verify that all concept family IDs used in reference fixtures exist in the catalog."""
+    catalog_payload = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    catalog = ConceptFamilyCatalogModel.model_validate(catalog_payload)
+    catalog_family_ids = set(catalog.families)
+
+    for fixture_dir, model_cls in [
+        (BACKEND_V2_VALID_DIR, BackendManifestV2Model),
+        (PROCESSOR_V2_VALID_DIR, ProcessorManifestV2Model),
+    ]:
+        for path in sorted(fixture_dir.glob("*.json")):
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            model = model_cls.model_validate(payload)
+            for binding in model.concept_bindings:
+                assert binding.family in catalog_family_ids, (
+                    f"Fixture {path.name} binds to unknown concept family '{binding.family}'"
+                )

--- a/implementations/python/tests/test_concept_authority.py
+++ b/implementations/python/tests/test_concept_authority.py
@@ -275,6 +275,53 @@ def test_concept_binding_entry_rejects_extra_fields():
         )
 
 
+@pytest.mark.parametrize(
+    ("fixture_path", "model_cls"),
+    [
+        (BACKEND_V2_VALID_DIR / "stub.json", BackendManifestV2Model),
+        (PROCESSOR_V2_VALID_DIR / "reference.json", ProcessorManifestV2Model),
+    ],
+)
+def test_manifest_bindings_reject_unknown_catalog_families(fixture_path: Path, model_cls: type) -> None:
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    payload["concept_bindings"][0]["family"] = "made-up-family"
+    with pytest.raises(ValidationError, match="concept-families-v1"):
+        model_cls.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("fixture_path", "model_cls", "invalid_scope"),
+    [
+        (
+            BACKEND_V2_VALID_DIR / "stub.json",
+            BackendManifestV2Model,
+            "capabilities.provisioner.not_a_real_field",
+        ),
+        (
+            PROCESSOR_V2_VALID_DIR / "reference.json",
+            ProcessorManifestV2Model,
+            "capabilities.not_a_real_field",
+        ),
+    ],
+)
+def test_manifest_bindings_reject_unknown_scopes(
+    fixture_path: Path,
+    model_cls: type,
+    invalid_scope: str,
+) -> None:
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    payload["concept_bindings"][0]["scope"] = invalid_scope
+    with pytest.raises(ValidationError, match="governed manifest vocabulary surface"):
+        model_cls.model_validate(payload)
+
+
+def test_backend_manifest_bindings_reject_omitted_optional_surface() -> None:
+    payload = json.loads((BACKEND_V2_VALID_DIR / "stub.json").read_text(encoding="utf-8"))
+    payload["capabilities"]["evaluator"] = None
+    with pytest.raises(ValidationError, match="does not resolve to a declared field"):
+        BackendManifestV2Model.model_validate(payload)
+
+
 def test_reference_fixture_bindings_resolve_to_authoritative_catalog():
     """Verify that all concept family IDs used in reference fixtures exist in the catalog."""
     catalog_payload = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))

--- a/implementations/python/tests/test_processor_manifest.py
+++ b/implementations/python/tests/test_processor_manifest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 from aces_cli.main import app
-from aces_contracts.apparatus import RealizationSupportDeclaration
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.contracts import ProcessorManifestModel, ProcessorManifestV2Model
 from aces_contracts.vocabulary import ProcessorFeature, RealizationSupportMode
 from aces_processor.capabilities import ProcessorManifest
@@ -56,6 +56,13 @@ def _processor_realization_support() -> tuple[RealizationSupportDeclaration, ...
     )
 
 
+def _processor_concept_bindings() -> tuple[ConceptBinding, ...]:
+    return (
+        ConceptBinding(scope="capabilities.supported_sdl_versions", family="scenarios"),
+        ConceptBinding(scope="capabilities.supported_features", family="apparatus-declarations"),
+    )
+
+
 def test_processor_feature_enum_values():
     expected = {
         "compilation",
@@ -79,6 +86,7 @@ def test_processor_manifest_construction():
         supported_features=frozenset({ProcessorFeature.COMPILATION}),
         compatible_backends=frozenset({"stub"}),
         realization_support=_processor_realization_support(),
+        concept_bindings=_processor_concept_bindings(),
     )
     assert manifest.name == "test"
     assert manifest.version == "1.0.0"
@@ -88,6 +96,7 @@ def test_processor_manifest_construction():
     assert manifest.compatible_backends == frozenset({"stub"})
     assert manifest.constraints == {}
     assert manifest.realization_support == _processor_realization_support()
+    assert manifest.concept_bindings == _processor_concept_bindings()
 
 
 def test_processor_manifest_frozen():
@@ -99,6 +108,7 @@ def test_processor_manifest_frozen():
         supported_features=frozenset({ProcessorFeature.COMPILATION}),
         compatible_backends=frozenset({"stub"}),
         realization_support=_processor_realization_support(),
+        concept_bindings=_processor_concept_bindings(),
     )
     with pytest.raises(AttributeError):
         manifest.name = "changed"
@@ -118,6 +128,7 @@ def test_processor_manifest_with_features():
         supported_features=frozenset({ProcessorFeature.COMPILATION, ProcessorFeature.PLANNING}),
         compatible_backends=frozenset({"stub"}),
         realization_support=_processor_realization_support(),
+        concept_bindings=_processor_concept_bindings(),
     )
     assert ProcessorFeature.COMPILATION in manifest.supported_features
     assert ProcessorFeature.PLANNING in manifest.supported_features
@@ -174,6 +185,10 @@ def test_processor_manifest_v2_model_roundtrip():
                 "constraints": {},
             }
         ],
+        "concept_bindings": [
+            {"scope": "capabilities.supported_sdl_versions", "family": "scenarios"},
+            {"scope": "capabilities.supported_features", "family": "apparatus-declarations"},
+        ],
         "constraints": {"max_nodes": "64"},
         "capabilities": {
             "supported_sdl_versions": ["sdl-authoring-input-v1"],
@@ -187,6 +202,8 @@ def test_processor_manifest_v2_model_roundtrip():
         ProcessorFeature.COMPILATION,
         ProcessorFeature.PLANNING,
     ]
+    assert model.concept_bindings[0].scope == "capabilities.supported_sdl_versions"
+    assert model.concept_bindings[0].family == "scenarios"
     assert model.model_dump(mode="json") == payload
 
 

--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.policy.repo_policy import evaluate_repo_policy
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def setup_policy_repo(tmp_path: Path) -> Path:
+    policy_dir = tmp_path / "tools" / "policy"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(REPO_ROOT / "tools" / "policy" / "adr_policy.yaml", policy_dir / "adr_policy.yaml")
+
+    adr_dir = tmp_path / "docs" / "decisions" / "adrs"
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    write_text(
+        adr_dir / "adr-001-example.md",
+        "# ADR-001: Example ADR\n\n## Status\nAccepted\n\n## Date\n2026-04-05\n",
+    )
+    write_text(
+        adr_dir / "README.md",
+        "| Number | Title | Status | Date |\n"
+        "| --- | --- | --- | --- |\n"
+        "| [001](adr-001-example.md) | Example ADR | Accepted | 2026-04-05 |\n",
+    )
+    return tmp_path
+
+
+def test_generated_schema_direct_edits_require_driver_changes(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(repo_root / "contracts" / "schemas" / "backend-manifest" / "schema.json", "{}\n")
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["contracts/schemas/backend-manifest/schema.json"],
+    )
+
+    assert [failure.rule_id for failure in failures] == ["generated-schema-direct-edit"]
+
+
+def test_generated_schema_edits_pass_when_driver_changes_are_present(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(repo_root / "contracts" / "schemas" / "backend-manifest" / "schema.json", "{}\n")
+    write_text(repo_root / "tools" / "generate_contract_schemas.py", "print('regen')\n")
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        [
+            "contracts/schemas/backend-manifest/schema.json",
+            "tools/generate_contract_schemas.py",
+        ],
+    )
+
+    assert "generated-schema-direct-edit" not in {failure.rule_id for failure in failures}
+
+
+def test_package_import_direction_blocks_aces_compatibility_imports(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_processor" / "planner.py",
+        "from aces.runtime import legacy\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["implementations/python/packages/aces_processor/planner.py"],
+        check_set="file-local",
+    )
+
+    assert [failure.rule_id for failure in failures] == ["compatibility-import-direction"]
+
+
+def test_compatibility_layer_rejects_non_wrapper_logic(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "implementations" / "python" / "src" / "aces" / "runtime.py",
+        "def build_runtime():\n    return 1\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["implementations/python/src/aces/runtime.py"],
+        check_set="file-local",
+    )
+
+    assert [failure.rule_id for failure in failures] == ["compatibility-wrapper-only"]
+
+
+def test_changelog_is_required_for_source_changes(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_processor" / "runtime.py",
+        "VALUE = 1\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["implementations/python/packages/aces_processor/runtime.py"],
+    )
+
+    assert [failure.rule_id for failure in failures] == ["changelog-required"]
+
+
+def test_concept_authority_tokens_are_reserved_to_allowed_surfaces(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "docs" / "drafts" / "concept-authority-notes.md",
+        "# stray\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["docs/drafts/concept-authority-notes.md"],
+        check_set="file-local",
+    )
+
+    assert [failure.rule_id for failure in failures] == ["concept-authority-reserved-path"]
+
+
+def test_adr_readme_must_match_adr_documents(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "docs" / "decisions" / "adrs" / "README.md",
+        "| Number | Title | Status | Date |\n"
+        "| --- | --- | --- | --- |\n"
+        "| [001](adr-001-example.md) | Wrong Title | Accepted | 2026-04-05 |\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["docs/decisions/adrs/adr-001-example.md"],
+    )
+
+    assert [failure.rule_id for failure in failures] == ["adr-index-sync"]
+
+
+def test_adr_index_accepts_legacy_inline_status_and_date_fields(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "docs" / "decisions" / "adrs" / "adr-001-example.md",
+        "# ADR-001: Example ADR\n\n**Status:** Accepted\n**Date:** 2026-04-05\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["docs/decisions/adrs/adr-001-example.md"],
+    )
+
+    assert failures == []

--- a/implementations/python/tests/test_requirement_governance.py
+++ b/implementations/python/tests/test_requirement_governance.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.policy.requirement_governance import detect_requirement_uid, evaluate_requirement_governance
+
+
+class FakeClient:
+    def __init__(self, requirements: dict[str, dict], traceability: dict[str, list[dict]]) -> None:
+        self.requirements = requirements
+        self.traceability = traceability
+
+    def get_requirement(self, project: str, uid: str) -> dict:
+        return self.requirements[uid]
+
+    def get_traceability(self, requirement_id: str) -> list[dict]:
+        return self.traceability.get(requirement_id, [])
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def setup_policy_repo(tmp_path: Path) -> Path:
+    policy_dir = tmp_path / "tools" / "policy"
+    policy_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(REPO_ROOT / "tools" / "policy" / "requirement_order.yaml", policy_dir / "requirement_order.yaml")
+    return tmp_path
+
+
+def make_client(*, requirement_status: str = "DRAFT", api_412_status: str = "DRAFT") -> FakeClient:
+    requirements = {
+        "GOV-918": {"id": "req-gov-918", "uid": "GOV-918", "status": requirement_status},
+        "API-412": {"id": "req-api-412", "uid": "API-412", "status": api_412_status},
+        "RUN-300": {"id": "req-run-300", "uid": "RUN-300", "status": "ACTIVE"},
+        "RUN-313": {"id": "req-run-313", "uid": "RUN-313", "status": "DRAFT"},
+        "GOV-917": {"id": "req-gov-917", "uid": "GOV-917", "status": "ACTIVE"},
+        "GOV-919": {"id": "req-gov-919", "uid": "GOV-919", "status": "ACTIVE"},
+        "GOV-920": {"id": "req-gov-920", "uid": "GOV-920", "status": "ACTIVE"},
+        "GOV-921": {"id": "req-gov-921", "uid": "GOV-921", "status": "ACTIVE"},
+        "GOV-922": {"id": "req-gov-922", "uid": "GOV-922", "status": "ACTIVE"},
+    }
+    traceability = {
+        "req-gov-918": [
+            {
+                "artifact_identifier": "implementations/python/packages/aces_processor/bindings.py",
+                "artifact_type": "CODE_FILE",
+                "link_type": "IMPLEMENTS",
+            },
+            {
+                "artifact_identifier": "implementations/python/tests/test_concept_authority.py",
+                "artifact_type": "TEST",
+                "link_type": "TESTS",
+            },
+        ],
+        "req-api-412": [
+            {
+                "artifact_identifier": "implementations/python/packages/aces_processor/manifest.py",
+                "artifact_type": "CODE_FILE",
+                "link_type": "IMPLEMENTS",
+            }
+        ],
+        "req-run-313": [],
+    }
+    return FakeClient(requirements=requirements, traceability=traceability)
+
+
+def test_detect_requirement_uid_from_branch_name() -> None:
+    assert detect_requirement_uid("feature/GOV-918-cross-artifact-binding") == "GOV-918"
+    assert detect_requirement_uid("15-gov-918-cross-artifact-concept-binding") == "GOV-918"
+    assert detect_requirement_uid("feature/no-uid-here") is None
+
+
+def test_archived_requirements_are_rejected(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    client = make_client(requirement_status="ARCHIVED")
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        ["implementations/python/packages/aces_processor/bindings.py"],
+        client=client,
+        requirement_uid="GOV-918",
+    )
+
+    assert [failure.rule_id for failure in failures] == ["requirement-invalid-status"]
+
+
+def test_blocked_phase_requires_previous_phase_completion(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    client = make_client(api_412_status="DRAFT")
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_processor" / "manifest.py",
+        "VALUE = 1\n",
+    )
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        ["implementations/python/packages/aces_processor/manifest.py"],
+        client=client,
+        requirement_uid="API-412",
+    )
+
+    assert [failure.rule_id for failure in failures] == ["requirement-order-blocked"]
+
+
+def test_ownership_mismatch_is_reported(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    client = make_client()
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_sdl" / "parser.py",
+        "VALUE = 1\n",
+    )
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        ["implementations/python/packages/aces_sdl/parser.py"],
+        client=client,
+        requirement_uid="GOV-918",
+    )
+
+    assert {failure.rule_id for failure in failures} == {
+        "requirement-ownership-mismatch",
+        "traceability-missing-implements",
+    }
+
+
+def test_missing_traceability_links_are_reported(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    client = make_client()
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_processor" / "new_binding.py",
+        "VALUE = 1\n",
+    )
+    write_text(
+        repo_root / "implementations" / "python" / "tests" / "test_new_binding.py",
+        "def test_value():\n    assert True\n",
+    )
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        [
+            "implementations/python/packages/aces_processor/new_binding.py",
+            "implementations/python/tests/test_new_binding.py",
+        ],
+        client=client,
+        requirement_uid="RUN-313",
+    )
+
+    assert {failure.rule_id for failure in failures} == {
+        "traceability-missing-implements",
+        "traceability-missing-tests",
+    }
+
+
+def test_requirement_governance_passes_for_allowed_paths_and_traceability(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    client = make_client()
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_processor" / "bindings.py",
+        "VALUE = 1\n",
+    )
+    write_text(
+        repo_root / "implementations" / "python" / "tests" / "test_concept_authority.py",
+        "def test_value():\n    assert True\n",
+    )
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        [
+            "implementations/python/packages/aces_processor/bindings.py",
+            "implementations/python/tests/test_concept_authority.py",
+        ],
+        client=client,
+        requirement_uid="GOV-918",
+    )
+
+    assert failures == []
+
+
+def test_requirement_governance_accepts_camel_case_traceability_payload(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    requirements = {
+        "GOV-918": {"id": "req-gov-918", "uid": "GOV-918", "status": "ACTIVE"},
+    }
+    client = FakeClient(
+        requirements=requirements,
+        traceability={
+            "req-gov-918": [
+                {
+                    "artifactIdentifier": "implementations/python/packages/aces_contracts/contracts.py",
+                    "artifactType": "CODE_FILE",
+                    "linkType": "IMPLEMENTS",
+                },
+                {
+                    "artifactIdentifier": "implementations/python/tests/test_requirement_governance.py",
+                    "artifactType": "TEST",
+                    "linkType": "TESTS",
+                },
+            ]
+        },
+    )
+    write_text(
+        repo_root / "implementations" / "python" / "packages" / "aces_contracts" / "contracts.py",
+        "VALUE = 1\n",
+    )
+    write_text(
+        repo_root / "implementations" / "python" / "tests" / "test_requirement_governance.py",
+        "def test_value():\n    assert True\n",
+    )
+
+    failures = evaluate_requirement_governance(
+        repo_root,
+        [
+            "implementations/python/packages/aces_contracts/contracts.py",
+            "implementations/python/tests/test_requirement_governance.py",
+        ],
+        client=client,
+        requirement_uid="GOV-918",
+    )
+
+    assert failures == []

--- a/implementations/python/tests/test_runtime_contracts.py
+++ b/implementations/python/tests/test_runtime_contracts.py
@@ -131,6 +131,7 @@ def test_manifest_schemas_publish_v1_and_v2_with_shared_and_enum_constrained_sha
         "supported_contract_versions",
         "compatibility",
         "realization_support",
+        "concept_bindings",
         "capabilities",
     ]
     assert generated["processor-manifest-v2"]["properties"]["identity"]["$ref"] == "#/$defs/ApparatusIdentityModel"
@@ -150,12 +151,34 @@ def test_manifest_schemas_publish_v1_and_v2_with_shared_and_enum_constrained_sha
         "supported_contract_versions",
         "compatibility",
         "realization_support",
+        "concept_bindings",
         "capabilities",
     ]
     assert processor_v1["properties"]["supported_sdl_versions"]["minItems"] == 1
     assert processor_v1["properties"]["supported_contract_versions"]["minItems"] == 1
     assert processor_v1["properties"]["supported_features"]["minItems"] == 1
     assert processor_v1["properties"]["compatible_backends"]["minItems"] == 1
+
+
+def test_concept_binding_schema_in_v2_manifests():
+    generated = schema_bundle()
+
+    for schema_name in ("backend-manifest-v2", "processor-manifest-v2"):
+        schema = generated[schema_name]
+        assert "concept_bindings" in schema["properties"], f"{schema_name} should have concept_bindings"
+        assert "concept_bindings" in schema["required"], f"{schema_name} should require concept_bindings"
+        bindings_prop = schema["properties"]["concept_bindings"]
+        assert bindings_prop["type"] == "array"
+        assert bindings_prop["minItems"] == 1
+        assert "$ref" in bindings_prop["items"]
+        assert "ConceptBindingEntryModel" in bindings_prop["items"]["$ref"]
+
+    binding_def = generated["backend-manifest-v2"]["$defs"]["ConceptBindingEntryModel"]
+    assert binding_def["additionalProperties"] is False
+    assert "scope" in binding_def["properties"]
+    assert "family" in binding_def["properties"]
+    assert binding_def["properties"]["scope"]["pattern"]
+    assert binding_def["properties"]["family"]["pattern"]
 
 
 def test_concept_authority_schema_enforces_keyed_catalog_and_provenance_rules():

--- a/implementations/python/tests/test_runtime_manager.py
+++ b/implementations/python/tests/test_runtime_manager.py
@@ -1442,6 +1442,7 @@ class TestRuntimeManager:
             supported_contract_versions=altered_manifest.supported_contract_versions,
             compatibility=altered_manifest.compatibility,
             realization_support=altered_manifest.realization_support,
+            concept_bindings=altered_manifest.concept_bindings,
             constraints=altered_manifest.constraints,
             provisioner=altered_manifest.provisioner,
             orchestrator=altered_manifest.orchestrator,

--- a/implementations/python/tests/test_runtime_planner.py
+++ b/implementations/python/tests/test_runtime_planner.py
@@ -6,7 +6,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from aces_contracts.apparatus import RealizationSupportDeclaration
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.vocabulary import RealizationSupportMode
 
 from aces.backends.stubs import create_stub_manifest
@@ -74,6 +74,7 @@ def _limited_backend_manifest(
                 disclosure_kinds=frozenset({"runtime-snapshot-v1"}),
             ),
         ),
+        concept_bindings=(ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),),
         provisioner=provisioner,
         orchestrator=orchestrator,
         evaluator=evaluator,

--- a/implementations/python/tests/test_runtime_registry.py
+++ b/implementations/python/tests/test_runtime_registry.py
@@ -1,7 +1,7 @@
 """Runtime registry tests."""
 
 import pytest
-from aces_contracts.apparatus import RealizationSupportDeclaration
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.vocabulary import RealizationSupportMode
 
 from aces.backends.stubs import create_stub_components, create_stub_manifest
@@ -127,6 +127,9 @@ class TestBackendRegistry:
                         supported_constraint_kinds=frozenset({"node-type"}),
                         disclosure_kinds=frozenset({"runtime-snapshot-v1"}),
                     ),
+                ),
+                concept_bindings=(
+                    ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
                 ),
                 provisioner=ProvisionerCapabilities(
                     name="manifest-a-provisioner",

--- a/notes/reconstructed-work-order-after-gov-917.md
+++ b/notes/reconstructed-work-order-after-gov-917.md
@@ -1,0 +1,60 @@
+# Reconstructed Work Order After GOV-917
+
+Date reconstructed: 2026-04-05
+
+This note captures the most likely intended requirement order immediately after
+the `GOV-917` canonical concept authority work, based on repository state,
+ADR text, Ground Control requirement records, and recoverable Cursor workspace
+metadata.
+
+## Likely intended side sequence
+
+The strongest evidence indicates that work was meant to continue briefly in the
+`GOV-917` follow-on cluster before returning to the broader repository
+realignment order:
+
+1. `GOV-917` Canonical Concept Authority For Cyber-Domain Meaning
+2. `GOV-918` Cross-Artifact Concept Binding
+3. `GOV-919` ACES Extension Discipline Over Shared Concept Authorities
+4. `GOV-920` Shared Semantic Profiles
+5. `GOV-921` Shared Reference Models
+6. `GOV-922` Controlled Vocabularies And Enumerations
+
+There is also evidence that the concept-authority line expanded further the
+same day into:
+
+7. `GOV-923` Gateway And Bridge Contracts
+8. `GOV-924` Translation-Path Provenance And Validation
+9. `GOV-925` Standards Profiles And Compatible Stack Recommendation
+10. `GOV-926` Federation-Level VV&A And Accreditation Basis
+
+## Return to ADR-010 order
+
+After the concept-authority side sequence, the intended return path appears to
+be the explicit ordering from ADR-010:
+
+1. `API-412` and `API-413`
+2. `RUN-300` and related runtime/control-plane requirements
+3. `RUN-313`, `RUN-314`, and `RUN-315`
+4. Remaining unfinished `SEM-*` work
+5. Deferred broader `API-400` expansion surfaces
+
+## Why this reconstruction is likely correct
+
+- `GOV-917` was implemented in commit `8ccd1b1` on 2026-04-05.
+- The branch name for that work is `486-canonical-concept-authority-for-cyber-domain-meaning`.
+- The concept-authority spec and design note both explicitly split the related
+  follow-on problem into `GOV-918` through `GOV-922`.
+- In Ground Control, `GOV-918` through `GOV-926` were created immediately after
+  `GOV-917` on 2026-04-05, suggesting they were intentionally queued as a
+  coherent cluster.
+- ADR-010 still provides the standing post-realignment requirement order:
+  `API-412`/`API-413`, then `RUN-300`, then `RUN-313`/`RUN-314`/`RUN-315`,
+  then remaining `SEM-*`, then deferred `API-400` children.
+
+## Caveat
+
+The newest Cursor conversation body was not recoverable as a full transcript.
+Cursor preserved workspace/session metadata for `aces-sdl`, but the relevant
+agent transcript append path was failing, so this note is a reconstruction from
+repo artifacts and Ground Control rather than a verbatim chat record.

--- a/tools/check_repo_policy.py
+++ b/tools/check_repo_policy.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from policy.common import REPO_ROOT, apply_exceptions, changed_paths, failures_to_json, load_exceptions
+from policy.repo_policy import evaluate_repo_policy
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate ACES SDL repo policy rules.")
+    parser.add_argument("--staged", action="store_true", help="Check staged changes instead of working tree changes.")
+    parser.add_argument("--base-rev", help="Compare against a specific git revision.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    parser.add_argument(
+        "--check-set",
+        choices=("full", "file-local"),
+        default="full",
+        help="Run the full policy set or only file-local edit guards.",
+    )
+    parser.add_argument("paths", nargs="*", help="Explicit repo-relative paths to check.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paths = [Path(path).as_posix() for path in args.paths] if args.paths else changed_paths(REPO_ROOT, staged=args.staged, base_rev=args.base_rev)
+    failures = evaluate_repo_policy(REPO_ROOT, paths, check_set=args.check_set)
+    failures = apply_exceptions(failures, load_exceptions(REPO_ROOT))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_requirement_governance.py
+++ b/tools/check_requirement_governance.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from policy.common import REPO_ROOT, apply_exceptions, changed_paths, failures_to_json, load_exceptions
+from policy.requirement_governance import (
+    GroundControlHttpClient,
+    evaluate_requirement_governance,
+    requirement_uid_from_context,
+)
+
+GOVERNED_ROOTS = ("implementations/", "contracts/", "specs/", "docs/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate requirement order and traceability against Ground Control.")
+    parser.add_argument("--staged", action="store_true", help="Check staged changes instead of working tree changes.")
+    parser.add_argument("--base-rev", help="Compare against a specific git revision.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    parser.add_argument("--requirement-uid", help="Explicit requirement UID override.")
+    parser.add_argument("paths", nargs="*", help="Explicit repo-relative paths to check.")
+    return parser.parse_args()
+
+
+def current_branch(repo_root: Path) -> str | None:
+    proc = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    branch = proc.stdout.strip()
+    return branch or None
+
+
+def requires_requirement_context(paths: list[str]) -> bool:
+    return any(path.startswith(GOVERNED_ROOTS) for path in paths)
+
+
+def main() -> int:
+    args = parse_args()
+    paths = [Path(path).as_posix() for path in args.paths] if args.paths else changed_paths(REPO_ROOT, staged=args.staged, base_rev=args.base_rev)
+    uid = requirement_uid_from_context(current_branch(REPO_ROOT), args.requirement_uid)
+    if not requires_requirement_context(paths):
+        return 0
+    if not uid:
+        failure = [
+            {
+                "rule_id": "requirement-context-missing",
+                "message": "requirement UID is missing; set ACES_REQUIREMENT_UID or include a UID like GOV-918 in the branch name",
+                "path": None,
+            }
+        ]
+        if args.json:
+            print(json.dumps(failure, indent=2))
+        else:
+            print("[requirement-context-missing] requirement UID is missing; set ACES_REQUIREMENT_UID or include a UID like GOV-918 in the branch name", file=sys.stderr)
+        return 1
+
+    client = GroundControlHttpClient(base_url=(os.environ.get("GC_BASE_URL") or "http://gc-dev:8000"))
+    try:
+        failures = evaluate_requirement_governance(REPO_ROOT, paths, client=client, requirement_uid=uid)
+    except RuntimeError as exc:
+        print(f"[ground-control-unavailable] {exc}", file=sys.stderr)
+        return 1
+
+    failures = apply_exceptions(failures, load_exceptions(REPO_ROOT), requirement_uid=uid)
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/policy/__init__.py
+++ b/tools/policy/__init__.py
@@ -1,0 +1,1 @@
+"""Repo policy enforcement helpers for ACES SDL."""

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -1,0 +1,48 @@
+policy_version: 1
+
+legacy_top_level_roots:
+  - conformance
+  - schemas
+  - src
+
+source_roots:
+  - implementations/python/packages
+  - implementations/python/src
+
+changelog_path: CHANGELOG.md
+
+generated_contracts:
+  generated_roots:
+    - contracts/schemas
+  driver_paths:
+    - tools/generate_contract_schemas.py
+    - implementations/python/packages/aces_contracts
+    - implementations/python/packages/aces_backend_protocols
+    - implementations/python/packages/aces_processor
+
+compatibility_layer:
+  root: implementations/python/src/aces
+  owning_root: implementations/python/packages
+  forbidden_import_prefixes:
+    - aces.
+
+concept_authority:
+  reserved_path_tokens:
+    - concept-authority
+    - concept-families-v1
+  allowed_paths:
+    - specs/concept-authority
+    - contracts/concept-authority
+    - contracts/schemas/concept-authority
+    - contracts/fixtures/concept-authority
+    - docs/explain/reference/shared-concept-model.md
+    - docs/decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline.md
+    - implementations/python/tests/test_concept_authority.py
+    - implementations/python/packages/aces_contracts
+    - implementations/python/packages/aces_backend_protocols
+    - implementations/python/packages/aces_processor
+    - notes/reconstructed-work-order-after-gov-917.md
+
+adr_index:
+  index_path: docs/decisions/adrs/README.md
+  adr_glob: docs/decisions/adrs/adr-*.md

--- a/tools/policy/common.py
+++ b/tools/policy/common.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+import fnmatch
+import json
+import subprocess
+from typing import Iterable
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class PolicyFailure:
+    rule_id: str
+    message: str
+    path: str | None = None
+
+    def render(self) -> str:
+        if self.path:
+            return f"[{self.rule_id}] {self.path}: {self.message}"
+        return f"[{self.rule_id}] {self.message}"
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    return data or {}
+
+
+def repo_path(value: str | Path) -> str:
+    return Path(value).as_posix().strip("/")
+
+
+def run_git(args: list[str], repo_root: Path = REPO_ROOT) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return proc.stdout
+
+
+def changed_paths(
+    repo_root: Path = REPO_ROOT,
+    *,
+    staged: bool = False,
+    base_rev: str | None = None,
+) -> list[str]:
+    if staged:
+        output = run_git(["diff", "--name-only", "--cached"], repo_root=repo_root)
+    elif base_rev:
+        output = run_git(["diff", "--name-only", base_rev, "HEAD"], repo_root=repo_root)
+    else:
+        output = run_git(["diff", "--name-only", "HEAD"], repo_root=repo_root)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def path_matches_prefix(path: str, prefix: str) -> bool:
+    norm = repo_path(path)
+    pref = repo_path(prefix)
+    return norm == pref or norm.startswith(f"{pref}/")
+
+
+def path_matches_any(path: str, prefixes: Iterable[str]) -> bool:
+    return any(path_matches_prefix(path, prefix) for prefix in prefixes)
+
+
+def glob_matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def load_exceptions(repo_root: Path = REPO_ROOT) -> list[dict]:
+    raw = load_yaml(repo_root / "tools" / "policy" / "exceptions.yaml")
+    return raw.get("exceptions", [])
+
+
+def exception_active(entry: dict, *, today: date | None = None) -> bool:
+    if today is None:
+        today = date.today()
+    expires_at = entry.get("expires_at")
+    if not expires_at:
+        return True
+    return today <= date.fromisoformat(str(expires_at))
+
+
+def apply_exceptions(
+    failures: list[PolicyFailure],
+    exceptions: list[dict],
+    *,
+    requirement_uid: str | None = None,
+) -> list[PolicyFailure]:
+    if not failures or not exceptions:
+        return failures
+
+    remaining: list[PolicyFailure] = []
+    for failure in failures:
+        waived = False
+        for entry in exceptions:
+            if not exception_active(entry):
+                continue
+            if entry.get("rule_id") != failure.rule_id:
+                continue
+            if requirement_uid and entry.get("requirement_uid") not in {None, requirement_uid}:
+                continue
+            match_paths = entry.get("paths") or []
+            if failure.path and match_paths and not path_matches_any(failure.path, match_paths):
+                continue
+            waived = True
+            break
+        if not waived:
+            remaining.append(failure)
+    return remaining
+
+
+def failures_to_json(failures: list[PolicyFailure]) -> str:
+    return json.dumps(
+        [
+            {"rule_id": failure.rule_id, "message": failure.message, "path": failure.path}
+            for failure in failures
+        ],
+        indent=2,
+        sort_keys=True,
+    )

--- a/tools/policy/exceptions.yaml
+++ b/tools/policy/exceptions.yaml
@@ -1,0 +1,1 @@
+exceptions: []

--- a/tools/policy/repo_policy.py
+++ b/tools/policy/repo_policy.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from .common import PolicyFailure, load_yaml, path_matches_any, path_matches_prefix
+
+
+def load_policy(repo_root: Path) -> dict:
+    return load_yaml(repo_root / "tools" / "policy" / "adr_policy.yaml")
+
+
+def evaluate_repo_policy(
+    repo_root: Path,
+    changed: list[str],
+    *,
+    check_set: str = "full",
+) -> list[PolicyFailure]:
+    policy = load_policy(repo_root)
+    failures: list[PolicyFailure] = []
+
+    if not changed:
+        return failures
+
+    failures.extend(_check_legacy_roots(policy, changed))
+    failures.extend(_check_generated_schema_edits(policy, changed))
+    failures.extend(_check_package_import_direction(repo_root, policy, changed))
+    failures.extend(_check_compatibility_wrappers(repo_root, policy, changed))
+    failures.extend(_check_concept_authority_reservations(policy, changed))
+
+    if check_set == "full":
+        failures.extend(_check_changelog(policy, changed))
+        failures.extend(_check_adr_index(repo_root, policy, changed))
+
+    return failures
+
+
+def _check_legacy_roots(policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    forbidden = policy.get("legacy_top_level_roots", [])
+    for path in changed:
+        top = path.split("/", 1)[0]
+        if top in forbidden:
+            failures.append(
+                PolicyFailure(
+                    "legacy-top-level-root",
+                    "legacy top-level roots are not authoritative; place the artifact under specs/, contracts/, docs/, or implementations/",
+                    path,
+                )
+            )
+    return failures
+
+
+def _check_generated_schema_edits(policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    generated_roots = policy["generated_contracts"]["generated_roots"]
+    drivers = policy["generated_contracts"]["driver_paths"]
+    touched_generated = [path for path in changed if path_matches_any(path, generated_roots)]
+    if not touched_generated:
+        return []
+    if any(path_matches_any(path, drivers) for path in changed):
+        return []
+    return [
+        PolicyFailure(
+            "generated-schema-direct-edit",
+            "published schemas are generated artifacts; update the generator inputs and regenerate instead of editing schemas directly",
+            path,
+        )
+        for path in touched_generated
+    ]
+
+
+def _check_package_import_direction(repo_root: Path, policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    package_root = repo_root / policy["compatibility_layer"]["owning_root"]
+    prefixes = tuple(policy["compatibility_layer"]["forbidden_import_prefixes"])
+    for rel_path in changed:
+        if not rel_path.endswith(".py") or not path_matches_prefix(rel_path, package_root.relative_to(repo_root).as_posix()):
+            continue
+        path = repo_root / rel_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel_path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith(prefixes):
+                        failures.append(
+                            PolicyFailure(
+                                "compatibility-import-direction",
+                                "owning packages must not import from compatibility-only aces.* modules",
+                                rel_path,
+                            )
+                        )
+            elif isinstance(node, ast.ImportFrom) and node.module and node.module.startswith(prefixes):
+                failures.append(
+                    PolicyFailure(
+                        "compatibility-import-direction",
+                        "owning packages must not import from compatibility-only aces.* modules",
+                        rel_path,
+                    )
+                )
+    return failures
+
+
+def _check_compatibility_wrappers(repo_root: Path, policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    compat_root = policy["compatibility_layer"]["root"]
+    for rel_path in changed:
+        if not rel_path.endswith(".py") or not path_matches_prefix(rel_path, compat_root):
+            continue
+        path = repo_root / rel_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel_path)
+        if not _is_wrapper_module(tree):
+            failures.append(
+                PolicyFailure(
+                    "compatibility-wrapper-only",
+                    "compatibility-layer modules must remain wrappers/re-exports only",
+                    rel_path,
+                )
+            )
+    return failures
+
+
+def _is_wrapper_module(tree: ast.Module) -> bool:
+    allowed_import_names = {"reexport", "package_version"}
+    allowed_calls = {"_reexport", "package_version"}
+    for node in tree.body:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            continue
+        if isinstance(node, ast.ImportFrom):
+            if node.module != "aces._compat":
+                return False
+            if any(alias.name not in allowed_import_names for alias in node.names):
+                return False
+            continue
+        if isinstance(node, ast.Assign):
+            if any(not isinstance(target, ast.Name) for target in node.targets):
+                return False
+            target_names = {target.id for target in node.targets if isinstance(target, ast.Name)}
+            if target_names == {"__all__"} and isinstance(node.value, (ast.List, ast.Tuple)):
+                continue
+            if target_names == {"__version__"} and isinstance(node.value, ast.Call):
+                if isinstance(node.value.func, ast.Name) and node.value.func.id in allowed_calls:
+                    continue
+            return False
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            if isinstance(node.value.func, ast.Name) and node.value.func.id == "_reexport":
+                continue
+            return False
+        if isinstance(node, ast.Delete):
+            continue
+        return False
+    return True
+
+
+def _check_concept_authority_reservations(policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    tokens = policy["concept_authority"]["reserved_path_tokens"]
+    allowed = policy["concept_authority"]["allowed_paths"]
+    for path in changed:
+        if any(token in path for token in tokens) and not path_matches_any(path, allowed):
+            failures.append(
+                PolicyFailure(
+                    "concept-authority-reserved-path",
+                    "concept-authority artifacts must stay in the approved authority surfaces",
+                    path,
+                )
+            )
+    return failures
+
+
+def _check_changelog(policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    changelog_path = policy["changelog_path"]
+    source_roots = policy["source_roots"]
+    source_changed = any(path_matches_any(path, source_roots) and path.endswith(".py") for path in changed)
+    if source_changed and changelog_path not in changed:
+        return [
+            PolicyFailure(
+                "changelog-required",
+                "source changes require a CHANGELOG.md update",
+                changelog_path,
+            )
+        ]
+    return []
+ADR_HEADER_RE = re.compile(r"^# ADR-(\d{3}): (.+)$", re.MULTILINE)
+README_ROW_RE = re.compile(r"^\| \[(\d{3})\]\(([^)]+)\) \| (.+?) \| (.+?) \| (\d{4}-\d{2}-\d{2}) \|$", re.MULTILINE)
+
+
+def _parse_adr_file(path: Path) -> tuple[str, str, str, str]:
+    text = path.read_text(encoding="utf-8")
+    header = ADR_HEADER_RE.search(text)
+    if not header:
+        raise ValueError(f"{path} is missing ADR header")
+    status = _normalize_adr_status(_extract_markdown_section(text, "Status"))
+    date = _extract_markdown_section(text, "Date")
+    return header.group(1), header.group(2).strip(), status.strip(), date.strip()
+
+
+def _extract_markdown_section(text: str, section: str) -> str:
+    marker = f"## {section}"
+    start = text.find(marker)
+    if start != -1:
+        body = text[start + len(marker) :]
+        body = body.lstrip()
+        next_header = body.find("\n## ")
+        if next_header != -1:
+            body = body[:next_header]
+        return body.strip().splitlines()[0].strip()
+
+    legacy_marker = re.search(rf"^\*\*{re.escape(section)}:\*\*\s*(.+)$", text, re.MULTILINE)
+    if legacy_marker:
+        return legacy_marker.group(1).strip()
+
+    raise ValueError(f"missing {section} section")
+
+
+def _normalize_adr_status(status: str) -> str:
+    normalized = " ".join(status.split())
+    lowered = normalized.lower()
+    if lowered in {"accepted", "proposed", "deprecated"}:
+        return lowered
+    superseded = re.fullmatch(r"superseded by (adr-\d{3})", lowered)
+    if superseded:
+        return f"superseded by {superseded.group(1).upper()}"
+    return normalized
+
+
+def _check_adr_index(repo_root: Path, policy: dict, changed: list[str]) -> list[PolicyFailure]:
+    index_path = policy["adr_index"]["index_path"]
+    if not any(path.startswith("docs/decisions/adrs/") for path in changed):
+        return []
+
+    adr_dir = repo_root / "docs" / "decisions" / "adrs"
+    adr_files = sorted(
+        path
+        for path in adr_dir.glob("adr-*.md")
+        if path.name != "README.md"
+    )
+    expected: dict[str, tuple[str, str, str, str]] = {}
+    for adr_file in adr_files:
+        number, title, status, date_value = _parse_adr_file(adr_file)
+        expected[number] = (adr_file.name, title, status, date_value)
+
+    readme_text = (repo_root / index_path).read_text(encoding="utf-8")
+    actual = {
+        number: (Path(link).name, title.strip(), _normalize_adr_status(status), date_value)
+        for number, link, title, status, date_value in README_ROW_RE.findall(readme_text)
+    }
+
+    if expected != actual:
+        return [
+            PolicyFailure(
+                "adr-index-sync",
+                "ADR index is out of sync with the ADR documents",
+                index_path,
+            )
+        ]
+    return []

--- a/tools/policy/requirement_governance.py
+++ b/tools/policy/requirement_governance.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import re
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+import json
+
+from .common import PolicyFailure, load_yaml, path_matches_any
+
+
+UID_RE = re.compile(r"\b([A-Z]{3}-\d{3})\b", re.IGNORECASE)
+
+
+def load_policy(repo_root: Path) -> dict:
+    return load_yaml(repo_root / "tools" / "policy" / "requirement_order.yaml")
+
+
+class RequirementClient(Protocol):
+    def get_requirement(self, project: str, uid: str) -> dict: ...
+
+    def get_traceability(self, requirement_id: str) -> list[dict]: ...
+
+
+class GroundControlHttpClient:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def _request(self, path: str, *, params: dict[str, str] | None = None) -> dict | list:
+        url = f"{self.base_url}{path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        request = Request(url, headers={"X-Actor": "repo-policy"})
+        try:
+            with urlopen(request) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"{exc.code}: {body}") from exc
+        except URLError as exc:
+            raise RuntimeError(str(exc.reason)) from exc
+
+    def get_requirement(self, project: str, uid: str) -> dict:
+        return self._request(f"/api/v1/requirements/uid/{uid}", params={"project": project})
+
+    def get_traceability(self, requirement_id: str) -> list[dict]:
+        return self._request(f"/api/v1/requirements/{requirement_id}/traceability")
+
+
+@dataclass(frozen=True)
+class PhaseMatch:
+    phase_id: str
+    phase: dict
+
+
+def _traceability_value(link: dict, snake_case: str, camel_case: str) -> str | None:
+    value = link.get(snake_case)
+    if value is not None:
+        return value
+    raw_value = link.get(camel_case)
+    return raw_value if isinstance(raw_value, str) else None
+
+
+def detect_requirement_uid(branch_name: str | None) -> str | None:
+    if not branch_name:
+        return None
+    match = UID_RE.search(branch_name)
+    return match.group(1).upper() if match else None
+
+
+def evaluate_requirement_governance(
+    repo_root: Path,
+    changed: list[str],
+    *,
+    client: RequirementClient,
+    requirement_uid: str,
+) -> list[PolicyFailure]:
+    policy = load_policy(repo_root)
+    project = policy["project"]
+    failures: list[PolicyFailure] = []
+
+    requirement = client.get_requirement(project, requirement_uid)
+    status = requirement["status"]
+    if status in {"ARCHIVED", "DEPRECATED"}:
+        return [
+            PolicyFailure(
+                "requirement-invalid-status",
+                f"{requirement_uid} is {status} and is not valid for implementation work",
+            )
+        ]
+
+    phase_match = match_phase(policy, requirement_uid)
+    if phase_match is None:
+        return [
+            PolicyFailure(
+                "requirement-policy-missing",
+                f"{requirement_uid} is not mapped in tools/policy/requirement_order.yaml",
+            )
+        ]
+
+    failures.extend(_check_phase_predecessors(policy, client, phase_match))
+    failures.extend(_check_path_ownership(policy, phase_match, changed))
+    failures.extend(_check_traceability(client, requirement, policy, changed))
+
+    return failures
+
+
+def match_phase(policy: dict, requirement_uid: str) -> PhaseMatch | None:
+    for phase in policy.get("phases", []):
+        if requirement_uid in phase.get("requirements", []):
+            return PhaseMatch(phase["id"], phase)
+        for pattern in phase.get("patterns", []):
+            if re.match(pattern, requirement_uid):
+                return PhaseMatch(phase["id"], phase)
+    return None
+
+
+def _check_phase_predecessors(
+    policy: dict,
+    client: RequirementClient,
+    match: PhaseMatch,
+) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    blocked_until = match.phase.get("blocked_until", [])
+    project = policy["project"]
+    for phase_id in blocked_until:
+        phase = next(phase for phase in policy["phases"] if phase["id"] == phase_id)
+        if phase.get("manual_release"):
+            failures.append(
+                PolicyFailure(
+                    "requirement-order-blocked",
+                    f"{match.phase_id} remains deferred until {phase_id} is explicitly released",
+                )
+            )
+            continue
+        incomplete: list[str] = []
+        for uid in phase.get("requirements", []):
+            status = client.get_requirement(project, uid)["status"]
+            if status != "ACTIVE":
+                incomplete.append(f"{uid} ({status})")
+        if incomplete:
+            failures.append(
+                PolicyFailure(
+                    "requirement-order-blocked",
+                    f"{match.phase_id} is blocked until {phase_id} is complete; incomplete prerequisites: {', '.join(incomplete)}",
+                )
+            )
+    return failures
+
+
+def _check_path_ownership(policy: dict, match: PhaseMatch, changed: list[str]) -> list[PolicyFailure]:
+    allowed = policy.get("ownership", {}).get(match.phase_id, [])
+    if not allowed:
+        return []
+    failures: list[PolicyFailure] = []
+    relevant = [
+        path
+        for path in changed
+        if path.startswith("implementations/")
+        or path.startswith("contracts/")
+        or path.startswith("specs/")
+        or path.startswith("docs/")
+    ]
+    for path in relevant:
+        if not path_matches_any(path, allowed):
+            failures.append(
+                PolicyFailure(
+                    "requirement-ownership-mismatch",
+                    f"{match.phase_id} changes must stay within the mapped ownership roots for that phase",
+                    path,
+                )
+            )
+    return failures
+
+
+def _check_traceability(
+    client: RequirementClient,
+    requirement: dict,
+    policy: dict,
+    changed: list[str],
+) -> list[PolicyFailure]:
+    traceability = client.get_traceability(requirement["id"])
+    code_links = {
+        artifact_identifier
+        for link in traceability
+        if _traceability_value(link, "artifact_type", "artifactType") == "CODE_FILE"
+        and _traceability_value(link, "link_type", "linkType") == "IMPLEMENTS"
+        and (artifact_identifier := _traceability_value(link, "artifact_identifier", "artifactIdentifier")) is not None
+    }
+    test_links = {
+        artifact_identifier
+        for link in traceability
+        if _traceability_value(link, "artifact_type", "artifactType") == "TEST"
+        and _traceability_value(link, "link_type", "linkType") == "TESTS"
+        and (artifact_identifier := _traceability_value(link, "artifact_identifier", "artifactIdentifier")) is not None
+    }
+    failures: list[PolicyFailure] = []
+    required_code_roots = policy["traceability"]["required_code_roots"]
+    required_test_roots = policy["traceability"]["required_test_roots"]
+
+    for path in changed:
+        if path_matches_any(path, required_code_roots) and path.endswith(".py") and path not in code_links:
+            failures.append(
+                PolicyFailure(
+                    "traceability-missing-implements",
+                    f"{requirement['uid']} is missing an IMPLEMENTS traceability link for this code file",
+                    path,
+                )
+            )
+        if path_matches_any(path, required_test_roots) and path.endswith(".py") and path not in test_links:
+            failures.append(
+                PolicyFailure(
+                    "traceability-missing-tests",
+                    f"{requirement['uid']} is missing a TESTS traceability link for this test file",
+                    path,
+                )
+            )
+    return failures
+
+
+def requirement_uid_from_context(branch_name: str | None, explicit_uid: str | None) -> str | None:
+    return explicit_uid or os.environ.get("ACES_REQUIREMENT_UID") or detect_requirement_uid(branch_name)

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -1,0 +1,109 @@
+project: aces-sdl
+
+phases:
+  - id: gov-concept-authority
+    requirements:
+      - GOV-917
+      - GOV-918
+      - GOV-919
+      - GOV-920
+      - GOV-921
+      - GOV-922
+  - id: api400-core
+    requirements:
+      - API-412
+      - API-413
+    blocked_until:
+      - gov-concept-authority
+  - id: runtime-core
+    requirements:
+      - RUN-300
+    blocked_until:
+      - api400-core
+  - id: reference-implementations
+    requirements:
+      - RUN-313
+      - RUN-314
+      - RUN-315
+    blocked_until:
+      - runtime-core
+  - id: semantics-expansion
+    patterns:
+      - ^SEM-
+    blocked_until:
+      - reference-implementations
+  - id: api400-deferred
+    requirements:
+      - API-405
+      - API-406
+      - API-407
+      - API-408
+      - API-409
+      - API-410
+      - API-411
+      - API-414
+      - API-415
+      - API-416
+      - API-417
+      - API-418
+      - API-419
+      - API-420
+      - API-421
+    blocked_until:
+      - semantics-expansion
+    manual_release: true
+
+ownership:
+  gov-concept-authority:
+    - specs/concept-authority
+    - contracts/concept-authority
+    - contracts/schemas/concept-authority
+    - contracts/schemas/README.md
+    - contracts/fixtures/concept-authority
+    - docs/explain/reference/shared-concept-model.md
+    - docs/decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline.md
+    - implementations/python/packages/aces_contracts
+    - implementations/python/packages/aces_backend_protocols
+    - implementations/python/packages/aces_processor
+    - implementations/python/tests/test_concept_authority.py
+    - implementations/python/tests/test_repo_policy_tools.py
+    - implementations/python/tests/test_requirement_governance.py
+    - CHANGELOG.md
+  api400-core:
+    - contracts/fixtures/backend-manifest
+    - contracts/fixtures/processor-manifest
+    - contracts/schemas/backend-manifest
+    - contracts/schemas/processor-manifest
+    - implementations/python/packages/aces_backend_protocols
+    - implementations/python/packages/aces_contracts
+    - implementations/python/packages/aces_processor
+    - implementations/python/tests/test_backend_manifest.py
+    - implementations/python/tests/test_processor_manifest.py
+    - implementations/python/tests/test_runtime_contracts.py
+    - CHANGELOG.md
+    - tools/generate_contract_schemas.py
+  runtime-core:
+    - implementations/python/packages/aces_processor
+    - implementations/python/packages/aces_contracts
+    - implementations/python/tests
+    - contracts/schemas/control-plane
+    - contracts/fixtures/control-plane
+    - CHANGELOG.md
+  reference-implementations:
+    - implementations/python/packages
+    - implementations/python/tests
+    - contracts/fixtures
+    - CHANGELOG.md
+  semantics-expansion:
+    - implementations/python/packages/aces_processor
+    - implementations/python/packages/aces_sdl
+    - implementations/python/tests
+    - specs/formal
+    - CHANGELOG.md
+
+traceability:
+  required_code_roots:
+    - implementations/python/packages
+    - implementations/python/src
+  required_test_roots:
+    - implementations/python/tests

--- a/tools/verify_all.py
+++ b/tools/verify_all.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run repo policy and requirement governance checks.")
+    parser.add_argument("--staged", action="store_true", help="Check staged changes.")
+    parser.add_argument("--base-rev", help="Compare against a specific git revision.")
+    parser.add_argument("--requirement-uid", help="Explicit requirement UID override.")
+    parser.add_argument("--skip-requirement", action="store_true", help="Skip Ground Control-backed requirement governance.")
+    return parser.parse_args()
+
+
+def run(args: list[str]) -> int:
+    proc = subprocess.run(args)
+    return proc.returncode
+
+
+def main() -> int:
+    args = parse_args()
+    shared_args: list[str] = []
+    if args.staged:
+        shared_args.append("--staged")
+    if args.base_rev:
+        shared_args.extend(["--base-rev", args.base_rev])
+
+    if run([sys.executable, "tools/check_repo_policy.py", *shared_args]) != 0:
+        return 1
+
+    if not args.skip_requirement:
+        requirement_args = [sys.executable, "tools/check_requirement_governance.py", *shared_args]
+        if args.requirement_uid:
+            requirement_args.extend(["--requirement-uid", args.requirement_uid])
+        if run(requirement_args) != 0:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds required `concept_bindings` section to v2 backend and processor manifests
- Each binding entry maps a dot-delimited field path (`scope`) to a canonical concept family (`family`) from the concept-authority catalog
- Implements the "artifact binding layer" from ADR-012, preventing artifact-local strings from becoming de facto semantics

## Changes

- **New types**: `ConceptFamilyId` (pattern-constrained string), `ConceptBindingEntryModel` (Pydantic), `ConceptBinding` (frozen dataclass)
- **V2 manifests**: `BackendManifestV2Model` and `ProcessorManifestV2Model` now require `concept_bindings` with `min_length=1` and scope uniqueness validation
- **Emission code**: Backend and processor manifest emission functions include concept bindings
- **Fixtures**: All v2 valid fixtures updated with bindings; 4 new invalid fixtures (missing, duplicate scope, invalid family, missing bindings)
- **JSON Schemas**: Regenerated for backend-manifest-v2 and processor-manifest-v2
- **Tests**: 12 new test functions across 4 test files; cross-catalog validation test
- **Docs**: Updated schemas README and shared-concept-model design doc

Closes #15

## Test plan

- [x] `pre-commit run --all-files` passes (all hooks green)
- [x] 594 tests pass, 1 skipped
- [x] Schema drift detection test passes
- [x] Cross-catalog validation confirms all fixture family IDs exist in authoritative catalog
- [x] Invalid fixtures properly rejected by Pydantic validation