### PR TITLE
Add schema publication manifest verification

### DIFF
--- a/changelog.d/65.fixed.md
+++ b/changelog.d/65.fixed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added an authoritative schema publication manifest and verification gate for the current `contracts/schemas/` tree.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -8,6 +8,11 @@ The goal of this bucket is organizational clarity:
 - `fixtures/` contains valid and invalid payload corpora for those contracts
 - `profiles/` contains capability profile declarations
 
+`schema-publication-manifest.json` is the authoritative publication inventory
+for the current machine-readable schema set. The contracts verification gate
+checks that every entry points at `contracts/schemas/`, that every listed schema
+exists, and that every JSON Schema file under `contracts/schemas/` is listed.
+
 These assets are intentionally language-neutral. Any conformance runners or
 implementation-specific validation helpers belong under `implementations/`,
 not here.

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "schema-publication-manifest/v1",
+  "schemas": [
+    {
+      "contract_id": "backend-manifest-v2",
+      "schema_path": "contracts/schemas/backend-manifest/backend-manifest-v2.json"
+    },
+    {
+      "contract_id": "concept-families-v1",
+      "schema_path": "contracts/schemas/concept-authority/concept-families-v1.json"
+    },
+    {
+      "contract_id": "controlled-vocabularies-v1",
+      "schema_path": "contracts/schemas/concept-authority/controlled-vocabularies-v1.json"
+    },
+    {
+      "contract_id": "evaluation-history-event-stream-v1",
+      "schema_path": "contracts/schemas/control-plane/evaluation-history-event-stream-v1.json"
+    },
+    {
+      "contract_id": "evaluation-plan-v1",
+      "schema_path": "contracts/schemas/plans/evaluation-plan-v1.json"
+    },
+    {
+      "contract_id": "evaluation-result-envelope-v1",
+      "schema_path": "contracts/schemas/control-plane/evaluation-result-envelope-v1.json"
+    },
+    {
+      "contract_id": "instantiated-scenario-v1",
+      "schema_path": "contracts/schemas/sdl/instantiated-scenario-v1.json"
+    },
+    {
+      "contract_id": "operation-receipt-v1",
+      "schema_path": "contracts/schemas/control-plane/operation-receipt-v1.json"
+    },
+    {
+      "contract_id": "operation-status-v1",
+      "schema_path": "contracts/schemas/control-plane/operation-status-v1.json"
+    },
+    {
+      "contract_id": "orchestration-plan-v1",
+      "schema_path": "contracts/schemas/plans/orchestration-plan-v1.json"
+    },
+    {
+      "contract_id": "participant-episode-history-event-stream-v1",
+      "schema_path": "contracts/schemas/control-plane/participant-episode-history-event-stream-v1.json"
+    },
+    {
+      "contract_id": "participant-episode-state-envelope-v1",
+      "schema_path": "contracts/schemas/control-plane/participant-episode-state-envelope-v1.json"
+    },
+    {
+      "contract_id": "processor-manifest-v2",
+      "schema_path": "contracts/schemas/processor-manifest/processor-manifest-v2.json"
+    },
+    {
+      "contract_id": "provisioning-plan-v1",
+      "schema_path": "contracts/schemas/plans/provisioning-plan-v1.json"
+    },
+    {
+      "contract_id": "reference-models-v1",
+      "schema_path": "contracts/schemas/concept-authority/reference-models-v1.json"
+    },
+    {
+      "contract_id": "runtime-snapshot-v1",
+      "schema_path": "contracts/schemas/snapshots/runtime-snapshot-v1.json"
+    },
+    {
+      "contract_id": "scenario-instantiation-request-v1",
+      "schema_path": "contracts/schemas/sdl/scenario-instantiation-request-v1.json"
+    },
+    {
+      "contract_id": "sdl-authoring-input-v1",
+      "schema_path": "contracts/schemas/sdl/sdl-authoring-input-v1.json"
+    },
+    {
+      "contract_id": "semantic-profile-v1",
+      "schema_path": "contracts/schemas/profiles/semantic-profile-v1.json"
+    },
+    {
+      "contract_id": "workflow-cancellation-request-v1",
+      "schema_path": "contracts/schemas/control-plane/workflow-cancellation-request-v1.json"
+    },
+    {
+      "contract_id": "workflow-history-event-stream-v1",
+      "schema_path": "contracts/schemas/control-plane/workflow-history-event-stream-v1.json"
+    },
+    {
+      "contract_id": "workflow-result-envelope-v1",
+      "schema_path": "contracts/schemas/control-plane/workflow-result-envelope-v1.json"
+    }
+  ]
+}

