### PR TITLE
31 run 311 participant episode lifecycle and reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR-013 ("Participant Episode Lifecycle Boundaries") in
   `docs/decisions/adrs/` defining the contract-surface boundary
   discipline that drives this work.
-- End-to-end coverage in
+- Contract-surface coverage in
   `implementations/python/tests/test_run_311_participant_episode_lifecycle.py`
-  satisfying every clause of the requirement (initialization, reset,
-  completion, timeout, truncation, interruption, restart) while
-  preserving stable participant identity across resets and restarts.
+  exercising every clause of the requirement (initialization, reset,
+  completion, timeout, truncation, interruption, restart) at the
+  ``ParticipantEpisodeExecutionState`` /
+  ``ParticipantEpisodeHistoryEvent`` boundary, plus the per-clause
+  invariants on stable participant identity across resets/restarts.
+  End-to-end coverage of the runtime + HTTP control surfaces lives
+  alongside the participant runtime added under finding 1 below
+  (``test_runtime_control_plane.py::TestParticipantEpisodeControlPlane``
+  and
+  ``test_runtime_control_plane_api.py::TestParticipantEpisodeHttpRoutes``).
 - `RuntimeSnapshot` and `RuntimeSnapshotEnvelopeModel` now carry
   `participant_episode_results` and `participant_episode_history`
   alongside the existing `orchestration_*` and `evaluation_*` surfaces.
