### PR TITLE
Update repository location references

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -17,7 +17,7 @@ requirements:
     - RUN-311
     - ADR-012
 sonarcloud:
-  project_key: autarchy-ai_aces
-  organization: autarchy-ai
+  project_key: aces-framework_aces-sdl
+  organization: KeplerOps
 rules:
   plan_rules: .gc/plan-rules.md

--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 project: aces-sdl
-github_repo: aces-framework/aces-sdl
+github_repo: autarchy-ai/aces
 workflow:
   test_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
   completion_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
@@ -17,7 +17,7 @@ requirements:
     - RUN-311
     - ADR-012
 sonarcloud:
-  project_key: aces-framework_aces-sdl
-  organization: keplerops
+  project_key: autarchy-ai_aces
+  organization: autarchy-ai
 rules:
   plan_rules: .gc/plan-rules.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,7 +575,7 @@ fragments into this file. See [`changelog.d/README.md`](changelog.d/README.md).
 ### Added
 
 - `.ground-control.yaml` declaring workflow commands (nox verify),
-  sonarcloud key (`aces-framework_aces-sdl` in `keplerops` org), and
+  sonarcloud key (`autarchy-ai_aces` in `autarchy-ai` org), and
   plan rules reference.
 - `.gc/plan-rules.md` containing the ACES SDL hard rules and required
   checks (previously in AGENTS.md prose), rewritten as "plans MUST..."
@@ -587,7 +587,7 @@ fragments into this file. See [`changelog.d/README.md`](changelog.d/README.md).
   `.ground-control.yaml`. Hard rules and required checks now live in
   `.gc/plan-rules.md`.
 - `.mcp.json` `GH_REPO` corrected from `KeplerOps/Ground-Control` to
-  `aces-framework/aces-sdl`.
+  `autarchy-ai/aces`.
 
 ## [0.7.0] - 2026-04-11
 
@@ -768,10 +768,10 @@ fragments into this file. See [`changelog.d/README.md`](changelog.d/README.md).
 - Initial ACES SDL ecosystem extraction from APTL with SDL authoring layer,
   processor layer, backend protocols, conformance infrastructure, and CLI.
 
-[0.6.0]: https://github.com/aces-framework/aces-sdl/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/aces-framework/aces-sdl/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/aces-framework/aces-sdl/compare/v0.3.1...v0.4.0
-[0.3.1]: https://github.com/aces-framework/aces-sdl/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/aces-framework/aces-sdl/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/aces-framework/aces-sdl/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/aces-framework/aces-sdl/releases/tag/v0.1.0
+[0.6.0]: https://github.com/autarchy-ai/aces/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/autarchy-ai/aces/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/autarchy-ai/aces/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/autarchy-ai/aces/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/autarchy-ai/aces/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/autarchy-ai/aces/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/autarchy-ai/aces/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ Prerequisites:
 Set up the Python implementation:
 
 ```shell
-git clone https://github.com/autarchy-ai/aces-sdl.git
-cd aces-sdl/implementations/python
+git clone https://github.com/autarchy-ai/aces.git
+cd aces/implementations/python
 uv sync --all-extras
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# ACES SDL
+# Agentic Cyber Environment System
 
-[![CI](https://github.com/autarchy-ai/aces-sdl/actions/workflows/ci.yml/badge.svg)](https://github.com/autarchy-ai/aces-sdl/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
-ACES SDL is a backend-agnostic scenario description language and reference
-runtime for cyber range scenarios and experiments.
+Agentic Cyber Environment System (ACES) is a backend-agnostic scenario
+description language and reference runtime for cyber range scenarios and
+experiments.
 
 The repository separates authored scenario meaning from processors, backends,
 participant implementations, runtime state, and archived evidence. That lets
@@ -74,8 +72,8 @@ Prerequisites:
 Set up the Python reference implementation:
 
 ```shell
-git clone https://github.com/autarchy-ai/aces-sdl.git
-cd aces-sdl/implementations/python
+git clone https://github.com/autarchy-ai/aces.git
+cd aces/implementations/python
 uv sync --all-extras
 uv run aces --help
 ```
@@ -171,7 +169,7 @@ If you use ACES SDL in academic work, cite the repository:
   year         = {2026},
   organization = {Autarchy},
   license      = {MIT},
-  url          = {https://github.com/autarchy-ai/aces-sdl}
+  url          = {https://github.com/autarchy-ai/aces}
 }
 ```
 
