### PR TITLE
Add participant episode lifecycle contract surface for RUN-311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `iter_participant_episode_snapshot_violations` no longer produces
-  cascading duplicate violations when a stream-level rule fires. The
-  validator now advances ``last_sequence`` and ``sequence_to_episode``
-  after every yielded violation except strict backward movement, so a
-  single ungated sequence transition reports one error instead of one
-  error per follow-up event at the new sequence number.
+  cascading duplicate violations when a stream-level rule fires. Both
+  the sequence-transition gate and the per-sequence ``episode_id``
+  stability check now advance stream state after every yielded
+  violation except strict backward movement, so an ungated sequence
+  transition reports one error per transition and an ``episode_id``
+  mismatch reports each distinct transition (e.g. ``A -> B`` then
+  ``B -> C``) instead of repeating the same comparison against the
+  first-observed id.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the new processor models, contract models, schema-version constant,
   ADR-013, the conformance wiring, and the lifecycle test.
 
+### Fixed
+
+- `iter_participant_episode_snapshot_violations` no longer produces
+  cascading duplicate violations when a stream-level rule fires. The
+  validator now advances ``last_sequence`` and ``sequence_to_episode``
+  after every yielded violation except strict backward movement, so a
+  single ungated sequence transition reports one error instead of one
+  error per follow-up event at the new sequence number.
+
 ### Changed
 
 - `tools/policy/requirement_order.yaml`: `RUN-311` added to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ground Control IMPLEMENTS and TESTS traceability links from `RUN-311`
   to the new processor models, contract models, schema-version constant,
   ADR-013, and the lifecycle test.
+- `RuntimeSnapshot` / `RuntimeSnapshotEnvelopeModel` now carry
+  `participant_episode_results` and `participant_episode_history`
+  alongside the existing `orchestration_*` and `evaluation_*` surfaces,
+  with matching serialization in
+  `aces_processor/control_plane_api.py::_snapshot_model`,
+  `aces_processor/control_plane_store.py::_snapshot_payload`, and
+  `aces_conformance/conformance.py`, so the participant-episode contract
+  surface is reachable through `/snapshot` responses and durable snapshot
+  state instead of being forced into `RuntimeSnapshot.metadata`.
+- `ParticipantEpisodeHistoryEvent` now enforces the sequence-number
+  semantics that link history events to the state chain: an
+  `episode_initialized` event must carry `sequence_number=0`, and
+  `episode_reset` / `episode_restarted` events must carry
+  `sequence_number>0`. These match the existing invariants on
+  `ParticipantEpisodeExecutionState` so a history stream that is valid
+  per the schema can always be reconstructed into a valid state chain.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-11
+
+### Added
+
+- Participant episode lifecycle contract surface for `RUN-311`
+  ("Participant Episode Lifecycle And Reset"):
+  `ParticipantEpisodeStatus`, `ParticipantEpisodeTerminalReason`,
+  `ParticipantEpisodeControlAction`, `ParticipantEpisodeHistoryEventType`,
+  `ParticipantEpisodeExecutionState`, and `ParticipantEpisodeHistoryEvent`
+  in `implementations/python/packages/aces_processor/models.py`; closed-world
+  `ParticipantEpisodeStateModel` and `ParticipantEpisodeHistoryEventModel`
+  with `participant-episode-state-envelope-v1` and
+  `participant-episode-history-event-stream-v1` `schema_bundle()` entries
+  in `implementations/python/packages/aces_contracts/contracts.py`; the
+  `participant-episode-state/v1` schema-version constant in
+  `implementations/python/packages/aces_contracts/versions.py`; generated
+  JSON Schemas under `contracts/schemas/control-plane/`; valid/invalid
+  fixture corpora under `contracts/fixtures/control-plane/`; ADR-013
+  ("Participant Episode Lifecycle Boundaries") in
+  `docs/decisions/adrs/`; and end-to-end coverage in
+  `implementations/python/tests/test_run_311_participant_episode_lifecycle.py`
+  satisfying every clause of the requirement (initialization, reset,
+  completion, timeout, truncation, interruption, and restart) while
+  preserving stable participant identity across resets and restarts.
+- Ground Control IMPLEMENTS and TESTS traceability links from `RUN-311`
+  to the new processor models, contract models, schema-version constant,
+  ADR-013, and the lifecycle test.
+
+### Changed
+
+- `tools/policy/requirement_order.yaml`: `RUN-311` added to the
+  `runtime-core` phase (it is the next runtime/control-plane sibling
+  after `RUN-300`), and `docs/decisions/adrs` added to the
+  `runtime-core` ownership block so ADR-013 clears
+  `check_requirement_governance.py` path-ownership review.
+
 ## [0.9.0] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data instead of reporting it as an unknown contract. The reference
   backend stub fixture at
   `contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json`
-  is updated to match the widened authority list.
+  is updated to match the widened authority list. The
+  `_live_target_cases()` live conformance probe also serializes
+  `participant_episode_results` / `participant_episode_history` so a
+  backend advertising the full-remote profile cannot pass conformance
+  with malformed RUN-311 data.
+- `aces_processor.manager._participant_episode_contract_diagnostics`
+  validates participant episode results and history on every backend
+  apply, so invalid RUN-311 data now fails the live apply path with a
+  `runtime.backend-contract-invalid` diagnostic instead of being
+  silently persisted into `RuntimeSnapshot`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,75 +9,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Participant episode lifecycle contract surface for `RUN-311`
-  ("Participant Episode Lifecycle And Reset"):
-  `ParticipantEpisodeStatus`, `ParticipantEpisodeTerminalReason`,
-  `ParticipantEpisodeControlAction`, `ParticipantEpisodeHistoryEventType`,
-  `ParticipantEpisodeExecutionState`, and `ParticipantEpisodeHistoryEvent`
-  in `implementations/python/packages/aces_processor/models.py`; closed-world
-  `ParticipantEpisodeStateModel` and `ParticipantEpisodeHistoryEventModel`
-  with `participant-episode-state-envelope-v1` and
-  `participant-episode-history-event-stream-v1` `schema_bundle()` entries
-  in `implementations/python/packages/aces_contracts/contracts.py`; the
-  `participant-episode-state/v1` schema-version constant in
-  `implementations/python/packages/aces_contracts/versions.py`; generated
-  JSON Schemas under `contracts/schemas/control-plane/`; valid/invalid
-  fixture corpora under `contracts/fixtures/control-plane/`; ADR-013
-  ("Participant Episode Lifecycle Boundaries") in
-  `docs/decisions/adrs/`; and end-to-end coverage in
+- `RUN-311` ("Participant Episode Lifecycle And Reset") participant
+  episode contract surface: `ParticipantEpisodeStatus`,
+  `ParticipantEpisodeTerminalReason`, `ParticipantEpisodeControlAction`,
+  `ParticipantEpisodeHistoryEventType`,
+  `ParticipantEpisodeExecutionState`, and
+  `ParticipantEpisodeHistoryEvent` in
+  `implementations/python/packages/aces_processor/models.py`, modelling
+  current lifecycle state, terminal reasons, and control actions as
+  three distinct categories per ADR-013.
+- Closed-world contract models `ParticipantEpisodeStateModel` and
+  `ParticipantEpisodeHistoryEventModel` plus matching
+  `participant-episode-state-envelope-v1` /
+  `participant-episode-history-event-stream-v1` entries in
+  `schema_bundle()`, with the new `participant-episode-state/v1`
+  schema-version constant in
+  `implementations/python/packages/aces_contracts/versions.py`.
+- Generated JSON Schemas in `contracts/schemas/control-plane/` and
+  minimal valid/invalid fixture pairs in
+  `contracts/fixtures/control-plane/`.
+- ADR-013 ("Participant Episode Lifecycle Boundaries") in
+  `docs/decisions/adrs/` defining the contract-surface boundary
+  discipline that drives this work.
+- End-to-end coverage in
   `implementations/python/tests/test_run_311_participant_episode_lifecycle.py`
   satisfying every clause of the requirement (initialization, reset,
-  completion, timeout, truncation, interruption, and restart) while
+  completion, timeout, truncation, interruption, restart) while
   preserving stable participant identity across resets and restarts.
-- Ground Control IMPLEMENTS and TESTS traceability links from `RUN-311`
-  to the new processor models, contract models, schema-version constant,
-  ADR-013, and the lifecycle test.
-- `RuntimeSnapshot` / `RuntimeSnapshotEnvelopeModel` now carry
+- `RuntimeSnapshot` and `RuntimeSnapshotEnvelopeModel` now carry
   `participant_episode_results` and `participant_episode_history`
-  alongside the existing `orchestration_*` and `evaluation_*` surfaces,
-  with matching serialization in
-  `aces_processor/control_plane_api.py::_snapshot_model`,
+  alongside the existing `orchestration_*` and `evaluation_*` surfaces.
+  Both are keyed by the stable `participant_address`. Matching
+  serialization in `aces_processor/control_plane_api.py::_snapshot_model`,
   `aces_processor/control_plane_store.py::_snapshot_payload`, and
-  `aces_conformance/conformance.py`, so the participant-episode contract
-  surface is reachable through `/snapshot` responses and durable snapshot
-  state instead of being forced into `RuntimeSnapshot.metadata`.
-- `ParticipantEpisodeHistoryEvent` now enforces the sequence-number
-  semantics that link history events to the state chain: an
-  `episode_initialized` event must carry `sequence_number=0`, and
-  `episode_reset` / `episode_restarted` events must carry
-  `sequence_number>0`. These match the existing invariants on
-  `ParticipantEpisodeExecutionState` so a history stream that is valid
-  per the schema can always be reconstructed into a valid state chain.
-- `participant-episode-state-envelope-v1` and
-  `participant-episode-history-event-stream-v1` are now declared in
-  `BACKEND_SUPPORTED_CONTRACT_IDS` / `PROCESSOR_SUPPORTED_CONTRACT_IDS`
-  (so backends and processors can honestly advertise the RUN-311
-  surface), registered in the conformance
+  `aces_conformance/conformance.py` routes the new data through
+  `/snapshot` responses and durable snapshot state instead of forcing
+  it into `RuntimeSnapshot.metadata`.
+- Stream-level invariants on `ParticipantEpisodeHistoryEvent`:
+  `episode_initialized` must carry `sequence_number=0`, and
+  `episode_reset` / `episode_restarted` must carry `sequence_number>0`,
+  matching the `ParticipantEpisodeExecutionState` invariants so a valid
+  history stream can always be reconstructed into a valid state chain.
+- Manifest-authority registration: the new
+  `participant-episode-state-envelope-v1` and
+  `participant-episode-history-event-stream-v1` contract ids are now
+  members of `BACKEND_SUPPORTED_CONTRACT_IDS` and
+  `PROCESSOR_SUPPORTED_CONTRACT_IDS`, added to the conformance
   `FULL_REMOTE_CONTROL_PLANE` profile requirements, and wired into
   `aces_conformance.conformance._validate_payload` and
-  `_semantic_diagnostics` so schema validation, round-trip construction,
-  and runtime-snapshot semantic checks all cover participant episode
-  data instead of reporting it as an unknown contract. The reference
-  backend stub fixture at
+  `_semantic_diagnostics`. The reference backend stub fixture at
   `contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json`
-  is updated to match the widened authority list. The
-  `_live_target_cases()` live conformance probe also serializes
+  is updated to match the widened authority list.
+- `_live_target_cases()` live conformance probe now serializes
   `participant_episode_results` / `participant_episode_history` so a
   backend advertising the full-remote profile cannot pass conformance
   with malformed RUN-311 data.
-- `aces_processor.manager._participant_episode_contract_diagnostics`
-  validates participant episode results and history on every backend
-  apply, so invalid RUN-311 data now fails the live apply path with a
-  `runtime.backend-contract-invalid` diagnostic instead of being
-  silently persisted into `RuntimeSnapshot`.
+- Shared snapshot invariant iterator
+  `aces_processor.models.iter_participant_episode_snapshot_violations`,
+  consumed by both the runtime-manager apply path
+  (`_participant_episode_contract_diagnostics`) and the conformance
+  semantic-check path (`_participant_episode_snapshot_diagnostics`) so
+  both callers use one source of truth for per-entry validation and
+  stream-level consistency (outer-key/inner-address match, monotonic
+  `sequence_number`, stable `episode_id` per sequence, and `RESET` /
+  `RESTARTED` gating on cross-sequence transitions).
+- Ground Control IMPLEMENTS and TESTS traceability links from `RUN-311`
+  to the new processor models, contract models, schema-version constant,
+  ADR-013, the conformance wiring, and the lifecycle test.
 
 ### Changed
 
 - `tools/policy/requirement_order.yaml`: `RUN-311` added to the
   `runtime-core` phase (it is the next runtime/control-plane sibling
-  after `RUN-300`), and `docs/decisions/adrs` added to the
-  `runtime-core` ownership block so ADR-013 clears
-  `check_requirement_governance.py` path-ownership review.
+  after `RUN-300`). Phase ownership widened to cover
+  `docs/decisions/adrs`, `contracts/schemas/snapshots`,
+  `contracts/schemas/backend-manifest`,
+  `contracts/schemas/processor-manifest`,
+  `contracts/fixtures/backend-manifest`,
+  `contracts/fixtures/processor-manifest`, and
+  `implementations/python/packages/aces_conformance` so the ADR and the
+  conformance/schema wiring clear `check_requirement_governance.py`.
+- `aces_conformance.conformance._validate_event_stream` extracted from
+  the repeated history-stream validation blocks so workflow, evaluation,
+  and participant-episode history streams share one helper.
 
 ## [0.9.0] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sequence_number>0`. These match the existing invariants on
   `ParticipantEpisodeExecutionState` so a history stream that is valid
   per the schema can always be reconstructed into a valid state chain.
+- `participant-episode-state-envelope-v1` and
+  `participant-episode-history-event-stream-v1` are now declared in
+  `BACKEND_SUPPORTED_CONTRACT_IDS` / `PROCESSOR_SUPPORTED_CONTRACT_IDS`
+  (so backends and processors can honestly advertise the RUN-311
+  surface), registered in the conformance
+  `FULL_REMOTE_CONTROL_PLANE` profile requirements, and wired into
+  `aces_conformance.conformance._validate_payload` and
+  `_semantic_diagnostics` so schema validation, round-trip construction,
+  and runtime-snapshot semantic checks all cover participant episode
+  data instead of reporting it as an unknown contract. The reference
+  backend stub fixture at
+  `contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json`
+  is updated to match the widened authority list.
 
 ### Changed
 

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
@@ -15,7 +15,9 @@
     "workflow-result-envelope-v1",
     "workflow-history-event-stream-v1",
     "evaluation-result-envelope-v1",
-    "evaluation-history-event-stream-v1"
+    "evaluation-history-event-stream-v1",
+    "participant-episode-state-envelope-v1",
+    "participant-episode-history-event-stream-v1"
   ],
   "compatibility": {
     "processors": ["aces-reference-processor"]

--- a/contracts/fixtures/control-plane/participant-episode-history-event-stream-v1/invalid/unknown-extra.json
+++ b/contracts/fixtures/control-plane/participant-episode-history-event-stream-v1/invalid/unknown-extra.json
@@ -1,0 +1,13 @@
+[
+  {
+    "event_type": "episode_initialized",
+    "timestamp": "2026-04-11T10:00:00Z",
+    "participant_address": "participant.alice",
+    "episode_id": "ep-0001",
+    "sequence_number": 0,
+    "terminal_reason": null,
+    "control_action": "initialize",
+    "details": {},
+    "unknown_field": "rejected by closed-world schema"
+  }
+]

--- a/contracts/fixtures/control-plane/participant-episode-history-event-stream-v1/valid/initialized-then-completed.json
+++ b/contracts/fixtures/control-plane/participant-episode-history-event-stream-v1/valid/initialized-then-completed.json
@@ -1,0 +1,22 @@
+[
+  {
+    "event_type": "episode_initialized",
+    "timestamp": "2026-04-11T10:00:00Z",
+    "participant_address": "participant.alice",
+    "episode_id": "ep-0001",
+    "sequence_number": 0,
+    "terminal_reason": null,
+    "control_action": "initialize",
+    "details": {}
+  },
+  {
+    "event_type": "episode_completed",
+    "timestamp": "2026-04-11T10:05:00Z",
+    "participant_address": "participant.alice",
+    "episode_id": "ep-0001",
+    "sequence_number": 0,
+    "terminal_reason": "completed",
+    "control_action": null,
+    "details": {}
+  }
+]

--- a/contracts/fixtures/control-plane/participant-episode-state-envelope-v1/invalid/unknown-extra.json
+++ b/contracts/fixtures/control-plane/participant-episode-state-envelope-v1/invalid/unknown-extra.json
@@ -1,0 +1,14 @@
+{
+  "state_schema_version": "participant-episode-state/v1",
+  "participant_address": "participant.alice",
+  "episode_id": "ep-0001",
+  "sequence_number": 0,
+  "status": "initializing",
+  "terminal_reason": null,
+  "initialized_at": "2026-04-11T10:00:00Z",
+  "updated_at": "2026-04-11T10:00:00Z",
+  "terminated_at": null,
+  "last_control_action": "initialize",
+  "previous_episode_id": null,
+  "unknown_field": "rejected by closed-world schema"
+}

--- a/contracts/fixtures/control-plane/participant-episode-state-envelope-v1/valid/initialized.json
+++ b/contracts/fixtures/control-plane/participant-episode-state-envelope-v1/valid/initialized.json
@@ -1,0 +1,13 @@
+{
+  "state_schema_version": "participant-episode-state/v1",
+  "participant_address": "participant.alice",
+  "episode_id": "ep-0001",
+  "sequence_number": 0,
+  "status": "initializing",
+  "terminal_reason": null,
+  "initialized_at": "2026-04-11T10:00:00Z",
+  "updated_at": "2026-04-11T10:00:00Z",
+  "terminated_at": null,
+  "last_control_action": "initialize",
+  "previous_episode_id": null
+}

--- a/contracts/schemas/backend-manifest/backend-manifest-v2.json
+++ b/contracts/schemas/backend-manifest/backend-manifest-v2.json
@@ -605,7 +605,9 @@
           "workflow-result-envelope-v1",
           "workflow-history-event-stream-v1",
           "evaluation-result-envelope-v1",
-          "evaluation-history-event-stream-v1"
+          "evaluation-history-event-stream-v1",
+          "participant-episode-state-envelope-v1",
+          "participant-episode-history-event-stream-v1"
         ],
         "minLength": 1,
         "type": "string"

