### PR TITLE
ADR-016: semantic-layer scope/coverage model + structural gate (SEM-200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-05-10
+
+### Added
+
+- ADR-016 ("Semantic Layer Scope and Coverage Model (SEM-200)") under
+  `docs/decisions/adrs/`: `SEM-200` is recorded as a system-level umbrella
+  requirement that is the *parent* of its ~28 `SEM-2xx` children (the construct
+  families) and `DEPENDS_ON` `DSL-100`; a number of `EXP-*` / `AUT-*` / `GOV-*` /
+  `ASR-*` / API/runtime requirements `DEPENDS_ON` it as downstream consumers and
+  do not gate it. ADR-016 fixes the *model* — the seven canonical lifecycle
+  phases (authoring, validation, instantiation, compilation, planning, execution,
+  observation), the construct-family concept, the `active` / `partial` /
+  `planned` status vocabulary, and `SEM-200`'s definition of done (every
+  `SEM-2xx` child `ACTIVE`; no `partial`/`planned` rows in the coverage table;
+  cross-stage agreement tests extended construct-wide; the unassigned-wave
+  `SEM-2xx` children assigned to a wave). `SEM-200` stays `DRAFT` until then.
+- `docs/explain/reference/shared-semantic-integrity.md` (the architecture-preflight
+  guardrails note for `SEM-200`) gains the live, ADR-016-governed `## Coverage
+  Model` table mapping every semantic construct family to its owning
+  requirement(s), realizing artifacts, covered lifecycle phases, and status. The
+  table lives in this mutable reference note — not in the immutable ADR — so
+  routine `SEM-2xx` implementation PRs can update their construct family's row
+  without an ADR amendment; ADR-016 governs it and is linked from it. For
+  `planned` rows the table records the owning requirement(s) only; the intended
+  scope and wave come from those requirements' Ground Control records, not from a
+  duplicated table column. Higher-level capabilities that consume the semantic
+  layer (cross-run comparability, federation/standards profiles, …) are tracked
+  by their own requirements, not in this table.
+- `tools/check_semantic_coverage.py` — a filesystem-only structural gate that
+  parses that Coverage Model table and fails if a row is malformed, a status or
+  lifecycle-phase token is unrecognised, an owning-requirement token is not
+  UID-shaped, an artifact-cell token that looks like a path is missing, escapes
+  the repo root, or is not under a supported root, an `active`/`partial` row
+  names no lifecycle phase or no existing *non-test* realizing artifact, an
+  `active` row names no existing `implementations/python/tests/test_*.py` test, a
+  `planned` row claims phases or artifacts, or ADR-016 stops referencing the note
+  by path. Row diagnostics report the real source-line number. Failures use
+  `tools.policy.common.PolicyFailure`, and the CLI honours `--json` and the
+  shared `tools/policy/exceptions.yaml` waiver mechanism, like the other `policy`
+  nox-stage entry points. Wired into the `policy` step of the nox verification
+  graph (`_run_policy` in `noxfile.py`) for working-tree runs only (skipped on
+  the `--staged` pre-commit invocation, since it validates files on disk), added
+  to `TARGETED_POLICY_TESTS`, and the new tooling test is exempted in
+  `check_requirement_governance.py`'s `REQUIREMENT_CONTEXT_EXEMPT_PATHS`
+  alongside the other policy-tooling tests; covered by
+  `implementations/python/tests/test_semantic_coverage.py`.
+
 ## [0.14.0] - 2026-05-10
 
 ### Added

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -41,3 +41,4 @@ Each ADR includes:
 | [013](adr-013-participant-episode-lifecycle-boundaries.md) | Participant Episode Lifecycle Boundaries | accepted | 2026-04-11 |
 | [014](adr-014-nox-as-canonical-verification-graph.md) | nox as the Canonical Verification Graph | accepted | 2026-05-09 |
 | [015](adr-015-sdl-processor-layering-and-source-file-size-cap.md) | SDL-Processor Layering and Source-File Size Cap | accepted | 2026-05-10 |
+| [016](adr-016-semantic-layer-scope-and-coverage-model.md) | Semantic Layer Scope and Coverage Model (SEM-200) | accepted | 2026-05-10 |

