### PR TITLE
Adopt towncrier changelog fragments

### DIFF
--- a/.gc/plan-rules.md
+++ b/.gc/plan-rules.md
@@ -24,3 +24,8 @@ These encode the hard rules previously in `AGENTS.md` prose.
   concept-authority surfaces.
 - Plans MUST keep IMPLEMENTS and TESTS traceability in Ground Control
   aligned with changed code and tests.
+- Plans with a user-visible change MUST add a fragment under
+  `changelog.d/<issue>.<type>.md` (or `changelog.d/+<slug>.<type>.md`
+  for issue-free entries), where `<type>` is one of `security`, `added`,
+  `changed`, `deprecated`, `removed`, `fixed`; do not edit `CHANGELOG.md`
+  directly outside release-collation commits.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Changelog entries are collated from fragments under changelog.d/. This
+# union driver is only a fallback for release-collation commits and straggler
+# hand-edits that still touch CHANGELOG.md.
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+PRs do **not** edit this file directly. Add a fragment under
+[`changelog.d/`](changelog.d/) instead; release-time `towncrier build` collates
+fragments into this file. See [`changelog.d/README.md`](changelog.d/README.md).
+
+<!-- towncrier release notes start -->
+
 ## [0.17.0] - 2026-05-10
 
 ### Added

--- a/changelog.d/+towncrier-adoption.added.md
+++ b/changelog.d/+towncrier-adoption.added.md
@@ -1,0 +1,1 @@
+Adopted `towncrier` changelog fragments so PRs add release-note snippets under `changelog.d/` instead of hand-editing `CHANGELOG.md`.

--- a/changelog.d/65.fixed.md
+++ b/changelog.d/65.fixed.md
@@ -1,3 +1,1 @@
-### Fixed
-
-- Added an authoritative schema publication manifest and verification gate for the current `contracts/schemas/` tree.
+Added an authoritative schema publication manifest and verification gate for the current `contracts/schemas/` tree.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,42 @@
+# Changelog Fragments
+
+Every PR with a user-visible change adds one Markdown fragment in this
+directory. At release time, `towncrier build` collates the fragments into
+[`../CHANGELOG.md`](../CHANGELOG.md) and removes the consumed files.
+
+This avoids merge conflicts from multiple PRs editing the top of
+`CHANGELOG.md`.
+
+## Add A Fragment
+
+Create one file named:
+
+```text
+<issue>.<type>.md
+```
+
+`<issue>` is the GitHub issue or PR number. For issue-free entries, prefix a
+slug with `+`, for example `+fix-typo.fixed.md`, to suppress an issue suffix.
+
+`<type>` must be one of:
+
+- `security`
+- `added`
+- `changed`
+- `deprecated`
+- `removed`
+- `fixed`
+
+The file body is the bullet text. Keep it to one paragraph when possible.
+
+## Build The Changelog
+
+```sh
+uvx towncrier build --version <X.Y.Z> --date $(date -u +%F)
+```
+
+Preview without writing:
+
+```sh
+uvx towncrier build --draft --version <X.Y.Z>
+```