--- a/contracts/schemas/control-plane/participant-episode-history-event-stream-v1.json
+++ b/contracts/schemas/control-plane/participant-episode-history-event-stream-v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "additionalProperties": false,
+    "properties": {
+      "control_action": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Control Action"
+      },
+      "details": {
+        "additionalProperties": true,
+        "title": "Details",
+        "type": "object"
+      },
+      "episode_id": {
+        "title": "Episode Id",
+        "type": "string"
+      },
+      "event_type": {
+        "title": "Event Type",
+        "type": "string"
+      },
+      "participant_address": {
+        "title": "Participant Address",
+        "type": "string"
+      },
+      "sequence_number": {
+        "title": "Sequence Number",
+        "type": "integer"
+      },
+      "terminal_reason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Terminal Reason"
+      },
+      "timestamp": {
+        "title": "Timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "event_type",
+      "timestamp",
+      "participant_address",
+      "episode_id",
+      "sequence_number"
+    ],
+    "title": "ParticipantEpisodeHistoryEventModel",
+    "type": "object"
+  },
+  "title": "ParticipantEpisodeHistoryEventStream",
+  "type": "array"
+}

--- a/contracts/schemas/control-plane/participant-episode-state-envelope-v1.json
+++ b/contracts/schemas/control-plane/participant-episode-state-envelope-v1.json
@@ -1,0 +1,86 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "episode_id": {
+      "title": "Episode Id",
+      "type": "string"
+    },
+    "initialized_at": {
+      "title": "Initialized At",
+      "type": "string"
+    },
+    "last_control_action": {
+      "title": "Last Control Action",
+      "type": "string"
+    },
+    "participant_address": {
+      "title": "Participant Address",
+      "type": "string"
+    },
+    "previous_episode_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Previous Episode Id"
+    },
+    "sequence_number": {
+      "title": "Sequence Number",
+      "type": "integer"
+    },
+    "state_schema_version": {
+      "const": "participant-episode-state/v1",
+      "default": "participant-episode-state/v1",
+      "title": "State Schema Version",
+      "type": "string"
+    },
+    "status": {
+      "title": "Status",
+      "type": "string"
+    },
+    "terminal_reason": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Terminal Reason"
+    },
+    "terminated_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Terminated At"
+    },
+    "updated_at": {
+      "title": "Updated At",
+      "type": "string"
+    }
+  },
+  "required": [
+    "participant_address",
+    "episode_id",
+    "sequence_number",
+    "status",
+    "initialized_at",
+    "updated_at",
+    "last_control_action"
+  ],
+  "title": "ParticipantEpisodeStateModel",
+  "type": "object"
+}

--- a/contracts/schemas/processor-manifest/processor-manifest-v2.json
+++ b/contracts/schemas/processor-manifest/processor-manifest-v2.json
@@ -157,7 +157,9 @@
           "workflow-result-envelope-v1",
           "workflow-history-event-stream-v1",
           "evaluation-result-envelope-v1",
-          "evaluation-history-event-stream-v1"
+          "evaluation-history-event-stream-v1",
+          "participant-episode-state-envelope-v1",
+          "participant-episode-history-event-stream-v1"
         ],
         "minLength": 1,
         "type": "string"

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -578,6 +578,7 @@
     }
   },
   "additionalProperties": false,
+  "description": "Published envelope for a live runtime snapshot.\n\nParticipant episode surfaces (``participant_episode_results`` and\n``participant_episode_history``) are both keyed by the stable\n``participant_address`` of the participant the state/history belongs\nto. The results map carries the currently-live episode state per\nparticipant; prior episodes survive only through the append-only\nhistory stream and the ``previous_episode_id`` chain on each state.\nSee ADR-013.",
   "properties": {
     "entries": {
       "additionalProperties": {

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -185,6 +185,155 @@
       "title": "EvaluationResultStateModel",
       "type": "object"
     },
+    "ParticipantEpisodeHistoryEventModel": {
+      "additionalProperties": false,
+      "properties": {
+        "control_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Control Action"
+        },
+        "details": {
+          "additionalProperties": true,
+          "title": "Details",
+          "type": "object"
+        },
+        "episode_id": {
+          "title": "Episode Id",
+          "type": "string"
+        },
+        "event_type": {
+          "title": "Event Type",
+          "type": "string"
+        },
+        "participant_address": {
+          "title": "Participant Address",
+          "type": "string"
+        },
+        "sequence_number": {
+          "title": "Sequence Number",
+          "type": "integer"
+        },
+        "terminal_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Terminal Reason"
+        },
+        "timestamp": {
+          "title": "Timestamp",
+          "type": "string"
+        }
+      },
+      "required": [
+        "event_type",
+        "timestamp",
+        "participant_address",
+        "episode_id",
+        "sequence_number"
+      ],
+      "title": "ParticipantEpisodeHistoryEventModel",
+      "type": "object"
+    },
+    "ParticipantEpisodeStateModel": {
+      "additionalProperties": false,
+      "properties": {
+        "episode_id": {
+          "title": "Episode Id",
+          "type": "string"
+        },
+        "initialized_at": {
+          "title": "Initialized At",
+          "type": "string"
+        },
+        "last_control_action": {
+          "title": "Last Control Action",
+          "type": "string"
+        },
+        "participant_address": {
+          "title": "Participant Address",
+          "type": "string"
+        },
+        "previous_episode_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Previous Episode Id"
+        },
+        "sequence_number": {
+          "title": "Sequence Number",
+          "type": "integer"
+        },
+        "state_schema_version": {
+          "const": "participant-episode-state/v1",
+          "default": "participant-episode-state/v1",
+          "title": "State Schema Version",
+          "type": "string"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "terminal_reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Terminal Reason"
+        },
+        "terminated_at": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Terminated At"
+        },
+        "updated_at": {
+          "title": "Updated At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "participant_address",
+        "episode_id",
+        "sequence_number",
+        "status",
+        "initialized_at",
+        "updated_at",
+        "last_control_action"
+      ],
+      "title": "ParticipantEpisodeStateModel",
+      "type": "object"
+    },
     "SnapshotEntryModel": {
       "additionalProperties": false,
       "properties": {
@@ -474,6 +623,23 @@
         "$ref": "#/$defs/WorkflowExecutionStateModel"
       },
       "title": "Orchestration Results",
+      "type": "object"
+    },
+    "participant_episode_history": {
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/$defs/ParticipantEpisodeHistoryEventModel"
+        },
+        "type": "array"
+      },
+      "title": "Participant Episode History",
+      "type": "object"
+    },
+    "participant_episode_results": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ParticipantEpisodeStateModel"
+      },
+      "title": "Participant Episode Results",
       "type": "object"
     },
     "schema_version": {

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -38,3 +38,4 @@ Each ADR includes:
 | [010](adr-010-repository-realignment-order-and-compatibility-policy.md) | Repository Realignment Order and Compatibility Policy | accepted | 2026-04-04 |
 | [011](adr-011-narrow-end-to-end-mvp-validation.md) | Narrow End-to-End MVP Validation | accepted | 2026-04-04 |
 | [012](adr-012-shared-concept-authority-and-aces-extension-discipline.md) | Shared Concept Authority and ACES Extension Discipline | accepted | 2026-04-05 |
+| [013](adr-013-participant-episode-lifecycle-boundaries.md) | Participant Episode Lifecycle Boundaries | accepted | 2026-04-11 |

--- a/docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md
+++ b/docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md
@@ -1,0 +1,145 @@
+# ADR-013: Participant Episode Lifecycle Boundaries
+
+## Status
+
+accepted
+
+## Date
+
+2026-04-11
+
+## Context
+
+`RUN-311` requires explicit participant episode initialization, reset,
+completion, timeout, truncation, interruption, and restart handling.
+
+The processor already has multiple lifecycle surfaces:
+
+- workflow execution state/history
+- evaluation execution state/history
+- control-plane operation receipt/status
+- live runtime snapshot persistence
+
+Those surfaces already solve real problems, but they do **not** currently model
+participant episodes. If `RUN-311` is implemented by overloading one of them,
+the architecture will blur distinct concerns:
+
+- workflow control semantics vs participant execution semantics
+- control-plane request lifecycle vs participant episode lifecycle
+- backend service/process restart vs explicit participant reset/restart
+- mutable live state vs durable episode history
+- backend apparatus vs participant-implementation apparatus
+
+The repository also already has explicit guidance from ADR-004, ADR-008, and
+ADR-009 that processor/runtime contracts must stay schema-first, portable, and
+separate from backend- or SDL-only meaning.
+
+## Decision
+
+### 1. Model participant episodes as their own processor/runtime contract surface
+
+Participant episode state is a first-class execution artifact. It must not be
+encoded as:
+
+- `WorkflowExecutionState`
+- `EvaluationExecutionState`
+- `OperationReceipt` or `OperationStatus`
+- ad hoc `RuntimeSnapshot.metadata` blobs
+
+Participant execution therefore extends the existing processor/runtime
+architecture with a dedicated participant-episode contract surface rather than
+reusing a neighboring lifecycle type with different semantics.
+
+### 2. Reuse the existing schema-first boundary pattern
+
+Participant episode support must follow the same boundary discipline already
+used for workflows and evaluations:
+
+- plain-data external envelopes
+- versioned schema-first contracts
+- typed in-process normalization helpers behind the boundary
+- validation against compiled/runtime contracts rather than backend-native
+  object identity
+
+Portable contract shape remains authored in the contract-model source and then
+published to `contracts/schemas/`; schema files are generated artifacts and
+must not become hand-maintained side channels.
+
+### 3. Keep lifecycle state, terminal reason, and control actions separate
+
+`RUN-311` mixes several different categories of lifecycle concern. They must
+not be flattened into one overloaded enum.
+
+- initialization, reset, and restart are control actions/transitions
+- completion, timeout, truncation, and interruption are terminal outcomes or
+  terminal reasons
+- current episode state is a separate concern from both of the above
+
+This mirrors the repository's current workflow discipline, where live status
+and terminal reason are already distinct fields.
+
+### 4. Preserve explicit episode identity across resets and restarts
+
+A participant implementation may stay bound to one stable participant address
+or apparatus identity across multiple episodes, but each episode instance must
+remain distinguishable in state and history.
+
+Reset or restart handling must therefore create explicit new episode state
+rather than mutating prior episode history in place and pretending that the run
+was uninterrupted.
+
+### 5. Reuse existing processor cross-cutting concerns
+
+Participant episode work must reuse the processor's existing cross-cutting
+concerns instead of introducing parallel stacks:
+
+- structured `Diagnostic` reporting for validation and execution failures
+- control-plane audit, idempotency, and request fingerprint handling
+- existing control-plane security roles and request-size/error-redaction
+  behavior
+- existing snapshot/store durability patterns for live state
+- existing manifest/apparatus discipline that keeps processor, backend, and
+  participant-implementation surfaces distinct
+
+This work must not add a separate exception hierarchy, logging/audit mechanism,
+or out-of-band persistence path for participant episodes.
+
+### 6. Scope boundaries
+
+This decision does **not**:
+
+- add new SDL authoring syntax for episode semantics
+- collapse participant episode control into workflow-step semantics
+- treat backend process restarts as equivalent to participant episode restarts
+- redesign the full archival run-provenance model
+
+`RUN-311` is processor/runtime control semantics. It should extend processor
+contracts and live execution surfaces first, while preserving the existing
+boundary between authored SDL meaning and apparatus/runtime realization.
+
+## Consequences
+
+### Positive
+
+- Participant episode lifecycle work now has a clear home in the architecture.
+- Existing workflow/evaluation/control-plane patterns can be reused directly
+  instead of re-invented.
+- Reset, truncation, interruption, and restart semantics can remain explicit
+  and reviewable.
+
+### Negative
+
+- The processor gains another explicit execution-contract family rather than
+  hiding episode behavior inside existing lifecycle types.
+- Implementors cannot shortcut the work by reusing workflow status enums or
+  control-plane operation states wholesale.
+
+### Risks
+
+- If episode identity is not preserved across resets/restarts, replay and
+  provenance claims will remain ambiguous.
+- If participant episode data is stored as metadata without contracts,
+  validation and portability will degrade quickly.
+- If participant lifecycle logic is split between backend internals and
+  processor contracts, the repo will end up with duplicate semantics and
+  inconsistent failure handling.

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -19,6 +19,8 @@ from aces_contracts.contracts import (
     OperationReceiptModel,
     OperationStatusModel,
     OrchestrationPlanModel,
+    ParticipantEpisodeHistoryEventModel,
+    ParticipantEpisodeStateModel,
     ProvisioningPlanModel,
     RuntimeSnapshotEnvelopeModel,
     WorkflowExecutionStateModel,
@@ -34,6 +36,8 @@ from aces_processor.manager import (
 from aces_processor.models import (
     Diagnostic,
     EvaluationExecutionState,
+    ParticipantEpisodeExecutionState,
+    ParticipantEpisodeHistoryEvent,
     RuntimeDomain,
     RuntimeSnapshot,
     RuntimeSnapshotEnvelope,
@@ -123,6 +127,8 @@ _PROFILE_REQUIREMENTS: dict[BackendCapabilityProfile, frozenset[str]] = {
             "workflow-history-event-stream-v1",
             "evaluation-result-envelope-v1",
             "evaluation-history-event-stream-v1",
+            "participant-episode-state-envelope-v1",
+            "participant-episode-history-event-stream-v1",
         }
     ),
 }
@@ -138,6 +144,7 @@ _MODEL_VALIDATORS = {
     "runtime-snapshot-v1": RuntimeSnapshotEnvelopeModel.model_validate,
     "workflow-result-envelope-v1": WorkflowExecutionStateModel.model_validate,
     "evaluation-result-envelope-v1": EvaluationResultStateModel.model_validate,
+    "participant-episode-state-envelope-v1": ParticipantEpisodeStateModel.model_validate,
 }
 
 
@@ -235,6 +242,26 @@ def _validate_payload(contract_name: str, payload: Any) -> list[Diagnostic]:
                         f"evaluation history event is invalid: {exc}",
                     )
                 )
