### PR TITLE
Add lineage and prior work docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ product surface.
 - [Getting Started](#getting-started)
 - [Using the Python Reference Implementation](#using-the-python-reference-implementation)
 - [Repository Layout](#repository-layout)
+- [Lineage](#lineage)
 - [Documentation](#documentation)
 - [Verification](#verification)
 - [Contributing](#contributing)
@@ -116,6 +117,20 @@ uv run aces-mcp
 - `research/` - supporting literature and reference ecosystem material
 - `tools/` - repository maintenance, policy, and publication tooling
 - `changelog.d/` - towncrier release note fragments
+
+## Lineage
+
+- [Open Cyber Range SDL](https://documentation.opencyberrange.ee/docs/sdl/reference/)
+- [Open Cybersecurity Schema Framework](https://schema.ocsf.io/)
+- [CACAO Security Playbooks v2.0](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/security-playbooks-v2.0.html)
+- [STIX 2.1](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)
+- [CybORG](https://github.com/cage-challenge/CybORG)
+- [TENA](https://www.trmc.osd.mil/tena-about.html)
+- [IEEE High Level Architecture](https://standards.ieee.org/standard/1516-2025.html)
+- [SISO Cyber DEM](https://cdn.ymaws.com/www.sisostandards.org/resource/resmgr/standards_products/siso-std-025-2023_cyberdem.pdf)
+- [SISO Cyber FOM](https://www.sisostandards.org/news/690125/Publication-of-Cyber-FOM-and-SIRL-Users-Guide.htm)
+- [MITRE CALDERA](https://github.com/mitre/caldera)
+- [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team)
 
 ## Documentation
 

--- a/changelog.d/+add-lineage-docs.added.md
+++ b/changelog.d/+add-lineage-docs.added.md
@@ -1,0 +1,2 @@
+- Added a README lineage section listing the main prior-work influences behind
+  ACES.


### PR DESCRIPTION
## Summary

- Add a Lineage and Prior Work page for the SDL documentation.
- Link the page from the documentation index, SDL guide, and README.
- Add a changelog fragment for the documentation addition.

## Validation

- `implementations/python/.venv/bin/python tools/check_repo_policy.py`
- `GC_BASE_URL=http://127.0.0.1:8000 ACES_REQUIREMENT_UID=AUT-808 implementations/python/.venv/bin/python tools/check_requirement_governance.py`
- `GC_BASE_URL=http://127.0.0.1:8000 ACES_REQUIREMENT_UID=AUT-808 implementations/python/.venv/bin/python tools/verify_all.py`

Note: the local Ground Control endpoint was unavailable, so the governance check reported the repo's configured unavailable-endpoint skip path.