--- a/docs/decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md
+++ b/docs/decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md
@@ -1,0 +1,238 @@
+# ADR-016: Semantic Layer Scope and Coverage Model (SEM-200)
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-10
+
+## Context
+
+`SEM-200` ("Shared Semantic Integrity") is a system-level umbrella requirement.
+In the Ground Control graph it is a child of `SYS-001` ("ACES SDL Ecosystem"),
+it `DEPENDS_ON` `DSL-100` ("Author-Facing Scenario Language"), and it is the
+**parent** of roughly twenty-eight `SEM-2xx` child requirements — the construct
+families. A number of other requirements (across the experiment `EXP-*`,
+autonomy `AUT-*`, governance `GOV-*`, assurance `ASR-*`, and a few API/runtime
+requirements) `DEPENDS_ON` `SEM-200`: they are downstream consumers of the
+shared semantic layer, not prerequisites for it, and they do **not** gate
+`SEM-200`'s transition. Its statement —
+*"the ecosystem shall provide a shared semantic layer that gives scenario
+constructs explicit, consistent meaning across validation, instantiation,
+compilation, planning, execution, live observation, and experiment
+interpretation"* — is satisfied only when its `SEM-2xx` children are satisfied
+and the cross-stage agreement that ties them together is checkable. It is
+therefore not a single-pull-request deliverable.
+
+`SEM-201`–`SEM-205` are `ACTIVE` (fail-closed semantic validation, objective
+windows, workflow control, workflow compensation, canonical identities) — the
+"pilot domains" the originating issue (#4) names. The remaining `SEM-2xx`
+children and several adjacent requirements are `DRAFT`, spread across Waves 1,
+2, 3, and unassigned. Issue #4 itself records this state and asks, as follow-up,
+to "define the target semantic-layer scope across all relevant construct
+families", "identify uncovered construct domains and lifecycle phases", extend
+the shared semantic sources of truth "where needed", add construct-spanning
+cross-stage agreement tests, and "only transition `SEM-200` once the umbrella
+behavior is explicitly covered beyond the current pilot domains".
+
+This ADR does the first two of those follow-up items — by fixing the *model*
+below — and records the rest as the requirement's definition of done. It is the
+decision layer; the implementation-facing guardrails (which incumbents to
+extend, which gates a change must pass, which anti-patterns to avoid) live in
+[`docs/explain/reference/shared-semantic-integrity.md`](../../explain/reference/shared-semantic-integrity.md),
+which this ADR governs. It builds on, and does not restate, ADR-007 (lightweight
+formal-methods policy and FM0–FM3 classification), ADR-012 (shared concept
+authority and ACES extension discipline), ADR-013 (participant-episode lifecycle
+boundaries), and ADR-015 (SDL → processor layering).
+
+## Decision
+
+### Lifecycle phases
+
+The shared semantic layer spans seven canonical lifecycle phases, in order.
+Every construct family is evaluated against this fixed set; a downstream phase
+may *add* structure but must not *reinterpret* an upstream construct by local
+convention.
+
+1. **authoring** — authored SDL YAML parsed into closed SDL models (key
+   normalization, variable-key rejection, shorthand expansion).
+2. **validation** — `SemanticValidator` enforces static SDL semantics
+   (references, uniqueness, ambiguity, acyclicity, fail-closed resolution) and
+   collects all authoring errors.
+3. **instantiation** — `instantiate_scenario()` resolves parameters and
+   defaults, rejects unresolved placeholders, rebuilds a concrete
+   `InstantiatedScenario`, and reruns semantic validation.
+4. **compilation** — `compile_runtime_model()` emits canonical runtime
+   addresses, typed runtime resources, and compiled result/execution contracts.
+5. **planning** — `plan()` validates backend/processor capability semantics and
+   derives typed provisioning, orchestration, and evaluation plans (ordering,
+   dependency, refresh, applicability).
+6. **execution** — `RuntimeManager` / `RuntimeControlPlane` accept only
+   plan/result/snapshot data that passes the published contract and compiled
+   semantic gates; control-plane access is authenticated, authorized, durable,
+   idempotent, and audited.
+7. **observation** — live observation and (later) experiment interpretation
+   consume runtime snapshot, result, history, participant-episode, evidence,
+   provenance, and semantic-profile surfaces rather than backend-native objects.
+
+### Construct families and the coverage table
+
+`SEM-200`'s scope is a set of *construct families* — the scenario constructs
+whose cross-stage *meaning* can drift, and which therefore need shared semantic
+treatment. Pure SDL data-modeling constructs (topology, features, content,
+exercise timeline, …) are **not** construct families in this sense: their
+cross-stage integrity is provided by fail-closed validation (`SEM-201`),
+canonical identities (`SEM-205`), and the compiled representation (`RUN-302`),
+so they have no entry of their own unless a construct-specific semantic gap is
+later identified and a `SEM-*` requirement opened for it.
+
+Each construct family is owned by one or more requirements accountable for its
+cross-stage semantics — a `SEM-2xx` child for construct-specific semantics, a
+`DSL-*` requirement where the language model is the accountable artifact, or one
+of the cross-cutting/peer requirements (`SEM-201`, `SEM-205`, `RUN-301/302/303/304`,
+`API-401/402/403/404/412`, `ASR-503`, `GOV-920`, `RUN-311`, …) whose own work
+already realizes that family. A peer owner appearing on a row documents that the
+construct family is realized; it is not part of `SEM-200`'s transition gate —
+only the `SEM-2xx` children are (see the definition of done). Each row is
+realized by named artifacts (formal specs under `specs/formal/<domain>/`,
+semantic helpers under `aces_sdl.semantics` / `aces_processor.semantics`, the
+concept-authority stack under `aces_contracts`, runtime contracts, and the
+owning tests), and carries a status of `active` (owning requirement `ACTIVE` in
+Ground Control, semantics realized, named tests present), `partial` (some
+realization exists but the owning requirement or the coverage is incomplete), or
+`planned` (no realization yet; owned by a `DRAFT` requirement; future work). The
+structural gate enforces the *artifact-and-test-and-phase existence* implied by
+each status (`active` needs an existing test, `active`/`partial` need an existing
+non-test artifact and a phase, `planned` needs neither); whether a row's status
+truthfully matches the owning requirement's Ground Control state is a governance
+fact verified by requirement-governance review, not by the gate.
+
+The **live coverage table** is the `## Coverage Model` section of
+[`docs/explain/reference/shared-semantic-integrity.md`](../../explain/reference/shared-semantic-integrity.md),
+not this ADR: per `docs/decisions/adrs/README.md`, ADRs are immutable once
+accepted, whereas the coverage table is updated by every `SEM-2xx`
+implementation PR (it moves that construct family's row from `planned`/`partial`
+toward `active`). Keeping the mutable inventory in a governed reference note,
+and the fixed model and governance rules here, lets routine implementation work
+proceed without an ADR amendment. The structural gate
+`tools/check_semantic_coverage.py` validates that table's shape and that every
+repository path it names exists, and confirms this ADR still references the
+note.
+
+### How per-construct semantics land
+
+Per the guardrails note, future `SEM-200` work *extends the existing semantic
+authority stack* rather than introducing a parallel semantic registry: shared
+pure helpers, concept families, reference models, controlled vocabularies,
+semantic profiles, and runtime/provenance contracts are the extension surfaces.
+Each uncovered or partially covered construct family becomes its own
+`/implement <child-UID>` run, classified under ADR-007 (typically FM1–FM3), and
+ships its formal artifact, semantic helper, validator/compiler/planner wiring,
+tests, and the cross-stage agreement coverage for that family, and updates the
+coverage table. No `/implement` run claims `SEM-200` itself.
+
+### Definition of done for `SEM-200`
+
+`SEM-200` may transition `DRAFT → ACTIVE` only when **all** of the following
+hold:
+
+1. every `SEM-2xx` child requirement of `SEM-200` is `ACTIVE` in Ground Control
+   (or explicitly `DEPRECATED` / re-scoped with a recorded decision). The
+   `SEM-2xx` children are the umbrella's constituent requirements; the
+   cross-cutting/peer requirements that merely *own* a coverage-table row are not
+   gating — their being `ACTIVE` is already reflected in that row's status, not
+   in this rule. This avoids the circularity that gating on *every* row owner
+   would create (some peer owners themselves `DEPENDS_ON` `SEM-200`);
+2. no `partial` or `planned` rows remain in the coverage table — every construct
+   family is `active`. (A `SEM-2xx` child that is still `DRAFT` shows up as a
+   `partial`/`planned` row owned by it, so clauses 1 and 2 reinforce each
+   other.);
+3. the cross-stage agreement tests (today `implementations/python/tests/test_fm2_semantics.py`,
+   which exercises objective-window validator/compiler/planner agreement) are
+   extended to cover the other semantic construct families — workflow control,
+   compensation, planner ordering, runtime-result contracts, the participant
+   families, and so on — end to end across `authoring → validation →
+   instantiation → compilation → planning → execution → observation`;
+4. the unassigned-wave `SEM-2xx` children (`SEM-219`…`SEM-229`) have been
+   assigned to a wave (see Open Questions).
+
+Until then `SEM-200` stays `DRAFT` and is linked to its issue and documents
+with `DOCUMENTS` traceability, never `IMPLEMENTS`.
+
+## Consequences
+
+### Positive
+
+- The umbrella becomes tractable: every uncovered construct family has a named
+  owning requirement, whose Ground Control record (its statement and `wave`
+  field) is the authoritative scope and schedule for closing it — the coverage
+  table tracks realization status and does not duplicate the requirement
+  database into a column. Progress on `SEM-200` is the sum of bounded
+  `/implement <child-UID>` runs rather than an unbounded epic.
+- The transition rule is explicit: `SEM-200` is gated by its own `SEM-2xx`
+  children plus the no-`partial`/no-`planned`-rows condition, not by an
+  open-ended prose dependency list and not by peer requirements that are
+  themselves downstream of `SEM-200`.
+- The structural part of the coverage claims is machine-checked.
+  `tools/check_semantic_coverage.py` fails if a covered row points at an artifact
+  that no longer exists or escapes the repo root, if a covered row has no real
+  repository artifact behind it, if an `active` row names no existing test, if a
+  `planned` row starts claiming realization without an upgraded status, if a
+  lifecycle-phase or status token drifts, or if this ADR stops referencing the
+  coverage note by path. (The owning requirement's Ground Control status is a
+  governance fact reviewed by `check_requirement_governance.py` for the branch's
+  own requirement and by review for the rest, not enforced by this gate.) It
+  reuses `tools.policy.common.PolicyFailure`, `--json` output, and the shared
+  `tools/policy/exceptions.yaml` waiver mechanism, like the other `policy`
+  nox-stage entry points.
+- ADR immutability is preserved: the fixed model and governance rules are here;
+  the mutable inventory is in a reference note this ADR governs.
+- It is consistent with ADR-007 (each child is classified and carries the
+  proportionate formal artifact) and ADR-012 (work extends the concept-authority
+  stack, not a parallel registry).
+
+### Negative
+
+- The coverage table is a living artifact that every `SEM-2xx` implementation
+  PR must update (move a row from `planned`/`partial` toward `active`, add the
+  new spec/helper/test paths). That is intentional overhead — it is the
+  mechanism that keeps the umbrella honest — but it is overhead, and it lives in
+  a second file from this ADR.
+- The construct-family taxonomy in the note is a snapshot. New primary-source
+  review may add families or split existing ones; doing so updates the note, and
+  a change to the *model* (phases, statuses, the definition of done) is a new
+  ADR superseding this one.
+
+### Risks
+
+- If contributors update a child requirement's prose but not the coverage table,
+  the structural gate catches dangling artifact paths and unbacked covered rows
+  but not a *missing* row. Definition-of-done clause 1 (every `SEM-2xx` child
+  `ACTIVE`) plus requirement-governance review are the backstop.
+- The `planned` rows reference `DRAFT` requirements; if a child is later
+  re-scoped or merged, the corresponding row must be reconciled. Clause 1's
+  "or explicitly `DEPRECATED` / re-scoped with a recorded decision" covers that,
+  but it depends on the reconciliation actually happening.
+
+## Open Questions
+
+- `SEM-219`…`SEM-229` (the unassigned-wave `SEM-2xx` children of `SEM-200`)
+  currently have no wave assignment in Ground Control. Assigning them is a
+  requirement-governance decision (it changes the work order) and is
+  intentionally **not** done by the PR that introduced this ADR; it is flagged
+  for the maintainers. The coverage rows owned by those requirements are
+  `planned` regardless of wave.
+
+## References
+
+- Issue #4 — `SEM-200: Shared Semantic Integrity`
+- `docs/explain/reference/shared-semantic-integrity.md` — implementation-facing
+  guardrails this ADR governs, and home of the live `## Coverage Model` table
+- ADR-007 — Lightweight Formal Methods Policy for Semantic Systems
+- ADR-012 — Shared Concept Authority and ACES Extension Discipline
+- ADR-013 — Participant Episode Lifecycle Boundaries
+- ADR-015 — SDL-Processor Layering and Source-File Size Cap
+- `tools/check_semantic_coverage.py` — the structural gate for the coverage
+  table and the ADR↔note linkage

--- a/docs/explain/reference/README.md
+++ b/docs/explain/reference/README.md
@@ -7,3 +7,5 @@ themselves normative specifications or ADRs.
   - Reference coding expectations for the repo
 - [shared-concept-model.md](shared-concept-model.md)
   - Design guidance for `GOV-917` and related shared-concept-model work
+- [shared-semantic-integrity.md](shared-semantic-integrity.md)
+  - Architecture guardrails for `SEM-200` shared semantic integrity work

--- a/docs/explain/reference/shared-semantic-integrity.md
+++ b/docs/explain/reference/shared-semantic-integrity.md
@@ -1,0 +1,238 @@
+# Shared Semantic Integrity
+
+This note is the implementation-facing architecture preflight for `SEM-200`.
+The guardrails below are guidance, not an implementation plan.
+
+[ADR-016](../../decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md)
+fixes the *model* for `SEM-200` — the seven canonical lifecycle phases, the
+construct-family concept, the status vocabulary, and `SEM-200`'s definition of
+done — and is immutable once accepted. The *live* coverage table is the
+[`## Coverage Model`](#coverage-model) section at the end of this note, which
+ADR-016 governs; every `SEM-2xx` implementation PR moves its construct family's
+row toward `active` there. The structural gate `tools/check_semantic_coverage.py`
+validates that table on every `nox` policy run.
+
+`SEM-200` is broader than concept authority alone. It covers whether scenario
+constructs keep the same meaning across authoring, validation, instantiation,
+compilation, planning, execution, live observation, and later experiment
+interpretation. The implementation should extend the existing semantic
+authority stack rather than introduce another one.
+
+## Lifecycle Boundary
+
+The current canonical lifecycle is:
+
+1. authored SDL YAML is parsed into closed SDL models
+2. `SemanticValidator` enforces static SDL semantics and collects all authoring
+   errors
+3. `instantiate_scenario()` applies parameters/defaults, rejects unresolved
+   placeholders, rebuilds a concrete `InstantiatedScenario`, and reruns
+   semantic validation
+4. `compile_runtime_model()` emits canonical runtime addresses, typed runtime
+   resources, and compiled result/execution contracts
+5. `plan()` validates backend capability semantics and derives typed
+   provisioning, orchestration, and evaluation plans
+6. `RuntimeManager` and `RuntimeControlPlane` accept only plan/result/snapshot
+   data that passes the published contract and compiled semantic gates
+7. live observation and interpretation consume runtime snapshot, result,
+   history, participant-episode, evidence, provenance, and profile surfaces
+   rather than backend-native objects
+
+Each phase may add structure, but it must not reinterpret an upstream
+construct by local convention.
+
+## Canonical Incumbents
+
+Use these existing surfaces before adding anything new:
+
+- SDL shape and local parsing: `aces_sdl.SDLModel`, parser key normalization,
+  variable-key rejection, and `SDLParseError`
+- static SDL validation: `SemanticValidator` and `SDLValidationError`
+- instantiation: `instantiate_scenario()` and `SDLInstantiationError`
+- shared SDL semantics: `aces_sdl.semantics.objectives` and
+  `aces_sdl.semantics.workflow`
+- runtime graph semantics: `aces_processor.semantics.planner`
+- runtime diagnostics: `aces_processor.models.Diagnostic`
+- contract boundaries: `aces_contracts.contracts.ContractModel`,
+  `schema_bundle()`, generated `contracts/schemas/`, and fixture validation
+- concept authority: `contracts/concept-authority/`,
+  `specs/concept-authority/`, `aces_contracts.vocabulary`,
+  `manifest_authority`, `controlled_vocabularies`, `reference_models`, and
+  `semantic_profiles`
+- backend and processor declarations: shared `v2` apparatus manifests with
+  required `concept_bindings`, controlled vocabulary checks, supported contract
+  authority checks, and realization-support disclosures
+- live control plane: `control_plane_security`, `control_plane_api`,
+  `RuntimeControlPlane`, and `ControlPlaneStore`
+- formal-methods policy: ADR-007, the coding standards, and the existing
+  `specs/formal/<domain>/` artifacts
+
+## Cross-Cutting Gates
+
+A SEM-200 implementation must pass every gate it touches:
+
+- SDL parser gate: user-defined symbol keys stay concrete; `${var}` may only
+  substitute values, not create or rename semantic identities.
+- SDL model gate: Pydantic models remain closed where the repo already uses
+  `extra="forbid"`; new construct shape belongs in owning SDL models, not
+  untyped `dict` side channels.
+- semantic validation gate: fail closed on missing, ambiguous, cyclic, or
+  out-of-scope references; collect errors through the existing validation
+  exception instead of adding a new hierarchy.
+- instantiation gate: concrete scenarios must rerun semantic validation after
+  parameter/default substitution.
+- contract gate: external payloads use `ContractModel`, published schema
+  generation, fixtures, and `tools/check_json_artifacts.py`; do not edit
+  `contracts/schemas/` directly.
+- manifest/profile gate: supported contract versions, SDL versions, concept
+  families, binding scopes, controlled vocabulary terms, and semantic profile
+  phases must resolve through the existing authority helpers.
+- compiler/planner gate: canonical addresses, objective-window semantics,
+  workflow state contracts, and planner dependency semantics must come from the
+  shared helpers, not copied local algorithms.
+- backend boundary gate: backend exceptions and invalid payloads become
+  structured `Diagnostic` values; live results are validated against compiled
+  contracts before they enter snapshots.
+- HTTP/control-plane gate: request bodies are size-limited, authenticated,
+  authorized by role, audited, idempotency-fingerprinted, and returned through
+  published response models; internal errors stay redacted.
+- persistence gate: snapshots, operation records, and audit events are
+  plain-data envelopes. Do not store bearer tokens, secrets, raw credentials,
+  or backend-private objects in metadata, details, diagnostics, or evidence
+  references.
+- host/OS exposure gate: secrets and bearer tokens must not be passed in
+  command-line arguments, tracebacks, logs, audit `details`, semantic profile
+  artifacts, or scenario text. Runtime adapters should receive them through
+  headers or process-local configuration that is not echoed into diagnostics.
+
+## Extension Point
+
+The primary extension point is the governed semantic surface, not a new
+parallel model:
+
+- add a pure shared helper when the same rule must be consumed by validation,
+  compilation, planning, runtime validation, or tests
+- add concept families only when meaning must be shared across artifacts
+- add reference models only for recurrent shared structure
+- add controlled vocabularies only when portable value comparison matters
+- add semantic profile declarations when existing concept, contract, binding,
+  and behavior assumptions must be composed for an interoperable stack
+- add new profile phases or governed binding scopes only at the profile/schema
+  authority layer, not as hard-coded one-off checks in a caller
+
+Live observation and experiment interpretation should extend from runtime
+snapshot/result/history, participant-episode, evidence, provenance, and
+semantic-profile contracts. They should not overload evaluator `detail`,
+backend manifest strings, or profile selectors as hidden authority surfaces.
+
+## Guardrails
+
+- Keep concept authority, reference structure, controlled vocabulary values,
+  semantic profiles, SDL syntax, runtime contracts, and backend capability
+  profiles separate.
+- Treat `scenario-instantiation-request-v1.profile` as a selector until a
+  governed semantic profile contract gives it stronger meaning.
+- Preserve canonical identity semantics through composition/import expansion;
+  downstream phases should see resolved identities, not source-file layout.
+- Keep authoring, processing, execution, live observation, and interpretation
+  meanings aligned through tests that compare the same construct across stages.
+- Use the smallest adequate formal-methods artifact for the changed surface.
+  FM2/FM3 changes need explicit invariants and typed IR/contract coverage.
+
+## Anti-Patterns
+
+Avoid:
+
+- a second semantic registry beside concept authority and semantic profiles
+- direct edits to generated schemas under `contracts/schemas/`
+- duplicating SDL validation logic inside compiler, planner, conformance, or
+  backend adapters
+- raw string parsing where an existing structured model or helper exists
+- treating backend-native payloads as the portable observation contract
+- treating semantic profiles as backend capability profiles
+- treating controlled vocabularies as concept definitions
+- treating UCO or another ontology as the authoring syntax
+- adding SEM-200-specific exception, logging, audit, persistence, or schema
+  stacks
+- writing raw secrets, tokens, credentials, or full backend tracebacks into
+  diagnostics, audit records, snapshots, or JSON fixtures
+- solving the requirement by creating one universal scenario super-model
+
+## Non-Goals
+
+The preflight guardrails above do not implement the missing `SEM-200` coverage,
+add new schemas, add new construct-specific tests, or transition the requirement
+status. They only fix the architectural guardrails for the implementation that
+follows. The Coverage Model below is the inventory and tracker; closing each
+`planned`/`partial` row is its own `/implement <child-UID>` run.
+
+## Coverage Model
+
+This is the live, ADR-016-governed coverage table for `SEM-200`. It is mutable
+— each `SEM-2xx` implementation PR updates the affected row — and validated by
+the structural gate `tools/check_semantic_coverage.py`.
+
+Lifecycle phases (canonical, fixed, per ADR-016): `authoring`, `validation`,
+`instantiation`, `compilation`, `planning`, `execution`, `observation`.
+
+Status is one of:
+
+- `active` — the owning requirement is `ACTIVE` in Ground Control; the
+  construct's semantics are realized in a shared helper/spec; named tests cover
+  it. The structural gate enforces that the row names at least one lifecycle
+  phase, at least one *existing* non-test repository artifact, and at least one
+  *existing* test under `implementations/python/tests/test_*.py`; whether the
+  owning requirement is actually `ACTIVE` is a Ground Control fact verified by
+  requirement-governance review, not by the gate.
+- `partial` — some realization exists (a spec, a helper) but the owning
+  requirement is still `DRAFT` or the coverage is incomplete. The gate enforces
+  at least one phase and at least one existing non-test repository artifact.
+- `planned` — no realization yet; owned by a `DRAFT` requirement; future work.
+  Phases and artifacts are left as `—`; the gate enforces that they stay empty.
+  For a `planned` row, the construct family's intended lifecycle scope, future
+  artifact, and wave are defined by the owning requirement's record in Ground
+  Control (its statement and `wave` field) — this table tracks realization
+  status, not the requirement database, and deliberately carries no wave column.
+
+A construct family appears here only if its cross-stage *meaning* can drift, and
+only if a `SEM-2xx` child of `SEM-200` (or, for a foundational/peer concern such
+as the concept-authority meta-layer or the runtime/contract layers, an owning
+peer requirement that is already `ACTIVE`) accounts for it. Pure SDL
+data-modeling constructs (topology, features, content, exercise timeline, …) get
+their cross-stage integrity from fail-closed validation (`SEM-201`), canonical
+identities (`SEM-205`), and the compiled representation (`RUN-302`), so they have
+no row of their own unless a construct-specific semantic gap is later identified
+and a `SEM-*` requirement opened for it. Higher-level capabilities that *consume*
+the semantic layer (cross-run comparability, semantic diff, federation/standards
+profiles, …) are downstream of `SEM-200` rather than construct families of it,
+so they are tracked by their own requirements, not here.
+
+| Construct family | Owning requirement(s) | Phases covered | Realizing artifacts | Status |
+| --- | --- | --- | --- | --- |
+| Fail-closed semantic validation (cross-cutting gate) | SEM-201 | validation, instantiation | `implementations/python/packages/aces_sdl/validator.py`, `implementations/python/packages/aces_sdl/instantiate.py`, `implementations/python/tests/test_sdl_validator.py` | active |
+| Stable identifiers, parameterized values, and qualified references | DSL-101, DSL-102, SEM-205 | authoring, validation, instantiation, compilation, planning, observation | `implementations/python/packages/aces_sdl/parser.py`, `implementations/python/packages/aces_sdl/variables.py`, `implementations/python/packages/aces_sdl/validator.py`, `implementations/python/tests/test_sdl_parser.py`, `implementations/python/tests/test_sdl_validator.py` | active |
+| Deterministic module composition and canonical-identity stability across expansion | DSL-103, SEM-205 | authoring, validation, compilation | `implementations/python/packages/aces_sdl/composition.py`, `implementations/python/packages/aces_sdl/module_registry.py`, `specs/formal/composition-readiness.md`, `implementations/python/tests/test_sdl_module_registry.py` | active |
+| Instantiation and revalidation of concrete scenarios | RUN-301 | instantiation, validation | `implementations/python/packages/aces_sdl/instantiate.py`, `implementations/python/tests/test_sdl_validator.py`, `implementations/python/tests/test_run_300_lifecycle.py` | active |
+| Objective windows, referenced scopes, reachability, and refresh | SEM-202 | validation, compilation, planning | `implementations/python/packages/aces_sdl/semantics/objectives.py`, `specs/formal/objectives/README.md`, `specs/formal/objectives/window-consistency.md`, `implementations/python/tests/test_semantics_objectives.py`, `implementations/python/tests/test_fm2_semantics.py` | active |
+| Declarative objective actor binding, target resolution, and success interpretation | DSL-112, SEM-207 | authoring, validation, instantiation | `implementations/python/packages/aces_sdl/objectives.py`, `implementations/python/tests/test_sdl_validator.py` | partial |
+| Workflow control semantics (branching, joins, calling, retry, completion, history) | DSL-113, SEM-203 | authoring, validation, compilation, planning, execution, observation | `implementations/python/packages/aces_sdl/orchestration.py`, `implementations/python/packages/aces_sdl/semantics/workflow.py`, `specs/formal/workflows/README.md`, `specs/formal/workflows/state-machine.md`, `implementations/python/tests/test_sdl_validator.py`, `implementations/python/tests/test_runtime_models.py` | active |
+| Workflow compensation semantics (registration, triggering, ordering, observation) | SEM-204 | validation, compilation, execution, observation | `implementations/python/packages/aces_sdl/semantics/workflow.py`, `specs/formal/workflows/compensation.md`, `implementations/python/tests/test_sdl_validator.py`, `implementations/python/tests/test_runtime_manager.py` | active |
+| Assessment model and pipeline semantics (conditions, metrics, evaluations, TLOs, goals) | DSL-110, SEM-206 | authoring, validation | `implementations/python/packages/aces_sdl/scoring.py`, `implementations/python/packages/aces_sdl/conditions.py`, `implementations/python/tests/test_sdl_models.py` | partial |
+| Runtime compiled representation and canonical addresses | RUN-302 | compilation | `implementations/python/packages/aces_processor/compiler.py`, `implementations/python/tests/test_runtime_models.py`, `implementations/python/tests/test_fm2_semantics.py` | active |
+| Planner dependency, ordering, refresh, and applicability semantics | RUN-303 | planning | `implementations/python/packages/aces_processor/semantics/planner.py`, `implementations/python/packages/aces_processor/planner.py`, `specs/formal/planner/README.md`, `specs/formal/planner/dependency-ordering.md`, `implementations/python/tests/test_semantics_planner.py`, `implementations/python/tests/test_runtime_planner.py` | active |
+| Live execution state and lifecycle (snapshots, results, history) | RUN-304, API-402 | execution, observation | `implementations/python/packages/aces_processor/manager.py`, `implementations/python/packages/aces_processor/models.py`, `implementations/python/tests/test_runtime_manager.py`, `implementations/python/tests/test_runtime_models.py` | active |
+| Runtime result and evaluator-result contracts | ASR-503, API-402 | execution, observation | `specs/formal/runtime-contracts/README.md`, `specs/formal/runtime-contracts/workflow-results.md`, `specs/formal/runtime-contracts/evaluator-results.md`, `implementations/python/tests/test_runtime_contracts.py` | active |
+| Control-plane semantics (auth, durable state, idempotency, audit) | API-403, API-404 | execution, observation | `implementations/python/packages/aces_processor/control_plane_api.py`, `implementations/python/packages/aces_processor/control_plane_security.py`, `implementations/python/packages/aces_processor/control_plane_store.py`, `implementations/python/tests/test_runtime_control_plane.py`, `implementations/python/tests/test_runtime_control_plane_api.py` | active |
+| Backend and processor identity, capability, and compatibility manifests | API-401, API-412 | planning, execution | `implementations/python/packages/aces_processor/manifest.py`, `implementations/python/packages/aces_processor/capabilities.py`, `implementations/python/packages/aces_contracts/apparatus.py`, `implementations/python/packages/aces_contracts/manifest_authority.py`, `implementations/python/tests/test_backend_manifest.py`, `implementations/python/tests/test_processor_manifest.py` | active |
+| Concept authority, controlled vocabularies, reference models, and semantic profiles (meta-layer) | GOV-920 | authoring, validation, compilation, planning, execution | `specs/concept-authority/concept-authority.md`, `specs/concept-authority/semantic-profiles.md`, `implementations/python/packages/aces_contracts/semantic_profiles.py`, `implementations/python/packages/aces_contracts/controlled_vocabularies.py`, `implementations/python/packages/aces_contracts/reference_models.py`, `docs/explain/reference/shared-concept-model.md`, `implementations/python/tests/test_concept_authority.py`, `implementations/python/tests/test_semantic_profiles.py` | active |
+| Participant episode lifecycle boundaries (initialization, reset, completion, timeout, truncation, interruption) | RUN-311, SEM-222 | execution, observation | `docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md`, `implementations/python/tests/test_run_311_participant_episode_lifecycle.py` | partial |
+| Participant framing and behavior semantics (identity, role, starting conditions, actions, observations, state transitions) | ACT-601, ACT-602, SEM-208 | — | — | planned |
+| Multi-participant interaction, visibility, and information-boundary semantics | SEM-209, SEM-210, SEM-226 | — | — | planned |
+| Participant preconditions, effects, failure, causality, and attribution semantics | SEM-211, SEM-212 | — | — | planned |
+| Participant temporal, tool/affordance, and decision-surface semantics | SEM-213, SEM-219, SEM-220 | — | — | planned |
+| Participant reference trajectories, demonstrations, budgets, and quota/exhaustion semantics | SEM-221, SEM-223 | — | — | planned |
+| Participant outcome interpretation and derived operational context views | SEM-214, SEM-215 | — | — | planned |
+| Evidence, evaluation, view-boundary, and observability-plane semantics | SEM-216, SEM-224, SEM-225 | — | — | planned |
+| External knowledge bindings semantics | SEM-217 | — | — | planned |
+| Explicitness and realization semantics (binding declarations vs processor/backend realization) | SEM-218 | — | — | planned |
+| Clock, time-domain, advancement/pacing/synchronization, and temporal ordering/causality semantics | SEM-227, SEM-228, SEM-229 | — | — | planned |

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,14 +80,17 @@ decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline
 decisions/adrs/adr-013-participant-episode-lifecycle-boundaries
 decisions/adrs/adr-014-nox-as-canonical-verification-graph
 decisions/adrs/adr-015-sdl-processor-layering-and-source-file-size-cap
+decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model
 ```
 
 ```{toctree}
 :maxdepth: 2
 :caption: Reference
 
+explain/reference/README
 explain/reference/coding-standards
 explain/reference/shared-concept-model
+explain/reference/shared-semantic-integrity
 ```
 
 ```{toctree}

--- a/implementations/python/tests/test_semantic_coverage.py
+++ b/implementations/python/tests/test_semantic_coverage.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import pytest
+from tools.check_semantic_coverage import (
+    ADR_RELATIVE_PATH,
+    CANONICAL_PHASES,
+    COVERAGE_NOTE_RELATIVE_PATH,
+    VALID_STATUSES,
+    CoverageParseError,
+    evaluate_semantic_coverage,
+    main,
+    parse_coverage_rows,
+)
+
+# A stub ADR-016 that references the coverage note by basename, so the
+# ADR↔note linkage check passes in the seeded temp repo.
+_GOOD_ADR = """# ADR-016: Semantic Layer Scope and Coverage Model
+
+## Status
+accepted
+
+## Decision
+The live coverage table lives in `docs/explain/reference/shared-semantic-integrity.md`,
+which this ADR governs.
+"""
+
+# A minimal but well-formed coverage note: prose, then a Coverage Model section
+# with a table whose paths exist under the (temp) repo root.
+_GOOD_NOTE = """# Shared Semantic Integrity
+
+Guardrails note for SEM-200. The scope and coverage model are governed by
+ADR-016 (../../decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md).
+
+## Coverage Model
+
+Lifecycle phases (canonical, fixed): authoring, validation, instantiation,
+compilation, planning, execution, observation.
+
+| Construct family | Owning requirement(s) | Phases covered | Realizing artifacts | Status |
+| --- | --- | --- | --- | --- |
+| Objective windows | SEM-202 | validation, compilation, planning | `specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py` | active |
+| Assessment semantics | SEM-206, DSL-110 | — | — | planned |
+
+## Non-Goals
+Nothing else here.
+"""
+
+_ARTIFACTS_IN_GOOD_NOTE = (
+    "specs/formal/objectives/README.md",
+    "implementations/python/tests/test_semantics_objectives.py",
+)
+
+
+def _seed_repo(tmp_path: Path, note_body: str = _GOOD_NOTE, adr_body: str | None = _GOOD_ADR) -> Path:
+    """Create a temp repo skeleton: the coverage note, its governing ADR, and the artifacts named in the note."""
+    note_path = tmp_path / COVERAGE_NOTE_RELATIVE_PATH
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(note_body, encoding="utf-8")
+    if adr_body is not None:
+        adr_path = tmp_path / ADR_RELATIVE_PATH
+        adr_path.parent.mkdir(parents=True, exist_ok=True)
+        adr_path.write_text(adr_body, encoding="utf-8")
+    for rel in _ARTIFACTS_IN_GOOD_NOTE:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("placeholder\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_well_formed_note_passes(tmp_path: Path) -> None:
+    assert evaluate_semantic_coverage(_seed_repo(tmp_path)) == []
+
+
+def test_missing_note_fails(tmp_path: Path) -> None:
+    failures = evaluate_semantic_coverage(tmp_path)
+    assert any(f.rule_id == "coverage-note-missing" for f in failures)
+
+
+def test_missing_governing_adr_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, adr_body=None)
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-adr-missing" for f in failures)
+    assert any("adr-016" in f.render().lower() for f in failures)
+
+
+def test_adr_not_referencing_note_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, adr_body="# ADR-016: Something\n\n## Status\naccepted\n")
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-adr-unlinked" for f in failures)
+
+
+def test_adr_basename_only_reference_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, adr_body="# ADR-016: X\n\n## Status\naccepted\n\nSee shared-semantic-integrity.md.\n")
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-adr-unlinked" for f in failures)
+
+
+def test_missing_coverage_section_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("## Coverage Model", "## Something Else"))
+    failures = evaluate_semantic_coverage(repo)
+    assert any("coverage model" in f.render().lower() for f in failures)
+
+
+def test_unknown_status_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("| active |", "| done |"))
+    failures = evaluate_semantic_coverage(repo)
+    assert any("status" in f.render().lower() and "done" in f.render().lower() for f in failures)
+
+
+def test_unknown_phase_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("validation, compilation, planning", "validation, deployment"))
+    failures = evaluate_semantic_coverage(repo)
+    assert any("phase" in f.render().lower() and "deployment" in f.render().lower() for f in failures)
+
+
+def test_dangling_artifact_path_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`specs/formal/objectives/does-not-exist.md`"),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any("does-not-exist" in f.render() for f in failures)
+
+
+def test_active_row_without_artifacts_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "| Objective windows | SEM-202 | validation, compilation, planning | "
+            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py` | active |",
+            "| Objective windows | SEM-202 | validation | — | active |",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-incomplete" for f in failures)
+
+
+def test_active_row_with_only_prose_artifact_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
+            "objective window semantics live in the validator",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-incomplete" for f in failures)
+
+
+def test_active_row_without_test_artifact_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
+            "`specs/formal/objectives/README.md`",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-untested" for f in failures)
+
+
+def test_active_row_with_only_test_artifacts_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
+            "`implementations/python/tests/test_semantics_objectives.py`",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-incomplete" for f in failures)
+
+
+def test_unsupported_path_artifact_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`pyproject.toml`"))
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-artifact-unsupported" for f in failures)
+
+
+def test_planned_row_with_artifacts_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "| Assessment semantics | SEM-206, DSL-110 | — | — | planned |",
+            "| Assessment semantics | SEM-206, DSL-110 | validation | "
+            "`implementations/python/tests/test_semantics_objectives.py` | planned |",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert any(f.rule_id == "coverage-planned" for f in failures)
+
+
+def test_bad_requirement_uid_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("| SEM-202 |", "| sem-202 |"))
+    failures = evaluate_semantic_coverage(repo)
+    assert any("sem-202" in f.render().lower() for f in failures)
+
+
+def test_malformed_row_column_count_fails(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        _GOOD_NOTE.replace(
+            "| Assessment semantics | SEM-206, DSL-110 | — | — | planned |",
+            "| Assessment semantics | SEM-206, DSL-110 | — | planned |",
+        ),
+    )
+    failures = evaluate_semantic_coverage(repo)
+    assert failures
+
+
+def test_no_table_raises_parse_error() -> None:
+    body = "# Note\n\n## Coverage Model\n\nNo table here.\n\n## Next\nDone.\n"
+    with pytest.raises(CoverageParseError):
+        parse_coverage_rows(body)
+
+
+def test_missing_section_raises_parse_error() -> None:
+    with pytest.raises(CoverageParseError):
+        parse_coverage_rows("# Note\n\nNothing relevant.\n")
+
+
+def test_parse_rows_returns_expected_count() -> None:
+    rows = parse_coverage_rows(_GOOD_NOTE)
+    assert len(rows) == 2
+    assert rows[0].family == "Objective windows"
+    assert rows[0].owners == ["SEM-202"]
+    assert rows[0].status == "active"
+    assert rows[1].status == "planned"
+
+
+def test_row_line_number_accounts_for_prose_before_table() -> None:
+    body = (
+        "# Reference Note\n"  # line 1
+        "\n"  # line 2
+        "Intro paragraph.\n"  # line 3
+        "\n"  # line 4
+        "## Coverage Model\n"  # line 5
+        "\n"  # line 6
+        "Lifecycle phases: authoring, validation.\n"  # line 7
+        "Some more prose before the table.\n"  # line 8
+        "\n"  # line 9
+        "| Construct family | Owning requirement(s) | Phases covered | Realizing artifacts | Status |\n"  # line 10
+        "| --- | --- | --- | --- | --- |\n"  # line 11
+        "| Objective windows | SEM-202 | validation | `specs/x.md` | active |\n"  # line 12
+        "| Future thing | SEM-999 | — | — | planned |\n"  # line 13
+        "\n"
+        "## Next Section\nDone.\n"
+    )
+    rows = parse_coverage_rows(body)
+    assert [row.line_no for row in rows] == [12, 13]
+
+
+def test_cli_returns_nonzero_on_failure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--repo-root", str(tmp_path)]) == 1
+    assert capsys.readouterr().err.strip()
+
+
+def test_cli_returns_zero_when_clean(tmp_path: Path) -> None:
+    assert main(["--repo-root", str(_seed_repo(tmp_path))]) == 0
+
+
+def test_repo_coverage_note_is_well_formed() -> None:
+    """The real SEM-200 coverage note must pass the structural coverage gate."""
+    assert evaluate_semantic_coverage(REPO_ROOT) == []
+
+
+def test_constants_are_sane() -> None:
+    assert "validation" in CANONICAL_PHASES
+    assert set(VALID_STATUSES) == {"active", "partial", "planned"}
+    assert COVERAGE_NOTE_RELATIVE_PATH.endswith("shared-semantic-integrity.md")
+    assert ADR_RELATIVE_PATH.endswith("adr-016-semantic-layer-scope-and-coverage-model.md")

--- a/implementations/python/tests/test_semantic_coverage.py
+++ b/implementations/python/tests/test_semantic_coverage.py
@@ -19,8 +19,8 @@ from tools.check_semantic_coverage import (
     parse_coverage_rows,
 )
 
-# A stub ADR-016 that references the coverage note by basename, so the
-# ADR↔note linkage check passes in the seeded temp repo.
+# A stub ADR-016 that references the coverage note by its repo-relative path, so
+# the ADR↔note linkage check passes in the seeded temp repo.
 _GOOD_ADR = """# ADR-016: Semantic Layer Scope and Coverage Model
 
 ## Status
@@ -52,6 +52,13 @@ compilation, planning, execution, observation.
 Nothing else here.
 """
 
+_ACTIVE_ROW = (
+    "| Objective windows | SEM-202 | validation, compilation, planning | "
+    "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py` | active |"
+)
+_ARTIFACTS = "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`"
+_PLANNED_ROW = "| Assessment semantics | SEM-206, DSL-110 | — | — | planned |"
+
 _ARTIFACTS_IN_GOOD_NOTE = (
     "specs/formal/objectives/README.md",
     "implementations/python/tests/test_semantics_objectives.py",
@@ -74,6 +81,108 @@ def _seed_repo(tmp_path: Path, note_body: str = _GOOD_NOTE, adr_body: str | None
     return tmp_path
 
 
+def _flagged(failures, marker: str) -> bool:
+    """True if some failure matches ``marker`` by rule id or by a substring of its rendered text."""
+    needle = marker.lower()
+    return any(f.rule_id == marker or needle in f.render().lower() for f in failures)
+
+
+# (case id, mutated coverage note, marker the checker must flag)
+_NOTE_DEFECT_CASES = [
+    ("section-missing", _GOOD_NOTE.replace("## Coverage Model", "## Something Else"), "coverage model"),
+    ("status-unknown", _GOOD_NOTE.replace("| active |", "| done |"), "done"),
+    ("status-unknown-rule", _GOOD_NOTE.replace("| active |", "| done |"), "coverage-status"),
+    ("phase-unknown", _GOOD_NOTE.replace("validation, compilation, planning", "validation, deployment"), "deployment"),
+    (
+        "phase-unknown-rule",
+        _GOOD_NOTE.replace("validation, compilation, planning", "validation, deployment"),
+        "coverage-phase",
+    ),
+    ("owner-bad-uid", _GOOD_NOTE.replace("| SEM-202 |", "| sem-202 |"), "sem-202"),
+    (
+        "artifact-missing",
+        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`specs/formal/objectives/nope.md`"),
+        "nope.md",
+    ),
+    (
+        "artifact-missing-rule",
+        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`specs/formal/objectives/nope.md`"),
+        "coverage-artifact-missing",
+    ),
+    (
+        "artifact-unsupported",
+        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`pyproject.toml`"),
+        "coverage-artifact-unsupported",
+    ),
+    (
+        "artifact-escapes-root",
+        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`specs/../../escape.md`"),
+        "coverage-artifact-escape",
+    ),
+    (
+        "active-no-artifacts",
+        _GOOD_NOTE.replace(_ACTIVE_ROW, "| Objective windows | SEM-202 | validation | — | active |"),
+        "coverage-incomplete",
+    ),
+    (
+        "active-only-prose-artifact",
+        _GOOD_NOTE.replace(_ARTIFACTS, "objective window semantics live in the validator"),
+        "coverage-incomplete",
+    ),
+    (
+        "active-no-test-artifact",
+        _GOOD_NOTE.replace(_ARTIFACTS, "`specs/formal/objectives/README.md`"),
+        "coverage-untested",
+    ),
+    (
+        "active-only-test-artifact",
+        _GOOD_NOTE.replace(_ARTIFACTS, "`implementations/python/tests/test_semantics_objectives.py`"),
+        "coverage-incomplete",
+    ),
+    (
+        "planned-has-artifacts",
+        _GOOD_NOTE.replace(
+            _PLANNED_ROW,
+            "| Assessment semantics | SEM-206 | validation | `specs/formal/objectives/README.md` | planned |",
+        ),
+        "coverage-planned",
+    ),
+    (
+        "planned-has-phases",
+        _GOOD_NOTE.replace(_PLANNED_ROW, "| Assessment semantics | SEM-206 | validation | — | planned |"),
+        "coverage-planned",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("note_body", "marker"), [(n, m) for _, n, m in _NOTE_DEFECT_CASES], ids=[c for c, _, _ in _NOTE_DEFECT_CASES]
+)
+def test_note_defect_is_flagged(tmp_path: Path, note_body: str, marker: str) -> None:
+    failures = evaluate_semantic_coverage(_seed_repo(tmp_path, note_body))
+    assert _flagged(failures, marker)
+
+
+# (case id, ADR-016 body — or None to omit the file entirely, expected rule id)
+_ADR_LINKAGE_CASES = [
+    ("adr-absent", None, "coverage-adr-missing"),
+    ("adr-no-reference", "# ADR-016: Something\n\n## Status\naccepted\n", "coverage-adr-unlinked"),
+    (
+        "adr-basename-only",
+        "# ADR-016: X\n\n## Status\naccepted\n\nSee shared-semantic-integrity.md.\n",
+        "coverage-adr-unlinked",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("adr_body", "rule_id"), [(b, r) for _, b, r in _ADR_LINKAGE_CASES], ids=[c for c, _, _ in _ADR_LINKAGE_CASES]
+)
+def test_adr_linkage_defect_is_flagged(tmp_path: Path, adr_body: str | None, rule_id: str) -> None:
+    failures = evaluate_semantic_coverage(_seed_repo(tmp_path, adr_body=adr_body))
+    assert any(f.rule_id == rule_id for f in failures)
+
+
 def test_well_formed_note_passes(tmp_path: Path) -> None:
     assert evaluate_semantic_coverage(_seed_repo(tmp_path)) == []
 
@@ -83,142 +192,17 @@ def test_missing_note_fails(tmp_path: Path) -> None:
     assert any(f.rule_id == "coverage-note-missing" for f in failures)
 
 
-def test_missing_governing_adr_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, adr_body=None)
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-adr-missing" for f in failures)
-    assert any("adr-016" in f.render().lower() for f in failures)
-
-
-def test_adr_not_referencing_note_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, adr_body="# ADR-016: Something\n\n## Status\naccepted\n")
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-adr-unlinked" for f in failures)
-
-
-def test_adr_basename_only_reference_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, adr_body="# ADR-016: X\n\n## Status\naccepted\n\nSee shared-semantic-integrity.md.\n")
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-adr-unlinked" for f in failures)
-
-
-def test_missing_coverage_section_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("## Coverage Model", "## Something Else"))
-    failures = evaluate_semantic_coverage(repo)
-    assert any("coverage model" in f.render().lower() for f in failures)
-
-
-def test_unknown_status_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("| active |", "| done |"))
-    failures = evaluate_semantic_coverage(repo)
-    assert any("status" in f.render().lower() and "done" in f.render().lower() for f in failures)
-
-
-def test_unknown_phase_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("validation, compilation, planning", "validation, deployment"))
-    failures = evaluate_semantic_coverage(repo)
-    assert any("phase" in f.render().lower() and "deployment" in f.render().lower() for f in failures)
-
-
-def test_dangling_artifact_path_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`specs/formal/objectives/does-not-exist.md`"),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any("does-not-exist" in f.render() for f in failures)
-
-
-def test_active_row_without_artifacts_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "| Objective windows | SEM-202 | validation, compilation, planning | "
-            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py` | active |",
-            "| Objective windows | SEM-202 | validation | — | active |",
-        ),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-incomplete" for f in failures)
-
-
-def test_active_row_with_only_prose_artifact_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
-            "objective window semantics live in the validator",
-        ),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-incomplete" for f in failures)
-
-
-def test_active_row_without_test_artifact_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
-            "`specs/formal/objectives/README.md`",
-        ),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-untested" for f in failures)
-
-
-def test_active_row_with_only_test_artifacts_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "`specs/formal/objectives/README.md`, `implementations/python/tests/test_semantics_objectives.py`",
-            "`implementations/python/tests/test_semantics_objectives.py`",
-        ),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-incomplete" for f in failures)
-
-
-def test_unsupported_path_artifact_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("`specs/formal/objectives/README.md`", "`pyproject.toml`"))
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-artifact-unsupported" for f in failures)
-
-
-def test_planned_row_with_artifacts_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "| Assessment semantics | SEM-206, DSL-110 | — | — | planned |",
-            "| Assessment semantics | SEM-206, DSL-110 | validation | "
-            "`implementations/python/tests/test_semantics_objectives.py` | planned |",
-        ),
-    )
-    failures = evaluate_semantic_coverage(repo)
-    assert any(f.rule_id == "coverage-planned" for f in failures)
-
-
-def test_bad_requirement_uid_fails(tmp_path: Path) -> None:
-    repo = _seed_repo(tmp_path, _GOOD_NOTE.replace("| SEM-202 |", "| sem-202 |"))
-    failures = evaluate_semantic_coverage(repo)
-    assert any("sem-202" in f.render().lower() for f in failures)
-
-
 def test_malformed_row_column_count_fails(tmp_path: Path) -> None:
     repo = _seed_repo(
-        tmp_path,
-        _GOOD_NOTE.replace(
-            "| Assessment semantics | SEM-206, DSL-110 | — | — | planned |",
-            "| Assessment semantics | SEM-206, DSL-110 | — | planned |",
-        ),
+        tmp_path, _GOOD_NOTE.replace(_PLANNED_ROW, "| Assessment semantics | SEM-206, DSL-110 | — | planned |")
     )
     failures = evaluate_semantic_coverage(repo)
-    assert failures
+    assert any(f.rule_id == "coverage-model-parse" for f in failures)
 
 
 def test_no_table_raises_parse_error() -> None:
-    body = "# Note\n\n## Coverage Model\n\nNo table here.\n\n## Next\nDone.\n"
     with pytest.raises(CoverageParseError):
-        parse_coverage_rows(body)
+        parse_coverage_rows("# Note\n\n## Coverage Model\n\nNo table here.\n\n## Next\nDone.\n")
 
 
 def test_missing_section_raises_parse_error() -> None:
@@ -231,7 +215,10 @@ def test_parse_rows_returns_expected_count() -> None:
     assert len(rows) == 2
     assert rows[0].family == "Objective windows"
     assert rows[0].owners == ["SEM-202"]
+    assert rows[0].phases == ["validation", "compilation", "planning"]
     assert rows[0].status == "active"
+    assert rows[1].owners == ["SEM-206", "DSL-110"]
+    assert rows[1].phases == []
     assert rows[1].status == "planned"
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,7 @@ RUFF_CONFIG = PROJECT_ROOT / "pyproject.toml"
 TARGETED_POLICY_TESTS = [
     "implementations/python/tests/test_repo_policy_tools.py",
     "implementations/python/tests/test_requirement_governance.py",
+    "implementations/python/tests/test_semantic_coverage.py",
 ]
 CONTRACT_TRIGGER_PREFIXES = (
     "contracts/",
@@ -435,6 +436,16 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         reporter.run(
             "policy / requirement governance",
             lambda: _run_project_python(session, "tools/check_requirement_governance.py", *requirement_args),
+        )
+    # check_semantic_coverage.py validates live files on disk, not a staged
+    # snapshot, so it is meaningless (and misleading) under --staged. It runs in
+    # the working-tree policy invocations (`policy`, `hook-pre-push`, `verify`).
+    if "--staged" in args:
+        reporter.skip("policy / semantic coverage ADR", "skipped on staged check; runs on push and verify")
+    else:
+        reporter.run(
+            "policy / semantic coverage ADR",
+            lambda: _run_project_python(session, "tools/check_semantic_coverage.py"),
         )
 
 

--- a/tools/check_requirement_governance.py
+++ b/tools/check_requirement_governance.py
@@ -36,6 +36,7 @@ REQUIREMENT_CONTEXT_EXEMPT_PATHS = {
     "CHANGELOG.md",
     "implementations/python/tests/test_repo_policy_tools.py",
     "implementations/python/tests/test_requirement_governance.py",
+    "implementations/python/tests/test_semantic_coverage.py",
 }
 REQUIREMENT_CONTEXT_EXEMPT_PREFIXES = ("tools/",)
 

--- a/tools/check_semantic_coverage.py
+++ b/tools/check_semantic_coverage.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Structural gate for the SEM-200 semantic-layer coverage model.
+
+ADR-016 ("Semantic Layer Scope and Coverage Model") fixes the *model* — the
+seven canonical lifecycle phases, the construct-family concept, the status
+vocabulary, and SEM-200's definition of done — and is immutable once accepted.
+The *live* coverage table itself is a mutable reference note,
+``docs/explain/reference/shared-semantic-integrity.md``, which ADR-016 governs:
+every ``SEM-2xx`` implementation PR moves its construct family's row toward
+``active`` there, not in the ADR.
+
+A coverage table that nothing checks rots within weeks. This checker enforces
+exactly what it can prove from the filesystem (it never calls Ground Control, so
+it cannot become flaky in CI); the *correctness* of a row's status against the
+owning requirement's Ground Control state is a governance fact, not enforced
+here. What is enforced:
+
+* every row has the expected five columns, a recognised status, requirement-UID-
+  shaped owners, and canonical lifecycle-phase tokens;
+* every artifact-cell token that looks like a path (it contains ``/`` or ends in
+  a source-file extension) resolves under the repository root, lies under a
+  supported root, and exists on disk — an unsupported, escaping, or missing path
+  is a failure, not silently treated as prose;
+* an ``active`` row names at least one lifecycle phase, at least one existing
+  *non-test* realizing artifact, and at least one existing
+  ``implementations/python/tests/test_*.py`` test;
+* a ``partial`` row names at least one lifecycle phase and at least one existing
+  *non-test* realizing artifact;
+* a ``planned`` row names no phases and no artifacts (if it has artifacts it is
+  at least ``partial``);
+* ADR-016 still exists and still references the coverage note by its repo-relative
+  (or ADR-relative) path, so the ADR↔note linkage cannot silently rot.
+
+Failures use ``tools.policy.common.PolicyFailure`` and the CLI honours ``--json``
+and the shared ``tools/policy/exceptions.yaml`` waiver mechanism, like the other
+``policy`` nox-stage entry points (``check_repo_policy.py``, ``check_requirement_governance.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.policy.common import PolicyFailure, apply_exceptions, failures_to_json, load_exceptions
+
+# The reference note that holds the live coverage table (mutable, ADR-governed).
+COVERAGE_NOTE_RELATIVE_PATH = "docs/explain/reference/shared-semantic-integrity.md"
+# The ADR that fixes the coverage model and governs the note (immutable).
+ADR_RELATIVE_PATH = "docs/decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md"
+
+# The canonical lifecycle phases SEM-200 spans, in order. Kept in lockstep with
+# ADR-016 and the coverage note.
+CANONICAL_PHASES: tuple[str, ...] = (
+    "authoring",
+    "validation",
+    "instantiation",
+    "compilation",
+    "planning",
+    "execution",
+    "observation",
+)
+
+# Coverage statuses. ``active`` = owning requirement ACTIVE in Ground Control,
+# semantics realized in a shared helper/spec, named tests cover it (the GC state
+# is reviewed, not gated here); ``partial`` = some realization exists but
+# coverage or the owning requirement is incomplete; ``planned`` = no realization
+# yet (owned by a DRAFT requirement, future work).
+VALID_STATUSES: tuple[str, ...] = ("active", "partial", "planned")
+
+# Repo-relative roots / exact files under which a path-like artifact token is
+# allowed to live. A path-like token outside these is a failure, not prose.
+_ARTIFACT_PATH_PREFIXES: tuple[str, ...] = (
+    "specs/",
+    "implementations/",
+    "contracts/",
+    "docs/",
+    "tools/",
+    "examples/",
+)
+_ARTIFACT_PATH_EXACT: frozenset[str] = frozenset({"noxfile.py", "Makefile", "Dockerfile"})
+# Source-file extensions that, on a token with no spaces, mark it as path-like.
+_PATHISH_SUFFIXES: tuple[str, ...] = (
+    ".py",
+    ".md",
+    ".rst",
+    ".txt",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".rego",
+    ".sh",
+    ".sql",
+)
+_TEST_PATH_PREFIX = "implementations/python/tests/test_"
+
+_EMPTY_CELL_TOKENS: frozenset[str] = frozenset({"", "-", "—", "–", "n/a", "none", "tbd"})
+
+_REQUIREMENT_UID_RE = re.compile(r"^[A-Z]{2,4}-\d{3}$")
+_HEADING_RE = re.compile(r"^#{1,6}\s")
+_COVERAGE_HEADING_RE = re.compile(r"^#{2,4}\s+Coverage Model\s*$")
+_SEPARATOR_CELL_RE = re.compile(r"^:?-{2,}:?$")
+_BACKTICK_SPAN_RE = re.compile(r"`([^`]+)`")
+
+_EXPECTED_COLUMNS = 5
+
+
+class CoverageParseError(ValueError):
+    """The coverage note's Coverage Model section or table is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class CoverageRow:
+    family: str
+    owners: list[str]
+    phases: list[str]
+    artifacts: list[str]
+    status: str
+    line_no: int
+
+
+def _fail(rule_id: str, message: str, path: str | None) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _cells(line: str) -> list[str]:
+    """Split a Markdown table row into trimmed cells, dropping the edge empties."""
+    parts = [part.strip() for part in line.strip().split("|")]
+    if parts and parts[0] == "":
+        parts = parts[1:]
+    if parts and parts[-1] == "":
+        parts = parts[:-1]
+    return parts
+
+
+def _is_empty_cell(cell: str) -> bool:
+    return cell.strip().lower() in _EMPTY_CELL_TOKENS
+
+
+def _split_simple_tokens(cell: str) -> list[str]:
+    if _is_empty_cell(cell):
+        return []
+    return [token.strip() for token in cell.split(",") if token.strip()]
+
+
+def _split_phase_tokens(cell: str) -> list[str]:
+    return [token.lower() for token in _split_simple_tokens(cell)]
+
+
+def _extract_artifact_tokens(cell: str) -> list[str]:
+    if _is_empty_cell(cell):
+        return []
+    spans = _BACKTICK_SPAN_RE.findall(cell)
+    tokens = spans if spans else cell.split(",")
+    return [token.strip() for token in tokens if token.strip() and not _is_empty_cell(token)]
+
+
+def _looks_path_like(token: str) -> bool:
+    if token in _ARTIFACT_PATH_EXACT:
+        return True
+    if " " in token:
+        return False
+    return "/" in token or token.endswith(_PATHISH_SUFFIXES)
+
+
+def _is_supported_repo_path(token: str) -> bool:
+    return token in _ARTIFACT_PATH_EXACT or token.startswith(_ARTIFACT_PATH_PREFIXES)
+
+
+def _is_test_path(token: str) -> bool:
+    return token.startswith(_TEST_PATH_PREFIX) and token.endswith(".py")
+
+
+def _resolve_within(repo_root: Path, rel: str) -> Path | None:
+    """Resolve ``rel`` under ``repo_root``; return None if it escapes the root."""
+    root = repo_root.resolve()
+    candidate = (root / rel).resolve()
+    if candidate == root or root in candidate.parents:
+        return candidate
+    return None
+
+
+def parse_coverage_rows(note_text: str) -> list[CoverageRow]:
+    """Parse the Coverage Model table out of the coverage note's text.
+
+    Raises:
+        CoverageParseError: if the section heading is absent, no table follows
+            it, the header/separator are malformed, or a data row has the wrong
+            number of cells.
+    """
+    lines = note_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if _COVERAGE_HEADING_RE.match(line.strip()):
+            start = index + 1
+            break
+    if start is None:
+        raise CoverageParseError("coverage note is missing the '## Coverage Model' section")
+
+    table_lines: list[tuple[int, str]] = []
+    in_table = False
+    for offset, line in enumerate(lines[start:], start=start):
+        if _HEADING_RE.match(line):
+            break
+        if line.lstrip().startswith("|"):
+            in_table = True
+            table_lines.append((offset, line))
+        elif in_table:
+            break
+    if len(table_lines) < 3:
+        raise CoverageParseError(
+            "coverage note's Coverage Model section has no table (need header, separator, >=1 row)"
+        )
+
+    header = _cells(table_lines[0][1])
+    if len(header) != _EXPECTED_COLUMNS:
+        raise CoverageParseError(
+            f"Coverage Model table header must have {_EXPECTED_COLUMNS} columns, found {len(header)}: {header}"
+        )
+    separator = _cells(table_lines[1][1])
+    if len(separator) != _EXPECTED_COLUMNS or not all(_SEPARATOR_CELL_RE.match(cell) for cell in separator):
+        raise CoverageParseError(f"Coverage Model table separator row is malformed: {separator}")
+
+    rows: list[CoverageRow] = []
+    for source_index, raw in table_lines[2:]:
+        cells = _cells(raw)
+        if len(cells) != _EXPECTED_COLUMNS:
+            raise CoverageParseError(
+                f"Coverage Model row at line {source_index + 1} has {len(cells)} cells, "
+                f"expected {_EXPECTED_COLUMNS}: {raw.strip()}"
+            )
+        rows.append(
+            CoverageRow(
+                family=cells[0],
+                owners=_split_simple_tokens(cells[1]),
+                phases=_split_phase_tokens(cells[2]),
+                artifacts=_extract_artifact_tokens(cells[3]),
+                status=cells[4].strip().lower(),
+                line_no=source_index + 1,
+            )
+        )
+    return rows
+
+
+def _supported_roots_phrase() -> str:
+    return ", ".join((*_ARTIFACT_PATH_PREFIXES, *sorted(_ARTIFACT_PATH_EXACT)))
+
+
+def _check_artifacts(repo_root: Path, row: CoverageRow, where: str, note: str) -> tuple[list[PolicyFailure], int, int]:
+    """Validate the artifact cell; return (failures, existing non-test count, existing test count)."""
+    failures: list[PolicyFailure] = []
+    realization_paths = 0
+    test_paths = 0
+    for token in row.artifacts:
+        if not _looks_path_like(token):
+            continue  # descriptive prose, not a checkable artifact
+        if not _is_supported_repo_path(token):
+            failures.append(
+                _fail(
+                    "coverage-artifact-unsupported",
+                    f"{where}: artifact '{token}' looks like a path but is not under a supported root ({_supported_roots_phrase()})",
+                    note,
+                )
+            )
+            continue
+        resolved = _resolve_within(repo_root, token)
+        if resolved is None:
+            failures.append(
+                _fail("coverage-artifact-escape", f"{where}: artifact path escapes the repo root: {token}", note)
+            )
+            continue
+        if not resolved.exists():
+            failures.append(_fail("coverage-artifact-missing", f"{where}: artifact path does not exist: {token}", note))
+            continue
+        if _is_test_path(token):
+            test_paths += 1
+        else:
+            realization_paths += 1
+    return failures, realization_paths, test_paths
+
+
+def _check_row(repo_root: Path, row: CoverageRow) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    note = COVERAGE_NOTE_RELATIVE_PATH
+    where = f"row '{row.family}' (line {row.line_no})"
+
+    if not row.family:
+        failures.append(_fail("coverage-family", f"line {row.line_no}: construct family cell is empty", note))
+
+    if not row.owners:
+        failures.append(_fail("coverage-owner", f"{where}: no owning requirement UID", note))
+    for owner in row.owners:
+        if not _REQUIREMENT_UID_RE.match(owner):
+            failures.append(_fail("coverage-owner", f"{where}: invalid requirement UID '{owner}'", note))
+
+    for phase in row.phases:
+        if phase not in CANONICAL_PHASES:
+            failures.append(
+                _fail(
+                    "coverage-phase",
+                    f"{where}: unknown lifecycle phase '{phase}' (expected one of {', '.join(CANONICAL_PHASES)})",
+                    note,
+                )
+            )
+
+    artifact_failures, realization_paths, test_paths = _check_artifacts(repo_root, row, where, note)
+    failures.extend(artifact_failures)
+
+    if row.status not in VALID_STATUSES:
+        failures.append(
+            _fail(
+                "coverage-status",
+                f"{where}: unknown status '{row.status}' (expected one of {', '.join(VALID_STATUSES)})",
+                note,
+            )
+        )
+        return failures
+
+    if row.status in ("active", "partial"):
+        if not row.phases:
+            failures.append(
+                _fail(
+                    "coverage-incomplete", f"{where}: status '{row.status}' requires at least one lifecycle phase", note
+                )
+            )
+        if realization_paths == 0:
+            failures.append(
+                _fail(
+                    "coverage-incomplete",
+                    f"{where}: status '{row.status}' requires at least one existing non-test realizing artifact (spec/helper/code)",
+                    note,
+                )
+            )
+        if row.status == "active" and test_paths == 0:
+            failures.append(
+                _fail(
+                    "coverage-untested",
+                    f"{where}: status 'active' requires at least one existing test under {_TEST_PATH_PREFIX}*.py",
+                    note,
+                )
+            )
+    elif row.status == "planned":
+        if row.phases:
+            failures.append(
+                _fail("coverage-planned", f"{where}: status 'planned' must not list lifecycle phases", note)
+            )
+        if row.artifacts:
+            failures.append(
+                _fail("coverage-planned", f"{where}: status 'planned' must not list realizing artifacts", note)
+            )
+    return failures
+
+
+def _check_adr_links_note(repo_root: Path) -> list[PolicyFailure]:
+    adr_path = repo_root / ADR_RELATIVE_PATH
+    if not adr_path.is_file():
+        return [
+            _fail(
+                "coverage-adr-missing",
+                f"ADR-016 not found at {ADR_RELATIVE_PATH}; the coverage note must be governed by an ADR",
+                ADR_RELATIVE_PATH,
+            )
+        ]
+    adr_text = adr_path.read_text(encoding="utf-8")
+    rel_from_adr = os.path.relpath(COVERAGE_NOTE_RELATIVE_PATH, str(Path(ADR_RELATIVE_PATH).parent))
+    if COVERAGE_NOTE_RELATIVE_PATH not in adr_text and rel_from_adr not in adr_text:
+        return [
+            _fail(
+                "coverage-adr-unlinked",
+                f"{ADR_RELATIVE_PATH} no longer references the coverage note "
+                f"by path ({COVERAGE_NOTE_RELATIVE_PATH} or {rel_from_adr})",
+                ADR_RELATIVE_PATH,
+            )
+        ]
+    return []
+
+
+def evaluate_semantic_coverage(repo_root: Path, note_relative_path: str | None = None) -> list[PolicyFailure]:
+    """Return the list of structural failures for the SEM-200 coverage model (empty = OK)."""
+    rel = note_relative_path or COVERAGE_NOTE_RELATIVE_PATH
+    note_path = repo_root / rel
+    if not note_path.is_file():
+        return [_fail("coverage-note-missing", f"coverage note not found: {rel}", rel)]
+
+    failures: list[PolicyFailure] = list(_check_adr_links_note(repo_root))
+
+    try:
+        rows = parse_coverage_rows(note_path.read_text(encoding="utf-8"))
+    except CoverageParseError as exc:
+        failures.append(_fail("coverage-model-parse", str(exc), rel))
+        return failures
+
+    if not rows:
+        failures.append(_fail("coverage-model-empty", "Coverage Model table has no rows", rel))
+        return failures
+
+    for row in rows:
+        failures.extend(_check_row(repo_root, row))
+    return failures
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate the SEM-200 semantic-layer coverage model (ADR-016).")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to the repo containing this file).",
+    )
+    parser.add_argument(
+        "--note-path",
+        default=None,
+        help="Repo-relative path to the coverage note (defaults to the canonical location).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_semantic_coverage(args.repo_root, args.note_path)
+    exceptions_file = args.repo_root / "tools" / "policy" / "exceptions.yaml"
+    if exceptions_file.is_file():
+        failures = apply_exceptions(failures, load_exceptions(args.repo_root))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

`SEM-200` ("Shared Semantic Integrity") is a system-level umbrella requirement — the parent of ~28 `SEM-2xx` children (the construct families), a dependency of `DSL-100`, and a dependency *target* of many `EXP-*`/`AUT-*`/`GOV-*`/`ASR-*`/API/runtime requirements. It is not a single-PR deliverable. This PR makes the umbrella tractable without claiming it (the `/implement 4` run was routed to the "scoping ADR first" path).

- **ADR-016** (`docs/decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md`) fixes the *model*: the seven canonical lifecycle phases (authoring → validation → instantiation → compilation → planning → execution → observation), the construct-family concept, the `active`/`partial`/`planned` status vocabulary, and `SEM-200`'s definition of done — every `SEM-2xx` child `ACTIVE`; no `partial`/`planned` rows in the coverage table; cross-stage agreement tests extended construct-wide; the unassigned-wave `SEM-2xx` children assigned to a wave. `SEM-200` stays `DRAFT` until then (it keeps its `DOCUMENTS` link to issue #4, never `IMPLEMENTS`).
- The **live coverage table** lives in `docs/explain/reference/shared-semantic-integrity.md` — the architecture-preflight guardrails note, which is mutable and ADR-016-governed — so routine `SEM-2xx` implementation PRs update their construct family's row without an ADR amendment (ADRs are immutable once accepted).
- **`tools/check_semantic_coverage.py`** is a filesystem-only structural gate over that table (no Ground Control calls, CI-safe): row shape and column count, recognised status, UID-shaped owners, canonical lifecycle phases, every path-like artifact under a supported root and existing on disk, `active`/`partial` rows backed by a real *non-test* artifact and a phase, `active` rows backed by an existing test, `planned` rows empty, and ADR-016 still referencing the note by path. Failures use `tools.policy.common.PolicyFailure`; the CLI honours `--json` and `tools/policy/exceptions.yaml`. Wired into the `policy` nox stage for working-tree runs (skipped on the `--staged` pre-commit invocation), added to `TARGETED_POLICY_TESTS`, and the new tooling test is exempted in `check_requirement_governance.py` alongside the other policy-tooling tests.
- Adds the ADR index row, `docs/index.md` toctree entries (also fixing a pre-existing "not in any toctree" warning for `docs/explain/reference/README.md`), and the `CHANGELOG.md` entry (`[0.15.0]`).

## Why not `Closes #4`

`SEM-200` is forward-looking — this PR scopes it, it does not implement it. The issue is closed by the `/implement` workflow after Ground Control reconciliation, and `SEM-200` remains `DRAFT`.

## Verification

`nox -s verify` green (hygiene, policy incl. the new `policy / semantic coverage ADR` gate, lint, contracts, full pytest sweep incl. `test_semantic_coverage.py`, docs build). Pre-push `gc_codex_review` ran the full 3-cycle cap; all findings from all three cycles were fixed (fix history on issue #4); cycle 4 declined by the maintainer.

## Open item

The unassigned-wave `SEM-2xx` children (`SEM-219`…`SEM-229`) need wave assignments — a Ground Control requirement-governance decision, recorded as an open question in ADR-016 for the maintainers; not made by this PR.

Refs #4