--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -13,6 +13,7 @@ import pytest
 import tools.check_generated_schemas as check_generated_schemas
 from tools.check_generated_schemas import _extra_published_schema_paths
 from tools.check_json_artifacts import collect_validation_targets, should_run_full_validation
+from tools.check_schema_publication import validate_schema_publication_manifest
 from tools.gitleaks_tool import _checksums_asset_name, _release_asset_name, gitleaks_binary_path
 from tools.policy.common import PolicyFailure
 from tools.policy.repo_policy import evaluate_repo_policy
@@ -657,10 +658,77 @@ def setup_json_validation_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def write_schema_publication_manifest(repo_root: Path, entries: list[dict[str, str]]) -> None:
+    import json
+
+    write_text(
+        repo_root / "contracts" / "schema-publication-manifest.json",
+        json.dumps({"schema_version": "schema-publication-manifest/v1", "schemas": entries}, indent=2) + "\n",
+    )
+
+
 def test_should_run_full_validation_for_schema_driver_paths() -> None:
     assert should_run_full_validation(["tools/generate_contract_schemas.py"]) is True
     assert should_run_full_validation(["implementations/python/packages/aces_contracts/contracts.py"]) is True
     assert should_run_full_validation(["contracts/concept-authority/concept-families-v1.json"]) is False