--- a/changelog.d/_template.md.jinja
+++ b/changelog.d/_template.md.jinja
@@ -1,0 +1,25 @@
+{# Custom Markdown template for the repo's Keep a Changelog format:
+
+       ## [X.Y.Z] - YYYY-MM-DD
+
+       ### Section
+
+       - bullet text (#issue)
+-#}
+## [{{ versiondata.version }}] - {{ versiondata.date }}
+
+{% for section, _ in sections.items() %}
+{% if sections[section] %}
+{% for category, _ in definitions.items() if category in sections[section] %}
+### {{ definitions[category]["name"] }}
+
+{% for text, values in sections[section][category].items() %}
+- {{ text }}{% if values %} {{ values | join(" ") }}{% endif %}
+{% endfor %}
+{{ "\n\n" -}}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -10,6 +10,7 @@ source_roots:
   - implementations/python/src
 
 changelog_path: CHANGELOG.md
+changelog_fragment_dir: changelog.d
 
 generated_contracts:
   generated_roots:

--- a/tools/policy/conftest/repo_policy.rego
+++ b/tools/policy/conftest/repo_policy.rego
@@ -43,11 +43,11 @@ deny contains result if {
   some path in input.changed
   path_matches_any(path, input.policy.source_roots)
   endswith(path, ".py")
-  not input.policy.changelog_path in input.changed
+  not changelog_signal_touched
   result := {
-    "msg": "source changes require a CHANGELOG.md update",
+    "msg": "source changes require a changelog fragment under changelog.d/",
     "rule_id": "changelog-required",
-    "path": input.policy.changelog_path,
+    "path": input.policy.changelog_fragment_dir,
   }
 }
 
@@ -55,6 +55,20 @@ deny contains result if {
 generated_driver_touched if {
   some path in input.changed
   path_matches_any(path, input.policy.generated_contracts.driver_paths)
+}
+
+
+changelog_signal_touched if {
+  input.policy.changelog_path in input.changed
+}
+
+
+changelog_signal_touched if {
+  some path in input.changed
+  path_matches_prefix(path, input.policy.changelog_fragment_dir)
+  endswith(path, ".md")
+  not endswith(path, "/README.md")
+  not startswith(path, sprintf("%s/_", [trim(input.policy.changelog_fragment_dir, "/")]))
 }
 
 

--- a/tools/policy/conftest/repo_policy_test.rego
+++ b/tools/policy/conftest/repo_policy_test.rego
@@ -13,6 +13,7 @@ test_legacy_root_is_blocked if {
       "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
       "source_roots": [],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 1
@@ -34,6 +35,7 @@ test_generated_schema_edits_require_driver_changes if {
       "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
       "source_roots": [],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 1
@@ -58,6 +60,7 @@ test_generated_schema_edits_pass_with_driver_change if {
       "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
       "source_roots": [],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 0
@@ -77,6 +80,7 @@ test_reserved_concept_authority_paths_are_enforced if {
       },
       "source_roots": [],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 1
@@ -95,6 +99,49 @@ test_changelog_is_required_for_source_changes if {
       "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
       "source_roots": ["implementations/python/packages"],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
+    },
+  }
+  count(failures) == 1
+  some failure in failures
+  failure.rule_id == "changelog-required"
+}
+
+
+test_changelog_fragment_satisfies_source_changes if {
+  failures := deny with input as {
+    "changed": [
+      "implementations/python/packages/aces_processor/runtime.py",
+      "changelog.d/132.added.md",
+    ],
+    "check_set": "full",
+    "policy": {
+      "legacy_top_level_roots": [],
+      "generated_contracts": {"generated_roots": [], "driver_paths": []},
+      "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
+      "source_roots": ["implementations/python/packages"],
+      "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
+    },
+  }
+  count(failures) == 0
+}
+
+
+test_changelog_readme_does_not_satisfy_source_changes if {
+  failures := deny with input as {
+    "changed": [
+      "implementations/python/packages/aces_processor/runtime.py",
+      "changelog.d/README.md",
+    ],
+    "check_set": "full",
+    "policy": {
+      "legacy_top_level_roots": [],
+      "generated_contracts": {"generated_roots": [], "driver_paths": []},
+      "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
+      "source_roots": ["implementations/python/packages"],
+      "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 1
@@ -113,6 +160,7 @@ test_file_local_mode_skips_changelog if {
       "concept_authority": {"reserved_path_tokens": [], "allowed_paths": []},
       "source_roots": ["implementations/python/packages"],
       "changelog_path": "CHANGELOG.md",
+      "changelog_fragment_dir": "changelog.d",
     },
   }
   count(failures) == 0

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,40 @@
+[tool.towncrier]
+name = "aces-sdl"
+filename = "CHANGELOG.md"
+directory = "changelog.d"
+template = "changelog.d/_template.md.jinja"
+title_format = false
+start_string = "<!-- towncrier release notes start -->\n"
+issue_format = "(#{issue})"
+wrap = false
+all_bullets = true
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
## Summary
- Add Towncrier configuration and changelog.d fragment docs/template
- Mark CHANGELOG.md for release-note insertion and avoid direct PR edits
- Add .gitattributes union fallback for CHANGELOG.md
- Update repo policy so source changes can satisfy changelog signaling with changelog.d fragments
- Add the adoption fragment for this change

## Verification
- implementations/python/.venv/bin/python tools/check_repo_policy.py
- implementations/python/.venv/bin/python tools/check_requirement_governance.py
- uv run --project implementations/python --frozen python -c 'from tools.policy.conftest_tool import verify_conftest_policy; verify_conftest_policy()'
- uv run --project implementations/python --frozen python -m pytest implementations/python/tests/test_repo_policy_tools.py -q
- uv tool run towncrier build --draft --version 0.18.0
- uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s policy lint

Closes #132