+    elif contract_name == "participant-episode-history-event-stream-v1":
+        if not isinstance(payload, list):
+            return [
+                _diagnostic(
+                    "conformance.schema-invalid",
+                    contract_name,
+                    "participant episode history payload must be a list",
+                )
+            ]
+        for index, event in enumerate(payload):
+            try:
+                ParticipantEpisodeHistoryEventModel.model_validate(event)
+            except Exception as exc:
+                diagnostics.append(
+                    _diagnostic(
+                        "conformance.schema-invalid",
+                        f"{contract_name}[{index}]",
+                        f"participant episode history event is invalid: {exc}",
+                    )
+                )
     else:
         diagnostics.append(
             _diagnostic(
@@ -288,6 +315,61 @@ def _snapshot_from_envelope(payload: dict[str, Any]) -> RuntimeSnapshot:
     )
 
 
+def _participant_episode_snapshot_diagnostics(
+    snapshot: RuntimeSnapshot,
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    if not isinstance(snapshot.participant_episode_results, dict):
+        return [
+            _diagnostic(
+                "conformance.semantic-invalid",
+                "runtime-snapshot.participant-episode-results",
+                "RuntimeSnapshot.participant_episode_results must be a dict.",
+            )
+        ]
+    if not isinstance(snapshot.participant_episode_history, dict):
+        return [
+            _diagnostic(
+                "conformance.semantic-invalid",
+                "runtime-snapshot.participant-episode-history",
+                "RuntimeSnapshot.participant_episode_history must be a dict.",
+            )
+        ]
+    for participant_address, result in snapshot.participant_episode_results.items():
+        try:
+            ParticipantEpisodeExecutionState.from_payload(result)
+        except (TypeError, ValueError) as exc:
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.semantic-invalid",
+                    f"participant-episode-state:{participant_address}",
+                    f"participant episode result semantics are invalid: {exc}",
+                )
+            )
+    for participant_address, history in snapshot.participant_episode_history.items():
+        if not isinstance(history, list):
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.semantic-invalid",
+                    f"participant-episode-history:{participant_address}",
+                    "participant episode history must be a list of events.",
+                )
+            )
+            continue
+        for index, event in enumerate(history):
+            try:
+                ParticipantEpisodeHistoryEvent.from_payload(event)
+            except (TypeError, ValueError) as exc:
+                diagnostics.append(
+                    _diagnostic(
+                        "conformance.semantic-invalid",
+                        f"participant-episode-history:{participant_address}[{index}]",
+                        f"participant episode history event semantics are invalid: {exc}",
+                    )
+                )
+    return diagnostics
+
+
 def _semantic_diagnostics(contract_name: str, payload: Any) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
     if contract_name == "workflow-result-envelope-v1":
@@ -314,12 +396,46 @@ def _semantic_diagnostics(contract_name: str, payload: Any) -> list[Diagnostic]:
                 )
             )
         return diagnostics
+    if contract_name == "participant-episode-state-envelope-v1":
+        try:
+            ParticipantEpisodeExecutionState.from_payload(payload)
+        except (TypeError, ValueError) as exc:
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.semantic-invalid",
+                    contract_name,
+                    f"participant episode state semantics are invalid: {exc}",
+                )
+            )
+        return diagnostics
+    if contract_name == "participant-episode-history-event-stream-v1":
+        if not isinstance(payload, list):
+            return [
+                _diagnostic(
+                    "conformance.semantic-invalid",
+                    contract_name,
+                    "participant episode history payload must be a list",
+                )
+            ]
+        for index, event in enumerate(payload):
+            try:
+                ParticipantEpisodeHistoryEvent.from_payload(event)
+            except (TypeError, ValueError) as exc:
+                diagnostics.append(
+                    _diagnostic(
+                        "conformance.semantic-invalid",
+                        f"{contract_name}[{index}]",
+                        f"participant episode history event semantics are invalid: {exc}",
+                    )
+                )
+        return diagnostics
     if contract_name != "runtime-snapshot-v1":
         return []
     snapshot = _snapshot_from_envelope(payload)
     return [
         *_workflow_result_contract_diagnostics(snapshot),
         *_evaluation_result_contract_diagnostics(snapshot),
+        *_participant_episode_snapshot_diagnostics(snapshot),
     ]
 
 

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -276,6 +276,14 @@ def _snapshot_from_envelope(payload: dict[str, Any]) -> RuntimeSnapshot:
             address: [event.model_dump(mode="json") for event in history]
             for address, history in validated.evaluation_history.items()
         },
+        participant_episode_results={
+            participant_address: result.model_dump(mode="json")
+            for participant_address, result in validated.participant_episode_results.items()
+        },
+        participant_episode_history={
+            participant_address: [event.model_dump(mode="json") for event in history]
+            for participant_address, history in validated.participant_episode_history.items()
+        },
         metadata=dict(validated.metadata),
     )
 

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -673,6 +673,11 @@ def _live_target_cases(
         "orchestration_history": dict(control_plane.snapshot.orchestration_history),
         "evaluation_results": dict(control_plane.snapshot.evaluation_results),
         "evaluation_history": dict(control_plane.snapshot.evaluation_history),
+        "participant_episode_results": dict(control_plane.snapshot.participant_episode_results),
+        "participant_episode_history": {
+            participant_address: list(events)
+            for participant_address, events in control_plane.snapshot.participant_episode_history.items()
+        },
         "metadata": dict(control_plane.snapshot.metadata),
     }
     snapshot_diags = [

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -44,6 +44,7 @@ from aces_processor.models import (
     Severity,
     SnapshotEntry,
     WorkflowExecutionState,
+    iter_participant_episode_snapshot_violations,
 )
 from aces_processor.planner import plan
 from aces_processor.registry import RuntimeTarget
@@ -148,6 +149,16 @@ _MODEL_VALIDATORS = {
 }
 
 
+_EVENT_STREAM_VALIDATORS: dict[str, tuple[type, str]] = {
+    "workflow-history-event-stream-v1": (WorkflowHistoryEventModel, "workflow"),
+    "evaluation-history-event-stream-v1": (EvaluationHistoryEventModel, "evaluation"),
+    "participant-episode-history-event-stream-v1": (
+        ParticipantEpisodeHistoryEventModel,
+        "participant episode",
+    ),
+}
+
+
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
@@ -187,6 +198,43 @@ def _load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _validate_event_stream(
+    *,
+    contract_name: str,
+    payload: Any,
+    model_cls: type,
+    event_label: str,
+) -> list[Diagnostic]:
+    """Validate a published history event stream against one Pydantic model.
+
+    Shared by the workflow, evaluation, and participant-episode history
+    event streams so adding a new stream type only requires extending
+    ``_EVENT_STREAM_VALIDATORS``.
+    """
+
+    if not isinstance(payload, list):
+        return [
+            _diagnostic(
+                "conformance.schema-invalid",
+                contract_name,
+                f"{event_label} history payload must be a list",
+            )
+        ]
+    diagnostics: list[Diagnostic] = []
+    for index, event in enumerate(payload):
+        try:
+            model_cls.model_validate(event)
+        except Exception as exc:
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.schema-invalid",
+                    f"{contract_name}[{index}]",
+                    f"{event_label} history event is invalid: {exc}",
+                )
+            )
+    return diagnostics
+
+
 def _validate_payload(contract_name: str, payload: Any) -> list[Diagnostic]:
     diagnostics: list[Diagnostic] = []
     validator = _MODEL_VALIDATORS.get(contract_name)
@@ -202,66 +250,15 @@ def _validate_payload(contract_name: str, payload: Any) -> list[Diagnostic]:
                 )
             )
             return diagnostics
-    elif contract_name == "workflow-history-event-stream-v1":
-        if not isinstance(payload, list):
-            return [
-                _diagnostic(
-                    "conformance.schema-invalid",
-                    contract_name,
-                    "workflow history payload must be a list",
-                )
-            ]
-        for index, event in enumerate(payload):
-            try:
-                WorkflowHistoryEventModel.model_validate(event)
-            except Exception as exc:
-                diagnostics.append(
-                    _diagnostic(
-                        "conformance.schema-invalid",
-                        f"{contract_name}[{index}]",
-                        f"workflow history event is invalid: {exc}",
-                    )
-                )
-    elif contract_name == "evaluation-history-event-stream-v1":
-        if not isinstance(payload, list):
-            return [
-                _diagnostic(
-                    "conformance.schema-invalid",
-                    contract_name,
-                    "evaluation history payload must be a list",
-                )
-            ]
-        for index, event in enumerate(payload):
-            try:
-                EvaluationHistoryEventModel.model_validate(event)
-            except Exception as exc:
-                diagnostics.append(
-                    _diagnostic(
-                        "conformance.schema-invalid",
-                        f"{contract_name}[{index}]",
-                        f"evaluation history event is invalid: {exc}",
-                    )
-                )
-    elif contract_name == "participant-episode-history-event-stream-v1":
-        if not isinstance(payload, list):
-            return [
-                _diagnostic(
-                    "conformance.schema-invalid",
-                    contract_name,
-                    "participant episode history payload must be a list",
-                )
-            ]
-        for index, event in enumerate(payload):
-            try:
-                ParticipantEpisodeHistoryEventModel.model_validate(event)
-            except Exception as exc:
-                diagnostics.append(
-                    _diagnostic(
-                        "conformance.schema-invalid",
-                        f"{contract_name}[{index}]",
-                        f"participant episode history event is invalid: {exc}",
-                    )
-                )
+    elif contract_name in _EVENT_STREAM_VALIDATORS:
+        diagnostics.extend(
+            _validate_event_stream(
+                contract_name=contract_name,
+                payload=payload,
+                model_cls=_EVENT_STREAM_VALIDATORS[contract_name][0],
+                event_label=_EVENT_STREAM_VALIDATORS[contract_name][1],
+            )
+        )
     else:
         diagnostics.append(
             _diagnostic(
@@ -318,56 +315,21 @@ def _snapshot_from_envelope(payload: dict[str, Any]) -> RuntimeSnapshot:
 def _participant_episode_snapshot_diagnostics(
     snapshot: RuntimeSnapshot,
 ) -> list[Diagnostic]:
-    diagnostics: list[Diagnostic] = []
-    if not isinstance(snapshot.participant_episode_results, dict):
-        return [
-            _diagnostic(
-                "conformance.semantic-invalid",
-                "runtime-snapshot.participant-episode-results",
-                "RuntimeSnapshot.participant_episode_results must be a dict.",
-            )
-        ]
-    if not isinstance(snapshot.participant_episode_history, dict):
-        return [
-            _diagnostic(
-                "conformance.semantic-invalid",
-                "runtime-snapshot.participant-episode-history",
-                "RuntimeSnapshot.participant_episode_history must be a dict.",
-            )
-        ]
-    for participant_address, result in snapshot.participant_episode_results.items():
-        try:
-            ParticipantEpisodeExecutionState.from_payload(result)
-        except (TypeError, ValueError) as exc:
-            diagnostics.append(
-                _diagnostic(
-                    "conformance.semantic-invalid",
-                    f"participant-episode-state:{participant_address}",
-                    f"participant episode result semantics are invalid: {exc}",
-                )
-            )
-    for participant_address, history in snapshot.participant_episode_history.items():
-        if not isinstance(history, list):
-            diagnostics.append(
-                _diagnostic(
-                    "conformance.semantic-invalid",
-                    f"participant-episode-history:{participant_address}",
-                    "participant episode history must be a list of events.",
-                )
-            )
-            continue
-        for index, event in enumerate(history):
-            try:
-                ParticipantEpisodeHistoryEvent.from_payload(event)
-            except (TypeError, ValueError) as exc:
-                diagnostics.append(
-                    _diagnostic(
-                        "conformance.semantic-invalid",
-                        f"participant-episode-history:{participant_address}[{index}]",
-                        f"participant episode history event semantics are invalid: {exc}",
-                    )
-                )
-    return diagnostics
+    """Surface participant-episode snapshot invariants as conformance diagnostics.
+
+    Delegates to ``iter_participant_episode_snapshot_violations`` so the
+    conformance path and the manager apply path share one source of truth
+    for every RUN-311 invariant, and wraps each violation in a
+    ``conformance.semantic-invalid`` diagnostic.
+    """
+
+    return [
+        _diagnostic("conformance.semantic-invalid", address, message)
+        for address, message in iter_participant_episode_snapshot_violations(
+            snapshot.participant_episode_results,
+            snapshot.participant_episode_history,
+        )
+    ]
 
 
 def _semantic_diagnostics(contract_name: str, payload: Any) -> list[Diagnostic]:

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -233,6 +233,8 @@ class RuntimeSnapshotEnvelopeModel(ContractModel):
     orchestration_history: dict[str, list[WorkflowHistoryEventModel]] = Field(default_factory=dict)
     evaluation_results: dict[str, EvaluationResultStateModel] = Field(default_factory=dict)
     evaluation_history: dict[str, list[EvaluationHistoryEventModel]] = Field(default_factory=dict)
+    participant_episode_results: dict[str, ParticipantEpisodeStateModel] = Field(default_factory=dict)
+    participant_episode_history: dict[str, list[ParticipantEpisodeHistoryEventModel]] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -227,6 +227,17 @@ class SnapshotEntryModel(ContractModel):
 
 
 class RuntimeSnapshotEnvelopeModel(ContractModel):
+    """Published envelope for a live runtime snapshot.
+
+    Participant episode surfaces (``participant_episode_results`` and
+    ``participant_episode_history``) are both keyed by the stable
+    ``participant_address`` of the participant the state/history belongs
+    to. The results map carries the currently-live episode state per
+    participant; prior episodes survive only through the append-only
+    history stream and the ``previous_episode_id`` chain on each state.
+    See ADR-013.
+    """
+
     schema_version: Literal[RUNTIME_SNAPSHOT_SCHEMA_VERSION] = RUNTIME_SNAPSHOT_SCHEMA_VERSION
     entries: dict[str, SnapshotEntryModel] = Field(default_factory=dict)
     orchestration_results: dict[str, WorkflowExecutionStateModel] = Field(default_factory=dict)

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -27,6 +27,7 @@ from .versions import (
     CONTROLLED_VOCABULARIES_SCHEMA_VERSION,
     EVALUATION_STATE_SCHEMA_VERSION,
     OPERATION_SCHEMA_VERSION,
+    PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION,
     PROCESSOR_MANIFEST_V2_SCHEMA_VERSION,
     REFERENCE_MODELS_SCHEMA_VERSION,
     RUNTIME_SNAPSHOT_SCHEMA_VERSION,
@@ -161,6 +162,31 @@ class EvaluationHistoryEventModel(ContractModel):
     max_score: int | None = None
     detail: str | None = None
     evidence_refs: list[str] = Field(default_factory=list)
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ParticipantEpisodeStateModel(ContractModel):
+    state_schema_version: Literal[PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION] = PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION
+    participant_address: str
+    episode_id: str
+    sequence_number: int
+    status: str
+    terminal_reason: str | None = None
+    initialized_at: str
+    updated_at: str
+    terminated_at: str | None = None
+    last_control_action: str
+    previous_episode_id: str | None = None
+
+
+class ParticipantEpisodeHistoryEventModel(ContractModel):
+    event_type: str
+    timestamp: str
+    participant_address: str
+    episode_id: str
+    sequence_number: int
+    terminal_reason: str | None = None
+    control_action: str | None = None
     details: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -1122,6 +1148,13 @@ def schema_bundle() -> dict[str, dict[str, Any]]:
             "type": "array",
             "items": EvaluationHistoryEventModel.model_json_schema(),
         },
+        "participant-episode-state-envelope-v1": ParticipantEpisodeStateModel.model_json_schema(),
+        "participant-episode-history-event-stream-v1": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ParticipantEpisodeHistoryEventStream",
+            "type": "array",
+            "items": ParticipantEpisodeHistoryEventModel.model_json_schema(),
+        },
         "operation-receipt-v1": OperationReceiptModel.model_json_schema(),
         "operation-status-v1": OperationStatusModel.model_json_schema(),
     }
@@ -1156,6 +1189,9 @@ __all__ = [
     "OperationStatusModel",
     "OrchestrationPlanModel",
     "OrchestratorCapabilitiesModel",
+    "PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION",
+    "ParticipantEpisodeHistoryEventModel",
+    "ParticipantEpisodeStateModel",
     "PlanOperationModel",
     "ProcessorFeature",
     "PROCESSOR_MANIFEST_V2_SCHEMA_VERSION",

--- a/implementations/python/packages/aces_contracts/manifest_authority.py
+++ b/implementations/python/packages/aces_contracts/manifest_authority.py
@@ -23,6 +23,8 @@ PROCESSOR_SUPPORTED_CONTRACT_IDS = (
     "workflow-history-event-stream-v1",
     "evaluation-result-envelope-v1",
     "evaluation-history-event-stream-v1",
+    "participant-episode-state-envelope-v1",
+    "participant-episode-history-event-stream-v1",
 )
 
 # These are the published backend-facing and live-control-plane contracts a
@@ -41,6 +43,8 @@ BACKEND_SUPPORTED_CONTRACT_IDS = (
     "workflow-history-event-stream-v1",
     "evaluation-result-envelope-v1",
     "evaluation-history-event-stream-v1",
+    "participant-episode-state-envelope-v1",
+    "participant-episode-history-event-stream-v1",
 )
 
 

--- a/implementations/python/packages/aces_contracts/versions.py
+++ b/implementations/python/packages/aces_contracts/versions.py
@@ -12,3 +12,4 @@ WORKFLOW_CANCELLATION_REQUEST_SCHEMA_VERSION = "workflow-cancellation-request/v1
 RUNTIME_SNAPSHOT_SCHEMA_VERSION = "runtime-snapshot/v1"
 OPERATION_SCHEMA_VERSION = "runtime-operation/v1"
 EVALUATION_STATE_SCHEMA_VERSION = "evaluation-result-state/v1"
+PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION = "participant-episode-state/v1"

--- a/implementations/python/packages/aces_processor/control_plane_api.py
+++ b/implementations/python/packages/aces_processor/control_plane_api.py
@@ -138,6 +138,8 @@ def _snapshot_model(envelope: RuntimeSnapshotEnvelope) -> RuntimeSnapshotEnvelop
             "orchestration_history": dict(snapshot.orchestration_history),
             "evaluation_results": dict(snapshot.evaluation_results),
             "evaluation_history": dict(snapshot.evaluation_history),
+            "participant_episode_results": dict(snapshot.participant_episode_results),
+            "participant_episode_history": dict(snapshot.participant_episode_history),
             "metadata": dict(snapshot.metadata),
         }
     )