+
+
+def test_schema_publication_manifest_accepts_complete_current_schema_inventory(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    write_text(repo_root / "contracts" / "schemas" / "sdl" / "sdl-authoring-input-v1.json", "{}\n")
+    write_text(repo_root / "contracts" / "schemas" / "control-plane" / "operation-status-v1.json", "{}\n")
+    write_schema_publication_manifest(
+        repo_root,
+        [
+            {
+                "contract_id": "operation-status-v1",
+                "schema_path": "contracts/schemas/control-plane/operation-status-v1.json",
+            },
+            {
+                "contract_id": "sdl-authoring-input-v1",
+                "schema_path": "contracts/schemas/sdl/sdl-authoring-input-v1.json",
+            },
+        ],
+    )
+
+    assert validate_schema_publication_manifest(repo_root) == []
+
+
+def test_schema_publication_manifest_rejects_missing_published_schema_entry(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    write_text(repo_root / "contracts" / "schemas" / "sdl" / "sdl-authoring-input-v1.json", "{}\n")
+    write_text(repo_root / "contracts" / "schemas" / "control-plane" / "operation-status-v1.json", "{}\n")
+    write_schema_publication_manifest(
+        repo_root,
+        [
+            {
+                "contract_id": "sdl-authoring-input-v1",
+                "schema_path": "contracts/schemas/sdl/sdl-authoring-input-v1.json",
+            },
+        ],
+    )
+
+    assert validate_schema_publication_manifest(repo_root) == [
+        "schema manifest is missing published schema: contracts/schemas/control-plane/operation-status-v1.json"
+    ]
+
+
+def test_schema_publication_manifest_rejects_paths_outside_contract_schemas(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    write_text(repo_root / "schemas" / "legacy.json", "{}\n")
+    write_schema_publication_manifest(
+        repo_root,
+        [
+            {
+                "contract_id": "legacy",
+                "schema_path": "schemas/legacy.json",
+            },
+        ],
+    )
+
+    assert validate_schema_publication_manifest(repo_root) == [
+        "schema manifest path must be under contracts/schemas/: schemas/legacy.json"
+    ]
 
 
 def test_collect_validation_targets_includes_only_schema_governed_artifacts(tmp_path: Path) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -452,6 +452,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
 def _run_contracts(session: nox.Session, reporter: SessionReporter, *args: str) -> None:
     _sync_project(session)
     reporter.run(
+        "contracts / schema publication manifest",
+        lambda: _run_project_python(session, "tools/check_schema_publication.py"),
+    )
+    reporter.run(
         "contracts / generated schema drift",
         lambda: _run_project_python(session, "tools/check_generated_schemas.py"),
     )

--- a/tools/check_schema_publication.py
+++ b/tools/check_schema_publication.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify the authoritative schema publication manifest."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = Path("contracts/schema-publication-manifest.json")
+SCHEMAS_PREFIX = "contracts/schemas/"
+SCHEMA_VERSION = "schema-publication-manifest/v1"
+
+
+def _published_schema_paths(repo_root: Path) -> set[str]:
+    schemas_root = repo_root / "contracts" / "schemas"
+    return {path.relative_to(repo_root).as_posix() for path in sorted(schemas_root.rglob("*.json"))}
+
+
+def _load_manifest(repo_root: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    manifest_file = repo_root / MANIFEST_PATH
+    if not manifest_file.exists():
+        return None, [f"schema publication manifest is missing: {MANIFEST_PATH.as_posix()}"]
+    try:
+        payload = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"schema publication manifest is not valid JSON: {exc.msg}"]
+    if not isinstance(payload, dict):
+        return None, ["schema publication manifest must be a JSON object"]
+    return payload, []
+
+
+def validate_schema_publication_manifest(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Return validation failures for the checked-in schema publication manifest."""
+
+    payload, failures = _load_manifest(repo_root)
+    if payload is None:
+        return failures
+
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"schema manifest schema_version must be {SCHEMA_VERSION!r}")
+
+    entries = payload.get("schemas")
+    if not isinstance(entries, list) or not entries:
+        failures.append("schema manifest must define a non-empty schemas array")
+        return failures
+
+    manifest_paths: set[str] = set()
+    manifest_ids: set[str] = set()
+    previous_id = ""
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            failures.append(f"schema manifest entry {index} must be an object")
+            continue
+
+        contract_id = entry.get("contract_id")
+        schema_path = entry.get("schema_path")
+        if not isinstance(contract_id, str) or not contract_id:
+            failures.append(f"schema manifest entry {index} contract_id must be a non-empty string")
+            continue
+        if not isinstance(schema_path, str) or not schema_path:
+            failures.append(f"schema manifest entry {contract_id} schema_path must be a non-empty string")
+            continue
+
+        if contract_id <= previous_id:
+            failures.append("schema manifest entries must be sorted by contract_id")
+        previous_id = contract_id
+
+        if contract_id in manifest_ids:
+            failures.append(f"schema manifest contains duplicate contract_id: {contract_id}")
+        manifest_ids.add(contract_id)
+
+        if schema_path in manifest_paths:
+            failures.append(f"schema manifest contains duplicate schema_path: {schema_path}")
+        manifest_paths.add(schema_path)
+
+        if schema_path != Path(schema_path).as_posix() or schema_path.startswith(("/", "../")):
+            failures.append(f"schema manifest path must be a normalized repo-relative path: {schema_path}")
+            continue
+        if not schema_path.startswith(SCHEMAS_PREFIX):
+            failures.append(f"schema manifest path must be under contracts/schemas/: {schema_path}")
+            continue
+        if not schema_path.endswith(".json"):
+            failures.append(f"schema manifest path must point to a JSON schema file: {schema_path}")
+            continue
+
+        path = repo_root / schema_path
+        if not path.is_file():
+            failures.append(f"schema manifest path does not exist: {schema_path}")
+            continue
+        if path.stem != contract_id:
+            failures.append(f"schema manifest contract_id {contract_id!r} must match schema filename {path.stem!r}")
+
+    published_paths = _published_schema_paths(repo_root)
+    for path in sorted(published_paths - manifest_paths):
+        failures.append(f"schema manifest is missing published schema: {path}")
+    for path in sorted(manifest_paths - published_paths):
+        if path.startswith(SCHEMAS_PREFIX):
+            failures.append(f"schema manifest references unpublished schema: {path}")
+
+    return failures
+
+
+def main() -> int:
+    failures = validate_schema_publication_manifest(REPO_ROOT)
+    if failures:
+        for failure in failures:
+            print(f"[schema-publication] {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add an authoritative schema publication manifest under contracts/
- Add a checker that validates manifest completeness and path confinement against contracts/schemas/
- Wire the checker into the nox contracts gate and cover it with tooling tests

## Requirement
- ASR-501: Normative Machine-Readable Schemas

## Verification
- ACES_REQUIREMENT_UID=ASR-501 implementations/python/.venv/bin/python tools/check_repo_policy.py
- ACES_REQUIREMENT_UID=ASR-501 implementations/python/.venv/bin/python tools/check_requirement_governance.py (Ground Control unavailable, tool skipped remote-backed check)
- ACES_REQUIREMENT_UID=ASR-501 implementations/python/.venv/bin/python tools/verify_all.py
- pre-commit run --all-files
- gc_codex_review pre-push cycle 1: zero findings

Closes #65