@@ -61,9 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json`
   is updated to match the widened authority list.
 - `_live_target_cases()` live conformance probe now serializes
-  `participant_episode_results` / `participant_episode_history` so a
-  backend advertising the full-remote profile cannot pass conformance
-  with malformed RUN-311 data.
+  `participant_episode_results` / `participant_episode_history` from
+  the live ``RuntimeControlPlane.snapshot``. Note: the original drop
+  of this entry overstated coverage by implying serialization alone
+  rejected malformed data; the *active* lifecycle drive that actually
+  produces and validates participant data lives under finding 4 below.
 - Shared snapshot invariant iterator
   `aces_processor.models.iter_participant_episode_snapshot_violations`,
   consumed by both the runtime-manager apply path
@@ -79,6 +88,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Production-readiness review finding 5: tighten the original 0.10.0
+  release notes that overstated RUN-311 completeness relative to the
+  contract-only code that initially landed. The
+  ``test_run_311_participant_episode_lifecycle.py`` entry is now
+  scoped to "contract-surface coverage" with an explicit pointer to
+  the runtime/HTTP test classes added under finding 1, and the
+  ``_live_target_cases`` entry now distinguishes the original
+  serialization-only behavior from the active lifecycle drive added
+  under finding 4. Findings 1-4 below independently document the
+  runtime, conformance, and validation gaps the original wording
+  understated; this entry exists so the historical Added section
+  describes only what shipped at each point in time.
 - Production-readiness review finding 4: ``aces_conformance.conformance``
   now actively drives a full participant episode lifecycle whenever the
   target advertises a participant runtime. ``_live_target_cases`` calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `iter_participant_episode_snapshot_violations` now cross-checks each
+  ``participant_episode_results`` entry against the head of the
+  corresponding ``participant_episode_history`` chain. A stale result
+  that still points at an earlier episode than the history shows — the
+  specific scenario raised as production-readiness review finding 2 —
+  fails validation with ``does not match head of history chain``.
+  Identity (``episode_id`` + ``sequence_number``), status category, and
+  ``terminal_reason`` must all agree with the last valid history event
+  for the same participant. Apply-path and conformance semantic-check
+  paths both pick this up automatically via the shared helper.
 - `iter_participant_episode_snapshot_violations` no longer produces
   cascading duplicate violations when a stream-level rule fires. Both
   the sequence-transition gate and the per-sequence ``episode_id``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Production-readiness review finding 4: ``aces_conformance.conformance``
+  now actively drives a full participant episode lifecycle whenever the
+  target advertises a participant runtime. ``_live_target_cases`` calls
+  the new ``_drive_participant_episode_probe`` which submits
+  ``initialize`` / ``reset`` / ``terminate`` / ``restart`` through the
+  control plane, then adds a ``participant-snapshot-consistent``
+  conformance case that fails when ``participant_episode_results`` or
+  ``participant_episode_history`` is empty after the lifecycle, or when
+  the resulting snapshot violates ``iter_participant_episode_snapshot_violations``.
+  Backends that register a participant runtime but never publish
+  state/history through the snapshot now fail conformance instead of
+  silently certifying clean. Regression coverage in
+  ``test_live_probe_catches_participant_runtime_that_does_not_populate_snapshot``.
 - Production-readiness review finding 3: ``profile_for_manifest`` now
   promotes a manifest that declares orchestrator, evaluator, AND
   participant runtime to ``BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Production-readiness review finding 1: RUN-311 now ships an actual
+  runtime capability, not just contracts and validators. New
+  ``ParticipantRuntime`` backend protocol on
+  ``aces_backend_protocols/protocols.py`` defines ``initialize`` /
+  ``reset`` / ``restart`` / ``terminate`` plus the standard
+  ``status`` / ``results`` / ``history`` observation methods. New
+  ``ParticipantRuntimeCapabilities`` capability block on
+  ``BackendCapabilitySet`` plus a ``has_participant_runtime`` property
+  on ``BackendManifest`` let backends advertise the surface and let
+  ``RuntimeTarget`` shape validation reject targets whose component
+  presence does not match the manifest. ``RuntimeControlPlane``
+  exposes ``initialize_participant_episode``,
+  ``reset_participant_episode``, ``restart_participant_episode``, and
+  ``terminate_participant_episode``, each routing through the existing
+  idempotency / persistence / audit pipeline and emitting an
+  ``OperationReceipt`` / ``OperationStatus`` under a new
+  ``RuntimeDomain.PARTICIPANT`` domain. ``control_plane_api.py``
+  publishes the four matching POST routes under
+  ``/participants/{participant_address}/episodes/*`` with closed-world
+  request bodies. The reference stub backend gains a new
+  ``StubParticipantRuntime`` that implements every transition with
+  RUN-311-correct sequence/episode_id/previous_episode_id semantics
+  and updates the snapshot in lockstep with the published contract.
+  Tests cover the in-process control plane lifecycle, the HTTP API,
+  the rejection paths (no participant runtime, already terminated,
+  duplicate initialize, etc.), idempotency replay, and a full
+  end-to-end ``initialize → reset → terminate → restart`` chain that
+  must satisfy ``iter_participant_episode_snapshot_violations``.
 - `iter_participant_episode_snapshot_violations` now cross-checks each
   ``participant_episode_results`` entry against the head of the
   corresponding ``participant_episode_history`` chain. A stale result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Production-readiness review finding 3: ``profile_for_manifest`` now
+  promotes a manifest that declares orchestrator, evaluator, AND
+  participant runtime to ``BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE``
+  so the default ``run_target_conformance`` path automatically validates
+  the live target against the participant-episode contract family
+  (RUN-311) without callers having to override the profile.
+  ``_capability_gaps`` now requires a ``participant_runtime`` component
+  for that profile, and ``test_runtime_conformance`` covers both the
+  promotion path and the orchestration-evaluation fallback for backends
+  that omit the participant runtime block.
 - Production-readiness review finding 1: RUN-311 now ships an actual
   runtime capability, not just contracts and validators. New
   ``ParticipantRuntime`` backend protocol on

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
@@ -90,6 +90,10 @@
       "supports_scoring": true,
       "supports_objectives": true,
       "constraints": {}
+    },
+    "participant_runtime": {
+      "name": "stub-participant-runtime",
+      "constraints": {}
     }
   }
 }

--- a/contracts/schemas/backend-manifest/backend-manifest-v2.json
+++ b/contracts/schemas/backend-manifest/backend-manifest-v2.json
@@ -46,6 +46,17 @@
           ],
           "default": null
         },
+        "participant_runtime": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParticipantRuntimeCapabilitiesModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "provisioner": {
           "$ref": "#/$defs/ProvisionerCapabilitiesModel"
         }
@@ -287,6 +298,29 @@
         "supported_sections"
       ],
       "title": "OrchestratorCapabilitiesModel",
+      "type": "object"
+    },
+    "ParticipantRuntimeCapabilitiesModel": {
+      "additionalProperties": false,
+      "description": "Participant-episode lifecycle capability block (RUN-311).\n\nA backend that declares this block advertises that it implements\nthe full participant episode control surface on the\n``ParticipantRuntime`` protocol: ``initialize`` / ``reset`` /\n``restart`` / ``terminate`` plus ``status`` / ``results`` /\n``history``. Consumers of the manifest can infer the\n``FULL_REMOTE_CONTROL_PLANE`` conformance profile from this block.",
+      "properties": {
+        "constraints": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Constraints",
+          "type": "object"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "ParticipantRuntimeCapabilitiesModel",
       "type": "object"
     },
     "ProvisionerCapabilitiesModel": {

--- a/implementations/python/packages/aces_backend_protocols/capabilities.py
+++ b/implementations/python/packages/aces_backend_protocols/capabilities.py
@@ -135,12 +135,35 @@ class EvaluatorCapabilities:
 
 
 @dataclass(frozen=True)
+class ParticipantRuntimeCapabilities:
+    """Participant-episode lifecycle support declaration.
+
+    Declaring this capability means the backend exposes the full
+    participant episode control surface defined in RUN-311:
+    ``initialize``, ``reset``, ``restart``, and ``terminate`` on the
+    ``ParticipantRuntime`` protocol, plus the ``status``/``results``/
+    ``history`` observation methods. A backend that advertises this
+    capability MUST populate ``RuntimeSnapshot.participant_episode_results``
+    and ``participant_episode_history`` so downstream consumers see the
+    state machine transitions.
+    """
+
+    name: str
+    constraints: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("ParticipantRuntimeCapabilities.name must be non-empty")
+
+
+@dataclass(frozen=True)
 class BackendCapabilitySet:
     """Backend-specific nested capability blocks."""
 
     provisioner: ProvisionerCapabilities
     orchestrator: OrchestratorCapabilities | None = None
     evaluator: EvaluatorCapabilities | None = None
+    participant_runtime: ParticipantRuntimeCapabilities | None = None
 
 
 @dataclass(frozen=True)
@@ -184,6 +207,7 @@ class BackendManifest:
         provisioner: ProvisionerCapabilities | None = None,
         orchestrator: OrchestratorCapabilities | None = None,
         evaluator: EvaluatorCapabilities | None = None,
+        participant_runtime: ParticipantRuntimeCapabilities | None = None,
     ) -> None:
         if identity is None:
             if name is None:
@@ -198,6 +222,7 @@ class BackendManifest:
                 provisioner=provisioner,
                 orchestrator=orchestrator,
                 evaluator=evaluator,
+                participant_runtime=participant_runtime,
             )
         supported_contract_versions = frozenset(supported_contract_versions)
         if not supported_contract_versions:
@@ -244,12 +269,20 @@ class BackendManifest:
         return self.capabilities.evaluator
 
     @property
+    def participant_runtime(self) -> ParticipantRuntimeCapabilities | None:
+        return self.capabilities.participant_runtime
+
+    @property
     def has_orchestrator(self) -> bool:
         return self.orchestrator is not None
 
     @property
     def has_evaluator(self) -> bool:
         return self.evaluator is not None
+
+    @property
+    def has_participant_runtime(self) -> bool:
+        return self.participant_runtime is not None
 
     @property
     def evaluator_supported_sections(self) -> frozenset[str]:

--- a/implementations/python/packages/aces_backend_protocols/manifest.py
+++ b/implementations/python/packages/aces_backend_protocols/manifest.py
@@ -89,6 +89,14 @@ def backend_manifest_v2_model(manifest: BackendManifest) -> BackendManifestV2Mod
                 if manifest.evaluator is not None
                 else None
             ),
+            "participant_runtime": (
+                {
+                    "name": manifest.participant_runtime.name,
+                    "constraints": dict(manifest.participant_runtime.constraints),
+                }
+                if manifest.participant_runtime is not None
+                else None
+            ),
         },
     )
 

--- a/implementations/python/packages/aces_backend_protocols/protocols.py
+++ b/implementations/python/packages/aces_backend_protocols/protocols.py
@@ -7,6 +7,10 @@ from aces_processor.models import (
     Diagnostic,
     EvaluationPlan,
     OrchestrationPlan,
+    ParticipantEpisodeInitializeRequest,
+    ParticipantEpisodeResetRequest,
+    ParticipantEpisodeRestartRequest,
+    ParticipantEpisodeTerminateRequest,
     ProvisioningPlan,
     RuntimeSnapshot,
 )
@@ -81,4 +85,72 @@ class Evaluator(Protocol):
 
     def stop(self, snapshot: RuntimeSnapshot) -> ApplyResult:
         """Stop evaluation and clear evaluation state."""
+        ...
+
+
+class ParticipantRuntime(Protocol):
+    """Drives participant episode lifecycle transitions (RUN-311).
+
+    The four control methods map 1:1 to the ``ParticipantEpisodeControlAction``
+    enum. Each method is idempotent from the caller's perspective — the
+    control plane routes duplicate submissions through its idempotency
+    record store before reaching the backend. The backend is responsible
+    for mutating ``RuntimeSnapshot.participant_episode_results`` and
+    ``RuntimeSnapshot.participant_episode_history`` in a way that stays
+    consistent with the RUN-311 invariants enforced by
+    ``iter_participant_episode_snapshot_violations``.
+    """
+
+    def initialize(
+        self,
+        request: ParticipantEpisodeInitializeRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Create the first episode for a participant (sequence_number=0)."""
+        ...
+
+    def reset(
+        self,
+        request: ParticipantEpisodeResetRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Start a new episode instance from a non-terminal predecessor.
+
+        Must allocate a new ``episode_id`` and increment
+        ``sequence_number``, preserving the stable participant identity and
+        linking back to the prior ``episode_id`` via ``previous_episode_id``.
+        """
+        ...
+
+    def restart(
+        self,
+        request: ParticipantEpisodeRestartRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Start a new episode instance from a terminated predecessor.
+
+        Must allocate a new ``episode_id`` and increment
+        ``sequence_number``, preserving the stable participant identity and
+        linking back to the prior ``episode_id`` via ``previous_episode_id``.
+        """
+        ...
+
+    def terminate(
+        self,
+        request: ParticipantEpisodeTerminateRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Drive the current episode to ``TERMINATED`` with the given reason."""
+        ...
+
+    def status(self) -> dict[str, Any]:
+        """Return current participant runtime status."""
+        ...
+
+    def results(self) -> dict[str, dict[str, Any]]:
+        """Return the most recent participant episode result envelopes."""
+        ...
+
+    def history(self) -> dict[str, list[dict[str, Any]]]:
+        """Return participant episode history events."""
         ...

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -9,6 +9,7 @@ from aces_backend_protocols.capabilities import (
     BackendManifest,
     EvaluatorCapabilities,
     OrchestratorCapabilities,
+    ParticipantRuntimeCapabilities,
     ProvisionerCapabilities,
     WorkflowFeature,
     WorkflowStatePredicateFeature,
@@ -23,6 +24,16 @@ from aces_processor.models import (
     Diagnostic,
     EvaluationPlan,
     OrchestrationPlan,
+    ParticipantEpisodeControlAction,
+    ParticipantEpisodeExecutionState,
+    ParticipantEpisodeHistoryEvent,
+    ParticipantEpisodeHistoryEventType,
+    ParticipantEpisodeInitializeRequest,
+    ParticipantEpisodeResetRequest,
+    ParticipantEpisodeRestartRequest,
+    ParticipantEpisodeStatus,
+    ParticipantEpisodeTerminalReason,
+    ParticipantEpisodeTerminateRequest,
     ProvisioningPlan,
     RuntimeDomain,
     RuntimeSnapshot,
@@ -40,14 +51,29 @@ def _current_backend_version() -> str:
         return "0.0.0+unknown"
 
 
-def create_stub_manifest(**config) -> BackendManifest:
-    """Return the fully capable stub manifest."""
+def create_stub_manifest(
+    *,
+    with_participant_runtime: bool = True,
+    **config,
+) -> BackendManifest:
+    """Return the fully capable stub manifest.
+
+    ``with_participant_runtime=False`` omits the participant runtime
+    capability block so legacy tests that construct targets with only
+    provisioner/orchestrator/evaluator components still satisfy
+    ``registry.target-shape-mismatch`` validation. Production callers
+    should leave this at its default.
+    """
 
     del config
+    supported_contract_versions = set(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS)
+    if not with_participant_runtime:
+        supported_contract_versions.discard("participant-episode-state-envelope-v1")
+        supported_contract_versions.discard("participant-episode-history-event-stream-v1")
     return BackendManifest(
         name="stub",
         version=_current_backend_version(),
-        supported_contract_versions=frozenset(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS),
+        supported_contract_versions=frozenset(supported_contract_versions),
         compatible_processors=frozenset({"aces-reference-processor"}),
         concept_bindings=(
             ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
@@ -125,6 +151,9 @@ def create_stub_manifest(**config) -> BackendManifest:
                 supported_sections=frozenset({"conditions", "metrics", "evaluations", "tlos", "goals", "objectives"}),
                 supports_scoring=True,
                 supports_objectives=True,
+            ),
+            participant_runtime=(
+                ParticipantRuntimeCapabilities(name="stub-participant-runtime") if with_participant_runtime else None
             ),
         ),
     )
@@ -426,6 +455,312 @@ class StubEvaluator:
         )
 
 
+class StubParticipantRuntime:
+    """In-memory participant runtime that drives RUN-311 transitions.
+
+    Each control method allocates new history events and advances the
+    current ``participant_episode_results`` entry in lockstep so the
+    resulting snapshot always satisfies
+    ``iter_participant_episode_snapshot_violations`` — identity is
+    stable across resets/restarts, history is append-only, and the
+    current result is the head of the history chain.
+    """
+
+    def __init__(self) -> None:
+        self._results: dict[str, dict[str, object]] = {}
+        self._history: dict[str, list[dict[str, object]]] = {}
+        self._episode_counter: dict[str, int] = {}
+
+    def initialize(
+        self,
+        request: ParticipantEpisodeInitializeRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        if not address:
+            return self._reject(snapshot, "participant_address must be non-empty", address)
+        if address in snapshot.participant_episode_results:
+            return self._reject(
+                snapshot,
+                f"participant {address!r} already has a live episode; use reset or restart",
+                address,
+            )
+        now = _now_iso()
+        episode_id = request.episode_id or self._allocate_episode_id(address)
+        state = ParticipantEpisodeExecutionState(
+            participant_address=address,
+            episode_id=episode_id,
+            sequence_number=0,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=now,
+            updated_at=now,
+            last_control_action=ParticipantEpisodeControlAction.INITIALIZE,
+        )
+        events = [
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_INITIALIZED,
+                timestamp=now,
+                participant_address=address,
+                episode_id=episode_id,
+                sequence_number=0,
+                control_action=ParticipantEpisodeControlAction.INITIALIZE,
+            ),
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=now,
+                participant_address=address,
+                episode_id=episode_id,
+                sequence_number=0,
+            ),
+        ]
+        return self._apply(snapshot, address, state, events, replace_history=True)
+
+    def reset(
+        self,
+        request: ParticipantEpisodeResetRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        if not address:
+            return self._reject(snapshot, "participant_address must be non-empty", address)
+        current = snapshot.participant_episode_results.get(address)
+        if current is None:
+            return self._reject(
+                snapshot,
+                f"cannot reset participant {address!r}: no live episode",
+                address,
+            )
+        try:
+            current_state = ParticipantEpisodeExecutionState.from_payload(current)
+        except (TypeError, ValueError) as exc:
+            return self._reject(snapshot, f"current state is invalid: {exc}", address)
+        if current_state.status == ParticipantEpisodeStatus.TERMINATED:
+            return self._reject(
+                snapshot,
+                f"cannot reset terminated participant {address!r}; use restart",
+                address,
+            )
+        now = _now_iso()
+        new_episode_id = request.episode_id or self._allocate_episode_id(address)
+        new_sequence = current_state.sequence_number + 1
+        new_state = ParticipantEpisodeExecutionState(
+            participant_address=address,
+            episode_id=new_episode_id,
+            sequence_number=new_sequence,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=now,
+            updated_at=now,
+            last_control_action=ParticipantEpisodeControlAction.RESET,
+            previous_episode_id=current_state.episode_id,
+        )
+        events = [
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RESET,
+                timestamp=now,
+                participant_address=address,
+                episode_id=new_episode_id,
+                sequence_number=new_sequence,
+                control_action=ParticipantEpisodeControlAction.RESET,
+                details={
+                    "previous_episode_id": current_state.episode_id,
+                    "reason": request.reason,
+                },
+            ),
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=now,
+                participant_address=address,
+                episode_id=new_episode_id,
+                sequence_number=new_sequence,
+            ),
+        ]
+        return self._apply(snapshot, address, new_state, events, replace_history=False)
+
+    def restart(
+        self,
+        request: ParticipantEpisodeRestartRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        if not address:
+            return self._reject(snapshot, "participant_address must be non-empty", address)
+        current = snapshot.participant_episode_results.get(address)
+        if current is None:
+            return self._reject(
+                snapshot,
+                f"cannot restart participant {address!r}: no live episode",
+                address,
+            )
+        try:
+            current_state = ParticipantEpisodeExecutionState.from_payload(current)
+        except (TypeError, ValueError) as exc:
+            return self._reject(snapshot, f"current state is invalid: {exc}", address)
+        if current_state.status != ParticipantEpisodeStatus.TERMINATED:
+            return self._reject(
+                snapshot,
+                f"cannot restart non-terminated participant {address!r}; use reset",
+                address,
+            )
+        now = _now_iso()
+        new_episode_id = request.episode_id or self._allocate_episode_id(address)
+        new_sequence = current_state.sequence_number + 1
+        new_state = ParticipantEpisodeExecutionState(
+            participant_address=address,
+            episode_id=new_episode_id,
+            sequence_number=new_sequence,
+            status=ParticipantEpisodeStatus.RUNNING,
+            initialized_at=now,
+            updated_at=now,
+            last_control_action=ParticipantEpisodeControlAction.RESTART,
+            previous_episode_id=current_state.episode_id,
+        )
+        events = [
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RESTARTED,
+                timestamp=now,
+                participant_address=address,
+                episode_id=new_episode_id,
+                sequence_number=new_sequence,
+                control_action=ParticipantEpisodeControlAction.RESTART,
+                details={
+                    "previous_episode_id": current_state.episode_id,
+                    "reason": request.reason,
+                },
+            ),
+            ParticipantEpisodeHistoryEvent(
+                event_type=ParticipantEpisodeHistoryEventType.EPISODE_RUNNING,
+                timestamp=now,
+                participant_address=address,
+                episode_id=new_episode_id,
+                sequence_number=new_sequence,
+            ),
+        ]
+        return self._apply(snapshot, address, new_state, events, replace_history=False)
+
+    def terminate(
+        self,
+        request: ParticipantEpisodeTerminateRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        if not address:
+            return self._reject(snapshot, "participant_address must be non-empty", address)
+        current = snapshot.participant_episode_results.get(address)
+        if current is None:
+            return self._reject(
+                snapshot,
+                f"cannot terminate participant {address!r}: no live episode",
+                address,
+            )
+        try:
+            current_state = ParticipantEpisodeExecutionState.from_payload(current)
+        except (TypeError, ValueError) as exc:
+            return self._reject(snapshot, f"current state is invalid: {exc}", address)
+        if current_state.status == ParticipantEpisodeStatus.TERMINATED:
+            return self._reject(
+                snapshot,
+                f"participant {address!r} is already terminated",
+                address,
+            )
+        now = _now_iso()
+        terminal_reason = request.terminal_reason
+        terminal_event_type = _PARTICIPANT_TERMINAL_EVENT_FOR_REASON[terminal_reason]
+        new_state = ParticipantEpisodeExecutionState(
+            participant_address=address,
+            episode_id=current_state.episode_id,
+            sequence_number=current_state.sequence_number,
+            status=ParticipantEpisodeStatus.TERMINATED,
+            terminal_reason=terminal_reason,
+            initialized_at=current_state.initialized_at,
+            updated_at=now,
+            terminated_at=now,
+            last_control_action=current_state.last_control_action,
+            previous_episode_id=current_state.previous_episode_id,
+        )
+        events = [
+            ParticipantEpisodeHistoryEvent(
+                event_type=terminal_event_type,
+                timestamp=now,
+                participant_address=address,
+                episode_id=current_state.episode_id,
+                sequence_number=current_state.sequence_number,
+                terminal_reason=terminal_reason,
+                details={"detail": request.detail},
+            ),
+        ]
+        return self._apply(snapshot, address, new_state, events, replace_history=False)
+
+    def status(self) -> dict[str, object]:
+        return {
+            "participants": len(self._results),
+            "running": sum(1 for result in self._results.values() if result.get("status") == "running"),
+        }
+
+    def results(self) -> dict[str, dict[str, object]]:
+        return {address: dict(result) for address, result in self._results.items()}
+
+    def history(self) -> dict[str, list[dict[str, object]]]:
+        return {address: list(events) for address, events in self._history.items()}
+
+    def _apply(
+        self,
+        snapshot: RuntimeSnapshot,
+        address: str,
+        state: ParticipantEpisodeExecutionState,
+        new_events: list[ParticipantEpisodeHistoryEvent],
+        *,
+        replace_history: bool,
+    ) -> ApplyResult:
+        results = {addr: dict(result) for addr, result in snapshot.participant_episode_results.items()}
+        history = {addr: list(events) for addr, events in snapshot.participant_episode_history.items()}
+        results[address] = state.to_payload()
+        if replace_history:
+            history[address] = [event.to_payload() for event in new_events]
+        else:
+            history.setdefault(address, [])
+            history[address].extend(event.to_payload() for event in new_events)
+        self._results = results
+        self._history = history
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                participant_episode_results=results,
+                participant_episode_history=history,
+            ),
+            changed_addresses=[address],
+        )
+
+    def _reject(self, snapshot: RuntimeSnapshot, message: str, address: str) -> ApplyResult:
+        diagnostic = Diagnostic(
+            code="runtime.participant-runtime.rejected",
+            domain="runtime",
+            address=address or "runtime.participant-runtime",
+            message=message,
+        )
+        return ApplyResult(success=False, snapshot=snapshot, diagnostics=[diagnostic])
+
+    def _allocate_episode_id(self, address: str) -> str:
+        next_index = self._episode_counter.get(address, 0) + 1
+        self._episode_counter[address] = next_index
+        return f"{address}-episode-{next_index}"
+
+
+_PARTICIPANT_TERMINAL_EVENT_FOR_REASON: dict[
+    ParticipantEpisodeTerminalReason,
+    ParticipantEpisodeHistoryEventType,
+] = {
+    ParticipantEpisodeTerminalReason.COMPLETED: ParticipantEpisodeHistoryEventType.EPISODE_COMPLETED,
+    ParticipantEpisodeTerminalReason.TIMED_OUT: ParticipantEpisodeHistoryEventType.EPISODE_TIMED_OUT,
+    ParticipantEpisodeTerminalReason.TRUNCATED: ParticipantEpisodeHistoryEventType.EPISODE_TRUNCATED,
+    ParticipantEpisodeTerminalReason.INTERRUPTED: ParticipantEpisodeHistoryEventType.EPISODE_INTERRUPTED,
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
 def create_stub_components(
     *,
     manifest: BackendManifest,
@@ -433,11 +768,12 @@ def create_stub_components(
 ) -> RuntimeTargetComponents:
     """Factory for stub runtime components."""
 
-    del manifest, config
+    del config
     return RuntimeTargetComponents(
         provisioner=StubProvisioner(),
         orchestrator=StubOrchestrator(),
         evaluator=StubEvaluator(),
+        participant_runtime=StubParticipantRuntime() if manifest.has_participant_runtime else None,
     )
 
 
@@ -452,4 +788,5 @@ def create_stub_target(**config) -> RuntimeTarget:
         provisioner=components.provisioner,
         orchestrator=components.orchestrator,
         evaluator=components.evaluator,
+        participant_runtime=components.participant_runtime,
     )

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -38,6 +38,7 @@ from aces_processor.models import (
     EvaluationExecutionState,
     ParticipantEpisodeExecutionState,
     ParticipantEpisodeHistoryEvent,
+    ParticipantEpisodeTerminalReason,
     RuntimeDomain,
     RuntimeSnapshot,
     RuntimeSnapshotEnvelope,
@@ -573,6 +574,133 @@ def run_target_conformance(
     )
 
 
+def _drive_participant_episode_probe(
+    control_plane: RuntimeControlPlane,
+    *,
+    participant_address: str,
+) -> list[ConformanceCaseResult]:
+    """Drive a full RUN-311 participant lifecycle via the control plane.
+
+    Each control action becomes one ``ConformanceCaseResult`` so that
+    ``run_target_conformance`` reports a separate failure for any step
+    the backend rejects, and a final case validates the resulting
+    ``participant_episode_results`` / ``participant_episode_history``
+    against the shared snapshot invariants.
+
+    A target that registers a participant runtime but never populates
+    the snapshot fields fails the snapshot-state-not-empty check, so
+    the live conformance probe cannot certify a backend whose runtime
+    accepts every action but produces no observable state.
+    """
+
+    cases: list[ConformanceCaseResult] = []
+    actions = (
+        ("participant-initialize", lambda: control_plane.initialize_participant_episode(participant_address)),
+        ("participant-reset", lambda: control_plane.reset_participant_episode(participant_address)),
+        (
+            "participant-terminate",
+            lambda: control_plane.terminate_participant_episode(
+                participant_address,
+                terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+            ),
+        ),
+        ("participant-restart", lambda: control_plane.restart_participant_episode(participant_address)),
+    )
+    contract_name = "participant-episode-state-envelope-v1"
+    for case_name, invoke in actions:
+        try:
+            receipt = invoke()
+        except Exception as exc:  # pragma: no cover - defensive only
+            cases.append(
+                ConformanceCaseResult(
+                    name=case_name,
+                    contract_name=contract_name,
+                    valid=True,
+                    passed=False,
+                    diagnostics=(
+                        _diagnostic(
+                            "conformance.participant-runtime-failed",
+                            f"runtime.control-plane.participant.{participant_address}",
+                            f"{case_name} raised {type(exc).__name__}: {exc}",
+                        ),
+                    ),
+                )
+            )
+            continue
+        status = control_plane.get_operation(receipt.operation_id)
+        diagnostics: list[Diagnostic] = []
+        if status is None:
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.participant-runtime-missing-status",
+                    f"runtime.control-plane.participant.{participant_address}",
+                    f"{case_name} did not produce an OperationStatus record",
+                )
+            )
+        elif status.state.value not in {"succeeded"}:
+            diagnostics.append(
+                _diagnostic(
+                    "conformance.participant-runtime-failed",
+                    f"runtime.control-plane.participant.{participant_address}",
+                    (
+                        f"{case_name} returned state {status.state.value!r} with diagnostics: "
+                        + "; ".join(diag.message for diag in status.diagnostics)
+                    ),
+                )
+            )
+        cases.append(
+            ConformanceCaseResult(
+                name=case_name,
+                contract_name=contract_name,
+                valid=True,
+                passed=not diagnostics,
+                diagnostics=tuple(diagnostics),
+            )
+        )
+
+    snapshot = control_plane.snapshot
+    final_diagnostics: list[Diagnostic] = []
+    if not snapshot.participant_episode_results:
+        final_diagnostics.append(
+            _diagnostic(
+                "conformance.participant-runtime-empty",
+                f"runtime.snapshot.participant-episode-results.{participant_address}",
+                (
+                    "Participant runtime accepted every control action but the snapshot "
+                    "exposes no participant_episode_results. RUN-311 backends must publish "
+                    "live episode state through the snapshot."
+                ),
+            )
+        )
+    if not snapshot.participant_episode_history:
+        final_diagnostics.append(
+            _diagnostic(
+                "conformance.participant-runtime-empty",
+                f"runtime.snapshot.participant-episode-history.{participant_address}",
+                (
+                    "Participant runtime accepted every control action but the snapshot "
+                    "exposes no participant_episode_history. RUN-311 backends must publish "
+                    "live episode history events through the snapshot."
+                ),
+            )
+        )
+    for address, message in iter_participant_episode_snapshot_violations(
+        snapshot.participant_episode_results,
+        snapshot.participant_episode_history,
+    ):
+        final_diagnostics.append(_diagnostic("conformance.semantic-invalid", address, message))
+    cases.append(
+        ConformanceCaseResult(
+            name="participant-snapshot-consistent",
+            contract_name=contract_name,
+            valid=True,
+            passed=not final_diagnostics,
+            diagnostics=tuple(final_diagnostics),
+        )
+    )
+    return cases
+
+
 def _live_target_cases(
     target: RuntimeTarget,
     profile: BackendCapabilityProfile,
@@ -631,6 +759,13 @@ def _live_target_cases(
         control_plane.submit_orchestration(execution_plan.orchestration)
     if target.evaluator is not None:
         control_plane.submit_evaluation(execution_plan.evaluation)
+    if target.participant_runtime is not None:
+        cases.extend(
+            _drive_participant_episode_probe(
+                control_plane,
+                participant_address="participant.conformance",
+            )
+        )
     snapshot_payload = {
         "schema_version": RuntimeSnapshotEnvelope().schema_version,
         "entries": {

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -471,8 +471,20 @@ def run_fixture_suite(
 
 
 def profile_for_manifest(manifest: BackendManifest) -> BackendCapabilityProfile:
-    """Infer the nearest conformance profile for a backend manifest."""
+    """Infer the nearest conformance profile for a backend manifest.
 
+    A backend that declares orchestrator, evaluator, AND participant
+    runtime capabilities is treated as ``FULL_REMOTE_CONTROL_PLANE``,
+    so the default ``run_target_conformance`` path automatically
+    validates the live target against the participant-episode contract
+    family (RUN-311). Backends that only declare orchestrator/evaluator
+    fall back to ``ORCHESTRATION_EVALUATION``; orchestrator-only
+    declarations fall back to ``ORCHESTRATION_CAPABLE``; provisioner-only
+    backends remain at ``PROVISIONING_ONLY``.
+    """
+
+    if manifest.has_orchestrator and manifest.has_evaluator and manifest.has_participant_runtime:
+        return BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE
     if manifest.has_orchestrator and manifest.has_evaluator:
         return BackendCapabilityProfile.ORCHESTRATION_EVALUATION
     if manifest.has_orchestrator:
@@ -504,6 +516,8 @@ def _capability_gaps(
         and target.evaluator is None
     ):
         gaps.append("evaluator")
+    if profile == BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE and target.participant_runtime is None:
+        gaps.append("participant_runtime")
     return tuple(gaps)
 
 

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -556,10 +556,26 @@ class ProcessorCapabilitiesV2Model(ContractModel):
         return json_schema
 
 
+class ParticipantRuntimeCapabilitiesModel(ContractModel):
+    """Participant-episode lifecycle capability block (RUN-311).
+
+    A backend that declares this block advertises that it implements
+    the full participant episode control surface on the
+    ``ParticipantRuntime`` protocol: ``initialize`` / ``reset`` /
+    ``restart`` / ``terminate`` plus ``status`` / ``results`` /
+    ``history``. Consumers of the manifest can infer the
+    ``FULL_REMOTE_CONTROL_PLANE`` conformance profile from this block.
+    """
+
+    name: NonEmptyString
+    constraints: dict[str, str] = Field(default_factory=dict)
+
+
 class BackendCapabilitiesV2Model(ContractModel):
     provisioner: ProvisionerCapabilitiesModel
     orchestrator: OrchestratorCapabilitiesModel | None = None
     evaluator: EvaluatorCapabilitiesModel | None = None
+    participant_runtime: ParticipantRuntimeCapabilitiesModel | None = None
 
 
 class ProcessorManifestV2Model(ContractModel):
@@ -1205,6 +1221,7 @@ __all__ = [
     "PARTICIPANT_EPISODE_STATE_SCHEMA_VERSION",
     "ParticipantEpisodeHistoryEventModel",
     "ParticipantEpisodeStateModel",
+    "ParticipantRuntimeCapabilitiesModel",
     "PlanOperationModel",
     "ProcessorFeature",
     "PROCESSOR_MANIFEST_V2_SCHEMA_VERSION",

--- a/implementations/python/packages/aces_processor/control_plane.py
+++ b/implementations/python/packages/aces_processor/control_plane.py
@@ -25,6 +25,11 @@ from .models import (
     OperationState,
     OperationStatus,
     OrchestrationPlan,
+    ParticipantEpisodeInitializeRequest,
+    ParticipantEpisodeResetRequest,
+    ParticipantEpisodeRestartRequest,
+    ParticipantEpisodeTerminalReason,
+    ParticipantEpisodeTerminateRequest,
     ProvisioningPlan,
     RuntimeDomain,
     RuntimeSnapshot,
@@ -483,6 +488,187 @@ class RuntimeControlPlane:
             ControlPlaneOperationRecord(
                 receipt=receipt,
                 status=status,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        )
+        return receipt
+
+    def initialize_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message="Target does not provide a participant runtime.",
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeInitializeRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+        )
+        return self._execute_participant_action(
+            method=self._target.participant_runtime.initialize,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.initialize",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def reset_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        reason: str = "reset by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message="Target does not provide a participant runtime.",
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeResetRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+            reason=reason,
+        )
+        return self._execute_participant_action(
+            method=self._target.participant_runtime.reset,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.reset",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def restart_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        reason: str = "restarted by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message="Target does not provide a participant runtime.",
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeRestartRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+            reason=reason,
+        )
+        return self._execute_participant_action(
+            method=self._target.participant_runtime.restart,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.restart",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def terminate_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        terminal_reason: ParticipantEpisodeTerminalReason = ParticipantEpisodeTerminalReason.INTERRUPTED,
+        detail: str = "terminated by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message="Target does not provide a participant runtime.",
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeTerminateRequest(
+            participant_address=participant_address,
+            terminal_reason=terminal_reason,
+            detail=detail,
+        )
+        return self._execute_participant_action(
+            method=self._target.participant_runtime.terminate,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.terminate",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def _execute_participant_action(
+        self,
+        *,
+        method,
+        request,
+        address: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+    ) -> OperationReceipt:
+        existing = self._idempotent_receipt(
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+        if existing is not None:
+            return existing
+        operation_id = str(uuid4())
+        submitted_at = _utc_now()
+        status = OperationStatus(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            state=OperationState.RUNNING,
+            submitted_at=submitted_at,
+            updated_at=submitted_at,
+        )
+        receipt = OperationReceipt(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            submitted_at=submitted_at,
+            accepted=True,
+        )
+        self._persist_record(
+            ControlPlaneOperationRecord(
+                receipt=receipt,
+                status=status,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        )
+        result = _call_backend_apply(
+            method,
+            request,
+            self._snapshot,
+            address=address,
+            snapshot=self._snapshot,
+        )
+        self._snapshot = result.snapshot
+        self._store.save_snapshot(self._snapshot)
+        final_state = OperationState.SUCCEEDED if result.success else OperationState.FAILED
+        final_status = OperationStatus(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            state=final_state,
+            submitted_at=submitted_at,
+            updated_at=_utc_now(),
+            diagnostics=[*status.diagnostics, *result.diagnostics],
+            changed_addresses=list(result.changed_addresses),
+        )
+        self._persist_record(
+            ControlPlaneOperationRecord(
+                receipt=receipt,
+                status=final_status,
                 idempotency_key=idempotency_key,
                 request_fingerprint=request_fingerprint,
             )

--- a/implementations/python/packages/aces_processor/control_plane_api.py
+++ b/implementations/python/packages/aces_processor/control_plane_api.py
@@ -17,6 +17,7 @@ from aces_contracts.contracts import (
 )
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
 
 from .control_plane import RuntimeControlPlane
 from .control_plane_security import (
@@ -32,11 +33,35 @@ from .models import (
     OperationStatus,
     OrchestrationOp,
     OrchestrationPlan,
+    ParticipantEpisodeTerminalReason,
     ProvisioningPlan,
     ProvisionOp,
     RuntimeSnapshotEnvelope,
     Severity,
 )
+
+
+class _ParticipantInitializeBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    episode_id: str | None = None
+
+
+class _ParticipantResetBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    episode_id: str | None = None
+    reason: str = Field(default="reset by operator")
+
+
+class _ParticipantRestartBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    episode_id: str | None = None
+    reason: str = Field(default="restarted by operator")
+
+
+class _ParticipantTerminateBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    terminal_reason: str = Field(default=ParticipantEpisodeTerminalReason.INTERRUPTED.value)
+    detail: str = Field(default="terminated by operator")
 
 
 def _diagnostic_from_mapping(payload: dict[str, Any]) -> Diagnostic:
@@ -485,5 +510,152 @@ def create_control_plane_app(
                 "diagnostics": [asdict(diag) for diag in receipt.diagnostics],
             }
         )
+
+    def _receipt_response(receipt) -> OperationReceiptModel:
+        return OperationReceiptModel.model_validate(
+            {
+                "schema_version": receipt.schema_version,
+                "operation_id": receipt.operation_id,
+                "domain": receipt.domain.value,
+                "submitted_at": receipt.submitted_at,
+                "accepted": receipt.accepted,
+                "diagnostics": [asdict(diag) for diag in receipt.diagnostics],
+            }
+        )
+
+    @app.post(
+        "/participants/{participant_address}/episodes/initialize",
+        response_model=OperationReceiptModel,
+    )
+    async def initialize_participant_episode(
+        participant_address: str,
+        request: Request,
+        body: _ParticipantInitializeBody | None = None,
+        identity: ControlPlaneIdentity = Depends(_mutating_identity),
+    ) -> OperationReceiptModel:
+        payload = body or _ParticipantInitializeBody()
+        try:
+            receipt = control_plane.initialize_participant_episode(
+                participant_address,
+                episode_id=payload.episode_id,
+                idempotency_key=request.headers.get("idempotency-key", ""),
+                request_fingerprint=_request_fingerprint(
+                    request,
+                    getattr(request.state, "raw_body", b""),
+                ),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        control_plane.record_audit(
+            action="initialize_participant_episode",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+            operation_id=receipt.operation_id,
+        )
+        return _receipt_response(receipt)
+
+    @app.post(
+        "/participants/{participant_address}/episodes/reset",
+        response_model=OperationReceiptModel,
+    )
+    async def reset_participant_episode(
+        participant_address: str,
+        request: Request,
+        body: _ParticipantResetBody | None = None,
+        identity: ControlPlaneIdentity = Depends(_mutating_identity),
+    ) -> OperationReceiptModel:
+        payload = body or _ParticipantResetBody()
+        try:
+            receipt = control_plane.reset_participant_episode(
+                participant_address,
+                episode_id=payload.episode_id,
+                reason=payload.reason,
+                idempotency_key=request.headers.get("idempotency-key", ""),
+                request_fingerprint=_request_fingerprint(
+                    request,
+                    getattr(request.state, "raw_body", b""),
+                ),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        control_plane.record_audit(
+            action="reset_participant_episode",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+            operation_id=receipt.operation_id,
+        )
+        return _receipt_response(receipt)
+
+    @app.post(
+        "/participants/{participant_address}/episodes/restart",
+        response_model=OperationReceiptModel,
+    )
+    async def restart_participant_episode(
+        participant_address: str,
+        request: Request,
+        body: _ParticipantRestartBody | None = None,
+        identity: ControlPlaneIdentity = Depends(_mutating_identity),
+    ) -> OperationReceiptModel:
+        payload = body or _ParticipantRestartBody()
+        try:
+            receipt = control_plane.restart_participant_episode(
+                participant_address,
+                episode_id=payload.episode_id,
+                reason=payload.reason,
+                idempotency_key=request.headers.get("idempotency-key", ""),
+                request_fingerprint=_request_fingerprint(
+                    request,
+                    getattr(request.state, "raw_body", b""),
+                ),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        control_plane.record_audit(
+            action="restart_participant_episode",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+            operation_id=receipt.operation_id,
+        )
+        return _receipt_response(receipt)
+
+    @app.post(
+        "/participants/{participant_address}/episodes/terminate",
+        response_model=OperationReceiptModel,
+    )
+    async def terminate_participant_episode(
+        participant_address: str,
+        request: Request,
+        body: _ParticipantTerminateBody | None = None,
+        identity: ControlPlaneIdentity = Depends(_mutating_identity),
+    ) -> OperationReceiptModel:
+        payload = body or _ParticipantTerminateBody()
+        try:
+            terminal_reason = ParticipantEpisodeTerminalReason(payload.terminal_reason)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"invalid terminal_reason: {exc}") from exc
+        try:
+            receipt = control_plane.terminate_participant_episode(
+                participant_address,
+                terminal_reason=terminal_reason,
+                detail=payload.detail,
+                idempotency_key=request.headers.get("idempotency-key", ""),
+                request_fingerprint=_request_fingerprint(
+                    request,
+                    getattr(request.state, "raw_body", b""),
+                ),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        control_plane.record_audit(
+            action="terminate_participant_episode",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+            operation_id=receipt.operation_id,
+        )
+        return _receipt_response(receipt)
 
     return app

--- a/implementations/python/packages/aces_processor/manager.py
+++ b/implementations/python/packages/aces_processor/manager.py
@@ -1184,6 +1184,7 @@ class RuntimeManager:
             provisioner=target.provisioner,
             orchestrator=target.orchestrator,
             evaluator=target.evaluator,
+            participant_runtime=target.participant_runtime,
         )
         self._target = target
         self._snapshot = initial_snapshot if initial_snapshot is not None else RuntimeSnapshot()

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -1559,6 +1559,14 @@ def iter_participant_episode_snapshot_violations(
     - Cross-sequence transitions are gated by an ``EPISODE_RESET`` or
       ``EPISODE_RESTARTED`` event (the first sequence number observed in
       a history stream is exempt because history may be truncated).
+    - When both a ``participant_episode_results`` entry and a non-empty
+      ``participant_episode_history`` entry exist for the same
+      participant, the current result must match the head of the history
+      chain: same ``episode_id``, same ``sequence_number``, and a status
+      that is consistent with the head event type and terminal reason.
+      A stale result that points at an earlier episode than the history
+      shows is a semantic inconsistency that breaks replay and operator
+      reasoning.
     """
 
     results_key = "runtime.snapshot.participant-episode-results"
@@ -1676,6 +1684,90 @@ def iter_participant_episode_snapshot_violations(
                 )
             sequence_to_episode[event.sequence_number] = event.episode_id
             last_sequence = event.sequence_number
+
+    # Cross-check: when both a result and a non-empty history exist for the
+    # same participant, the result must match the head of the history chain.
+    # An absent history is allowed (truncated observation); a present history
+    # whose last event describes a different episode than the current result
+    # is a stale result that breaks replay and operator reasoning.
+    if isinstance(participant_episode_results, Mapping) and isinstance(participant_episode_history, Mapping):
+        for outer_key, result in participant_episode_results.items():
+            if not isinstance(outer_key, str) or not outer_key:
+                continue
+            if not isinstance(result, Mapping):
+                continue
+            history = participant_episode_history.get(outer_key)
+            if not isinstance(history, list) or not history:
+                continue
+            try:
+                normalized_result = ParticipantEpisodeExecutionState.from_payload(result)
+            except (TypeError, ValueError):
+                continue
+            last_event: ParticipantEpisodeHistoryEvent | None = None
+            for event in history:
+                if not isinstance(event, Mapping):
+                    continue
+                try:
+                    candidate = ParticipantEpisodeHistoryEvent.from_payload(event)
+                except (TypeError, ValueError):
+                    continue
+                if candidate.participant_address != outer_key:
+                    continue
+                last_event = candidate
+            if last_event is None:
+                continue
+            if (
+                last_event.episode_id != normalized_result.episode_id
+                or last_event.sequence_number != normalized_result.sequence_number
+            ):
+                yield (
+                    outer_key,
+                    (
+                        f"participant episode result (episode_id="
+                        f"{normalized_result.episode_id!r}, sequence_number="
+                        f"{normalized_result.sequence_number}) does not match head of "
+                        f"history chain (episode_id={last_event.episode_id!r}, "
+                        f"sequence_number={last_event.sequence_number})"
+                    ),
+                )
+                continue
+            if normalized_result.status == ParticipantEpisodeStatus.TERMINATED:
+                if last_event.event_type not in _PARTICIPANT_EPISODE_TERMINAL_EVENTS:
+                    yield (
+                        outer_key,
+                        (
+                            f"participant episode result status is 'terminated' but head "
+                            f"history event is {last_event.event_type.value!r}, not a "
+                            f"terminal event"
+                        ),
+                    )
+                elif normalized_result.terminal_reason != last_event.terminal_reason:
+                    expected = (
+                        normalized_result.terminal_reason.value
+                        if normalized_result.terminal_reason is not None
+                        else None
+                    )
+                    got = last_event.terminal_reason.value if last_event.terminal_reason is not None else None
+                    yield (
+                        outer_key,
+                        (
+                            f"participant episode result terminal_reason {expected!r} does "
+                            f"not match head history terminal_reason {got!r}"
+                        ),
+                    )
+            elif normalized_result.status in (
+                ParticipantEpisodeStatus.INITIALIZING,
+                ParticipantEpisodeStatus.RUNNING,
+            ):
+                if last_event.event_type in _PARTICIPANT_EPISODE_TERMINAL_EVENTS:
+                    yield (
+                        outer_key,
+                        (
+                            f"participant episode result status is "
+                            f"{normalized_result.status.value!r} but head history event is "
+                            f"terminal ({last_event.event_type.value!r})"
+                        ),
+                    )
 
 
 def validate_evaluation_result(

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -38,6 +38,7 @@ class RuntimeDomain(str, Enum):
     PROVISIONING = "provisioning"
     ORCHESTRATION = "orchestration"
     EVALUATION = "evaluation"
+    PARTICIPANT = "participant"
 
 
 class ChangeAction(str, Enum):
@@ -2118,6 +2119,64 @@ class WorkflowCancellationRequest:
     workflow_address: str
     run_id: str | None = None
     reason: str = "cancelled by operator"
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeInitializeRequest:
+    """Portable request for initializing the first episode of a participant.
+
+    Carries the stable ``participant_address`` plus an optional
+    caller-provided ``episode_id`` hint (the backend allocates one if the
+    caller does not supply one). See RUN-311.
+    """
+
+    participant_address: str
+    episode_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeResetRequest:
+    """Portable request for resetting a non-terminal participant episode.
+
+    The backend must allocate a new ``episode_id``, increment
+    ``sequence_number``, preserve the stable participant identity, and
+    link to the prior episode via ``previous_episode_id``.
+    """
+
+    participant_address: str
+    episode_id: str | None = None
+    reason: str = "reset by operator"
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeRestartRequest:
+    """Portable request for restarting a terminated participant episode.
+
+    The backend must allocate a new ``episode_id``, increment
+    ``sequence_number``, preserve the stable participant identity, and
+    link to the prior episode via ``previous_episode_id``.
+    """
+
+    participant_address: str
+    episode_id: str | None = None
+    reason: str = "restarted by operator"
+
+
+@dataclass(frozen=True)
+class ParticipantEpisodeTerminateRequest:
+    """Portable request for driving the current episode to ``TERMINATED``.
+
+    The ``terminal_reason`` must be one of the published
+    ``ParticipantEpisodeTerminalReason`` values; the control plane
+    defaults to ``INTERRUPTED`` for operator-driven termination but
+    backends may also call this method with a terminal reason reflecting
+    an internally-detected ``COMPLETED``, ``TIMED_OUT``, or ``TRUNCATED``
+    condition.
+    """
+
+    participant_address: str
+    terminal_reason: ParticipantEpisodeTerminalReason = ParticipantEpisodeTerminalReason.INTERRUPTED
+    detail: str = "terminated by operator"
 
 
 @dataclass(frozen=True)

--- a/implementations/python/packages/aces_processor/registry.py
+++ b/implementations/python/packages/aces_processor/registry.py
@@ -6,7 +6,12 @@ from inspect import Signature, signature
 from typing import Any
 
 from aces_backend_protocols.capabilities import BackendManifest
-from aces_backend_protocols.protocols import Evaluator, Orchestrator, Provisioner
+from aces_backend_protocols.protocols import (
+    Evaluator,
+    Orchestrator,
+    ParticipantRuntime,
+    Provisioner,
+)
 
 
 def _require_invokable_method(
@@ -48,6 +53,7 @@ def _validate_runtime_target_shape(
     provisioner: Provisioner | None,
     orchestrator: Orchestrator | None,
     evaluator: Evaluator | None,
+    participant_runtime: ParticipantRuntime | None,
 ) -> None:
     if manifest is None:
         raise ValueError("RuntimeTarget requires an explicit manifest.")
@@ -57,8 +63,11 @@ def _validate_runtime_target_shape(
         raise ValueError("registry.target-shape-mismatch: orchestrator presence does not match the manifest.")
     if manifest.has_evaluator != (evaluator is not None):
         raise ValueError("registry.target-shape-mismatch: evaluator presence does not match the manifest.")
+    if manifest.has_participant_runtime != (participant_runtime is not None):
+        raise ValueError("registry.target-shape-mismatch: participant_runtime presence does not match the manifest.")
     sample_plan = object()
     sample_snapshot = object()
+    sample_request = object()
     _require_invokable_method(
         provisioner,
         label="provisioner",
@@ -131,6 +140,48 @@ def _validate_runtime_target_shape(
         method_name="stop",
         invocation_args=(sample_snapshot,),
     )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="initialize",
+        invocation_args=(sample_request, sample_snapshot),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="reset",
+        invocation_args=(sample_request, sample_snapshot),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="restart",
+        invocation_args=(sample_request, sample_snapshot),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="terminate",
+        invocation_args=(sample_request, sample_snapshot),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="status",
+        invocation_args=(),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="results",
+        invocation_args=(),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
+        method_name="history",
+        invocation_args=(),
+    )
 
 
 @dataclass(frozen=True)
@@ -142,6 +193,7 @@ class RuntimeTarget:
     provisioner: Provisioner
     orchestrator: Orchestrator | None = None
     evaluator: Evaluator | None = None
+    participant_runtime: ParticipantRuntime | None = None
 
     def __post_init__(self) -> None:
         _validate_runtime_target_shape(
@@ -149,6 +201,7 @@ class RuntimeTarget:
             provisioner=self.provisioner,
             orchestrator=self.orchestrator,
             evaluator=self.evaluator,
+            participant_runtime=self.participant_runtime,
         )
 
 
@@ -159,6 +212,7 @@ class RuntimeTargetComponents:
     provisioner: Provisioner
     orchestrator: Orchestrator | None = None
     evaluator: Evaluator | None = None
+    participant_runtime: ParticipantRuntime | None = None
 
 
 @dataclass(frozen=True)
@@ -212,6 +266,7 @@ class BackendRegistry:
             provisioner=components.provisioner,
             orchestrator=components.orchestrator,
             evaluator=components.evaluator,
+            participant_runtime=components.participant_runtime,
         )
 
         return RuntimeTarget(
@@ -220,6 +275,7 @@ class BackendRegistry:
             provisioner=components.provisioner,
             orchestrator=components.orchestrator,
             evaluator=components.evaluator,
+            participant_runtime=components.participant_runtime,
         )
 
     def list_backends(self) -> list[str]:

--- a/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
+++ b/implementations/python/tests/test_run_311_participant_episode_lifecycle.py
@@ -873,6 +873,299 @@ class TestRun311ParticipantEpisodeLifecycle:
         assert any(f"{EP1!r} -> {EP2!r}" in msg for msg in mismatch_messages)
         assert any(f"{EP2!r} -> {EP3!r}" in msg for msg in mismatch_messages)
 
+    def test_runtime_apply_path_rejects_stale_result_not_matching_history_head(self):
+        """Cross-check invariant — when both a result and a non-empty history
+        exist for the same participant, the result must be the head of the
+        history chain. Reproduces the reviewer's exact scenario: the result
+        still points at terminated episode ``ep-0001`` / sequence ``0`` while
+        the history already shows a restart into running episode ``ep-0002``
+        / sequence ``1``. Prior to this check the validator returned zero
+        diagnostics for that snapshot.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "terminated",
+                    "terminal_reason": "completed",
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": T1,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_completed",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": "completed",
+                        "control_action": None,
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_restarted",
+                        "timestamp": T2,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": "restart",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T3,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics, (
+            "apply path must reject a stale result that does not match the "
+            "head of the history chain (reviewer finding 2)"
+        )
+        assert all(diag.code == "runtime.backend-contract-invalid" for diag in diagnostics)
+        assert any("does not match head of history chain" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_terminated_result_with_non_terminal_history_head(self):
+        """Cross-check invariant — a result claiming ``status=terminated`` must
+        be accompanied by a terminal history event. A running result claiming
+        termination without matching terminal history is inconsistent.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "terminated",
+                    "terminal_reason": "completed",
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": T1,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("terminated" in diag.message and "not a terminal event" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_terminal_reason_mismatch_with_history_head(self):
+        """Cross-check invariant — when result and history agree on episode
+        identity, their terminal reasons must also agree. A result with
+        ``terminal_reason=completed`` pointing at a history head whose
+        ``terminal_reason=timed_out`` is semantically inconsistent.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "terminated",
+                    "terminal_reason": "completed",
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": T1,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_timed_out",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": "timed_out",
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("terminal_reason" in diag.message and "does not match" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_rejects_running_result_with_terminal_history_head(self):
+        """Cross-check invariant — a non-terminal result cannot coexist with a
+        terminal head event. The reviewer's scenario generalized: the head
+        is ahead of the result rather than behind.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP1,
+                    "sequence_number": 0,
+                    "status": "running",
+                    "terminal_reason": None,
+                    "initialized_at": T0,
+                    "updated_at": T1,
+                    "terminated_at": None,
+                    "last_control_action": "initialize",
+                    "previous_episode_id": None,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_completed",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": "completed",
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics
+        assert any("running" in diag.message and "terminal" in diag.message for diag in diagnostics)
+
+    def test_runtime_apply_path_accepts_result_matching_history_head(self):
+        """Cross-check invariant — the positive counterpart: a result whose
+        identity and status match the head of the history chain must pass
+        cleanly.
+        """
+
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": {
+                    "state_schema_version": "participant-episode-state/v1",
+                    "participant_address": "participant.alice",
+                    "episode_id": EP2,
+                    "sequence_number": 1,
+                    "status": "running",
+                    "terminal_reason": None,
+                    "initialized_at": T0,
+                    "updated_at": T3,
+                    "terminated_at": None,
+                    "last_control_action": "restart",
+                    "previous_episode_id": EP1,
+                }
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    {
+                        "event_type": "episode_initialized",
+                        "timestamp": T0,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": None,
+                        "control_action": "initialize",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_completed",
+                        "timestamp": T1,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP1,
+                        "sequence_number": 0,
+                        "terminal_reason": "completed",
+                        "control_action": None,
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_restarted",
+                        "timestamp": T2,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": "restart",
+                        "details": {},
+                    },
+                    {
+                        "event_type": "episode_running",
+                        "timestamp": T3,
+                        "participant_address": "participant.alice",
+                        "episode_id": EP2,
+                        "sequence_number": 1,
+                        "terminal_reason": None,
+                        "control_action": None,
+                        "details": {},
+                    },
+                ]
+            },
+        )
+
+        diagnostics = _participant_episode_contract_diagnostics(snapshot)
+
+        assert diagnostics == []
+
     def test_runtime_apply_path_accepts_valid_participant_episode_snapshot(self):
         """Runtime integration — a snapshot that contains only valid RUN-311
         data must pass the apply-path diagnostic helper cleanly. This is the

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -32,6 +32,29 @@ def test_target_conformance_passes_for_stub_target():
     assert report.passed is True
     assert not report.unsupported_contract_gaps
     assert not report.unsupported_capability_gaps
+    # RUN-311 finding 4: the live probe must actually drive every
+    # participant episode control action and end with a non-empty,
+    # consistent snapshot for the conformance participant.
+    case_names = {case.name for case in report.cases}
+    assert {
+        "participant-initialize",
+        "participant-reset",
+        "participant-terminate",
+        "participant-restart",
+        "participant-snapshot-consistent",
+    }.issubset(case_names)
+    for case in report.cases:
+        if case.name in {
+            "participant-initialize",
+            "participant-reset",
+            "participant-terminate",
+            "participant-restart",
+            "participant-snapshot-consistent",
+        }:
+            assert case.passed, (
+                f"Live participant probe case {case.name!r} must succeed for the stub backend; "
+                f"diagnostics: {[diag.message for diag in case.diagnostics]}"
+            )
 
 
 def test_profile_is_inferred_as_full_when_manifest_declares_participant_runtime():
@@ -56,6 +79,64 @@ def test_profile_falls_back_to_orchestration_evaluation_without_participant_runt
 
     manifest = create_stub_manifest(with_participant_runtime=False)
     assert profile_for_manifest(manifest) == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
+
+
+def test_live_probe_catches_participant_runtime_that_does_not_populate_snapshot():
+    """RUN-311 finding 4: a backend that exposes the participant runtime
+    surface but never publishes state/history through the snapshot must
+    fail conformance, not silently certify clean.
+    """
+    from aces_backend_stubs.stubs import (
+        StubEvaluator,
+        StubOrchestrator,
+        StubProvisioner,
+        create_stub_manifest,
+    )
+    from aces_processor.models import ApplyResult
+
+    class _SilentParticipantRuntime:
+        """Accepts every action without mutating the snapshot."""
+
+        def initialize(self, request, snapshot):
+            return ApplyResult(success=True, snapshot=snapshot)
+
+        def reset(self, request, snapshot):
+            return ApplyResult(success=True, snapshot=snapshot)
+
+        def restart(self, request, snapshot):
+            return ApplyResult(success=True, snapshot=snapshot)
+
+        def terminate(self, request, snapshot):
+            return ApplyResult(success=True, snapshot=snapshot)
+
+        def status(self):
+            return {}
+
+        def results(self):
+            return {}
+
+        def history(self):
+            return {}
+
+    manifest = create_stub_manifest()
+    target = RuntimeTarget(
+        name="silent-participant",
+        manifest=manifest,
+        provisioner=StubProvisioner(),
+        orchestrator=StubOrchestrator(),
+        evaluator=StubEvaluator(),
+        participant_runtime=_SilentParticipantRuntime(),
+    )
+
+    report = run_target_conformance(target)
+
+    assert report.profile == BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE
+    assert report.passed is False
+    snapshot_case = next(case for case in report.cases if case.name == "participant-snapshot-consistent")
+    assert snapshot_case.passed is False
+    messages = [diag.message for diag in snapshot_case.diagnostics]
+    assert any("exposes no participant_episode_results" in msg for msg in messages)
+    assert any("exposes no participant_episode_history" in msg for msg in messages)
 
 
 def test_fixture_suite_passes_for_full_remote_control_plane_profile():

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -28,16 +28,34 @@ def test_fixture_suite_passes_for_orchestration_evaluation_profile():
 def test_target_conformance_passes_for_stub_target():
     report = run_target_conformance(create_stub_target())
 
-    assert report.profile == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
+    assert report.profile == BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE
     assert report.passed is True
     assert not report.unsupported_contract_gaps
     assert not report.unsupported_capability_gaps
 
 
-def test_profile_is_inferred_from_manifest_shape():
+def test_profile_is_inferred_as_full_when_manifest_declares_participant_runtime():
+    """RUN-311 — finding 3: a manifest that declares orchestrator,
+    evaluator, and participant_runtime must infer the
+    ``FULL_REMOTE_CONTROL_PLANE`` profile so the default
+    ``run_target_conformance`` path validates the participant-episode
+    contract family without requiring callers to override the profile.
+    """
+
     target = create_stub_target()
 
-    assert profile_for_manifest(target.manifest) == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
+    assert profile_for_manifest(target.manifest) == BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE
+
+
+def test_profile_falls_back_to_orchestration_evaluation_without_participant_runtime():
+    """A manifest without participant_runtime continues to infer
+    ``ORCHESTRATION_EVALUATION`` so existing two-tier backends remain
+    compatible.
+    """
+    from aces_backend_stubs.stubs import create_stub_manifest
+
+    manifest = create_stub_manifest(with_participant_runtime=False)
+    assert profile_for_manifest(manifest) == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
 
 
 def test_fixture_suite_passes_for_full_remote_control_plane_profile():
@@ -158,13 +176,23 @@ def test_target_conformance_fails_when_declared_contracts_do_not_cover_profile_r
 
     report = run_target_conformance(target)
 
-    assert report.profile == BackendCapabilityProfile.ORCHESTRATION_EVALUATION
+    # The reference stub manifest now declares participant_runtime, so
+    # profile_for_manifest infers the FULL_REMOTE_CONTROL_PLANE profile
+    # (RUN-311 finding 3). The contract gap set therefore also covers
+    # the participant-episode contracts and the plan contracts that
+    # the FULL profile requires.
+    assert report.profile == BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE
     assert report.passed is False
     assert set(report.unsupported_contract_gaps) == {
         "evaluation-history-event-stream-v1",
+        "evaluation-plan-v1",
         "evaluation-result-envelope-v1",
         "operation-receipt-v1",
         "operation-status-v1",
+        "orchestration-plan-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-episode-state-envelope-v1",
+        "provisioning-plan-v1",
         "runtime-snapshot-v1",
         "workflow-history-event-stream-v1",
         "workflow-result-envelope-v1",

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -153,6 +153,7 @@ def test_target_conformance_fails_when_declared_contracts_do_not_cover_profile_r
         provisioner=components.provisioner,
         orchestrator=components.orchestrator,
         evaluator=components.evaluator,
+        participant_runtime=components.participant_runtime,
     )
 
     report = run_target_conformance(target)

--- a/implementations/python/tests/test_runtime_control_plane.py
+++ b/implementations/python/tests/test_runtime_control_plane.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import textwrap
 
+from aces_backend_stubs.stubs import create_stub_components, create_stub_manifest
+from aces_processor.models import iter_participant_episode_snapshot_violations
+
 from aces.backends.stubs import create_stub_target
 from aces.core.runtime.compiler import compile_runtime_model
 from aces.core.runtime.control_plane import RuntimeControlPlane
-from aces.core.runtime.models import OperationState, RuntimeDomain
+from aces.core.runtime.models import (
+    OperationState,
+    ParticipantEpisodeTerminalReason,
+    RuntimeDomain,
+)
 from aces.core.runtime.planner import plan
+from aces.core.runtime.registry import RuntimeTarget
 from aces.core.sdl import parse_sdl
 
 
@@ -82,3 +90,212 @@ workflows:
     assert workflow_result["workflow_status"] == "running"
     assert "run_id" in workflow_result
     assert snapshot.snapshot.orchestration_history
+
+
+class TestParticipantEpisodeControlPlane:
+    """RUN-311 — runtime-level participant episode control methods.
+
+    These exercise the full ``initialize → reset → terminate → restart``
+    lifecycle through the control plane, asserting that each backend
+    ``ApplyResult`` is persisted into the snapshot, each operation gets
+    a succeeded ``OperationStatus``, and the resulting
+    ``participant_episode_results`` / ``participant_episode_history``
+    satisfy the RUN-311 invariants.
+    """
+
+    def test_initialize_creates_first_episode_with_running_state(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+
+        receipt = control_plane.initialize_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+        snapshot = control_plane.get_snapshot()
+
+        assert receipt.accepted is True
+        assert receipt.domain == RuntimeDomain.PARTICIPANT
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED
+        state = snapshot.snapshot.participant_episode_results["participant.alice"]
+        assert state["status"] == "running"
+        assert state["sequence_number"] == 0
+        assert state["previous_episode_id"] is None
+        assert state["last_control_action"] == "initialize"
+        history = snapshot.snapshot.participant_episode_history["participant.alice"]
+        assert [event["event_type"] for event in history] == [
+            "episode_initialized",
+            "episode_running",
+        ]
+
+    def test_initialize_twice_rejects_duplicate(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        receipt = control_plane.initialize_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("already has a live episode" in diag.message for diag in status.diagnostics)
+
+    def test_reset_allocates_new_episode_preserving_identity(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        receipt = control_plane.reset_participant_episode("participant.alice", reason="operator reset")
+        status = control_plane.get_operation(receipt.operation_id)
+        snapshot = control_plane.get_snapshot()
+
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED
+        state = snapshot.snapshot.participant_episode_results["participant.alice"]
+        assert state["sequence_number"] == 1
+        assert state["last_control_action"] == "reset"
+        assert state["previous_episode_id"] == "participant.alice-episode-1"
+        assert state["episode_id"] == "participant.alice-episode-2"
+        assert state["status"] == "running"
+
+    def test_reset_rejects_terminated_participant(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+        control_plane.terminate_participant_episode(
+            "participant.alice",
+            terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+        )
+
+        receipt = control_plane.reset_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("use restart" in diag.message for diag in status.diagnostics)
+
+    def test_terminate_drives_state_to_terminated_with_reason(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        receipt = control_plane.terminate_participant_episode(
+            "participant.alice",
+            terminal_reason=ParticipantEpisodeTerminalReason.TIMED_OUT,
+        )
+        status = control_plane.get_operation(receipt.operation_id)
+        snapshot = control_plane.get_snapshot()
+
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED
+        state = snapshot.snapshot.participant_episode_results["participant.alice"]
+        assert state["status"] == "terminated"
+        assert state["terminal_reason"] == "timed_out"
+        assert state["terminated_at"] is not None
+        history = snapshot.snapshot.participant_episode_history["participant.alice"]
+        assert history[-1]["event_type"] == "episode_timed_out"
+        assert history[-1]["terminal_reason"] == "timed_out"
+
+    def test_terminate_rejects_already_terminated(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+        control_plane.terminate_participant_episode("participant.alice")
+
+        receipt = control_plane.terminate_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("already terminated" in diag.message for diag in status.diagnostics)
+
+    def test_restart_resumes_from_terminated_predecessor(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+        control_plane.terminate_participant_episode(
+            "participant.alice",
+            terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+        )
+
+        receipt = control_plane.restart_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+        snapshot = control_plane.get_snapshot()
+
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED
+        state = snapshot.snapshot.participant_episode_results["participant.alice"]
+        assert state["sequence_number"] == 1
+        assert state["last_control_action"] == "restart"
+        assert state["previous_episode_id"] == "participant.alice-episode-1"
+        assert state["status"] == "running"
+
+    def test_restart_rejects_non_terminated_participant(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        receipt = control_plane.restart_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("non-terminated" in diag.message for diag in status.diagnostics)
+
+    def test_initialize_rejects_target_without_participant_runtime(self):
+        manifest = create_stub_manifest(with_participant_runtime=False)
+        components = create_stub_components(manifest=manifest)
+        target = RuntimeTarget(
+            name="no-participant",
+            manifest=manifest,
+            provisioner=components.provisioner,
+            orchestrator=components.orchestrator,
+            evaluator=components.evaluator,
+        )
+        control_plane = RuntimeControlPlane(target)
+
+        receipt = control_plane.initialize_participant_episode("participant.alice")
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert receipt.accepted is False
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("does not provide a participant runtime" in diag.message for diag in receipt.diagnostics)
+
+    def test_full_lifecycle_snapshot_chain_is_consistent(self):
+        """End-to-end: initialize → reset → terminate → restart and verify
+        history chain matches the final result (RUN-311 cross-check invariant).
+        """
+        control_plane = RuntimeControlPlane(create_stub_target())
+
+        control_plane.initialize_participant_episode("participant.alice")
+        control_plane.reset_participant_episode("participant.alice")
+        control_plane.terminate_participant_episode(
+            "participant.alice",
+            terminal_reason=ParticipantEpisodeTerminalReason.COMPLETED,
+        )
+        control_plane.restart_participant_episode("participant.alice")
+
+        snapshot = control_plane.get_snapshot().snapshot
+        violations = list(
+            iter_participant_episode_snapshot_violations(
+                snapshot.participant_episode_results,
+                snapshot.participant_episode_history,
+            )
+        )
+        assert violations == [], (
+            f"Full participant lifecycle must satisfy every RUN-311 snapshot invariant; got violations: {violations}"
+        )
+
+    def test_initialize_is_idempotent_via_idempotency_key(self):
+        """Idempotency — a second submission with the same idempotency key
+        must return the original receipt without running the backend twice.
+        """
+        control_plane = RuntimeControlPlane(create_stub_target())
+
+        first = control_plane.initialize_participant_episode(
+            "participant.alice",
+            idempotency_key="init-alice-1",
+        )
+        second = control_plane.initialize_participant_episode(
+            "participant.alice",
+            idempotency_key="init-alice-1",
+        )
+
+        assert first.operation_id == second.operation_id
+        snapshot = control_plane.get_snapshot().snapshot
+        history = snapshot.participant_episode_history["participant.alice"]
+        assert [event["event_type"] for event in history] == [
+            "episode_initialized",
+            "episode_running",
+        ]

--- a/implementations/python/tests/test_runtime_control_plane_api.py
+++ b/implementations/python/tests/test_runtime_control_plane_api.py
@@ -604,3 +604,158 @@ workflows:
     assert result["workflow_status"] == "timed_out"
     assert result["compensation_status"] == "succeeded"
     assert any(event["event_type"] == "compensation_completed" for event in history)
+
+
+class TestParticipantEpisodeHttpRoutes:
+    """RUN-311 — HTTP surface for participant episode lifecycle control.
+
+    Each POST route must drive the same state-machine transitions as the
+    in-process control plane and the resulting ``/snapshot`` response
+    must expose the mutated ``participant_episode_results`` /
+    ``participant_episode_history`` fields in the RuntimeSnapshot envelope.
+    """
+
+    def _build_client(self):
+        target = create_stub_target()
+        control_plane = RuntimeControlPlane(target)
+        app = create_control_plane_app(
+            control_plane,
+            security=ControlPlaneSecurityConfig.strict_defaults(target_name=target.name),
+        )
+        return TestClient(app)
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "x-aces-client-verified": "true",
+            "x-aces-client-identity": "backend-service",
+        }
+
+    def test_initialize_route_creates_first_episode(self):
+        client = self._build_client()
+
+        response = client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+        snapshot = client.get("/snapshot", headers=self._headers).json()
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["accepted"] is True
+        assert body["domain"] == "participant"
+        state = snapshot["participant_episode_results"]["participant.alice"]
+        assert state["status"] == "running"
+        assert state["sequence_number"] == 0
+        history = snapshot["participant_episode_history"]["participant.alice"]
+        assert [event["event_type"] for event in history] == [
+            "episode_initialized",
+            "episode_running",
+        ]
+
+    def test_reset_route_allocates_new_episode(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.post(
+            "/participants/participant.alice/episodes/reset",
+            headers=self._headers,
+            json={"reason": "operator reset"},
+        )
+        snapshot = client.get("/snapshot", headers=self._headers).json()
+
+        assert response.status_code == 200
+        state = snapshot["participant_episode_results"]["participant.alice"]
+        assert state["sequence_number"] == 1
+        assert state["last_control_action"] == "reset"
+        assert state["previous_episode_id"] == "participant.alice-episode-1"
+
+    def test_terminate_route_drives_state_to_terminated(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.post(
+            "/participants/participant.alice/episodes/terminate",
+            headers=self._headers,
+            json={"terminal_reason": "completed"},
+        )
+        snapshot = client.get("/snapshot", headers=self._headers).json()
+
+        assert response.status_code == 200
+        state = snapshot["participant_episode_results"]["participant.alice"]
+        assert state["status"] == "terminated"
+        assert state["terminal_reason"] == "completed"
+        history = snapshot["participant_episode_history"]["participant.alice"]
+        assert history[-1]["event_type"] == "episode_completed"
+
+    def test_terminate_route_rejects_invalid_terminal_reason(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.post(
+            "/participants/participant.alice/episodes/terminate",
+            headers=self._headers,
+            json={"terminal_reason": "exploded"},
+        )
+
+        assert response.status_code == 400
+        assert "invalid terminal_reason" in response.json()["detail"]
+
+    def test_restart_route_resumes_after_termination(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+        client.post(
+            "/participants/participant.alice/episodes/terminate",
+            headers=self._headers,
+            json={"terminal_reason": "completed"},
+        )
+
+        response = client.post(
+            "/participants/participant.alice/episodes/restart",
+            headers=self._headers,
+            json={},
+        )
+        snapshot = client.get("/snapshot", headers=self._headers).json()
+
+        assert response.status_code == 200
+        state = snapshot["participant_episode_results"]["participant.alice"]
+        assert state["sequence_number"] == 1
+        assert state["status"] == "running"
+        assert state["last_control_action"] == "restart"
+
+    def test_routes_require_authenticated_identity(self):
+        client = self._build_client()
+
+        response = client.post(
+            "/participants/participant.alice/episodes/initialize",
+            json={},
+        )
+        assert response.status_code == 401
+
+    def test_routes_reject_unknown_body_fields(self):
+        """Closed-world request bodies — unknown fields must be rejected."""
+        client = self._build_client()
+
+        response = client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={"episode_id": "alice-1", "unknown": "value"},
+        )
+        assert response.status_code == 422

--- a/implementations/python/tests/test_runtime_manager.py
+++ b/implementations/python/tests/test_runtime_manager.py
@@ -806,7 +806,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -824,7 +824,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=FailingStartOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -849,7 +849,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=FailingStartEvaluator(calls, "evaluator"),
@@ -867,7 +867,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -887,7 +887,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=FailingStopOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -907,7 +907,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=FailingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -926,7 +926,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=InvalidValidationProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -944,7 +944,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=InvalidApplyProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -974,7 +974,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=provisioner_cls(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -992,7 +992,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RaisingStartOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1018,7 +1018,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowResultsOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1041,7 +1041,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowSchemaVersionOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1057,7 +1057,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=MissingWorkflowFieldsOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1073,7 +1073,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowLifecycleOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1089,7 +1089,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowOutcomeOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1105,7 +1105,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowAttemptCountOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1121,7 +1121,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowPendingOutcomeOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1137,7 +1137,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=MissingObservableWorkflowStepOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1153,7 +1153,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=ResultContractOnlyOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1169,7 +1169,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowCallHistoryOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1185,7 +1185,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=InvalidWorkflowCompensationOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1201,7 +1201,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=InvalidEvaluatorSchemaVersionEvaluator(calls, "evaluator"),
@@ -1217,7 +1217,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=MissingEvaluatorFieldsEvaluator(calls, "evaluator"),
@@ -1233,7 +1233,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=InvalidEvaluatorReadyPayloadEvaluator(calls, "evaluator"),
@@ -1249,7 +1249,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=MissingEvaluatorHistoryEvaluator(calls, "evaluator"),
@@ -1264,7 +1264,7 @@ class TestRuntimeManager:
     def test_status_exposes_plain_data_workflow_results(self):
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1287,7 +1287,7 @@ class TestRuntimeManager:
     def test_status_exposes_plain_data_evaluation_results_and_history(self):
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1337,7 +1337,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1357,7 +1357,7 @@ class TestRuntimeManager:
     def test_apply_rejects_unbound_direct_plan(self):
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1375,7 +1375,7 @@ class TestRuntimeManager:
     def test_manager_plan_binds_target_name(self):
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1389,7 +1389,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1408,14 +1408,14 @@ class TestRuntimeManager:
     def test_apply_rejects_target_name_mismatch(self):
         plan_target = RuntimeTarget(
             name="plan-target",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
         )
         manager_target = RuntimeTarget(
             name="other-target",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1430,12 +1430,12 @@ class TestRuntimeManager:
     def test_apply_rejects_manifest_mismatch(self):
         plan_target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
         )
-        altered_manifest = create_stub_manifest()
+        altered_manifest = create_stub_manifest(with_participant_runtime=False)
         altered_manifest = altered_manifest.__class__(
             name="stub-alt",
             version=altered_manifest.version,
@@ -1465,7 +1465,7 @@ class TestRuntimeManager:
     def test_apply_rejects_base_snapshot_mismatch(self):
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner([]),
             orchestrator=RecordingOrchestrator([]),
             evaluator=RecordingEvaluator([], "evaluator"),
@@ -1485,7 +1485,7 @@ class TestRuntimeManager:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1519,7 +1519,7 @@ nodes:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1539,7 +1539,7 @@ nodes:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1561,7 +1561,7 @@ nodes:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),
@@ -1577,7 +1577,7 @@ nodes:
         calls: list[str] = []
         target = RuntimeTarget(
             name="recording",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=RecordingProvisioner(calls),
             orchestrator=RecordingOrchestrator(calls),
             evaluator=RecordingEvaluator(calls, "evaluator"),

--- a/implementations/python/tests/test_runtime_registry.py
+++ b/implementations/python/tests/test_runtime_registry.py
@@ -185,43 +185,45 @@ class TestBackendRegistry:
         with pytest.raises(ValueError, match="registry.target-shape-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
-                provisioner=create_stub_components(manifest=create_stub_manifest()).provisioner,
+                manifest=create_stub_manifest(with_participant_runtime=False),
+                provisioner=create_stub_components(
+                    manifest=create_stub_manifest(with_participant_runtime=False)
+                ).provisioner,
                 orchestrator=None,
                 evaluator=None,
             )
 
     def test_direct_runtime_target_construction_rejects_bad_provisioner_contract(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=BadProvisioner(),
                 orchestrator=components.orchestrator,
                 evaluator=components.evaluator,
             )
 
     def test_direct_runtime_target_construction_rejects_bad_orchestrator_contract(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=components.provisioner,
                 orchestrator=BadOrchestrator(),
                 evaluator=components.evaluator,
             )
 
     def test_direct_runtime_target_construction_rejects_bad_evaluator_contract(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=components.provisioner,
                 orchestrator=components.orchestrator,
                 evaluator=BadEvaluator(),
@@ -231,11 +233,11 @@ class TestBackendRegistry:
         registry = BackendRegistry()
 
         def manifest_factory(**config):
-            return create_stub_manifest(**config)
+            return create_stub_manifest(with_participant_runtime=False, **config)
 
         def components_factory(*, manifest, **config):
             del manifest, config
-            components = create_stub_components(manifest=create_stub_manifest())
+            components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
             return RuntimeTargetComponents(
                 provisioner=BadProvisioner(),
                 orchestrator=components.orchestrator,
@@ -251,11 +253,11 @@ class TestBackendRegistry:
         registry = BackendRegistry()
 
         def manifest_factory(**config):
-            return create_stub_manifest(**config)
+            return create_stub_manifest(with_participant_runtime=False, **config)
 
         def components_factory(*, manifest, **config):
             del manifest, config
-            components = create_stub_components(manifest=create_stub_manifest())
+            components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
             return RuntimeTargetComponents(
                 provisioner=WrongSigProvisioner(),
                 orchestrator=components.orchestrator,
@@ -268,47 +270,47 @@ class TestBackendRegistry:
             registry.create("bad-signature")
 
     def test_direct_runtime_target_construction_rejects_wrong_signature_provisioner(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=WrongSigProvisioner(),
                 orchestrator=components.orchestrator,
                 evaluator=components.evaluator,
             )
 
     def test_direct_runtime_target_construction_rejects_wrong_signature_orchestrator(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=components.provisioner,
                 orchestrator=WrongSigOrchestrator(),
                 evaluator=components.evaluator,
             )
 
     def test_direct_runtime_target_construction_rejects_wrong_signature_evaluator(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         with pytest.raises(ValueError, match="registry.target-contract-mismatch"):
             RuntimeTarget(
                 name="broken",
-                manifest=create_stub_manifest(),
+                manifest=create_stub_manifest(with_participant_runtime=False),
                 provisioner=components.provisioner,
                 orchestrator=components.orchestrator,
                 evaluator=WrongSigEvaluator(),
             )
 
     def test_direct_runtime_target_construction_accepts_optional_extra_parameters(self):
-        components = create_stub_components(manifest=create_stub_manifest())
+        components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
 
         target = RuntimeTarget(
             name="optional",
-            manifest=create_stub_manifest(),
+            manifest=create_stub_manifest(with_participant_runtime=False),
             provisioner=OptionalArgProvisioner(),
             orchestrator=components.orchestrator,
             evaluator=components.evaluator,
@@ -324,7 +326,7 @@ class TestBackendRegistry:
 
         class LegacyComponents:
             def __init__(self) -> None:
-                components = create_stub_components(manifest=create_stub_manifest())
+                components = create_stub_components(manifest=create_stub_manifest(with_participant_runtime=False))
                 self.provisioner = components.provisioner
                 self.orchestrator = components.orchestrator
                 self.evaluators = (components.evaluator,)

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -100,6 +100,8 @@ ownership:
     - implementations/python/packages/aces_processor
     - implementations/python/packages/aces_contracts
     - implementations/python/packages/aces_conformance
+    - implementations/python/packages/aces_backend_protocols
+    - implementations/python/packages/aces_backend_stubs
     - implementations/python/tests
     - contracts/schemas/control-plane
     - contracts/schemas/snapshots


### PR DESCRIPTION
- **Fix production-readiness finding 2: cross-check result vs history head**
- **Fix production-readiness finding 1: add participant episode runtime surface**
- **Fix production-readiness finding 3: profile_for_manifest infers FULL profile**
- **Fix production-readiness finding 4: live conformance drives participant data**
- **Fix production-readiness finding 5: tighten 0.10.0 release notes**