--- a/implementations/python/packages/aces_processor/control_plane_store.py
+++ b/implementations/python/packages/aces_processor/control_plane_store.py
@@ -84,6 +84,11 @@ def _snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
         "orchestration_history": {address: list(events) for address, events in snapshot.orchestration_history.items()},
         "evaluation_results": dict(snapshot.evaluation_results),
         "evaluation_history": {address: list(events) for address, events in snapshot.evaluation_history.items()},
+        "participant_episode_results": dict(snapshot.participant_episode_results),
+        "participant_episode_history": {
+            participant_address: list(events)
+            for participant_address, events in snapshot.participant_episode_history.items()
+        },
         "metadata": dict(snapshot.metadata),
     }
 
@@ -111,6 +116,11 @@ def _snapshot_from_payload(payload: dict[str, Any]) -> RuntimeSnapshot:
         },
         evaluation_results=dict(payload.get("evaluation_results", {})),
         evaluation_history={address: list(events) for address, events in payload.get("evaluation_history", {}).items()},
+        participant_episode_results=dict(payload.get("participant_episode_results", {})),
+        participant_episode_history={
+            participant_address: list(events)
+            for participant_address, events in payload.get("participant_episode_history", {}).items()
+        },
         metadata=dict(payload.get("metadata", {})),
     )
 