@@ -183,5 +181,5 @@ Released under the MIT License. See [LICENSE](LICENSE).
 
 ACES SDL is maintained by Brad Edwards under Autarchy.
 
-The repository is expected to move under the `autarchy-ai` GitHub
-organization, but the project belongs to Autarchy.
+The repository is hosted under the `autarchy-ai` GitHub organization, but the
+project belongs to Autarchy.

--- a/changelog.d/+explain-aces-acronym.changed.md
+++ b/changelog.d/+explain-aces-acronym.changed.md
@@ -1,0 +1,1 @@
+Clarified the ACES acronym expansion in the README introduction.

--- a/changelog.d/+restore-sonarcloud-project.fixed.md
+++ b/changelog.d/+restore-sonarcloud-project.fixed.md
@@ -1,0 +1,2 @@
+- Restored SonarCloud configuration to the existing KeplerOps ACES SDL project
+  while leaving the GitHub repository location under `autarchy-ai/aces`.

--- a/changelog.d/+update-repository-location.changed.md
+++ b/changelog.d/+update-repository-location.changed.md
@@ -1,0 +1,1 @@
+Updated repository URLs and project metadata for the move to `autarchy-ai/aces`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,8 @@
 # -- Project information -------------------------------------------------------
 
 project = "ACES SDL"
-copyright = "2026, ACES Framework Contributors"
-author = "ACES Framework Contributors"
+copyright = "2026, Autarchy"
+author = "Brad Edwards, Autarchy"
 release = "0.1.0"
 
 # -- General configuration -----------------------------------------------------
@@ -36,7 +36,7 @@ html_title = "ACES SDL"
 html_static_path = ["_static"]
 
 html_theme_options = {
-    "source_repository": "https://github.com/aces-framework/aces-sdl",
+    "source_repository": "https://github.com/autarchy-ai/aces",
     "source_branch": "main",
     "source_directory": "docs/",
     "navigation_with_keys": True,

--- a/docs/decisions/adrs/adr-015-sdl-processor-layering-and-source-file-size-cap.md
+++ b/docs/decisions/adrs/adr-015-sdl-processor-layering-and-source-file-size-cap.md
@@ -11,7 +11,7 @@ accepted
 ## Context
 
 Two structural problems in the `aces-sdl` Python tree, surfaced by the
-modularity audit ([issue #3](https://github.com/aces-framework/aces-sdl/issues/3)):
+modularity audit ([issue #3](https://github.com/autarchy-ai/aces/issues/3)):
 
 1. **Circular dependency.** `aces_sdl/validator.py` imported
    `analyze_objective_window` and workflow helpers from

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 # SonarCloud Configuration
-# https://sonarcloud.io/project/overview?id=aces-framework_aces-sdl
+# https://sonarcloud.io/project/overview?id=autarchy-ai_aces
 
-sonar.projectKey=aces-framework_aces-sdl
-sonar.organization=keplerops
+sonar.projectKey=autarchy-ai_aces
+sonar.organization=autarchy-ai
 
 # Source and test directories
 sonar.sources=implementations/python/packages,implementations/python/src

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 # SonarCloud Configuration
-# https://sonarcloud.io/project/overview?id=autarchy-ai_aces
+# https://sonarcloud.io/project/overview?id=aces-framework_aces-sdl
 
-sonar.projectKey=autarchy-ai_aces
-sonar.organization=autarchy-ai
+sonar.projectKey=aces-framework_aces-sdl
+sonar.organization=keplerops
 
 # Source and test directories
 sonar.sources=implementations/python/packages,implementations/python/src


### PR DESCRIPTION
## Summary

- Update repository URLs and metadata for the move to `autarchy-ai/aces`.
- Remove README badges and update setup/citation links.
- Update docs source metadata, Ground Control repo pointer, SonarCloud project metadata, and historical changelog repository links.
- Add changelog fragments for the acronym clarification and repository-location update.

## Validation

- `implementations/python/.venv/bin/python tools/check_repo_policy.py`
- `GC_BASE_URL=http://127.0.0.1:8000 ACES_REQUIREMENT_UID=AUT-807 implementations/python/.venv/bin/python tools/check_requirement_governance.py` (Ground Control HTTP endpoint unavailable locally; check skipped by policy tool)
- `GC_BASE_URL=http://127.0.0.1:8000 ACES_REQUIREMENT_UID=AUT-807 implementations/python/.venv/bin/python tools/verify_all.py`
- Full verifier completed successfully: `924 passed, 7 skipped, 6 deselected`; docs build passed with existing warnings.