--- a/implementations/python/packages/aces_processor/manager.py
+++ b/implementations/python/packages/aces_processor/manager.py
@@ -18,8 +18,6 @@ from .models import (
     EvaluationResultContract,
     EvaluationResultStatus,
     ExecutionPlan,
-    ParticipantEpisodeExecutionState,
-    ParticipantEpisodeHistoryEvent,
     ProvisioningPlan,
     ProvisionOp,
     RuntimeDomain,
@@ -32,6 +30,7 @@ from .models import (
     WorkflowHistoryEventType,
     WorkflowResultContract,
     WorkflowStatus,
+    iter_participant_episode_snapshot_violations,
     validate_evaluation_result,
 )
 from .planner import plan
@@ -1063,103 +1062,19 @@ def _participant_episode_contract_diagnostics(
 ) -> list[Diagnostic]:
     """Validate participant-episode snapshot data against RUN-311 invariants.
 
-    Backends may populate ``participant_episode_results`` and
-    ``participant_episode_history`` on the snapshot. Both surfaces are
-    schema-first contracts with runtime invariants enforced by their
-    respective dataclass ``__post_init__`` methods; this helper reuses
-    those constructors so that invalid RUN-311 data is rejected on the
-    apply path instead of being silently persisted.
+    Delegates to ``iter_participant_episode_snapshot_violations`` so the
+    manager apply path and the conformance semantic-check path share one
+    source of truth for every invariant, and wraps each violation in a
+    ``runtime.backend-contract-invalid`` diagnostic.
     """
 
-    diagnostics: list[Diagnostic] = []
-    if not isinstance(snapshot.participant_episode_results, dict):
-        return [
-            _failure_diagnostic(
-                "runtime.backend-contract-invalid",
-                "runtime.apply.participant-episode-results",
-                "RuntimeSnapshot.participant_episode_results must be a dict.",
-            )
-        ]
-    if not isinstance(snapshot.participant_episode_history, dict):
-        return [
-            _failure_diagnostic(
-                "runtime.backend-contract-invalid",
-                "runtime.apply.participant-episode-history",
-                "RuntimeSnapshot.participant_episode_history must be a dict.",
-            )
-        ]
-
-    for participant_address, result in snapshot.participant_episode_results.items():
-        if not isinstance(participant_address, str):
-            diagnostics.append(
-                _failure_diagnostic(
-                    "runtime.backend-contract-invalid",
-                    "runtime.apply.participant-episode-results",
-                    "Participant episode result keys must be strings.",
-                )
-            )
-            continue
-        if not isinstance(result, dict):
-            diagnostics.append(
-                _failure_diagnostic(
-                    "runtime.backend-contract-invalid",
-                    participant_address,
-                    "Participant episode results must use plain-data mapping values.",
-                )
-            )
-            continue
-        try:
-            ParticipantEpisodeExecutionState.from_payload(result)
-        except (TypeError, ValueError) as exc:
-            diagnostics.append(
-                _failure_diagnostic(
-                    "runtime.backend-contract-invalid",
-                    participant_address,
-                    f"Participant episode result is invalid: {exc}",
-                )
-            )
-
-    for participant_address, history in snapshot.participant_episode_history.items():
-        if not isinstance(participant_address, str):
-            diagnostics.append(
-                _failure_diagnostic(
-                    "runtime.backend-contract-invalid",
-                    "runtime.apply.participant-episode-history",
-                    "Participant episode history keys must be strings.",
-                )
-            )
-            continue
-        if not isinstance(history, list):
-            diagnostics.append(
-                _failure_diagnostic(
-                    "runtime.backend-contract-invalid",
-                    participant_address,
-                    "Participant episode history must be a list of events.",
-                )
-            )
-            continue
-        for index, event in enumerate(history):
-            if not isinstance(event, dict):
-                diagnostics.append(
-                    _failure_diagnostic(
-                        "runtime.backend-contract-invalid",
-                        f"{participant_address}[{index}]",
-                        "Participant episode history events must use plain-data mapping values.",
-                    )
-                )
-                continue
-            try:
-                ParticipantEpisodeHistoryEvent.from_payload(event)
-            except (TypeError, ValueError) as exc:
-                diagnostics.append(
-                    _failure_diagnostic(
-                        "runtime.backend-contract-invalid",
-                        f"{participant_address}[{index}]",
-                        f"Participant episode history event is invalid: {exc}",
-                    )
-                )
-
-    return diagnostics
+    return [
+        _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+        for address, message in iter_participant_episode_snapshot_violations(
+            snapshot.participant_episode_results,
+            snapshot.participant_episode_history,
+        )
+    ]
 
 
 def _provenance_diagnostics(

--- a/implementations/python/packages/aces_processor/manager.py
+++ b/implementations/python/packages/aces_processor/manager.py
@@ -18,6 +18,8 @@ from .models import (
     EvaluationResultContract,
     EvaluationResultStatus,
     ExecutionPlan,
+    ParticipantEpisodeExecutionState,
+    ParticipantEpisodeHistoryEvent,
     ProvisioningPlan,
     ProvisionOp,
     RuntimeDomain,
@@ -242,6 +244,13 @@ def _call_backend_apply(
             success=False,
             snapshot=snapshot,
             diagnostics=evaluation_result_diagnostics,
+        )
+    participant_episode_result_diagnostics = _participant_episode_contract_diagnostics(result.snapshot)
+    if participant_episode_result_diagnostics:
+        return ApplyResult(
+            success=False,
+            snapshot=snapshot,
+            diagnostics=participant_episode_result_diagnostics,
         )
 
     return result
@@ -1043,6 +1052,110 @@ def _evaluation_result_contract_diagnostics(
                         "runtime.backend-contract-invalid",
                         evaluation_address,
                         "Running evaluation results may not end history with a terminal event.",
+                    )
+                )
+
+    return diagnostics
+
+
+def _participant_episode_contract_diagnostics(
+    snapshot: RuntimeSnapshot,
+) -> list[Diagnostic]:
+    """Validate participant-episode snapshot data against RUN-311 invariants.
+
+    Backends may populate ``participant_episode_results`` and
+    ``participant_episode_history`` on the snapshot. Both surfaces are
+    schema-first contracts with runtime invariants enforced by their
+    respective dataclass ``__post_init__`` methods; this helper reuses
+    those constructors so that invalid RUN-311 data is rejected on the
+    apply path instead of being silently persisted.
+    """
+
+    diagnostics: list[Diagnostic] = []
+    if not isinstance(snapshot.participant_episode_results, dict):
+        return [
+            _failure_diagnostic(
+                "runtime.backend-contract-invalid",
+                "runtime.apply.participant-episode-results",
+                "RuntimeSnapshot.participant_episode_results must be a dict.",
+            )
+        ]
+    if not isinstance(snapshot.participant_episode_history, dict):
+        return [
+            _failure_diagnostic(
+                "runtime.backend-contract-invalid",
+                "runtime.apply.participant-episode-history",
+                "RuntimeSnapshot.participant_episode_history must be a dict.",
+            )
+        ]
+
+    for participant_address, result in snapshot.participant_episode_results.items():
+        if not isinstance(participant_address, str):
+            diagnostics.append(
+                _failure_diagnostic(
+                    "runtime.backend-contract-invalid",
+                    "runtime.apply.participant-episode-results",
+                    "Participant episode result keys must be strings.",
+                )
+            )
+            continue
+        if not isinstance(result, dict):
+            diagnostics.append(
+                _failure_diagnostic(
+                    "runtime.backend-contract-invalid",
+                    participant_address,
+                    "Participant episode results must use plain-data mapping values.",
+                )
+            )
+            continue
+        try:
+            ParticipantEpisodeExecutionState.from_payload(result)
+        except (TypeError, ValueError) as exc:
+            diagnostics.append(
+                _failure_diagnostic(
+                    "runtime.backend-contract-invalid",
+                    participant_address,
+                    f"Participant episode result is invalid: {exc}",
+                )
+            )
+
+    for participant_address, history in snapshot.participant_episode_history.items():
+        if not isinstance(participant_address, str):
+            diagnostics.append(
+                _failure_diagnostic(
+                    "runtime.backend-contract-invalid",
+                    "runtime.apply.participant-episode-history",
+                    "Participant episode history keys must be strings.",
+                )
+            )
+            continue
+        if not isinstance(history, list):
+            diagnostics.append(
+                _failure_diagnostic(
+                    "runtime.backend-contract-invalid",
+                    participant_address,
+                    "Participant episode history must be a list of events.",
+                )
+            )
+            continue
+        for index, event in enumerate(history):
+            if not isinstance(event, dict):
+                diagnostics.append(
+                    _failure_diagnostic(
+                        "runtime.backend-contract-invalid",
+                        f"{participant_address}[{index}]",
+                        "Participant episode history events must use plain-data mapping values.",
+                    )
+                )
+                continue
+            try:
+                ParticipantEpisodeHistoryEvent.from_payload(event)
+            except (TypeError, ValueError) as exc:
+                diagnostics.append(
+                    _failure_diagnostic(
+                        "runtime.backend-contract-invalid",
+                        f"{participant_address}[{index}]",
+                        f"Participant episode history event is invalid: {exc}",
                     )
                 )
 

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -1632,6 +1632,12 @@ def iter_participant_episode_snapshot_violations(
         sequence_to_episode: dict[int, str] = {}
         for index, event in enumerate(normalized_events):
             locator = f"{outer_key}[{index}]"
+            # A strict backward movement cannot be reconciled into the same
+            # stream, so the event is dropped and stream state is not
+            # advanced for it. Every other violation path still advances
+            # stream state so that downstream events are not re-checked
+            # against stale ``last_sequence`` / ``sequence_to_episode``
+            # values.
             if event.sequence_number < last_sequence:
                 yield (
                     locator,
@@ -1641,20 +1647,23 @@ def iter_participant_episode_snapshot_violations(
                     ),
                 )
                 continue
-            if event.sequence_number > last_sequence and last_sequence != -1:
-                if event.event_type not in {
+            if (
+                event.sequence_number > last_sequence
+                and last_sequence != -1
+                and event.event_type
+                not in {
                     ParticipantEpisodeHistoryEventType.EPISODE_RESET,
                     ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
-                }:
-                    yield (
-                        locator,
-                        (
-                            f"participant episode transition to sequence_number "
-                            f"{event.sequence_number} must arrive via episode_reset or "
-                            f"episode_restarted; saw {event.event_type.value}"
-                        ),
-                    )
-                    continue
+                }
+            ):
+                yield (
+                    locator,
+                    (
+                        f"participant episode transition to sequence_number "
+                        f"{event.sequence_number} must arrive via episode_reset or "
+                        f"episode_restarted; saw {event.event_type.value}"
+                    ),
+                )
             expected_episode_id = sequence_to_episode.get(event.sequence_number)
             if expected_episode_id is None:
                 sequence_to_episode[event.sequence_number] = event.episode_id
@@ -1667,7 +1676,6 @@ def iter_participant_episode_snapshot_violations(
                         f"{expected_episode_id!r} -> {event.episode_id!r}"
                     ),
                 )
-                continue
             last_sequence = event.sequence_number
 
 

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -1665,9 +1665,7 @@ def iter_participant_episode_snapshot_violations(
                     ),
                 )
             expected_episode_id = sequence_to_episode.get(event.sequence_number)
-            if expected_episode_id is None:
-                sequence_to_episode[event.sequence_number] = event.episode_id
-            elif expected_episode_id != event.episode_id:
+            if expected_episode_id is not None and expected_episode_id != event.episode_id:
                 yield (
                     locator,
                     (
@@ -1676,6 +1674,7 @@ def iter_participant_episode_snapshot_violations(
                         f"{expected_episode_id!r} -> {event.episode_id!r}"
                     ),
                 )
+            sequence_to_episode[event.sequence_number] = event.episode_id
             last_sequence = event.sequence_number
 
 

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -24,6 +24,7 @@ from aces_backend_protocols.capabilities import (
 from aces_contracts.versions import (
     EVALUATION_STATE_SCHEMA_VERSION,
     OPERATION_SCHEMA_VERSION,
+    PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION,
     RUNTIME_SNAPSHOT_SCHEMA_VERSION,
     WORKFLOW_STATE_SCHEMA_VERSION,
 )
@@ -143,6 +144,65 @@ class EvaluationHistoryEventType(str, Enum):
     EVALUATION_UPDATED = "evaluation_updated"
     EVALUATION_READY = "evaluation_ready"
     EVALUATION_FAILED = "evaluation_failed"
+
+
+class ParticipantEpisodeStatus(str, Enum):
+    """Portable lifecycle position for one participant episode instance."""
+
+    INITIALIZING = "initializing"
+    RUNNING = "running"
+    TERMINATED = "terminated"
+
+
+class ParticipantEpisodeTerminalReason(str, Enum):
+    """Portable terminal-reason classifier for participant episodes."""
+
+    COMPLETED = "completed"
+    TIMED_OUT = "timed_out"
+    TRUNCATED = "truncated"
+    INTERRUPTED = "interrupted"
+
+
+class ParticipantEpisodeControlAction(str, Enum):
+    """Portable control actions that drive participant-episode transitions."""
+
+    INITIALIZE = "initialize"
+    RESET = "reset"
+    RESTART = "restart"
+
+
+class ParticipantEpisodeHistoryEventType(str, Enum):
+    """Portable history event kinds for participant episodes."""
+
+    EPISODE_INITIALIZED = "episode_initialized"
+    EPISODE_RUNNING = "episode_running"
+    EPISODE_COMPLETED = "episode_completed"
+    EPISODE_TIMED_OUT = "episode_timed_out"
+    EPISODE_TRUNCATED = "episode_truncated"
+    EPISODE_INTERRUPTED = "episode_interrupted"
+    EPISODE_RESET = "episode_reset"
+    EPISODE_RESTARTED = "episode_restarted"
+
+
+_PARTICIPANT_EPISODE_TERMINAL_EVENTS: dict[
+    "ParticipantEpisodeHistoryEventType",
+    "ParticipantEpisodeTerminalReason",
+] = {
+    ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED: ParticipantEpisodeTerminalReason.COMPLETED,
+    ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT: ParticipantEpisodeTerminalReason.TIMED_OUT,
+    ParticipantEpisodeHistoryEventType.EPISODE_TRUNCATED: ParticipantEpisodeTerminalReason.TRUNCATED,
+    ParticipantEpisodeHistoryEventType.EPISODE_INTERRUPTED: ParticipantEpisodeTerminalReason.INTERRUPTED,
+}
+
+
+_PARTICIPANT_EPISODE_CONTROL_EVENTS: dict[
+    "ParticipantEpisodeHistoryEventType",
+    "ParticipantEpisodeControlAction",
+] = {
+    ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED: ParticipantEpisodeControlAction.INITIALIZE,
+    ParticipantEpisodeHistoryEventType.EPISODE_RESET: ParticipantEpisodeControlAction.RESET,
+    ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED: ParticipantEpisodeControlAction.RESTART,
+}
 
 
 @dataclass(frozen=True)
@@ -1165,6 +1225,290 @@ class EvaluationExecutionState:
             raise ValueError("evaluation results may not report max_score without score")
         if self.score is not None and self.max_score is not None and float(self.score) > float(self.max_score):
             raise ValueError("evaluation result score may not exceed max_score")
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeExecutionState:
+    """Internal normalized participant-episode execution state envelope.
+
+    Models one bounded participant-execution episode with explicit identity.
+    Stable participant identity (``participant_address``) is preserved across
+    resets and restarts; each episode instance gets a fresh ``episode_id`` and
+    an incremented ``sequence_number``, and links back to the prior episode
+    via ``previous_episode_id`` so reset/restart history is never rewritten in
+    place.
+    """
+
+    state_schema_version: str = PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION
+    participant_address: str = ""
+    episode_id: str = ""
+    sequence_number: int = 0
+    status: ParticipantEpisodeStatus = ParticipantEpisodeStatus.INITIALIZING
+    terminal_reason: ParticipantEpisodeTerminalReason | None = None
+    initialized_at: str = ""
+    updated_at: str = ""
+    terminated_at: str | None = None
+    last_control_action: ParticipantEpisodeControlAction = ParticipantEpisodeControlAction.INITIALIZE
+    previous_episode_id: str | None = None
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> "ParticipantEpisodeExecutionState":
+        if not isinstance(payload, Mapping):
+            raise TypeError("participant episode payload must be a mapping")
+        missing_keys = [
+            key
+            for key in (
+                "state_schema_version",
+                "participant_address",
+                "episode_id",
+                "sequence_number",
+                "status",
+                "initialized_at",
+                "updated_at",
+                "last_control_action",
+            )
+            if key not in payload
+        ]
+        if missing_keys:
+            raise ValueError("participant episode payload is missing required fields: " + ", ".join(missing_keys))
+        sequence_number_raw = payload.get("sequence_number")
+        if isinstance(sequence_number_raw, bool) or not isinstance(sequence_number_raw, int):
+            raise TypeError("participant episode sequence_number must be an int")
+        status_raw = payload.get("status")
+        terminal_reason_raw = payload.get("terminal_reason")
+        last_control_action_raw = payload.get("last_control_action")
+        return cls(
+            state_schema_version=str(payload.get("state_schema_version")),
+            participant_address=str(payload.get("participant_address")),
+            episode_id=str(payload.get("episode_id")),
+            sequence_number=sequence_number_raw,
+            status=(
+                status_raw
+                if isinstance(status_raw, ParticipantEpisodeStatus)
+                else ParticipantEpisodeStatus(str(status_raw))
+            ),
+            terminal_reason=(
+                terminal_reason_raw
+                if isinstance(terminal_reason_raw, ParticipantEpisodeTerminalReason)
+                else (
+                    ParticipantEpisodeTerminalReason(str(terminal_reason_raw))
+                    if terminal_reason_raw is not None
+                    else None
+                )
+            ),
+            initialized_at=str(payload.get("initialized_at")),
+            updated_at=str(payload.get("updated_at")),
+            terminated_at=(str(payload["terminated_at"]) if payload.get("terminated_at") is not None else None),
+            last_control_action=(
+                last_control_action_raw
+                if isinstance(last_control_action_raw, ParticipantEpisodeControlAction)
+                else ParticipantEpisodeControlAction(str(last_control_action_raw))
+            ),
+            previous_episode_id=(
+                str(payload["previous_episode_id"]) if payload.get("previous_episode_id") is not None else None
+            ),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "state_schema_version": self.state_schema_version,
+            "participant_address": self.participant_address,
+            "episode_id": self.episode_id,
+            "sequence_number": self.sequence_number,
+            "status": self.status.value,
+            "terminal_reason": self.terminal_reason.value if self.terminal_reason is not None else None,
+            "initialized_at": self.initialized_at,
+            "updated_at": self.updated_at,
+            "terminated_at": self.terminated_at,
+            "last_control_action": self.last_control_action.value,
+            "previous_episode_id": self.previous_episode_id,
+        }
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state_schema_version, str) or not self.state_schema_version:
+            raise TypeError("participant episode state_schema_version must be a non-empty string")
+        if not isinstance(self.participant_address, str) or not self.participant_address:
+            raise TypeError("participant_address must be a non-empty string")
+        if not isinstance(self.episode_id, str) or not self.episode_id:
+            raise TypeError("episode_id must be a non-empty string")
+        if isinstance(self.sequence_number, bool) or not isinstance(self.sequence_number, int):
+            raise TypeError("sequence_number must be an int")
+        if self.sequence_number < 0:
+            raise ValueError("sequence_number must be >= 0")
+        if not isinstance(self.status, ParticipantEpisodeStatus):
+            raise TypeError("status must be a ParticipantEpisodeStatus")
+        if self.terminal_reason is not None and not isinstance(self.terminal_reason, ParticipantEpisodeTerminalReason):
+            raise TypeError("terminal_reason must be a ParticipantEpisodeTerminalReason or None")
+        if not isinstance(self.initialized_at, str) or not self.initialized_at:
+            raise TypeError("initialized_at must be a non-empty string")
+        if not isinstance(self.updated_at, str) or not self.updated_at:
+            raise TypeError("updated_at must be a non-empty string")
+        if self.terminated_at is not None and (not isinstance(self.terminated_at, str) or not self.terminated_at):
+            raise TypeError("terminated_at must be a non-empty string or None")
+        if not isinstance(self.last_control_action, ParticipantEpisodeControlAction):
+            raise TypeError("last_control_action must be a ParticipantEpisodeControlAction")
+        if self.previous_episode_id is not None and (
+            not isinstance(self.previous_episode_id, str) or not self.previous_episode_id
+        ):
+            raise TypeError("previous_episode_id must be a non-empty string or None")
+        if self.status in {ParticipantEpisodeStatus.INITIALIZING, ParticipantEpisodeStatus.RUNNING}:
+            if self.terminal_reason is not None:
+                raise ValueError("non-terminal participant episodes may not report a terminal_reason")
+            if self.terminated_at is not None:
+                raise ValueError("non-terminal participant episodes may not report a terminated_at timestamp")
+        if self.status == ParticipantEpisodeStatus.TERMINATED:
+            if self.terminal_reason is None:
+                raise ValueError("terminated participant episodes must report a terminal_reason")
+            if self.terminated_at is None:
+                raise ValueError("terminated participant episodes must report a terminated_at timestamp")
+        if self.sequence_number == 0:
+            if self.last_control_action != ParticipantEpisodeControlAction.INITIALIZE:
+                raise ValueError(
+                    "the first participant episode (sequence_number=0) must use the INITIALIZE control action"
+                )
+            if self.previous_episode_id is not None:
+                raise ValueError(
+                    "the first participant episode (sequence_number=0) must not link to a previous episode"
+                )
+        else:
+            if self.last_control_action == ParticipantEpisodeControlAction.INITIALIZE:
+                raise ValueError(
+                    "subsequent participant episodes (sequence_number>0) must use RESET or RESTART, not INITIALIZE"
+                )
+            if self.previous_episode_id is None:
+                raise ValueError(
+                    "subsequent participant episodes (sequence_number>0) must link to a previous_episode_id"
+                )
+            if self.previous_episode_id == self.episode_id:
+                raise ValueError("previous_episode_id must differ from episode_id; reset/restart create a new instance")
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeHistoryEvent:
+    """Internal normalized participant-episode history event.
+
+    History is append-only and per-episode-instance. Each event carries the
+    participant identity, the owning episode identity, and (when applicable)
+    the terminal reason or control action that the event records. The event
+    type, terminal reason, and control action are kept distinct categories so
+    history records cannot conflate "what happened" with "why it stopped" or
+    "what action drove the transition".
+    """
+
+    event_type: ParticipantEpisodeHistoryEventType
+    timestamp: str
+    participant_address: str
+    episode_id: str
+    sequence_number: int
+    terminal_reason: ParticipantEpisodeTerminalReason | None = None
+    control_action: ParticipantEpisodeControlAction | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> "ParticipantEpisodeHistoryEvent":
+        if not isinstance(payload, Mapping):
+            raise TypeError("participant episode history event must be a mapping")
+        missing_keys = [
+            key
+            for key in (
+                "event_type",
+                "timestamp",
+                "participant_address",
+                "episode_id",
+                "sequence_number",
+            )
+            if key not in payload
+        ]
+        if missing_keys:
+            raise ValueError("participant episode history event is missing required fields: " + ", ".join(missing_keys))
+        sequence_number_raw = payload.get("sequence_number")
+        if isinstance(sequence_number_raw, bool) or not isinstance(sequence_number_raw, int):
+            raise TypeError("participant episode history sequence_number must be an int")
+        terminal_reason_raw = payload.get("terminal_reason")
+        control_action_raw = payload.get("control_action")
+        return cls(
+            event_type=(
+                payload["event_type"]
+                if isinstance(payload["event_type"], ParticipantEpisodeHistoryEventType)
+                else ParticipantEpisodeHistoryEventType(str(payload["event_type"]))
+            ),
+            timestamp=str(payload["timestamp"]),
+            participant_address=str(payload["participant_address"]),
+            episode_id=str(payload["episode_id"]),
+            sequence_number=sequence_number_raw,
+            terminal_reason=(
+                terminal_reason_raw
+                if isinstance(terminal_reason_raw, ParticipantEpisodeTerminalReason)
+                else (
+                    ParticipantEpisodeTerminalReason(str(terminal_reason_raw))
+                    if terminal_reason_raw is not None
+                    else None
+                )
+            ),
+            control_action=(
+                control_action_raw
+                if isinstance(control_action_raw, ParticipantEpisodeControlAction)
+                else (
+                    ParticipantEpisodeControlAction(str(control_action_raw)) if control_action_raw is not None else None
+                )
+            ),
+            details=dict(payload.get("details", {})) if isinstance(payload.get("details", {}), Mapping) else {},
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "event_type": self.event_type.value,
+            "timestamp": self.timestamp,
+            "participant_address": self.participant_address,
+            "episode_id": self.episode_id,
+            "sequence_number": self.sequence_number,
+            "terminal_reason": self.terminal_reason.value if self.terminal_reason is not None else None,
+            "control_action": self.control_action.value if self.control_action is not None else None,
+            "details": dict(self.details),
+        }
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event_type, ParticipantEpisodeHistoryEventType):
+            raise TypeError("event_type must be a ParticipantEpisodeHistoryEventType")
+        if not isinstance(self.timestamp, str) or not self.timestamp:
+            raise TypeError("timestamp must be a non-empty string")
+        if not isinstance(self.participant_address, str) or not self.participant_address:
+            raise TypeError("participant_address must be a non-empty string")
+        if not isinstance(self.episode_id, str) or not self.episode_id:
+            raise TypeError("episode_id must be a non-empty string")
+        if isinstance(self.sequence_number, bool) or not isinstance(self.sequence_number, int):
+            raise TypeError("sequence_number must be an int")
+        if self.sequence_number < 0:
+            raise ValueError("sequence_number must be >= 0")
+        if self.terminal_reason is not None and not isinstance(self.terminal_reason, ParticipantEpisodeTerminalReason):
+            raise TypeError("terminal_reason must be a ParticipantEpisodeTerminalReason or None")
+        if self.control_action is not None and not isinstance(self.control_action, ParticipantEpisodeControlAction):
+            raise TypeError("control_action must be a ParticipantEpisodeControlAction or None")
+        if not isinstance(self.details, dict):
+            raise TypeError("details must be a dict")
+        expected_terminal_reason = _PARTICIPANT_EPISODE_TERMINAL_EVENTS.get(self.event_type)
+        if expected_terminal_reason is not None:
+            if self.terminal_reason != expected_terminal_reason:
+                raise ValueError(
+                    f"{self.event_type.value} history events must report terminal_reason "
+                    f"{expected_terminal_reason.value}"
+                )
+        elif self.terminal_reason is not None:
+            raise ValueError(f"{self.event_type.value} history events may not report a terminal_reason")
+        expected_control_action = _PARTICIPANT_EPISODE_CONTROL_EVENTS.get(self.event_type)
+        if expected_control_action is not None:
+            if self.control_action != expected_control_action:
+                raise ValueError(
+                    f"{self.event_type.value} history events must report control_action {expected_control_action.value}"
+                )
+        elif self.control_action is not None:
+            raise ValueError(f"{self.event_type.value} history events may not report a control_action")
 
 
 def validate_evaluation_result(

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -11,7 +11,7 @@ from bound runtime instances. The planner reconciles those instances against
 the current ``RuntimeSnapshot`` and emits a composite ``ExecutionPlan``.
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
@@ -185,8 +185,8 @@ class ParticipantEpisodeHistoryEventType(str, Enum):
 
 
 _PARTICIPANT_EPISODE_TERMINAL_EVENTS: dict[
-    "ParticipantEpisodeHistoryEventType",
-    "ParticipantEpisodeTerminalReason",
+    ParticipantEpisodeHistoryEventType,
+    ParticipantEpisodeTerminalReason,
 ] = {
     ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED: ParticipantEpisodeTerminalReason.COMPLETED,
     ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT: ParticipantEpisodeTerminalReason.TIMED_OUT,
@@ -196,8 +196,8 @@ _PARTICIPANT_EPISODE_TERMINAL_EVENTS: dict[
 
 
 _PARTICIPANT_EPISODE_CONTROL_EVENTS: dict[
-    "ParticipantEpisodeHistoryEventType",
-    "ParticipantEpisodeControlAction",
+    ParticipantEpisodeHistoryEventType,
+    ParticipantEpisodeControlAction,
 ] = {
     ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED: ParticipantEpisodeControlAction.INITIALIZE,
     ParticipantEpisodeHistoryEventType.EPISODE_RESET: ParticipantEpisodeControlAction.RESET,
@@ -1528,6 +1528,149 @@ class ParticipantEpisodeHistoryEvent:
             )
 
 
+def iter_participant_episode_snapshot_violations(
+    participant_episode_results: Any,
+    participant_episode_history: Any,
+) -> Iterator[tuple[str, str]]:
+    """Yield every participant-episode invariant violation in a snapshot.
+
+    Both arguments are the raw ``RuntimeSnapshot.participant_episode_results``
+    and ``RuntimeSnapshot.participant_episode_history`` maps keyed by the
+    stable ``participant_address``. The helper exists so that the runtime
+    manager apply path and the conformance semantic-check path share one
+    source of truth for RUN-311 invariants; each caller wraps the yielded
+    ``(address, message)`` tuples in its own diagnostic type.
+
+    The following invariants are checked:
+
+    - ``participant_episode_results`` / ``_history`` are mappings.
+    - Each outer key is a non-empty string.
+    - Each result value is a mapping and reconstructs through
+      ``ParticipantEpisodeExecutionState.from_payload`` (i.e. respects the
+      state-machine invariants enforced in ``__post_init__``).
+    - Each result's inner ``participant_address`` matches the outer key.
+    - Each history value is a list of mappings and every event reconstructs
+      through ``ParticipantEpisodeHistoryEvent.from_payload``.
+    - Each history event's inner ``participant_address`` matches the outer
+      key.
+    - Within one participant's history, ``sequence_number`` is monotonic
+      non-decreasing.
+    - Within one sequence number, ``episode_id`` is stable.
+    - Cross-sequence transitions are gated by an ``EPISODE_RESET`` or
+      ``EPISODE_RESTARTED`` event (the first sequence number observed in
+      a history stream is exempt because history may be truncated).
+    """
+
+    results_key = "runtime.snapshot.participant-episode-results"
+    history_key = "runtime.snapshot.participant-episode-history"
+
+    if not isinstance(participant_episode_results, Mapping):
+        yield (results_key, "participant_episode_results must be a mapping")
+    else:
+        for outer_key, result in participant_episode_results.items():
+            if not isinstance(outer_key, str) or not outer_key:
+                yield (results_key, "participant episode result keys must be non-empty strings")
+                continue
+            if not isinstance(result, Mapping):
+                yield (outer_key, "participant episode result must be a mapping")
+                continue
+            try:
+                normalized_result = ParticipantEpisodeExecutionState.from_payload(result)
+            except (TypeError, ValueError) as exc:
+                yield (outer_key, f"participant episode result is invalid: {exc}")
+                continue
+            if normalized_result.participant_address != outer_key:
+                yield (
+                    outer_key,
+                    (
+                        f"participant episode result outer key {outer_key!r} does not match "
+                        f"inner participant_address {normalized_result.participant_address!r}"
+                    ),
+                )
+
+    if not isinstance(participant_episode_history, Mapping):
+        yield (history_key, "participant_episode_history must be a mapping")
+        return
+
+    for outer_key, history in participant_episode_history.items():
+        if not isinstance(outer_key, str) or not outer_key:
+            yield (history_key, "participant episode history keys must be non-empty strings")
+            continue
+        if not isinstance(history, list):
+            yield (outer_key, "participant episode history must be a list of events")
+            continue
+        normalized_events: list[ParticipantEpisodeHistoryEvent] = []
+        per_entry_violations = False
+        for index, event in enumerate(history):
+            locator = f"{outer_key}[{index}]"
+            if not isinstance(event, Mapping):
+                yield (locator, "participant episode history event must be a mapping")
+                per_entry_violations = True
+                continue
+            try:
+                normalized_event = ParticipantEpisodeHistoryEvent.from_payload(event)
+            except (TypeError, ValueError) as exc:
+                yield (locator, f"participant episode history event is invalid: {exc}")
+                per_entry_violations = True
+                continue
+            if normalized_event.participant_address != outer_key:
+                yield (
+                    locator,
+                    (
+                        f"participant episode history event outer key {outer_key!r} does not match "
+                        f"inner participant_address {normalized_event.participant_address!r}"
+                    ),
+                )
+                per_entry_violations = True
+                continue
+            normalized_events.append(normalized_event)
+
+        if per_entry_violations:
+            continue
+
+        last_sequence = -1
+        sequence_to_episode: dict[int, str] = {}
+        for index, event in enumerate(normalized_events):
+            locator = f"{outer_key}[{index}]"
+            if event.sequence_number < last_sequence:
+                yield (
+                    locator,
+                    (
+                        f"participant episode history sequence_number went backward "
+                        f"({last_sequence} -> {event.sequence_number})"
+                    ),
+                )
+                continue
+            if event.sequence_number > last_sequence and last_sequence != -1:
+                if event.event_type not in {
+                    ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+                    ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+                }:
+                    yield (
+                        locator,
+                        (
+                            f"participant episode transition to sequence_number "
+                            f"{event.sequence_number} must arrive via episode_reset or "
+                            f"episode_restarted; saw {event.event_type.value}"
+                        ),
+                    )
+                    continue
+            expected_episode_id = sequence_to_episode.get(event.sequence_number)
+            if expected_episode_id is None:
+                sequence_to_episode[event.sequence_number] = event.episode_id
+            elif expected_episode_id != event.episode_id:
+                yield (
+                    locator,
+                    (
+                        f"participant episode history episode_id changed within "
+                        f"sequence_number {event.sequence_number}: "
+                        f"{expected_episode_id!r} -> {event.episode_id!r}"
+                    ),
+                )
+                continue
+            last_sequence = event.sequence_number
+
+
 def validate_evaluation_result(
     contract: EvaluationResultContract,
     state: EvaluationExecutionState,
@@ -1783,7 +1926,15 @@ class SnapshotEntry:
 
 @dataclass
 class RuntimeSnapshot:
-    """Current runtime snapshot."""
+    """Current runtime snapshot.
+
+    Participant episode surfaces (``participant_episode_results`` and
+    ``participant_episode_history``) are both keyed by the stable
+    ``participant_address``. The results map holds the *current* live
+    episode state for each participant; prior episode instances are
+    preserved only through the append-only history stream and the
+    ``previous_episode_id`` chain on each state. See ADR-013.
+    """
 
     entries: dict[str, SnapshotEntry] = field(default_factory=dict)
     orchestration_results: dict[str, dict[str, Any]] = field(default_factory=dict)

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -1509,6 +1509,23 @@ class ParticipantEpisodeHistoryEvent:
                 )
         elif self.control_action is not None:
             raise ValueError(f"{self.event_type.value} history events may not report a control_action")
+        if self.event_type == ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED and self.sequence_number != 0:
+            raise ValueError(
+                "episode_initialized history events must report sequence_number=0; "
+                "later episodes arrive via episode_reset or episode_restarted"
+            )
+        if (
+            self.event_type
+            in {
+                ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+                ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+            }
+            and self.sequence_number == 0
+        ):
+            raise ValueError(
+                f"{self.event_type.value} history events must report sequence_number>0; "
+                "the first episode uses episode_initialized"
+            )
 
 
 def validate_evaluation_result(
@@ -1773,6 +1790,8 @@ class RuntimeSnapshot:
     orchestration_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     evaluation_results: dict[str, dict[str, Any]] = field(default_factory=dict)
     evaluation_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    participant_episode_results: dict[str, dict[str, Any]] = field(default_factory=dict)
+    participant_episode_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def get(self, address: str) -> SnapshotEntry | None:
@@ -1789,6 +1808,8 @@ class RuntimeSnapshot:
         orchestration_history: dict[str, list[dict[str, Any]]] | None = None,
         evaluation_results: dict[str, dict[str, Any]] | None = None,
         evaluation_history: dict[str, list[dict[str, Any]]] | None = None,
+        participant_episode_results: dict[str, dict[str, Any]] | None = None,
+        participant_episode_history: dict[str, list[dict[str, Any]]] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> "RuntimeSnapshot":
         return RuntimeSnapshot(
@@ -1808,6 +1829,22 @@ class RuntimeSnapshot:
                 {address: list(events) for address, events in self.evaluation_history.items()}
                 if evaluation_history is None
                 else {address: list(events) for address, events in evaluation_history.items()}
+            ),
+            participant_episode_results=(
+                dict(self.participant_episode_results)
+                if participant_episode_results is None
+                else dict(participant_episode_results)
+            ),
+            participant_episode_history=(
+                {
+                    participant_address: list(events)
+                    for participant_address, events in self.participant_episode_history.items()
+                }
+                if participant_episode_history is None
+                else {
+                    participant_address: list(events)
+                    for participant_address, events in participant_episode_history.items()
+                }
             ),
             metadata=dict(self.metadata) if metadata is None else dict(metadata),
         )

--- a/implementations/python/tests/test_requirement_governance.py
+++ b/implementations/python/tests/test_requirement_governance.py
@@ -44,6 +44,7 @@ def make_client(*, requirement_status: str = "DRAFT", api_412_status: str = "DRA
         "GOV-918": {"id": "req-gov-918", "uid": "GOV-918", "status": requirement_status},
         "API-412": {"id": "req-api-412", "uid": "API-412", "status": api_412_status},
         "RUN-300": {"id": "req-run-300", "uid": "RUN-300", "status": "ACTIVE"},
+        "RUN-311": {"id": "req-run-311", "uid": "RUN-311", "status": "ACTIVE"},
         "RUN-313": {"id": "req-run-313", "uid": "RUN-313", "status": "DRAFT"},
         "GOV-917": {"id": "req-gov-917", "uid": "GOV-917", "status": "ACTIVE"},
         "GOV-919": {"id": "req-gov-919", "uid": "GOV-919", "status": "ACTIVE"},

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -351,29 +351,29 @@ class TestRun311ParticipantEpisodeLifecycle:
             )
 
     @pytest.mark.parametrize(
-        ("event_type", "expected_action"),
+        ("event_type", "expected_action", "sequence_number"),
         [
-            (ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED, ParticipantEpisodeControlAction.INITIALIZE),
-            (ParticipantEpisodeHistoryEventType.EPISODE_RESET, ParticipantEpisodeControlAction.RESET),
-            (ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED, ParticipantEpisodeControlAction.RESTART),
+            (ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED, ParticipantEpisodeControlAction.INITIALIZE, 0),
+            (ParticipantEpisodeHistoryEventType.EPISODE_RESET, ParticipantEpisodeControlAction.RESET, 1),
+            (ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED, ParticipantEpisodeControlAction.RESTART, 1),
         ],
     )
-    def test_history_event_control_action_must_match_event_type(self, event_type, expected_action):
+    def test_history_event_control_action_must_match_event_type(self, event_type, expected_action, sequence_number):
         """Clauses 2, 3, 8 expressed as history events — each control event type
         is coupled to exactly one control action, and non-control event types
         cannot carry a control_action.
         """
 
-        ok = _history_event(event_type=event_type, control_action=expected_action)
+        ok = _history_event(event_type=event_type, control_action=expected_action, sequence_number=sequence_number)
         assert ok.control_action == expected_action
 
         wrong_actions = [action for action in ParticipantEpisodeControlAction if action != expected_action]
         for action in wrong_actions:
             with pytest.raises(ValueError, match="must report control_action"):
-                _history_event(event_type=event_type, control_action=action)
+                _history_event(event_type=event_type, control_action=action, sequence_number=sequence_number)
 
         with pytest.raises(ValueError, match="must report control_action"):
-            _history_event(event_type=event_type, control_action=None)
+            _history_event(event_type=event_type, control_action=None, sequence_number=sequence_number)
 
         with pytest.raises(ValueError, match="may not report a control_action"):
             _history_event(
@@ -482,6 +482,47 @@ class TestRun311ParticipantEpisodeLifecycle:
                 "History event payload must round-trip via the schema-first "
                 f"boundary; drift on {event.event_type.value} would silently "
                 "lose lifecycle data."
+            )
+
+    def test_initialized_history_event_requires_sequence_number_zero(self):
+        """Invariant — ``episode_initialized`` events describe the very first
+        episode of a participant, so they must carry ``sequence_number=0``.
+        A history stream that emits ``episode_initialized`` at any later
+        sequence cannot correspond to a valid
+        ``ParticipantEpisodeExecutionState`` chain.
+        """
+
+        with pytest.raises(ValueError, match="episode_initialized history events must report sequence_number=0"):
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED,
+                sequence_number=1,
+                control_action=ParticipantEpisodeControlAction.INITIALIZE,
+            )
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+            ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+        ],
+    )
+    def test_reset_and_restart_history_events_require_sequence_number_greater_than_zero(self, event_type):
+        """Invariant — ``episode_reset`` and ``episode_restarted`` events describe
+        transitions into a new episode instance, which only exists for
+        ``sequence_number > 0``. The very first episode must arrive via
+        ``episode_initialized`` instead.
+        """
+
+        expected_action = (
+            ParticipantEpisodeControlAction.RESET
+            if event_type == ParticipantEpisodeHistoryEventType.EPISODE_RESET
+            else ParticipantEpisodeControlAction.RESTART
+        )
+        with pytest.raises(ValueError, match="must report sequence_number>0"):
+            _history_event(
+                event_type=event_type,
+                sequence_number=0,
+                control_action=expected_action,
             )
 
     def test_published_state_schema_matches_bundle_for_run_311(self):

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 from aces_contracts.contracts import schema_bundle
+from aces_processor.manager import _participant_episode_contract_diagnostics
 
 from aces.core.runtime.models import (
     ParticipantEpisodeControlAction,
@@ -34,6 +35,7 @@ from aces.core.runtime.models import (
     ParticipantEpisodeHistoryEventType,
     ParticipantEpisodeStatus,
     ParticipantEpisodeTerminalReason,
+    RuntimeSnapshot,
 )
 
 PARTICIPANT_ADDRESS = "participant.alice"
@@ -524,6 +526,111 @@ class TestRun311ParticipantEpisodeLifecycle:
                 sequence_number=0,
                 control_action=expected_action,
             )
+
+    def test_runtime_apply_path_rejects_invalid_participant_episode_result(self):
+        """Runtime integration — ``_participant_episode_contract_diagnostics``
+        is called on every backend apply. It must emit a
+        ``runtime.backend-contract-invalid`` diagnostic for any participant
+        episode result that violates the dataclass invariants, so invalid
+        RUN-311 data cannot be silently persisted through the manager path.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": "ep-0001",
+                    "sequence_number": 0,
+                    "status": "running",
+                    "terminal_reason": "completed",
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": None,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics, "apply path must reject invalid participant episode result"
+        assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
+        assert any(
+            "non-terminal participant episodes may not report a terminal_reason" in diag.message for diag in diagnostics
+        )
+
+    def test_runtime_apply_path_rejects_invalid_participant_episode_history_event(self):
+        """Runtime integration — the apply path must also reject a participant
+        episode history event whose sequence number disagrees with its event
+        type (for example ``episode_reset`` at ``sequence_number=0``).
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_reset",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": "ep-0001",
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "reset",
+                        "details": {},
+                    }
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics, "apply path must reject invalid participant episode history"
+        assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
+        assert any("must report sequence_number>0" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_accepts_valid_participant_episode_snapshot(self):
+        """Runtime integration — a snapshot that contains only valid RUN-311
+        data must pass the apply-path diagnostic helper cleanly. This is the
+        positive pair for the two rejection tests above.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "initializing",
+                    "terminal_reason": None,
+                    "initialized_at": T0,
+                    "updated_at": T0,
+                    "terminated_at": None,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    }
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics == []
 
     def test_published_state_schema_matches_bundle_for_run_311(self):
         """Schema parity — the on-disk control-plane schemas for the participant

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -1,0 +1,506 @@
+"""RUN-311: participant-episode lifecycle and reset integrity tests.
+
+RUN-311 ("Participant Episode Lifecycle And Reset") requires the runtime
+to support episodic participant execution with explicit initialization,
+reset, completion, timeout, truncation, interruption, and restart
+handling.
+
+ADR-013 ("Participant Episode Lifecycle Boundaries") locks in that
+participant episodes are their own processor/runtime contract surface
+that must not be aliased into ``WorkflowExecutionState``,
+``EvaluationExecutionState``, ``OperationStatus``, or
+``RuntimeSnapshot.metadata``. Lifecycle state, terminal reason, and
+control actions are kept as three distinct categories, and reset/restart
+must create a new episode instance while preserving stable participant
+identity.
+
+The tests in this module exercise every clause of RUN-311 against the
+``ParticipantEpisodeExecutionState`` and ``ParticipantEpisodeHistoryEvent``
+contract surfaces, plus the published JSON Schemas.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aces_contracts.contracts import schema_bundle
+
+from aces.core.runtime.models import (
+    ParticipantEpisodeControlAction,
+    ParticipantEpisodeExecutionState,
+    ParticipantEpisodeHistoryEvent,
+    ParticipantEpisodeHistoryEventType,
+    ParticipantEpisodeStatus,
+    ParticipantEpisodeTerminalReason,
+)
+
+PARTICIPANT_ADDRESS = "participant.alice"
+EP1 = "ep-0001"
+EP2 = "ep-0002"
+EP3 = "ep-0003"
+EP4 = "ep-0004"
+T0 = "2026-04-11T10:00:00Z"
+T1 = "2026-04-11T10:00:05Z"
+T2 = "2026-04-11T10:00:10Z"
+T3 = "2026-04-11T10:00:15Z"
+T4 = "2026-04-11T10:00:20Z"
+T5 = "2026-04-11T10:00:25Z"
+T6 = "2026-04-11T10:00:30Z"
+T7 = "2026-04-11T10:00:35Z"
+T8 = "2026-04-11T10:00:40Z"
+T9 = "2026-04-11T10:00:45Z"
+T10 = "2026-04-11T10:00:50Z"
+T11 = "2026-04-11T10:00:55Z"
+
+
+def _initialized_state(**overrides):
+    base = dict(
+        participant_address=PARTICIPANT_ADDRESS,
+        episode_id=EP1,
+        sequence_number=0,
+        status=ParticipantEpisodeStatus.INITIALIZING,
+        terminal_reason=None,
+        initialized_at=T0,
+        updated_at=T0,
+        terminated_at=None,
+        last_control_action=ParticipantEpisodeControlAction.INITIALIZE,
+        previous_episode_id=None,
+    )
+    base.update(overrides)
+    return ParticipantEpisodeExecutionState(**base)
+
+
+def _terminated_state(*, terminal_reason, **overrides):
+    base = dict(
+        participant_address=PARTICIPANT_ADDRESS,
+        episode_id=EP1,
+        sequence_number=0,
+        status=ParticipantEpisodeStatus.TERMINATED,
+        terminal_reason=terminal_reason,
+        initialized_at=T0,
+        updated_at=T1,
+        terminated_at=T1,
+        last_control_action=ParticipantEpisodeControlAction.INITIALIZE,
+        previous_episode_id=None,
+    )
+    base.update(overrides)
+    return ParticipantEpisodeExecutionState(**base)
+
+
+def _history_event(**overrides):
+    base = dict(
+        event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+        timestamp=T1,
+        participant_address=PARTICIPANT_ADDRESS,
+        episode_id=EP1,
+        sequence_number=0,
+        terminal_reason=None,
+        control_action=None,
+        details={},
+    )
+    base.update(overrides)
+    return ParticipantEpisodeHistoryEvent(**base)
+
+
+class TestRun311ParticipantEpisodeLifecycle:
+    """End-to-end participant-episode lifecycle integrity tests for RUN-311."""
+
+    def test_first_episode_initializes_with_stable_identity(self):
+        """Clauses 1, 2 — episodes carry explicit stable identity from initialization onward.
+
+        The first episode must use ``sequence_number=0`` and the
+        ``INITIALIZE`` control action, must not link to a previous
+        episode, must round-trip cleanly through ``to_payload`` /
+        ``from_payload`` (the schema-first contract boundary), and must
+        carry a stable ``participant_address`` and per-episode
+        ``episode_id`` so downstream consumers can distinguish the
+        participant from the bounded episode instance.
+        """
+
+        state = _initialized_state()
+
+        assert state.status == ParticipantEpisodeStatus.INITIALIZING
+        assert state.last_control_action == ParticipantEpisodeControlAction.INITIALIZE
+        assert state.previous_episode_id is None
+        assert state.terminal_reason is None
+        assert state.terminated_at is None
+        assert state.participant_address == PARTICIPANT_ADDRESS
+        assert state.episode_id == EP1
+
+        running = ParticipantEpisodeExecutionState(
+            participant_address=state.participant_address,
+            episode_id=state.episode_id,
+            sequence_number=state.sequence_number,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=state.initialized_at,
+            updated_at=T1,
+            last_control_action=state.last_control_action,
+        )
+        assert running.status == ParticipantEpisodeStatus.RUNNING
+        assert running.participant_address == state.participant_address
+        assert running.episode_id == state.episode_id
+        assert running.terminal_reason is None
+
+        round_trip = ParticipantEpisodeExecutionState.from_payload(running.to_payload())
+        assert round_trip == running, (
+            "Schema-first boundary must round-trip without loss; any drift "
+            "would mean the published JSON envelope cannot reconstruct the "
+            "in-process contract identity."
+        )
+
+    @pytest.mark.parametrize(
+        "terminal_reason",
+        [
+            ParticipantEpisodeTerminalReason.COMPLETED,
+            ParticipantEpisodeTerminalReason.TIMED_OUT,
+            ParticipantEpisodeTerminalReason.TRUNCATED,
+            ParticipantEpisodeTerminalReason.INTERRUPTED,
+        ],
+    )
+    def test_terminal_states_require_matching_terminal_reason(self, terminal_reason):
+        """Clauses 4-7 — every terminal outcome (completion, timeout, truncation,
+        interruption) is reachable, requires its terminal reason, and is
+        forbidden from non-terminal states.
+        """
+
+        state = _terminated_state(terminal_reason=terminal_reason)
+        assert state.status == ParticipantEpisodeStatus.TERMINATED
+        assert state.terminal_reason == terminal_reason
+        assert state.terminated_at == T1
+
+        with pytest.raises(ValueError, match="terminated participant episodes must report a terminal_reason"):
+            _terminated_state(terminal_reason=None)
+
+        with pytest.raises(
+            ValueError,
+            match="non-terminal participant episodes may not report a terminal_reason",
+        ):
+            _initialized_state(terminal_reason=terminal_reason)
+
+        with pytest.raises(
+            ValueError,
+            match="non-terminal participant episodes may not report a terminal_reason",
+        ):
+            _initialized_state(
+                status=ParticipantEpisodeStatus.RUNNING,
+                updated_at=T1,
+                terminal_reason=terminal_reason,
+            )
+
+    def test_reset_creates_new_episode_preserving_participant_identity(self):
+        """Clause 3 — reset spawns a new episode instance that keeps the
+        stable participant identity but has a fresh ``episode_id``,
+        an incremented ``sequence_number``, and a backreference to the
+        prior episode. The reset state must NOT mutate the prior state
+        in place (ADR-013 §4).
+        """
+
+        first = _initialized_state()
+        first_payload_before = first.to_payload()
+
+        reset = ParticipantEpisodeExecutionState(
+            participant_address=first.participant_address,
+            episode_id=EP2,
+            sequence_number=first.sequence_number + 1,
+            status=ParticipantEpisodeStatus.INITIALIZING,
+            initialized_at=T2,
+            updated_at=T2,
+            last_control_action=ParticipantEpisodeControlAction.RESET,
+            previous_episode_id=first.episode_id,
+        )
+
+        assert reset.participant_address == first.participant_address, (
+            "Participant identity must be preserved across resets so the "
+            "runtime can recognize that this is the same participant on a new "
+            "episode instance."
+        )
+        assert reset.episode_id != first.episode_id, (
+            "Each reset must allocate a new episode_id so prior episode history is never overwritten."
+        )
+        assert reset.sequence_number == first.sequence_number + 1
+        assert reset.previous_episode_id == first.episode_id
+        assert reset.last_control_action == ParticipantEpisodeControlAction.RESET
+        assert first.to_payload() == first_payload_before, (
+            "Reset must allocate a new state instance, not mutate the prior episode state in place."
+        )
+
+    def test_restart_after_termination_creates_new_episode_with_link_to_prior(self):
+        """Clause 8 — restart creates a fresh episode that links back to the
+        terminated prior episode. The chain ``initialized → terminated →
+        restarted`` must be reconstructable from the contract surface.
+        """
+
+        terminated = _terminated_state(terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED)
+        restart = ParticipantEpisodeExecutionState(
+            participant_address=terminated.participant_address,
+            episode_id=EP2,
+            sequence_number=terminated.sequence_number + 1,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=T2,
+            updated_at=T3,
+            last_control_action=ParticipantEpisodeControlAction.RESTART,
+            previous_episode_id=terminated.episode_id,
+        )
+
+        assert restart.participant_address == terminated.participant_address
+        assert restart.previous_episode_id == terminated.episode_id
+        assert restart.last_control_action == ParticipantEpisodeControlAction.RESTART
+        assert restart.sequence_number == terminated.sequence_number + 1
+        assert restart.episode_id != terminated.episode_id
+
+    @pytest.mark.parametrize(
+        "control_action",
+        [
+            ParticipantEpisodeControlAction.RESET,
+            ParticipantEpisodeControlAction.RESTART,
+        ],
+    )
+    def test_first_episode_rejects_reset_or_restart_control_action(self, control_action):
+        """Invariant — sequence_number=0 cannot be a reset or restart, because
+        there is no prior episode to come from.
+        """
+
+        with pytest.raises(
+            ValueError,
+            match=("the first participant episode \\(sequence_number=0\\) must use the INITIALIZE control action"),
+        ):
+            _initialized_state(last_control_action=control_action)
+
+    def test_subsequent_episode_requires_previous_episode_id(self):
+        """Invariant — sequence_number > 0 must always link to a previous episode
+        and cannot use the INITIALIZE control action.
+        """
+
+        with pytest.raises(
+            ValueError,
+            match=("subsequent participant episodes \\(sequence_number>0\\) must link to a previous_episode_id"),
+        ):
+            ParticipantEpisodeExecutionState(
+                participant_address=PARTICIPANT_ADDRESS,
+                episode_id=EP2,
+                sequence_number=1,
+                status=ParticipantEpisodeStatus.RUNNING,
+                initialized_at=T2,
+                updated_at=T2,
+                last_control_action=ParticipantEpisodeControlAction.RESET,
+                previous_episode_id=None,
+            )
+
+        with pytest.raises(
+            ValueError,
+            match=("subsequent participant episodes \\(sequence_number>0\\) must use RESET or RESTART, not INITIALIZE"),
+        ):
+            ParticipantEpisodeExecutionState(
+                participant_address=PARTICIPANT_ADDRESS,
+                episode_id=EP2,
+                sequence_number=1,
+                status=ParticipantEpisodeStatus.RUNNING,
+                initialized_at=T2,
+                updated_at=T2,
+                last_control_action=ParticipantEpisodeControlAction.INITIALIZE,
+                previous_episode_id=EP1,
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="previous_episode_id must differ from episode_id",
+        ):
+            ParticipantEpisodeExecutionState(
+                participant_address=PARTICIPANT_ADDRESS,
+                episode_id=EP2,
+                sequence_number=1,
+                status=ParticipantEpisodeStatus.RUNNING,
+                initialized_at=T2,
+                updated_at=T2,
+                last_control_action=ParticipantEpisodeControlAction.RESET,
+                previous_episode_id=EP2,
+            )
+
+    @pytest.mark.parametrize(
+        ("event_type", "expected_reason"),
+        [
+            (ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED, ParticipantEpisodeTerminalReason.COMPLETED),
+            (ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT, ParticipantEpisodeTerminalReason.TIMED_OUT),
+            (ParticipantEpisodeHistoryEventType.EPISODE_TRUNCATED, ParticipantEpisodeTerminalReason.TRUNCATED),
+            (ParticipantEpisodeHistoryEventType.EPISODE_INTERRUPTED, ParticipantEpisodeTerminalReason.INTERRUPTED),
+        ],
+    )
+    def test_history_event_terminal_reason_must_match_event_type(self, event_type, expected_reason):
+        """Clauses 4-7 expressed as history events — each terminal event type is
+        coupled to exactly one terminal reason, and non-terminal event types
+        cannot carry a terminal_reason.
+        """
+
+        ok = _history_event(event_type=event_type, terminal_reason=expected_reason)
+        assert ok.terminal_reason == expected_reason
+
+        wrong_reasons = [reason for reason in ParticipantEpisodeTerminalReason if reason != expected_reason]
+        for reason in wrong_reasons:
+            with pytest.raises(ValueError, match="must report terminal_reason"):
+                _history_event(event_type=event_type, terminal_reason=reason)
+
+        with pytest.raises(ValueError, match="must report terminal_reason"):
+            _history_event(event_type=event_type, terminal_reason=None)
+
+        with pytest.raises(ValueError, match="may not report a terminal_reason"):
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                terminal_reason=expected_reason,
+            )
+
+    @pytest.mark.parametrize(
+        ("event_type", "expected_action"),
+        [
+            (ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED, ParticipantEpisodeControlAction.INITIALIZE),
+            (ParticipantEpisodeHistoryEventType.EPISODE_RESET, ParticipantEpisodeControlAction.RESET),
+            (ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED, ParticipantEpisodeControlAction.RESTART),
+        ],
+    )
+    def test_history_event_control_action_must_match_event_type(self, event_type, expected_action):
+        """Clauses 2, 3, 8 expressed as history events — each control event type
+        is coupled to exactly one control action, and non-control event types
+        cannot carry a control_action.
+        """
+
+        ok = _history_event(event_type=event_type, control_action=expected_action)
+        assert ok.control_action == expected_action
+
+        wrong_actions = [action for action in ParticipantEpisodeControlAction if action != expected_action]
+        for action in wrong_actions:
+            with pytest.raises(ValueError, match="must report control_action"):
+                _history_event(event_type=event_type, control_action=action)
+
+        with pytest.raises(ValueError, match="must report control_action"):
+            _history_event(event_type=event_type, control_action=None)
+
+        with pytest.raises(ValueError, match="may not report a control_action"):
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                control_action=expected_action,
+            )
+
+    def test_history_event_payload_round_trip_for_full_lifecycle(self):
+        """Clauses 1-8 in one assertion — build a participant history that hits
+        every control action and every terminal reason and round-trip every
+        event through the schema-first payload boundary.
+        """
+
+        history = [
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED,
+                timestamp=T0,
+                control_action=ParticipantEpisodeControlAction.INITIALIZE,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=T1,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED,
+                timestamp=T2,
+                terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+                timestamp=T3,
+                episode_id=EP2,
+                sequence_number=1,
+                control_action=ParticipantEpisodeControlAction.RESET,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=T4,
+                episode_id=EP2,
+                sequence_number=1,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_INTERRUPTED,
+                timestamp=T5,
+                episode_id=EP2,
+                sequence_number=1,
+                terminal_reason=ParticipantEpisodeTerminalReason.INTERRUPTED,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+                timestamp=T6,
+                episode_id=EP3,
+                sequence_number=2,
+                control_action=ParticipantEpisodeControlAction.RESTART,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=T7,
+                episode_id=EP3,
+                sequence_number=2,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT,
+                timestamp=T8,
+                episode_id=EP3,
+                sequence_number=2,
+                terminal_reason=ParticipantEpisodeTerminalReason.TIMED_OUT,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+                timestamp=T9,
+                episode_id=EP4,
+                sequence_number=3,
+                control_action=ParticipantEpisodeControlAction.RESTART,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=T10,
+                episode_id=EP4,
+                sequence_number=3,
+            ),
+            _history_event(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_TRUNCATED,
+                timestamp=T11,
+                episode_id=EP4,
+                sequence_number=3,
+                terminal_reason=ParticipantEpisodeTerminalReason.TRUNCATED,
+            ),
+        ]
+
+        terminal_reasons_seen = {event.terminal_reason for event in history if event.terminal_reason is not None}
+        control_actions_seen = {event.control_action for event in history if event.control_action is not None}
+        assert terminal_reasons_seen == set(ParticipantEpisodeTerminalReason), (
+            "Lifecycle smoke history must reach every terminal reason exactly once."
+        )
+        assert control_actions_seen == set(ParticipantEpisodeControlAction), (
+            "Lifecycle smoke history must reach every control action exactly once."
+        )
+
+        for event in history:
+            assert event.participant_address == PARTICIPANT_ADDRESS, (
+                "Participant identity must be stable across the entire history, even after resets and restarts."
+            )
+            round_trip = ParticipantEpisodeHistoryEvent.from_payload(event.to_payload())
+            assert round_trip == event, (
+                "History event payload must round-trip via the schema-first "
+                f"boundary; drift on {event.event_type.value} would silently "
+                "lose lifecycle data."
+            )
+
+    def test_published_state_schema_matches_bundle_for_run_311(self):
+        """Schema parity — the on-disk control-plane schemas for the participant
+        episode envelope and the history event stream must equal the live
+        schema bundle. If a developer edits ``aces_contracts/contracts.py``
+        without re-running ``tools/generate_contract_schemas.py``, this test
+        gives a clear local failure mode.
+        """
+
+        repo_root = Path(__file__).resolve().parents[3]
+        schemas_dir = repo_root / "contracts" / "schemas" / "control-plane"
+        bundle = schema_bundle()
+        for schema_name in (
+            "participant-episode-state-envelope-v1",
+            "participant-episode-history-event-stream-v1",
+        ):
+            on_disk = json.loads((schemas_dir / f"{schema_name}.json").read_text(encoding="utf-8"))
+            assert on_disk == bundle[schema_name], (
+                f"Published schema {schema_name}.json drifted from "
+                "schema_bundle(); re-run tools/generate_contract_schemas.py."
+            )

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -773,6 +773,61 @@ class TestRun311ParticipantEpisodeLifecycle:
         assert diagnostics
         assert any("episode_id changed within sequence_number" in diag.message for diag in diagnostics)
 
+    def test_runtime_apply_path_stream_violations_do_not_cascade(self):
+        """Stream invariant — after a stream-level violation on one event,
+        subsequent events must be validated against the advanced sequence
+        state, not the pre-violation state. Otherwise a single bad
+        transition would produce the same "must arrive via reset/restart"
+        error on every follow-up event at the new sequence number.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T2,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        gate_messages = [
+            diag.message for diag in diagnostics if "must arrive via episode_reset or episode_restarted" in diag.message
+        ]
+        assert len(gate_messages) == 1, (
+            "Stream gate violation must fire exactly once per ungated transition, not once "
+            f"per event at the new sequence; got {len(gate_messages)} occurrences: {gate_messages}"
+        )
+
     def test_runtime_apply_path_accepts_valid_participant_episode_snapshot(self):
         """Runtime integration — a snapshot that contains only valid RUN-311
         data must pass the apply-path diagnostic helper cleanly. This is the

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -590,6 +590,189 @@ class TestRun311ParticipantEpisodeLifecycle:
         assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
         assert any("must report sequence_number>0" in diag.message for diag in diagnostics)
 
+    def test_runtime_apply_path_rejects_outer_key_mismatch_on_result(self):
+        """Stream invariant — the outer ``participant_episode_results`` key must
+        equal the inner ``participant_address``. Backends that key results by
+        one address but set a different ``participant_address`` on the state
+        corrupt the participant identity and must be rejected.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.bob",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "initializing",
+                    "terminal_reason": None,
+                    "initialized_at": T0,
+                    "updated_at": T0,
+                    "terminated_at": None,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics, "apply path must reject participant episode result with outer-key mismatch"
+        assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
+        assert any("does not match inner participant_address" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_outer_key_mismatch_on_history_event(self):
+        """Stream invariant — history events must carry the same
+        ``participant_address`` as the outer key they were indexed under.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.bob",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    }
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
+        assert any("does not match inner participant_address" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_history_sequence_going_backward(self):
+        """Stream invariant — sequence_number is monotonic non-decreasing
+        within one participant's history. A backend cannot emit events for
+        older episodes after newer ones.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_reset",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": "reset",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T2,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("sequence_number went backward" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_sequence_increment_without_reset_or_restart(self):
+        """Stream invariant — a transition into a new episode sequence must
+        be gated by an ``EPISODE_RESET`` or ``EPISODE_RESTARTED`` event, not
+        a plain ``EPISODE_RUNNING`` or terminal event.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("must arrive via episode_reset or episode_restarted" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_episode_id_changing_within_sequence(self):
+        """Stream invariant — within one sequence number, every history event
+        must share the same episode_id. A sudden change would mean the same
+        ``sequence_number`` spans two distinct episode instances.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("episode_id changed within sequence_number" in diag.message for diag in diagnostics)
+
     def test_runtime_apply_path_accepts_valid_participant_episode_snapshot(self):
         """Runtime integration — a snapshot that contains only valid RUN-311
         data must pass the apply-path diagnostic helper cleanly. This is the
@@ -629,6 +812,145 @@ class TestRun311ParticipantEpisodeLifecycle:
         )
 
         diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics == []
+
+    def test_runtime_snapshot_with_entries_preserves_participant_episode_surfaces(self):
+        """Snapshot integration — ``RuntimeSnapshot.with_entries`` must preserve
+        ``participant_episode_results`` and ``participant_episode_history`` when
+        they are not overridden, and must replace them when the caller passes
+        an explicit value. Both modes are exercised here.
+        """
+
+        results = {
+            "participant.alice": {
+                "state_schema_version": "participant-episode-state/v1",
+                "participant_address": "participant.alice",
+                "episode_id": EP1,
+                "sequence_number": 0,
+                "status": "running",
+                "terminal_reason": None,
+                "initialized_at": T0,
+                "updated_at": T1,
+                "terminated_at": None,
+                "last_control_action": "initialize",
+                "previous_episode_id": None,
+            }
+        }
+        history = {
+            "participant.alice": [
+                {
+                    "event_type": "episode_initialized",
+                    "timestamp": T0,
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "terminal_reason": None,
+                    "control_action": "initialize",
+                    "details": {},
+                }
+            ]
+        }
+        snapshot = RuntimeSnapshot(
+            participant_episode_results=results,
+            participant_episode_history=history,
+        )
+
+        preserved = snapshot.with_entries({})
+        assert preserved.participant_episode_results == results
+        assert preserved.participant_episode_history == history
+
+        replacement_results = {
+            "participant.bob": {
+                "state_schema_version": "participant-episode-state/v1",
+                "participant_address": "participant.bob",
+                "episode_id": "ep-bob-1",
+                "sequence_number": 0,
+                "status": "initializing",
+                "terminal_reason": None,
+                "initialized_at": T2,
+                "updated_at": T2,
+                "terminated_at": None,
+                "last_control_action": "initialize",
+                "previous_episode_id": None,
+            }
+        }
+        replaced = snapshot.with_entries(
+            {},
+            participant_episode_results=replacement_results,
+            participant_episode_history={},
+        )
+        assert replaced.participant_episode_results == replacement_results
+        assert replaced.participant_episode_history == {}
+        assert snapshot.participant_episode_results == results, (
+            "with_entries must not mutate the source snapshot's participant results"
+        )
+        assert snapshot.participant_episode_history == history, (
+            "with_entries must not mutate the source snapshot's participant history"
+        )
+
+    def test_runtime_snapshot_semantic_diagnostics_accept_valid_populated_payload(self):
+        """Conformance integration — a runtime-snapshot-v1 payload that
+        populates participant_episode_results and participant_episode_history
+        with a coherent initialize→running history must pass
+        ``_semantic_diagnostics`` cleanly. This is the positive counterpart to
+        the rejection tests in ``test_runtime_conformance.py`` and gives the
+        live probe direct coverage of the populated-payload path in
+        ``_live_target_cases``.
+        """
+
+        from aces_conformance.conformance import _semantic_diagnostics
+
+        snapshot_payload = {
+            "schema_version": "runtime-snapshot/v1",
+            "entries": {},
+            "orchestration_results": {},
+            "orchestration_history": {},
+            "evaluation_results": {},
+            "evaluation_history": {},
+            "participant_episode_results": {
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "running",
+                    "terminal_reason": None,
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": None,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            "participant_episode_history": {
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+            "metadata": {},
+        }
+
+        diagnostics = _semantic_diagnostics("runtime-snapshot-v1", snapshot_payload)
 
         assert diagnostics == []
 

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -828,6 +828,51 @@ class TestRun311ParticipantEpisodeLifecycle:
             f"per event at the new sequence; got {len(gate_messages)} occurrences: {gate_messages}"
         )
 
+    def test_runtime_apply_path_episode_id_mismatch_reports_transitions_not_repeats(self):
+        """Stream invariant — an ``episode_id`` mismatch within one sequence
+        must be reported as a one-off *transition* between episode_ids, not
+        as a repeated comparison against the first-observed id. For the
+        history ``[A, B, B, C]`` at the same sequence number the validator
+        must yield exactly two mismatch errors (``A -> B`` and ``B -> C``),
+        not three (``A -> B``, ``A -> B``, ``A -> C``).
+        """
+
+        def _event(timestamp: str, episode_id: str, event_type: str, control_action: str | None):
+            return {
+                "event_type": event_type,
+                "timestamp": timestamp,
+                "participant_address": "participant.alice",
+                "episode_id": episode_id,
+                "sequence_number": 0,
+                "terminal_reason": None,
+                "control_action": control_action,
+                "details": {},
+            }
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_history={
+                "participant.alice": [
+                    _event(T0, EP1, "episode_initialized", "initialize"),
+                    _event(T1, EP2, "episode_running", None),
+                    _event(T2, EP2, "episode_running", None),
+                    _event(T3, EP3, "episode_running", None),
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        mismatch_messages = [
+            diag.message for diag in diagnostics if "episode_id changed within sequence_number" in diag.message
+        ]
+        assert len(mismatch_messages) == 2, (
+            "episode_id mismatches must be reported as transitions (A->B, B->C), "
+            f"not as repeated comparisons against the first-observed id. Got "
+            f"{len(mismatch_messages)} mismatches: {mismatch_messages}"
+        )
+        assert any(f"{EP1!r} -> {EP2!r}" in msg for msg in mismatch_messages)
+        assert any(f"{EP2!r} -> {EP3!r}" in msg for msg in mismatch_messages)
+
     def test_runtime_apply_path_accepts_valid_participant_episode_snapshot(self):
         """Runtime integration — a snapshot that contains only valid RUN-311
         data must pass the apply-path diagnostic helper cleanly. This is the

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -94,7 +94,7 @@ def test_runtime_snapshot_semantic_diagnostics_reject_invalid_participant_episod
 
     codes = {diag.code for diag in diagnostics}
     assert "conformance.semantic-invalid" in codes
-    assert any("participant episode result semantics are invalid" in diag.message for diag in diagnostics)
+    assert any("participant episode result is invalid" in diag.message for diag in diagnostics)
 
 
 def test_runtime_snapshot_semantic_diagnostics_reject_invalid_participant_episode_history():
@@ -132,7 +132,7 @@ def test_runtime_snapshot_semantic_diagnostics_reject_invalid_participant_episod
 
     codes = {diag.code for diag in diagnostics}
     assert "conformance.semantic-invalid" in codes
-    assert any("participant episode history event semantics are invalid" in diag.message for diag in diagnostics)
+    assert any("must report sequence_number>0" in diag.message for diag in diagnostics)
 
 
 def test_target_conformance_fails_when_declared_contracts_do_not_cover_profile_requirements():

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from aces_backend_protocols.capabilities import BackendManifest
+from aces_conformance.conformance import _semantic_diagnostics
 
 from aces.backends.stubs import create_stub_components, create_stub_manifest, create_stub_target
 from aces.core.runtime.conformance import (
@@ -37,6 +38,101 @@ def test_profile_is_inferred_from_manifest_shape():
     target = create_stub_target()
 
     assert profile_for_manifest(target.manifest) == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
+
+
+def test_fixture_suite_passes_for_full_remote_control_plane_profile():
+    """RUN-311 — the FULL_REMOTE_CONTROL_PLANE profile now requires the
+    participant episode envelope + history event stream fixtures, so running
+    the fixture suite at that profile must succeed cleanly and must touch
+    every newly-registered contract.
+    """
+
+    report = run_fixture_suite(profile=BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE)
+
+    assert report.passed is True
+    assert not report.diagnostics
+    contract_names = {case.contract_name for case in report.cases}
+    assert "participant-episode-state-envelope-v1" in contract_names
+    assert "participant-episode-history-event-stream-v1" in contract_names
+
+
+def test_runtime_snapshot_semantic_diagnostics_reject_invalid_participant_episode_state():
+    """RUN-311 — a ``/snapshot`` payload that embeds participant episode state
+    that violates the state-machine invariants (e.g. ``status=running`` with a
+    terminal reason) must raise a ``conformance.semantic-invalid`` diagnostic.
+    Without this guard, invalid RUN-311 data could pass both schema validation
+    and conformance.
+    """
+
+    snapshot_payload = {
+        "schema_version": "runtime-snapshot/v1",
+        "entries": {},
+        "orchestration_results": {},
+        "orchestration_history": {},
+        "evaluation_results": {},
+        "evaluation_history": {},
+        "participant_episode_results": {
+            "participant.alice": {
+                "state_schema_version": "participant-episode-state/v1",
+                "participant_address": "participant.alice",
+                "episode_id": "ep-0001",
+                "sequence_number": 0,
+                "status": "running",
+                "terminal_reason": "completed",
+                "initialized_at": "2026-04-12T10:00:00Z",
+                "updated_at": "2026-04-12T10:00:05Z",
+                "terminated_at": None,
+                "last_control_action": "initialize",
+                "previous_episode_id": None,
+            }
+        },
+        "participant_episode_history": {},
+        "metadata": {},
+    }
+
+    diagnostics = _semantic_diagnostics("runtime-snapshot-v1", snapshot_payload)
+
+    codes = {diag.code for diag in diagnostics}
+    assert "conformance.semantic-invalid" in codes
+    assert any("participant episode result semantics are invalid" in diag.message for diag in diagnostics)
+
+
+def test_runtime_snapshot_semantic_diagnostics_reject_invalid_participant_episode_history():
+    """RUN-311 — a history stream emitting ``episode_reset`` at
+    ``sequence_number=0`` cannot correspond to any valid episode chain.
+    Conformance must reject it with a semantic diagnostic.
+    """
+
+    snapshot_payload = {
+        "schema_version": "runtime-snapshot/v1",
+        "entries": {},
+        "orchestration_results": {},
+        "orchestration_history": {},
+        "evaluation_results": {},
+        "evaluation_history": {},
+        "participant_episode_results": {},
+        "participant_episode_history": {
+            "participant.alice": [
+                {
+                    "event_type": "episode_reset",
+                    "timestamp": "2026-04-12T10:00:00Z",
+                    "participant_address": "participant.alice",
+                    "episode_id": "ep-0001",
+                    "sequence_number": 0,
+                    "terminal_reason": None,
+                    "control_action": "reset",
+                    "details": {},
+                }
+            ]
+        },
+        "metadata": {},
+    }
+
+    diagnostics = _semantic_diagnostics("runtime-snapshot-v1", snapshot_payload)
+
+    codes = {diag.code for diag in diagnostics}
+    assert "conformance.semantic-invalid" in codes
+    assert any("participant episode history event semantics are invalid" in diag.message for diag in diagnostics)
 
 
 def test_target_conformance_fails_when_declared_contracts_do_not_cover_profile_requirements():

--- a/notes/reconstructed-work-order-after-gov-917.md
+++ b/notes/reconstructed-work-order-after-gov-917.md
@@ -42,18 +42,18 @@ be the explicit ordering from ADR-010:
    - [x] `RUN-302` Compiled Processing Representation
    - [x] `RUN-303` Planning Semantics
    - [x] `RUN-304` Live Execution State And Lifecycle
+   - [x] `API-403` Per-Target Control Plane Contract
+   - [ ] `RUN-311` Participant Episode Lifecycle And Reset
+   - [ ] `RUN-312` Budgeted Participant Execution Accounting
+   - [ ] `RUN-317` Runtime Clock And Time-Domain Handling
+   - [ ] `RUN-318` Time Advancement And Synchronization Lifecycle
+   - [ ] `RUN-316` Operational Apparatus Observability
    - [ ] `RUN-305` Participant Runtime State And History
    - [ ] `RUN-306` Participant Decision And Execution Lifecycle
    - [ ] `RUN-307` Shared Operational State Model
    - [ ] `RUN-308` Concurrent Participant Execution
    - [ ] `RUN-309` Reproducible Participant Execution Context
    - [ ] `RUN-310` Intervention, Handoff, And Supervisory Lifecycle
-   - [ ] `RUN-311` Participant Episode Lifecycle And Reset
-   - [ ] `RUN-312` Budgeted Participant Execution Accounting
-   - [ ] `RUN-316` Operational Apparatus Observability
-   - [ ] `RUN-317` Runtime Clock And Time-Domain Handling
-   - [ ] `RUN-318` Time Advancement And Synchronization Lifecycle
-   - [x] `API-403` Per-Target Control Plane Contract
 3. Reference implementations
    - [ ] `RUN-313` Reference Processor Implementation
    - [ ] `RUN-314` Reference Emulation Backend

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -18,6 +18,7 @@ phases:
   - id: runtime-core
     requirements:
       - RUN-300
+      - RUN-311
     blocked_until:
       - api400-core
   - id: reference-implementations
@@ -101,6 +102,7 @@ ownership:
     - implementations/python/tests
     - contracts/schemas/control-plane
     - contracts/fixtures/control-plane
+    - docs/decisions/adrs
     - CHANGELOG.md
   reference-implementations:
     - implementations/python/packages

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -103,7 +103,11 @@ ownership:
     - implementations/python/tests
     - contracts/schemas/control-plane
     - contracts/schemas/snapshots
+    - contracts/schemas/backend-manifest
+    - contracts/schemas/processor-manifest
     - contracts/fixtures/control-plane
+    - contracts/fixtures/backend-manifest
+    - contracts/fixtures/processor-manifest
     - docs/decisions/adrs
     - CHANGELOG.md
   reference-implementations:

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -99,8 +99,10 @@ ownership:
   runtime-core:
     - implementations/python/packages/aces_processor
     - implementations/python/packages/aces_contracts
+    - implementations/python/packages/aces_conformance
     - implementations/python/tests
     - contracts/schemas/control-plane
+    - contracts/schemas/snapshots
     - contracts/fixtures/control-plane
     - docs/decisions/adrs
     - CHANGELOG.md


### PR DESCRIPTION
## Summary
- Adds a dedicated participant-episode execution contract surface
  (`ParticipantEpisodeStatus`, `ParticipantEpisodeTerminalReason`,
  `ParticipantEpisodeControlAction`, `ParticipantEpisodeHistoryEventType`,
  `ParticipantEpisodeExecutionState`, `ParticipantEpisodeHistoryEvent`)
  that is distinct from workflow, evaluation, operation, and snapshot
  lifecycles per ADR-013.
- Models current lifecycle state, terminal reason, and control actions
  as three separate enum families so no single concept is overloaded,
  and preserves stable participant identity across resets and restarts
  (each reset/restart allocates a new `episode_id` and increments
  `sequence_number` while back-linking to the prior instance).
- Publishes two new closed-world JSON Schemas via the existing
  `tools/generate_contract_schemas.py` into
  `contracts/schemas/control-plane/`, with minimal
  valid/invalid fixture pairs under `contracts/fixtures/control-plane/`.
- Extends `runtime-core` phase ownership to cover
  `docs/decisions/adrs` so ADR-013 clears governance, and adds RUN-311
  to the `runtime-core` phase in `tools/policy/requirement_order.yaml`.

Closes #31.

Requirement: [RUN-311 Participant Episode Lifecycle And Reset](https://github.com/aces-framework/aces-sdl/issues/31)

ADR: [ADR-013 Participant Episode Lifecycle Boundaries](docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md)

## Test plan
- [x] `nox -s verify` (full completion gate, 685 tests + policy +
      contracts + lint + hygiene) passed locally
- [x] New lifecycle test module
      `implementations/python/tests/test_run_311_participant_episode_lifecycle.py`
      covers every requirement clause (initialization, reset, completion,
      timeout, truncation, interruption, restart) plus invariants and
      schema parity
- [x] Ground Control IMPLEMENTS and TESTS links created for the new
      models, contract models, version constant, ADR-013, and the test
- [x] Schema regeneration is clean (`check_generated_schemas.py` green)
- [x] Fixture corpus validates against closed-world schemas