### PR TITLE
added: classification-based assurance policy and drift gate for ASR-505

### DIFF
--- a/changelog.d/68.added.md
+++ b/changelog.d/68.added.md
@@ -1,0 +1,1 @@
+Canonical machine-readable mapping for the classification-based assurance policy (ASR-505): `specs/formal/assurance-policy.yaml` enumerates every `FM` level's required and prohibited artifacts; `tools/check_assurance_policy.py` gates drift in CI; ADR-018 records the decision and `docs/specs/formal.md` is realigned to ADR-007's level names.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -43,3 +43,4 @@ Each ADR includes:
 | [015](adr-015-sdl-processor-layering-and-source-file-size-cap.md) | SDL-Processor Layering and Source-File Size Cap | accepted | 2026-05-10 |
 | [016](adr-016-semantic-layer-scope-and-coverage-model.md) | Semantic Layer Scope and Coverage Model (SEM-200) | accepted | 2026-05-10 |
 | [017](adr-017-conversation-surface-hardening.md) | Conversation Surface Hardening | accepted | 2026-05-17 |
+| [018](adr-018-classification-based-assurance-policy.md) | Canonical Mapping for the Classification-Based Assurance Policy | accepted | 2026-05-17 |

--- a/docs/decisions/adrs/adr-018-classification-based-assurance-policy.md
+++ b/docs/decisions/adrs/adr-018-classification-based-assurance-policy.md
@@ -1,0 +1,97 @@
+# ADR-018: Canonical Mapping for the Classification-Based Assurance Policy
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+[ADR-007](adr-007-lightweight-formal-methods-policy.md) adopted the
+classification-based assurance policy: structural changes get unit tests; static
+semantic changes add invariants; graph/constraint changes add typed IR/contract
+coverage; stateful/control changes add an abstract state-machine model. The
+ladder is named `FM0`/`FM1`/`FM2`/`FM3`.
+
+ASR-505 in the requirement inventory says the ecosystem **shall** define this
+policy and map structural, semantic, graph, and stateful changes to
+proportionate verification artifacts. The policy itself is defined in ADR-007
+and the contributor-facing
+[coding standards](../../explain/reference/coding-standards.md). The mapping is
+satisfied in prose.
+
+However, the same ladder is also described in
+[docs/specs/formal.md](../../specs/formal.md), and the prose has already
+drifted: that overview page labels `FM2` "dynamic semantic rules" and `FM3`
+"cross-system contracts" rather than ADR-007's
+"Semantic Graph / Constraint" and "Stateful / Control Semantics". Adding a new
+artifact type, a new `FM4`, or a new in-repo consumer today requires updating
+three independent prose surfaces and hoping none drift again. The architecture
+preflight on this work specifically called out the seam: keep the mapping
+data-driven or table-like so a future extension is a single-file edit.
+
+## Decision
+
+Establish a single canonical machine-readable surface for the classification-
+based assurance policy, alongside (not replacing) ADR-007's prose policy
+decision:
+
+1. **Canonical YAML.** `specs/formal/assurance-policy.yaml` enumerates each
+   `FM` level with `id`, `name`, `scope`, `change_categories`,
+   `required_artifacts`, and (for `FM0`) `prohibited_artifacts`. It names
+   ASR-505 in `requirement_refs` and ADR-007 / ADR-018 in `adr_refs`.
+
+2. **Structural gate.** `tools/check_assurance_policy.py` validates the YAML's
+   shape (every canonical level present, in canonical order, with the required
+   fields), enforces proportionality (`FM2`'s required artifacts are a
+   superset of `FM1`'s; `FM3`'s of `FM2`'s), enforces `FM0`'s prohibition on
+   TLA+ and Alloy, requires the change-category union to cover every word in
+   the ASR-505 statement (`structural`, `semantic`, `graph`, `stateful`), and
+   guards against drift by confirming ADR-007, `coding-standards.md`, and
+   `docs/specs/formal.md` each still mention every canonical level id. The
+   checker is wired into the `policy` nox session and into `verify`, so it
+   runs in every CI invocation.
+
+3. **ADR-007 remains the policy decision.** ADRs are immutable. ADR-018 does
+   not supersede ADR-007; it codifies the canonical seam that satisfies
+   ASR-505 against an already-decided policy. Downstream documents now point
+   at the canonical YAML as the source of truth and at ADR-007 as the policy
+   origin.
+
+4. **Doc realignment as part of this ADR's landing PR.** The drift between
+   `docs/specs/formal.md` and ADR-007 is fixed (the overview now uses ADR-007's
+   level names) so the new drift guard does not flag a pre-existing issue.
+
+## Consequences
+
+### Positive
+
+- A future `FM4` or a new artifact type is a single edit to the canonical YAML
+  plus a brief mention in each downstream doc; the drift guard catches any
+  consumer that forgets to update.
+- The policy is consumable by tooling (CI, code generators, future requirement
+  governance) without screen-scraping prose.
+- The structural gate runs in every CI pipeline, so the policy cannot rot
+  silently.
+- ASR-505 has a concrete artifact of record (the YAML plus the validator) and
+  can transition out of DRAFT.
+
+### Negative
+
+- One more policy gate in the `policy` nox session and the pre-push hook.
+- Editors of ADR-007, the coding standards, or the formal-specs overview must
+  remember to keep the level ids referenced verbatim (the drift guard fires
+  otherwise).
+
+### Risks
+
+- If a future change relabels the levels in ADR-007 (which is immutable but
+  conceivably superseded), the YAML and the drift guard must be updated in
+  lockstep. The drift guard fails loudly when this happens; it is a feature.
+- The proportionality invariant (`FM1` ⊆ `FM2` ⊆ `FM3`) assumes the ladder
+  remains monotonically additive. A future policy that introduces an
+  alternative branch instead of an inheritance chain will need to revisit the
+  validator's superset check.

--- a/docs/explain/reference/coding-standards.md
+++ b/docs/explain/reference/coding-standards.md
@@ -8,9 +8,14 @@ constraints, or execution-state semantics matter, while keeping ordinary
 structural work lightweight.
 
 The canonical decision framework is defined by
-[ADR-007](../adrs/adr-007-lightweight-formal-methods-policy.md). This document
-is the contributor-facing source of truth for how to apply that policy in day
-to day implementation and review.
+[ADR-007](../../decisions/adrs/adr-007-lightweight-formal-methods-policy.md),
+with the structural mapping codified in
+[`specs/formal/assurance-policy.yaml`](../../../specs/formal/assurance-policy.yaml)
+(see [ADR-018](../../decisions/adrs/adr-018-classification-based-assurance-policy.md)).
+The YAML is the machine-consumable source of truth for level ids, canonical
+level names, change categories, and required artifacts; the structural gate is
+`tools/check_assurance_policy.py`. This document is the contributor-facing
+prose for how to apply that policy in day to day implementation and review.
 
 ## Semantic Layers
 

--- a/docs/specs/formal.md
+++ b/docs/specs/formal.md
@@ -17,9 +17,15 @@ formal artifacts are warranted.
 
 ## FM Classification
 
-| Level | Scope | Artifacts |
-|-------|-------|-----------|
-| FM0 | Structural (parsing, models) | Unit tests only |
-| FM1 | Static semantic rules | Invariant lists + unit tests |
-| FM2 | Dynamic semantic rules | Formal specs + property-based tests |
-| FM3 | Cross-system contracts | Formal specs + conformance tests |
+The canonical mapping is
+[`specs/formal/assurance-policy.yaml`](../../specs/formal/assurance-policy.yaml)
+(see [ADR-018](../decisions/adrs/adr-018-classification-based-assurance-policy.md)),
+which is the structural source of truth and gates CI via
+`tools/check_assurance_policy.py`.
+
+| Level | Scope | Required artifacts |
+|-------|-------|--------------------|
+| FM0 | Structural (parsing, schema, local validation) | Unit tests |
+| FM1 | Static Semantic (cross-references, ambiguity, fail-closed) | Invariants + unit tests |
+| FM2 | Semantic Graph / Constraint (reachability, dependencies, portability) | FM1 + typed IR/contract coverage + targeted property-based or differential tests |
+| FM3 | Stateful / Control Semantics (state machines, branching, lifecycle) | FM2 + abstract state-machine model |

--- a/implementations/python/tests/test_assurance_policy.py
+++ b/implementations/python/tests/test_assurance_policy.py
@@ -1,0 +1,805 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.check_assurance_policy import (  # noqa: E402
+    ADR_POLICY_RELATIVE_PATH,
+    ADR_REF,
+    ADR_REFS,
+    ASSURANCE_POLICY_RELATIVE_PATH,
+    CANONICAL_LEVEL_IDS,
+    CODING_STANDARDS_RELATIVE_PATH,
+    FORMAL_OVERVIEW_RELATIVE_PATH,
+    REQUIRED_CHANGE_CATEGORIES,
+    REQUIREMENT_REF,
+    evaluate_assurance_policy,
+)
+
+# A canonical, well-formed policy YAML used as the positive case and as the
+# starting point for mutation in defect cases. The structure mirrors what the
+# real repo's YAML asserts; only the descriptive prose is trimmed.
+_GOOD_POLICY = """policy: classification-based-assurance
+requirement_refs:
+  - ASR-505
+adr_refs:
+  - ADR-007
+  - ADR-018
+levels:
+  - id: FM0
+    name: Structural
+    scope: Shape, parsing, schema, and local validation only.
+    change_categories: [structural]
+    required_artifacts: [unit_tests]
+    prohibited_artifacts: [TLA+, Alloy]
+  - id: FM1
+    name: Static Semantic
+    scope: Cross-references, uniqueness, ambiguity, acyclicity, fail-closed resolution.
+    change_categories: [semantic]
+    required_artifacts: [invariant_list, unit_tests]
+    recommended_artifacts: [property_based_tests]
+  - id: FM2
+    name: Semantic Graph / Constraint
+    scope: Reachability, visibility, dependency propagation, planner ordering, portability rules.
+    change_categories: [graph, constraint]
+    required_artifacts:
+      - invariant_list
+      - unit_tests
+      - typed_ir_or_contract_coverage
+      - property_based_or_differential_tests
+  - id: FM3
+    name: Stateful / Control Semantics
+    scope: State machines, branching, retries, joins, re-entry, lifecycle semantics, result contracts.
+    change_categories: [stateful, control]
+    required_artifacts:
+      - invariant_list
+      - unit_tests
+      - typed_ir_or_contract_coverage
+      - property_based_or_differential_tests
+      - abstract_state_machine_model
+    recommended_artifacts: [TLA+, Alloy]
+"""
+
+# Stub policy ADR-007 -- must reference every canonical level id AND every
+# canonical level name so the drift guard fires when the name changes (the
+# exact failure mode that motivated ADR-018).
+_GOOD_ADR = """# ADR-007: Lightweight Formal Methods Policy
+
+## Status
+accepted
+
+## Decision
+The classification ladder is FM0 (Structural), FM1 (Static Semantic),
+FM2 (Semantic Graph / Constraint), and FM3 (Stateful / Control Semantics).
+"""
+
+_GOOD_CODING_STANDARDS = """# Coding Standards
+
+The classification levels are FM0 Structural, FM1 Static Semantic,
+FM2 Semantic Graph / Constraint, and FM3 Stateful / Control Semantics.
+
+Required artifacts per level: unit tests (FM0), invariants + unit tests
+(FM1), typed IR/contract coverage and property-based or differential tests
+(FM2), and an abstract state-machine model (FM3).
+"""
+
+_GOOD_FORMAL_OVERVIEW = """# Formal Specifications
+
+| Level | Name | Required artifacts |
+|-------|------|--------------------|
+| FM0 | Structural | unit tests |
+| FM1 | Static Semantic | invariants + unit tests |
+| FM2 | Semantic Graph / Constraint | FM1 + typed IR/contract coverage + property-based or differential tests |
+| FM3 | Stateful / Control Semantics | FM2 + abstract state-machine model |
+"""
+
+
+def _seed_repo(
+    tmp_path: Path,
+    *,
+    policy_body: str = _GOOD_POLICY,
+    adr_body: str | None = _GOOD_ADR,
+    coding_standards_body: str | None = _GOOD_CODING_STANDARDS,
+    formal_overview_body: str | None = _GOOD_FORMAL_OVERVIEW,
+) -> Path:
+    """Seed a temp repo skeleton with the policy YAML and the three referencing docs."""
+    policy_path = tmp_path / ASSURANCE_POLICY_RELATIVE_PATH
+    policy_path.parent.mkdir(parents=True, exist_ok=True)
+    policy_path.write_text(policy_body, encoding="utf-8")
+
+    if adr_body is not None:
+        adr_path = tmp_path / ADR_POLICY_RELATIVE_PATH
+        adr_path.parent.mkdir(parents=True, exist_ok=True)
+        adr_path.write_text(adr_body, encoding="utf-8")
+
+    if coding_standards_body is not None:
+        cs_path = tmp_path / CODING_STANDARDS_RELATIVE_PATH
+        cs_path.parent.mkdir(parents=True, exist_ok=True)
+        cs_path.write_text(coding_standards_body, encoding="utf-8")
+
+    if formal_overview_body is not None:
+        fo_path = tmp_path / FORMAL_OVERVIEW_RELATIVE_PATH
+        fo_path.parent.mkdir(parents=True, exist_ok=True)
+        fo_path.write_text(formal_overview_body, encoding="utf-8")
+
+    return tmp_path
+
+
+def _flagged(failures, marker: str) -> bool:
+    """Return True if some failure matches ``marker`` by rule id or substring of its render."""
+    needle = marker.lower()
+    return any(f.rule_id == marker or needle in f.render().lower() for f in failures)
+
+
+# ----------------------------------------------------------------------------- #
+# Positive case -- the canonical YAML against canonical doc stubs is clean.     #
+# ----------------------------------------------------------------------------- #
+
+
+def test_good_policy_has_no_failures(tmp_path: Path) -> None:
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path))
+    assert failures == []
+
+
+# ----------------------------------------------------------------------------- #
+# Structural module-level invariants -- these must hold by construction.        #
+# ----------------------------------------------------------------------------- #
+
+
+def test_canonical_level_ids_cover_fm0_to_fm3() -> None:
+    # CANONICAL_LEVEL_IDS is the baseline floor (the policy may add FM4+
+    # in the YAML, but it can never drop one of these).
+    assert CANONICAL_LEVEL_IDS == ("FM0", "FM1", "FM2", "FM3")
+
+
+def test_required_change_categories_match_asr_505_statement() -> None:
+    assert set(REQUIRED_CHANGE_CATEGORIES) == {"structural", "semantic", "graph", "stateful"}
+
+
+def test_requirement_ref_is_asr_505() -> None:
+    assert REQUIREMENT_REF == "ASR-505"
+
+
+def test_adr_ref_is_adr_007() -> None:
+    assert ADR_REF == "ADR-007"
+
+
+def test_adr_refs_include_both_adr_007_and_adr_018() -> None:
+    # ADR-007 is the policy decision; ADR-018 governs THIS file. Both must
+    # be in the YAML's adr_refs, and the validator pins both.
+    assert "ADR-007" in ADR_REFS
+    assert "ADR-018" in ADR_REFS
+
+
+# ----------------------------------------------------------------------------- #
+# YAML missing, unparseable, wrong root shape.                                  #
+# ----------------------------------------------------------------------------- #
+
+
+def test_missing_policy_file_is_flagged(tmp_path: Path) -> None:
+    seeded = _seed_repo(tmp_path)
+    (seeded / ASSURANCE_POLICY_RELATIVE_PATH).unlink()
+    failures = evaluate_assurance_policy(seeded)
+    assert _flagged(failures, "assurance-policy-missing")
+
+
+def test_unparseable_policy_file_is_flagged(tmp_path: Path) -> None:
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body="this: is: : invalid"))
+    assert _flagged(failures, "assurance-policy-parse")
+
+
+def test_policy_root_must_be_mapping(tmp_path: Path) -> None:
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body="- just\n- a\n- list\n"))
+    assert _flagged(failures, "assurance-policy-shape")
+
+
+# ----------------------------------------------------------------------------- #
+# Sequence-field type strictness -- non-list values are rejected, not coerced.  #
+# This guards against the "silent coercion" failure mode where `levels:` (null) #
+# or `levels: not-a-list` would have skipped every per-level check.             #
+# ----------------------------------------------------------------------------- #
+
+
+def test_levels_null_is_flagged_as_missing_canonical_levels(tmp_path: Path) -> None:
+    body = _GOOD_POLICY[: _GOOD_POLICY.index("levels:")] + "levels:\n"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    # Every canonical level should be reported as missing.
+    for level_id in CANONICAL_LEVEL_IDS:
+        assert _flagged(failures, level_id), f"expected {level_id} to be flagged when levels is null"
+    assert _flagged(failures, "assurance-policy-level-missing")
+
+
+def test_levels_empty_list_is_flagged_explicitly(tmp_path: Path) -> None:
+    body = _GOOD_POLICY[: _GOOD_POLICY.index("levels:")] + "levels: []\n"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-levels-empty")
+    # Per-level missing checks must still fire.
+    for level_id in CANONICAL_LEVEL_IDS:
+        assert _flagged(failures, level_id), f"expected {level_id} to be flagged when levels is empty"
+
+
+def test_levels_non_list_value_is_rejected(tmp_path: Path) -> None:
+    body = _GOOD_POLICY[: _GOOD_POLICY.index("levels:")] + "levels: oops\n"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-field-type")
+
+
+def test_requirement_refs_non_list_value_is_rejected(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace("requirement_refs:\n  - ASR-505\n", "requirement_refs: ASR-505\n", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-field-type")
+
+
+def test_adr_refs_non_list_value_is_rejected(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace("adr_refs:\n  - ADR-007\n", "adr_refs: ADR-007\n", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-field-type")
+
+
+def test_level_required_artifacts_non_list_value_is_rejected(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "    required_artifacts: [unit_tests]\n",
+        "    required_artifacts: unit_tests\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-field-type")
+
+
+def test_level_required_artifacts_non_string_element_is_rejected(tmp_path: Path) -> None:
+    # YAML `required_artifacts: [unit_tests, null]` would have been
+    # silently stringified to ['unit_tests', 'None']. The strict-string
+    # check rejects it.
+    body = _GOOD_POLICY.replace(
+        "    required_artifacts: [unit_tests]\n",
+        "    required_artifacts: [unit_tests, null]\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-field-type")
+
+
+def test_adr_refs_non_string_element_is_rejected(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "adr_refs:\n  - ADR-007\n  - ADR-018\n",
+        "adr_refs:\n  - ADR-007\n  - ADR-018\n  - 17\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-field-type")
+
+
+# ----------------------------------------------------------------------------- #
+# Required top-level fields and value.                                          #
+# ----------------------------------------------------------------------------- #
+
+
+_TOP_LEVEL_FIELD_CASES = [
+    ("policy", "policy: classification-based-assurance\n"),
+    ("requirement_refs", "requirement_refs:\n  - ASR-505\n"),
+    ("adr_refs", "adr_refs:\n  - ADR-007\n"),
+    ("levels", "levels:\n"),
+]
+
+
+@pytest.mark.parametrize(
+    ("field", "needle"),
+    _TOP_LEVEL_FIELD_CASES,
+    ids=[case[0] for case in _TOP_LEVEL_FIELD_CASES],
+)
+def test_missing_top_level_field_is_flagged(tmp_path: Path, field: str, needle: str) -> None:
+    body = _GOOD_POLICY.replace(needle, "", 1)
+    assert body != _GOOD_POLICY, f"setup error for field {field}: needle not found in _GOOD_POLICY"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-field")
+    # Check the failure MESSAGE (not the rendered form) contains the field
+    # name -- the rule id "assurance-policy-field" itself contains "policy",
+    # so a substring-on-render check would be vacuously true for the "policy"
+    # case and silently mask an implementation that named the wrong field.
+    assert any(field in failure.message for failure in failures), (
+        f"expected a failure whose message names field {field!r}; got: {[failure.render() for failure in failures]}"
+    )
+
+
+def test_policy_value_must_match_canonical(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "policy: classification-based-assurance\n",
+        "policy: something-else\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-value")
+
+
+# ----------------------------------------------------------------------------- #
+# Levels: ladder shape, ordering, required keys, supersets.                     #
+# ----------------------------------------------------------------------------- #
+
+
+def test_missing_fm_level_is_flagged(tmp_path: Path) -> None:
+    # Drop the entire FM2 block from the policy.
+    lines = _GOOD_POLICY.splitlines(keepends=True)
+    keep: list[str] = []
+    skip = False
+    for line in lines:
+        if line.startswith("  - id: FM2"):
+            skip = True
+            continue
+        if skip and line.startswith("  - id: "):
+            skip = False
+        if not skip:
+            keep.append(line)
+    body = "".join(keep)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-missing")
+    assert _flagged(failures, "FM2")
+
+
+def test_duplicate_level_ids_are_flagged(tmp_path: Path) -> None:
+    # Append a second FM2 block at the end. `by_id` would otherwise silently
+    # keep only the second entry, masking the duplication.
+    duplicate_fm2 = (
+        "  - id: FM2\n"
+        "    name: Semantic Graph / Constraint\n"
+        "    scope: Duplicate entry that must be rejected as ambiguous.\n"
+        "    change_categories: [graph, constraint]\n"
+        "    required_artifacts:\n"
+        "      - invariant_list\n"
+        "      - unit_tests\n"
+        "      - typed_ir_or_contract_coverage\n"
+        "      - property_based_or_differential_tests\n"
+    )
+    body = _GOOD_POLICY + duplicate_fm2
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-duplicate")
+    assert _flagged(failures, "FM2")
+
+
+def test_levels_out_of_order_is_flagged(tmp_path: Path) -> None:
+    lines = _GOOD_POLICY.splitlines(keepends=True)
+    indices = [i for i, ln in enumerate(lines) if ln.startswith("  - id: ")]
+    assert len(indices) == 4
+    prologue = lines[: indices[0]]
+    fm0_block = lines[indices[0] : indices[1]]
+    fm1_block = lines[indices[1] : indices[2]]
+    fm2_block = lines[indices[2] : indices[3]]
+    fm3_block = lines[indices[3] :]
+    swapped = "".join(prologue + fm0_block + fm2_block + fm1_block + fm3_block)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=swapped))
+    assert _flagged(failures, "assurance-policy-level-order")
+
+
+def test_level_missing_required_key_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "    change_categories: [structural]\n",
+        "",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-field")
+
+
+_PROPORTIONALITY_BREAK_CASES = [
+    (
+        "FM2-not-superset-of-FM1",
+        (
+            "  - id: FM2\n    name: Semantic Graph / Constraint\n"
+            "    scope: Reachability, visibility, dependency propagation, planner ordering, portability rules.\n"
+            "    change_categories: [graph, constraint]\n"
+            "    required_artifacts:\n"
+            "      - invariant_list\n"
+            "      - unit_tests\n"
+            "      - typed_ir_or_contract_coverage\n"
+            "      - property_based_or_differential_tests\n"
+        ),
+        (
+            "  - id: FM2\n    name: Semantic Graph / Constraint\n"
+            "    scope: Reachability, visibility, dependency propagation, planner ordering, portability rules.\n"
+            "    change_categories: [graph, constraint]\n"
+            "    required_artifacts:\n"
+            "      - invariant_list\n"
+            "      - typed_ir_or_contract_coverage\n"
+            "      - property_based_or_differential_tests\n"
+        ),
+    ),
+    (
+        "FM3-not-superset-of-FM2",
+        (
+            "  - id: FM3\n    name: Stateful / Control Semantics\n"
+            "    scope: State machines, branching, retries, joins, re-entry, lifecycle semantics, result contracts.\n"
+            "    change_categories: [stateful, control]\n"
+            "    required_artifacts:\n"
+            "      - invariant_list\n"
+            "      - unit_tests\n"
+            "      - typed_ir_or_contract_coverage\n"
+            "      - property_based_or_differential_tests\n"
+            "      - abstract_state_machine_model\n"
+        ),
+        (
+            "  - id: FM3\n    name: Stateful / Control Semantics\n"
+            "    scope: State machines, branching, retries, joins, re-entry, lifecycle semantics, result contracts.\n"
+            "    change_categories: [stateful, control]\n"
+            "    required_artifacts:\n"
+            "      - invariant_list\n"
+            "      - unit_tests\n"
+            "      - property_based_or_differential_tests\n"
+            "      - abstract_state_machine_model\n"
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "old", "new"),
+    _PROPORTIONALITY_BREAK_CASES,
+    ids=[case[0] for case in _PROPORTIONALITY_BREAK_CASES],
+)
+def test_proportionality_break_is_flagged(tmp_path: Path, case_id: str, old: str, new: str) -> None:
+    body = _GOOD_POLICY.replace(old, new, 1)
+    assert body != _GOOD_POLICY, f"setup error for case {case_id}"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-proportionality")
+
+
+def test_fm0_missing_tla_plus_in_prohibited_artifacts(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "    prohibited_artifacts: [TLA+, Alloy]\n",
+        "    prohibited_artifacts: [Alloy]\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-fm0-prohibited")
+
+
+def test_fm0_missing_alloy_in_prohibited_artifacts(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace(
+        "    prohibited_artifacts: [TLA+, Alloy]\n",
+        "    prohibited_artifacts: [TLA+]\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-fm0-prohibited")
+
+
+# ----------------------------------------------------------------------------- #
+# Required-artifact floor (per ADR-007) -- a YAML edit that drops a required    #
+# artifact below the floor fails the gate. The proportionality check alone      #
+# would let "everything is unit_tests" pass.                                    #
+# ----------------------------------------------------------------------------- #
+
+
+_REQUIRED_FLOOR_CASES = [
+    (
+        "FM1-loses-invariants",
+        "  - id: FM1\n    name: Static Semantic\n    scope: Cross-references, uniqueness, ambiguity, acyclicity, fail-closed resolution.\n    change_categories: [semantic]\n    required_artifacts: [invariant_list, unit_tests]\n    recommended_artifacts: [property_based_tests]\n",
+        "  - id: FM1\n    name: Static Semantic\n    scope: Cross-references, uniqueness, ambiguity, acyclicity, fail-closed resolution.\n    change_categories: [semantic]\n    required_artifacts: [unit_tests]\n    recommended_artifacts: [property_based_tests]\n",
+    ),
+    (
+        "FM2-loses-typed-ir",
+        "      - typed_ir_or_contract_coverage\n      - property_based_or_differential_tests\n  - id: FM3",
+        "      - property_based_or_differential_tests\n  - id: FM3",
+    ),
+    (
+        "FM3-loses-abstract-state-machine-model",
+        "      - property_based_or_differential_tests\n      - abstract_state_machine_model\n    recommended_artifacts: [TLA+, Alloy]\n",
+        "      - property_based_or_differential_tests\n    recommended_artifacts: [TLA+, Alloy]\n",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "old", "new"),
+    _REQUIRED_FLOOR_CASES,
+    ids=[case[0] for case in _REQUIRED_FLOOR_CASES],
+)
+def test_required_artifact_floor_is_enforced(tmp_path: Path, case_id: str, old: str, new: str) -> None:
+    body = _GOOD_POLICY.replace(old, new, 1)
+    assert body != _GOOD_POLICY, f"setup error for case {case_id}"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-required-floor")
+
+
+def test_required_and_prohibited_overlap_is_flagged(tmp_path: Path) -> None:
+    # If a level lists unit_tests as both required and prohibited, that's
+    # an internal contradiction. Proportionality alone would not catch it.
+    body = _GOOD_POLICY.replace(
+        "    prohibited_artifacts: [TLA+, Alloy]\n",
+        "    prohibited_artifacts: [TLA+, Alloy, unit_tests]\n",
+        1,
+    )
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-required-prohibited-overlap")
+
+
+# ----------------------------------------------------------------------------- #
+# Category-to-level binding -- the validator pins which level owns which        #
+# canonical category, so reordering "structural" onto FM3 (or dropping it)      #
+# fails the gate.                                                               #
+# ----------------------------------------------------------------------------- #
+
+
+_CATEGORY_BINDING_CASES = [
+    ("FM0-loses-structural", "    change_categories: [structural]\n", "    change_categories: [shape]\n"),
+    ("FM1-loses-semantic", "    change_categories: [semantic]\n", "    change_categories: [static]\n"),
+    ("FM2-loses-graph", "    change_categories: [graph, constraint]\n", "    change_categories: [constraint]\n"),
+    ("FM3-loses-stateful", "    change_categories: [stateful, control]\n", "    change_categories: [control]\n"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "old", "new"),
+    _CATEGORY_BINDING_CASES,
+    ids=[case[0] for case in _CATEGORY_BINDING_CASES],
+)
+def test_category_to_level_binding_is_enforced(tmp_path: Path, case_id: str, old: str, new: str) -> None:
+    body = _GOOD_POLICY.replace(old, new, 1)
+    assert body != _GOOD_POLICY, f"setup error for case {case_id}: old string not found in _GOOD_POLICY"
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-categories")
+
+
+# ----------------------------------------------------------------------------- #
+# Pointing refs: ASR-505 in requirement_refs, ADR-007 in adr_refs.              #
+# ----------------------------------------------------------------------------- #
+
+
+def test_missing_asr_505_in_requirement_refs(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace("  - ASR-505\n", "  - ASR-999\n", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-requirement-ref")
+
+
+def test_missing_adr_007_in_adr_refs(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace("  - ADR-007\n", "  - ADR-999\n", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-adr-ref")
+
+
+def test_missing_adr_018_in_adr_refs(tmp_path: Path) -> None:
+    body = _GOOD_POLICY.replace("  - ADR-018\n", "", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-adr-ref")
+    assert _flagged(failures, "ADR-018")
+
+
+# ----------------------------------------------------------------------------- #
+# Doc drift -- each downstream doc must mention every canonical level id AND    #
+# every canonical level name. The drift guard catches both kinds of regression. #
+# ----------------------------------------------------------------------------- #
+
+
+def test_adr_missing_level_id_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_ADR.replace("FM2 (Semantic Graph / Constraint), and ", "", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, adr_body=body))
+    assert _flagged(failures, "assurance-policy-adr-drift")
+
+
+def test_adr_missing_canonical_name_is_flagged(tmp_path: Path) -> None:
+    # The ADR text still has 'FM2', but the canonical name has been changed --
+    # this is the exact drift mode (FM2 labeled "Dynamic Semantic Rules" while
+    # still saying "FM2") that ADR-018's drift guard was created to catch.
+    body = _GOOD_ADR.replace("Semantic Graph / Constraint", "Dynamic Semantic Rules", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, adr_body=body))
+    assert _flagged(failures, "assurance-policy-adr-drift")
+
+
+def test_coding_standards_missing_canonical_name_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_CODING_STANDARDS.replace("Stateful / Control Semantics", "Cross-System Contracts", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, coding_standards_body=body))
+    assert _flagged(failures, "assurance-policy-coding-standards-drift")
+
+
+def test_formal_overview_missing_canonical_name_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_FORMAL_OVERVIEW.replace("Static Semantic", "Static Rules", 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, formal_overview_body=body))
+    assert _flagged(failures, "assurance-policy-formal-overview-drift")
+
+
+def test_drift_guard_catches_swapped_pair(tmp_path: Path) -> None:
+    # Both 'FM2' and the canonical name 'Semantic Graph / Constraint' still
+    # appear in the doc, but they are no longer co-located -- the FM2 row in
+    # the table has been bound to 'Stateful / Control Semantics' (a real
+    # canonical name belonging to FM3) and vice-versa. The presence-only
+    # guards would miss this; the paired check catches it.
+    bad_overview = """# Formal Specifications
+
+| Level | Name |
+|-------|------|
+| FM0 | Structural |
+| FM1 | Static Semantic |
+| FM2 | Stateful / Control Semantics |
+| FM3 | Semantic Graph / Constraint |
+"""
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, formal_overview_body=bad_overview))
+    assert _flagged(failures, "assurance-policy-formal-overview-drift")
+    # The failure mentions the paired-co-location language so it is
+    # distinguishable from raw "missing id/name" failures.
+    assert any("not co-located" in failure.message for failure in failures), (
+        f"expected a paired-drift failure, got {[failure.render() for failure in failures]}"
+    )
+
+
+def test_coding_standards_missing_artifact_keyword_is_flagged(tmp_path: Path) -> None:
+    # The YAML requires `typed_ir_or_contract_coverage` for FM2/FM3. The
+    # mutable doc must mention at least one keyword variant ("typed IR" or
+    # "contract coverage"). A stub that names every level but mentions only
+    # unit tests + invariants + property-based + abstract state-machine
+    # (deliberately omitting both "typed IR" and "contract coverage")
+    # triggers the gate.
+    stale_coding_standards = """# Coding Standards
+
+The classification levels are FM0 Structural, FM1 Static Semantic,
+FM2 Semantic Graph / Constraint, and FM3 Stateful / Control Semantics.
+
+Required artifacts: unit tests, invariants, property-based or differential
+tests, and an abstract state-machine model.
+"""
+    # Belt-and-braces: confirm no keyword variant for the slug survives.
+    assert "typed IR" not in stale_coding_standards
+    assert "contract coverage" not in stale_coding_standards
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, coding_standards_body=stale_coding_standards))
+    assert _flagged(failures, "assurance-policy-coding-standards-drift")
+    assert any("typed_ir_or_contract_coverage" in failure.message for failure in failures)
+
+
+def test_formal_overview_missing_artifact_keyword_is_flagged(tmp_path: Path) -> None:
+    # Same shape as the coding-standards check: a stub that names every
+    # level but deliberately omits both "typed IR" and "contract coverage"
+    # triggers the gate.
+    stale_overview = """# Formal Specifications
+
+| Level | Name | Required artifacts |
+|-------|------|--------------------|
+| FM0 | Structural | unit tests |
+| FM1 | Static Semantic | invariants + unit tests |
+| FM2 | Semantic Graph / Constraint | FM1 + property-based or differential tests |
+| FM3 | Stateful / Control Semantics | FM2 + abstract state-machine model |
+"""
+    assert "typed IR" not in stale_overview
+    assert "contract coverage" not in stale_overview
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, formal_overview_body=stale_overview))
+    assert _flagged(failures, "assurance-policy-formal-overview-drift")
+    assert any("typed_ir_or_contract_coverage" in failure.message for failure in failures)
+
+
+def test_adr_007_immutable_doc_is_exempt_from_artifact_keyword_drift(tmp_path: Path) -> None:
+    # ADR-007 doesn't need to mention every required artifact. The mutable
+    # docs do. Strip every artifact keyword from the ADR stub; the artifact-
+    # keyword drift guard must stay quiet for that doc.
+    minimal_adr = """# ADR-007: Lightweight Formal Methods Policy
+
+## Status
+accepted
+
+## Decision
+The classification ladder is FM0 (Structural), FM1 (Static Semantic),
+FM2 (Semantic Graph / Constraint), and FM3 (Stateful / Control Semantics).
+"""
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, adr_body=minimal_adr))
+    assert not _flagged(failures, "assurance-policy-adr-drift")
+
+
+_MISSING_DOC_CASES = [
+    ("adr-missing", {"adr_body": None}, "assurance-policy-adr-missing"),
+    ("coding-standards-missing", {"coding_standards_body": None}, "assurance-policy-coding-standards-missing"),
+    ("formal-overview-missing", {"formal_overview_body": None}, "assurance-policy-formal-overview-missing"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "kwargs", "rule_id"),
+    _MISSING_DOC_CASES,
+    ids=[case[0] for case in _MISSING_DOC_CASES],
+)
+def test_missing_referencing_doc_is_flagged(tmp_path: Path, case_id: str, kwargs: dict, rule_id: str) -> None:
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, **kwargs))
+    assert _flagged(failures, rule_id)
+
+
+# ----------------------------------------------------------------------------- #
+# Drift expectations derive from the YAML -- adding a level beyond FM3 makes    #
+# every downstream doc obligated to mention it (and its canonical name).        #
+# ----------------------------------------------------------------------------- #
+
+
+_GOOD_FM4_BLOCK = (
+    "  - id: FM4\n"
+    "    name: Concurrent / Distributed Semantics\n"
+    "    scope: Multi-process state, message ordering, distributed commit.\n"
+    "    change_categories: [stateful, control, distributed]\n"
+    "    required_artifacts:\n"
+    "      - invariant_list\n"
+    "      - unit_tests\n"
+    "      - typed_ir_or_contract_coverage\n"
+    "      - property_based_or_differential_tests\n"
+    "      - abstract_state_machine_model\n"
+    "      - distributed_state_machine_model\n"
+)
+
+
+def test_adding_fm4_to_yaml_requires_mutable_downstream_docs_to_mention_it(tmp_path: Path) -> None:
+    # ADR-007 is immutable -- it must mention FM0..FM3 only. Adding FM4 to
+    # the YAML therefore obligates the MUTABLE docs (coding-standards.md and
+    # docs/specs/formal.md) but not ADR-007.
+    body = _GOOD_POLICY + _GOOD_FM4_BLOCK
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-coding-standards-drift")
+    assert _flagged(failures, "assurance-policy-formal-overview-drift")
+    assert _flagged(failures, "FM4")
+
+
+def test_adding_fm4_to_yaml_does_not_require_immutable_adr_007_to_mention_it(tmp_path: Path) -> None:
+    # The mirror invariant of the test above: ADR-007's drift guard must NOT
+    # fire on FM4-only additions, because ADR-007 is immutable. ADR-018 (and
+    # any future superseding ADR) is the canonical seam for extending the
+    # ladder.
+    body = _GOOD_POLICY + _GOOD_FM4_BLOCK
+    # Also extend the mutable docs so their drift guards stay quiet -- this
+    # isolates the ADR-007 guard. We append a short mention with the canonical
+    # name so the paired-co-location check passes.
+    coding_standards_with_fm4 = (
+        _GOOD_CODING_STANDARDS.rstrip() + "\nThe extended ladder now includes FM4 Concurrent / Distributed Semantics.\n"
+    )
+    formal_overview_with_fm4 = _GOOD_FORMAL_OVERVIEW.rstrip() + "\n| FM4 | Concurrent / Distributed Semantics |\n"
+    failures = evaluate_assurance_policy(
+        _seed_repo(
+            tmp_path,
+            policy_body=body,
+            coding_standards_body=coding_standards_with_fm4,
+            formal_overview_body=formal_overview_with_fm4,
+        )
+    )
+    # Coding-standards and formal-overview drift guards must be quiet now.
+    assert not _flagged(failures, "assurance-policy-coding-standards-drift")
+    assert not _flagged(failures, "assurance-policy-formal-overview-drift")
+    # ADR-007 drift guard must stay quiet -- it is not required to mention FM4.
+    assert not _flagged(failures, "assurance-policy-adr-drift")
+
+
+def test_fm4_inserted_before_fm3_is_flagged_as_out_of_order(tmp_path: Path) -> None:
+    # Insert the FM4 block BEFORE FM3 in the levels list. The numeric order
+    # check must fail (FM2 → FM4 → FM3 is not ascending).
+    insertion_marker = "  - id: FM3\n"
+    body = _GOOD_POLICY.replace(insertion_marker, _GOOD_FM4_BLOCK + insertion_marker, 1)
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-level-order")
+
+
+def test_fm4_with_artifacts_not_superset_of_fm3_is_flagged(tmp_path: Path) -> None:
+    # Add an FM4 block at the end whose required_artifacts drops one of
+    # FM3's. The consecutive-pair proportionality check must fire across
+    # every FM-numbered pair, not just FM2 → FM3.
+    bad_fm4 = (
+        "  - id: FM4\n"
+        "    name: Concurrent / Distributed Semantics\n"
+        "    scope: Multi-process state, message ordering, distributed commit.\n"
+        "    change_categories: [stateful, control, distributed]\n"
+        "    required_artifacts:\n"
+        "      - invariant_list\n"
+        "      - unit_tests\n"
+        "      - typed_ir_or_contract_coverage\n"
+        "      - property_based_or_differential_tests\n"
+        # `abstract_state_machine_model` is intentionally omitted -- FM4 is
+        # not a superset of FM3.
+        "      - distributed_state_machine_model\n"
+    )
+    body = _GOOD_POLICY + bad_fm4
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
+    assert _flagged(failures, "assurance-policy-proportionality")
+    assert _flagged(failures, "FM4")
+
+
+# ----------------------------------------------------------------------------- #
+# Real-repo invariant -- the actual checked-in YAML and docs must be clean.     #
+# ----------------------------------------------------------------------------- #
+
+
+def test_real_repo_assurance_policy_is_clean() -> None:
+    failures = evaluate_assurance_policy(REPO_ROOT)
+    assert failures == []

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,6 +24,7 @@ TARGETED_POLICY_TESTS = [
     "implementations/python/tests/test_repo_policy_tools.py",
     "implementations/python/tests/test_requirement_governance.py",
     "implementations/python/tests/test_semantic_coverage.py",
+    "implementations/python/tests/test_assurance_policy.py",
 ]
 CONTRACT_TRIGGER_PREFIXES = (
     "contracts/",
@@ -442,10 +443,15 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
     # the working-tree policy invocations (`policy`, `hook-pre-push`, `verify`).
     if "--staged" in args:
         reporter.skip("policy / semantic coverage ADR", "skipped on staged check; runs on push and verify")
+        reporter.skip("policy / assurance policy ADR", "skipped on staged check; runs on push and verify")
     else:
         reporter.run(
             "policy / semantic coverage ADR",
             lambda: _run_project_python(session, "tools/check_semantic_coverage.py"),
+        )
+        reporter.run(
+            "policy / assurance policy ADR",
+            lambda: _run_project_python(session, "tools/check_assurance_policy.py"),
         )
 
 

--- a/specs/formal/README.md
+++ b/specs/formal/README.md
@@ -25,3 +25,8 @@ This directory is intentionally optional. See
 `docs/explain/reference/coding-standards.md` and
 `docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md` for the policy on
 when formal artifacts are warranted.
+
+The canonical mapping from change classification to verification artifacts
+lives in `specs/formal/assurance-policy.yaml`, governed by
+`docs/decisions/adrs/adr-018-classification-based-assurance-policy.md` and
+gated by `tools/check_assurance_policy.py` (`nox -s policy`).

--- a/specs/formal/assurance-policy.yaml
+++ b/specs/formal/assurance-policy.yaml
@@ -1,0 +1,91 @@
+# Classification-Based Assurance Policy (ASR-505)
+#
+# Canonical machine-readable mapping from change classification to verification
+# artifacts. Required reading:
+#
+#   docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md  -- policy decision
+#   docs/decisions/adrs/adr-018-classification-based-assurance-policy.md  -- canonical seam
+#   docs/explain/reference/coding-standards.md  -- contributor-facing source of truth
+#   docs/specs/formal.md  -- formal-specs overview
+#
+# Drift between this file and those documents is guarded by
+# tools/check_assurance_policy.py. ADR-007 supplies the levels; this YAML is the
+# canonical seam that lets a future FM4 or new artifact type land in a single
+# place rather than requiring prose updates across the doc tree.
+
+policy: classification-based-assurance
+
+requirement_refs:
+  - ASR-505
+
+adr_refs:
+  - ADR-007
+  - ADR-018
+
+levels:
+  - id: FM0
+    name: Structural
+    scope: >-
+      Shape, parsing, schema, and local validation only. Use for syntactic and
+      structural work where behavior is determined entirely by data shape.
+    change_categories:
+      - structural
+    required_artifacts:
+      - unit_tests
+    prohibited_artifacts:
+      - TLA+
+      - Alloy
+
+  - id: FM1
+    name: Static Semantic
+    scope: >-
+      Cross-references, uniqueness, ambiguity, acyclicity, and fail-closed
+      resolution. Static rules over the parsed model.
+    change_categories:
+      - semantic
+    required_artifacts:
+      - invariant_list
+      - unit_tests
+    recommended_artifacts:
+      - property_based_tests
+
+  - id: FM2
+    name: Semantic Graph / Constraint
+    scope: >-
+      Reachability, visibility, dependency propagation, planner ordering, and
+      portability rules. Graph and constraint semantics across the model.
+    change_categories:
+      - graph
+      - constraint
+    required_artifacts:
+      - invariant_list
+      - unit_tests
+      - typed_ir_or_contract_coverage
+      - property_based_or_differential_tests
+
+  - id: FM3
+    name: Stateful / Control Semantics
+    scope: >-
+      State machines, branching, retries, joins, re-entry, lifecycle semantics,
+      and result contracts. Control-flow and stateful behavior.
+    change_categories:
+      - stateful
+      - control
+    required_artifacts:
+      - invariant_list
+      - unit_tests
+      - typed_ir_or_contract_coverage
+      - property_based_or_differential_tests
+      - abstract_state_machine_model
+    recommended_artifacts:
+      - TLA+
+      - Alloy
+
+out_of_scope:
+  - raw YAML syntax and parsing mechanics
+  - ordinary schema validation
+  - formatting and editorial documentation changes
+  - trivial refactors with unchanged semantics
+  - isolated field additions with no new invariants
+  - simple parser normalization or aliasing
+  - straightforward CRUD/config plumbing

--- a/tools/check_assurance_policy.py
+++ b/tools/check_assurance_policy.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Structural gate for the ASR-505 classification-based assurance policy.
+
+ADR-007 ("Lightweight Formal Methods Policy") and the contributor-facing
+``docs/explain/reference/coding-standards.md`` define the FM0/FM1/FM2/FM3
+ladder. ASR-505 says the ecosystem shall *define* a classification-based
+assurance policy that maps structural, semantic, graph, and stateful changes to
+proportionate verification artifacts. The canonical mapping lives in
+``specs/formal/assurance-policy.yaml`` -- one machine-readable artifact under
+the normative ``specs/`` tree (per ADR-009) that every downstream doc and tool
+references.
+
+This checker pins the YAML's structural invariants and guards against drift
+between the YAML and the three docs that name the levels (the immutable
+ADR-007, the contributor-facing coding standards, and the formal-specs
+overview). Failures use ``tools.policy.common.PolicyFailure`` and the CLI honours
+``--json`` and the shared ``tools/policy/exceptions.yaml`` waiver mechanism,
+matching the other policy gates (``check_repo_policy.py``,
+``check_requirement_governance.py``, ``check_semantic_coverage.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import yaml
+
+from tools.policy.common import PolicyFailure, apply_exceptions, failures_to_json, load_exceptions
+
+# --------------------------------------------------------------------------- #
+# Canonical paths and baseline policy invariants. Test code imports these     #
+# directly so a rename here surfaces in the test suite, not silently in       #
+# production. The validator otherwise derives its expectations from the YAML  #
+# itself, so adding FM4 only requires editing the YAML plus mentioning FM4 in #
+# each downstream doc; this baseline only encodes the floor the policy may    #
+# not drop below.                                                             #
+# --------------------------------------------------------------------------- #
+
+ASSURANCE_POLICY_RELATIVE_PATH = "specs/formal/assurance-policy.yaml"
+ADR_POLICY_RELATIVE_PATH = "docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md"
+CODING_STANDARDS_RELATIVE_PATH = "docs/explain/reference/coding-standards.md"
+FORMAL_OVERVIEW_RELATIVE_PATH = "docs/specs/formal.md"
+
+# The baseline canonical level ids. The YAML MAY add more levels (e.g. FM4),
+# but these four are the floor and must always be present.
+CANONICAL_LEVEL_IDS: tuple[str, ...] = ("FM0", "FM1", "FM2", "FM3")
+
+# The four words in the ASR-505 statement -- the validator pins each to a
+# specific level so reordering does not silently keep passing.
+REQUIRED_CHANGE_CATEGORIES: tuple[str, ...] = ("structural", "semantic", "graph", "stateful")
+
+# Which level owns which canonical change category. This is the category-to-
+# level binding the requirement statement implies.
+_LEVEL_PRIMARY_CATEGORY: dict[str, str] = {
+    "FM0": "structural",
+    "FM1": "semantic",
+    "FM2": "graph",
+    "FM3": "stateful",
+}
+
+REQUIREMENT_REF = "ASR-505"
+# ADR-007 is the policy decision; ADR-018 is the canonical-seam decision that
+# governs THIS file. Both must be named in the YAML so a future edit cannot
+# silently sever the governance link without failing the gate.
+ADR_REFS: tuple[str, ...] = ("ADR-007", "ADR-018")
+# Kept for backwards compatibility / external imports — equals the first ADR ref.
+ADR_REF = ADR_REFS[0]
+POLICY_VALUE = "classification-based-assurance"
+
+# Floor required-artifact obligations per level, sourced from ADR-007. The
+# YAML may add MORE required artifacts to any level; it may not drop these.
+# This is independent of the proportionality (superset) check.
+_LEVEL_REQUIRED_FLOOR: dict[str, frozenset[str]] = {
+    "FM0": frozenset({"unit_tests"}),
+    "FM1": frozenset({"invariant_list", "unit_tests"}),
+    "FM2": frozenset(
+        {"invariant_list", "unit_tests", "typed_ir_or_contract_coverage", "property_based_or_differential_tests"}
+    ),
+    "FM3": frozenset(
+        {
+            "invariant_list",
+            "unit_tests",
+            "typed_ir_or_contract_coverage",
+            "property_based_or_differential_tests",
+            "abstract_state_machine_model",
+        }
+    ),
+}
+
+_REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = ("policy", "requirement_refs", "adr_refs", "levels")
+_REQUIRED_LEVEL_FIELDS: tuple[str, ...] = (
+    "id",
+    "name",
+    "scope",
+    "change_categories",
+    "required_artifacts",
+)
+_LEVEL_SEQUENCE_FIELDS: tuple[str, ...] = (
+    "change_categories",
+    "required_artifacts",
+    "recommended_artifacts",
+    "prohibited_artifacts",
+)
+_FM0_PROHIBITED_ARTIFACTS: frozenset[str] = frozenset({"TLA+", "Alloy"})
+
+# Human-readable phrasings for each YAML artifact slug. The drift guard
+# requires the union of required artifacts (across all levels in the YAML) to
+# appear in each MUTABLE downstream doc (coding-standards.md, formal.md). A
+# stale doc that drops one of these phrases entirely fails the gate. ADR-007
+# is immutable, so it is exempt from this check.
+_ARTIFACT_DOC_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "unit_tests": ("unit tests",),
+    "invariant_list": ("invariant",),  # matches "invariants", "invariant list", etc.
+    "typed_ir_or_contract_coverage": ("typed IR", "contract coverage", "typed IR/contract"),
+    "property_based_or_differential_tests": (
+        "property-based",
+        "differential test",
+    ),
+    "abstract_state_machine_model": ("abstract state-machine", "state-machine model"),
+}
+
+
+def _fail(rule_id: str, message: str, path: str | None) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _check_top_level_fields(data: dict, path: str) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    for field in _REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in data:
+            failures.append(_fail("assurance-policy-field", f"missing required top-level field: {field}", path))
+    if "policy" in data and data["policy"] != POLICY_VALUE:
+        failures.append(
+            _fail(
+                "assurance-policy-value",
+                f"policy field must be '{POLICY_VALUE}', got '{data['policy']}'",
+                path,
+            )
+        )
+    # Reject non-list sequence fields rather than silently coercing them to [].
+    for field in ("requirement_refs", "adr_refs"):
+        if field in data and not isinstance(data[field], list):
+            failures.append(
+                _fail(
+                    "assurance-policy-field-type",
+                    f"top-level field '{field}' must be a YAML list; got {type(data[field]).__name__}",
+                    path,
+                )
+            )
+    if "levels" in data and not isinstance(data["levels"], list):
+        failures.append(
+            _fail(
+                "assurance-policy-field-type",
+                f"top-level field 'levels' must be a YAML list; got {type(data['levels']).__name__}",
+                path,
+            )
+        )
+    return failures
+
+
+def _check_refs(data: dict, path: str) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    requirement_refs = data.get("requirement_refs")
+    adr_refs = data.get("adr_refs")
+    # Top-level ref lists must contain only strings. Non-string entries are
+    # surfaced as type failures rather than silently stringified.
+    for field_name, value in (("requirement_refs", requirement_refs), ("adr_refs", adr_refs)):
+        if isinstance(value, list):
+            for item in value:
+                if not isinstance(item, str):
+                    failures.append(
+                        _fail(
+                            "assurance-policy-field-type",
+                            f"top-level field '{field_name}' must contain only strings; "
+                            f"got non-string element {item!r}",
+                            path,
+                        )
+                    )
+    requirement_strs = _refs_sequence(requirement_refs)
+    adr_strs = _refs_sequence(adr_refs)
+    if isinstance(requirement_refs, list) and REQUIREMENT_REF not in requirement_strs:
+        failures.append(
+            _fail(
+                "assurance-policy-requirement-ref",
+                f"requirement_refs must include {REQUIREMENT_REF}",
+                path,
+            )
+        )
+    if isinstance(adr_refs, list):
+        for required_adr in ADR_REFS:
+            if required_adr not in adr_strs:
+                failures.append(
+                    _fail(
+                        "assurance-policy-adr-ref",
+                        f"adr_refs must include {required_adr}",
+                        path,
+                    )
+                )
+    return failures
+
+
+def _level_sequence(level: dict, field: str) -> list[str]:
+    """Return the level's sequence field as a list of strings.
+
+    Non-string elements are silently dropped here so downstream set operations
+    (proportionality, floor, category-binding) are not corrupted. The shape
+    check in `_check_levels` separately reports any non-string element as a
+    `assurance-policy-level-field-type` failure, so dropping them here does
+    not mask the regression.
+    """
+    value = level.get(field)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _refs_sequence(value: Any) -> list[str]:
+    """Same shape as `_level_sequence` but for top-level refs."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _check_levels(levels: list[Any], path: str) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+
+    if not levels:
+        failures.append(
+            _fail(
+                "assurance-policy-levels-empty",
+                "levels list is empty; the policy must enumerate every canonical FM level",
+                path,
+            )
+        )
+
+    present_ids = [level.get("id") if isinstance(level, dict) else None for level in levels]
+
+    # Every baseline canonical level must be present (FM0..FM3 is the floor).
+    for expected in CANONICAL_LEVEL_IDS:
+        if expected not in present_ids:
+            failures.append(
+                _fail(
+                    "assurance-policy-level-missing",
+                    f"levels list is missing canonical level {expected}",
+                    path,
+                )
+            )
+
+    # Level ids must be unique. `by_id` would otherwise silently keep only the
+    # last entry, leaving a non-canonical mapping with ambiguous semantics.
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for level_id in present_ids:
+        if not isinstance(level_id, str):
+            continue
+        if level_id in seen:
+            duplicates.append(level_id)
+        else:
+            seen.add(level_id)
+    if duplicates:
+        failures.append(
+            _fail(
+                "assurance-policy-level-duplicate",
+                f"level ids must be unique; duplicates: {sorted(set(duplicates))}",
+                path,
+            )
+        )
+
+    # Every FM-numbered level must appear in ascending numeric order. This
+    # covers the baseline canonical levels AND any future FM4+ -- inserting
+    # FM4 before FM2 or between FM0 and FM1 is a failure.
+    fm_numbered_ids = [lid for lid in present_ids if isinstance(lid, str) and _fm_index(lid) is not None]
+    expected_fm_order = sorted(fm_numbered_ids, key=lambda lid: _fm_index(lid) or -1)
+    if fm_numbered_ids != expected_fm_order:
+        failures.append(
+            _fail(
+                "assurance-policy-level-order",
+                f"FM-numbered levels must appear in ascending numeric order; got {fm_numbered_ids}, "
+                f"expected {expected_fm_order}",
+                path,
+            )
+        )
+
+    # Per-level shape: required keys, sequence fields actually lists.
+    for level in levels:
+        if not isinstance(level, dict):
+            failures.append(_fail("assurance-policy-level-field", f"level entry is not a mapping: {level!r}", path))
+            continue
+        for field in _REQUIRED_LEVEL_FIELDS:
+            if field not in level:
+                failures.append(
+                    _fail(
+                        "assurance-policy-level-field",
+                        f"level '{level.get('id', '?')}' missing required field: {field}",
+                        path,
+                    )
+                )
+        for field in _LEVEL_SEQUENCE_FIELDS:
+            value = level.get(field) if field in level else None
+            if field in level and not isinstance(value, list):
+                failures.append(
+                    _fail(
+                        "assurance-policy-level-field-type",
+                        f"level '{level.get('id', '?')}' field '{field}' must be a YAML list; "
+                        f"got {type(value).__name__}",
+                        path,
+                    )
+                )
+                continue
+            if isinstance(value, list):
+                for item in value:
+                    if not isinstance(item, str):
+                        failures.append(
+                            _fail(
+                                "assurance-policy-level-field-type",
+                                f"level '{level.get('id', '?')}' field '{field}' must contain only "
+                                f"strings; got non-string element {item!r}",
+                                path,
+                            )
+                        )
+
+    # Each level must claim its primary canonical category. This pins the
+    # category-to-level binding, not just the union (the ASR-505 statement
+    # guard).
+    by_id = {lv.get("id"): lv for lv in levels if isinstance(lv, dict)}
+    for level_id, expected_category in _LEVEL_PRIMARY_CATEGORY.items():
+        level = by_id.get(level_id)
+        if level is None:
+            continue
+        categories = _level_sequence(level, "change_categories")
+        if expected_category not in categories:
+            failures.append(
+                _fail(
+                    "assurance-policy-categories",
+                    f"level {level_id} must claim canonical change category '{expected_category}' "
+                    f"(per the ASR-505 statement); got {categories}",
+                    path,
+                )
+            )
+
+    # Belt-and-suspenders: the union of every level's change_categories must
+    # still cover every word in the ASR-505 statement. This catches a future
+    # level that drops one of the canonical words without triggering the
+    # binding check above.
+    category_union = {
+        cat for level in levels if isinstance(level, dict) for cat in _level_sequence(level, "change_categories")
+    }
+    missing_categories = [cat for cat in REQUIRED_CHANGE_CATEGORIES if cat not in category_union]
+    if missing_categories:
+        failures.append(
+            _fail(
+                "assurance-policy-categories",
+                f"change_categories union must include every word in the ASR-505 statement "
+                f"({REQUIRED_CHANGE_CATEGORIES}); missing: {missing_categories}",
+                path,
+            )
+        )
+
+    # FM0 must prohibit TLA+ and Alloy explicitly.
+    fm0 = by_id.get("FM0")
+    if fm0 is not None:
+        prohibited = set(_level_sequence(fm0, "prohibited_artifacts"))
+        missing = sorted(_FM0_PROHIBITED_ARTIFACTS - prohibited)
+        if missing:
+            failures.append(
+                _fail(
+                    "assurance-policy-fm0-prohibited",
+                    f"FM0 must list {sorted(_FM0_PROHIBITED_ARTIFACTS)} in prohibited_artifacts; missing: {missing}",
+                    path,
+                )
+            )
+
+    # Per-level required-artifact floor (from ADR-007). The YAML may require
+    # MORE; it may not require less.
+    for level_id, floor in _LEVEL_REQUIRED_FLOOR.items():
+        level = by_id.get(level_id)
+        if level is None:
+            continue
+        required = set(_level_sequence(level, "required_artifacts"))
+        missing = sorted(floor - required)
+        if missing:
+            failures.append(
+                _fail(
+                    "assurance-policy-required-floor",
+                    f"{level_id}'s required_artifacts must include the ADR-007 floor; missing: {missing}",
+                    path,
+                )
+            )
+
+    # Required and prohibited sets must be disjoint per level.
+    for level in levels:
+        if not isinstance(level, dict):
+            continue
+        required = set(_level_sequence(level, "required_artifacts"))
+        prohibited = set(_level_sequence(level, "prohibited_artifacts"))
+        overlap = sorted(required & prohibited)
+        if overlap:
+            failures.append(
+                _fail(
+                    "assurance-policy-required-prohibited-overlap",
+                    f"level '{level.get('id', '?')}' has artifacts in both required_artifacts and "
+                    f"prohibited_artifacts: {overlap}",
+                    path,
+                )
+            )
+
+    # Consecutive-pair proportionality across every FM-numbered level, not
+    # just FM2/FM3. FM4 (if present) must be a superset of FM3, and so on.
+    fm_levels_ordered = sorted(
+        (lv for lv in levels if isinstance(lv, dict) and _fm_index(lv.get("id")) is not None),
+        key=lambda lv: _fm_index(lv.get("id")) or -1,
+    )
+    for parent, child in zip(fm_levels_ordered, fm_levels_ordered[1:], strict=False):
+        child_id = child.get("id", "?")
+        parent_id = parent.get("id", "?")
+        child_set = set(_level_sequence(child, "required_artifacts"))
+        parent_set = set(_level_sequence(parent, "required_artifacts"))
+        missing = sorted(parent_set - child_set)
+        if missing:
+            failures.append(
+                _fail(
+                    "assurance-policy-proportionality",
+                    f"{child_id}'s required_artifacts must be a superset of {parent_id}'s; "
+                    f"missing from {child_id}: {missing}",
+                    path,
+                )
+            )
+
+    return failures
+
+
+def _fm_index(level_id: Any) -> int | None:
+    """Return the numeric index of an FM-numbered level id (FM0 → 0), else None."""
+    if not isinstance(level_id, str) or not level_id.startswith("FM"):
+        return None
+    suffix = level_id[2:]
+    if not suffix.isdigit():
+        return None
+    return int(suffix)
+
+
+def _drift_targets(levels: list[Any]) -> list[tuple[str, str]]:
+    """Return (level_id, level_name) pairs that mutable downstream docs must mention.
+
+    Names are derived from the YAML so a future FM4 (or a name change to an
+    existing level) flows through to every drift check without editing this
+    file. The id is checked AS-IS; the name is checked after collapsing runs
+    of whitespace, since Markdown sometimes wraps long names.
+    """
+    targets: list[tuple[str, str]] = []
+    for level in levels:
+        if not isinstance(level, dict):
+            continue
+        level_id = level.get("id")
+        name = level.get("name")
+        if isinstance(level_id, str) and isinstance(name, str):
+            targets.append((level_id, name))
+    return targets
+
+
+def _baseline_drift_targets(levels: list[Any]) -> list[tuple[str, str]]:
+    """Return drift targets restricted to the BASELINE canonical levels.
+
+    Used for ADR-007, which is immutable per the ADR README and therefore
+    cannot be required to mention a future FM4. The baseline floor (FM0..FM3)
+    is fixed at policy adoption time; ADR-007 is required to mention it, and
+    nothing more. Extending the ladder requires a superseding or
+    complementary ADR (e.g. ADR-018, which governs the canonical YAML).
+    """
+    by_id = {lv.get("id"): lv for lv in levels if isinstance(lv, dict)}
+    targets: list[tuple[str, str]] = []
+    for canonical_id in CANONICAL_LEVEL_IDS:
+        level = by_id.get(canonical_id)
+        if not isinstance(level, dict):
+            # Level missing — _check_levels reports it separately. Fall back
+            # to id-only so the drift guard still runs.
+            targets.append((canonical_id, ""))
+            continue
+        name = level.get("name")
+        targets.append((canonical_id, name if isinstance(name, str) else ""))
+    return targets
+
+
+def _required_artifact_union(levels: list[Any]) -> set[str]:
+    """Return the union of YAML required_artifacts across every level."""
+    union: set[str] = set()
+    for level in levels:
+        if isinstance(level, dict):
+            union.update(_level_sequence(level, "required_artifacts"))
+    return union
+
+
+def _check_artifact_keyword_drift(
+    repo_root: Path,
+    doc_rel: str,
+    drift_rule_id: str,
+    required_artifacts: set[str],
+) -> list[PolicyFailure]:
+    """Verify each YAML-required artifact has at least one keyword variant in the doc.
+
+    Applied only to MUTABLE downstream docs. ADR-007 is exempt because it is
+    immutable; that boundary is the same one `_baseline_drift_targets` enforces.
+    """
+    doc_path = repo_root / doc_rel
+    if not doc_path.is_file():
+        return []  # missing-doc failure already raised by `_check_doc_drift`.
+    text = doc_path.read_text(encoding="utf-8").lower()
+    missing_slugs: list[str] = []
+    for slug in sorted(required_artifacts):
+        keywords = _ARTIFACT_DOC_KEYWORDS.get(slug)
+        if not keywords:
+            # Slug not in the keyword map yet — silently pass rather than
+            # bake an implicit "every new artifact slug must update the
+            # keyword map AND the doc". The keyword map is the
+            # contributor-facing surface; new slugs should be added
+            # alongside the YAML edit.
+            continue
+        # Case-insensitive match: docs may use "Invariants" or "invariant
+        # list" or "INVARIANT LIST" -- the keyword "invariant" should match
+        # all of them.
+        if not any(keyword.lower() in text for keyword in keywords):
+            missing_slugs.append(slug)
+    if missing_slugs:
+        return [
+            _fail(
+                drift_rule_id,
+                f"{doc_rel} no longer mentions every required artifact; missing keywords for: {missing_slugs}",
+                doc_rel,
+            )
+        ]
+    return []
+
+
+def _check_doc_drift(
+    repo_root: Path,
+    doc_rel: str,
+    missing_rule_id: str,
+    drift_rule_id: str,
+    targets: list[tuple[str, str]],
+) -> list[PolicyFailure]:
+    doc_path = repo_root / doc_rel
+    if not doc_path.is_file():
+        return [_fail(missing_rule_id, f"{doc_rel} is missing — the policy references it", doc_rel)]
+    text = doc_path.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+    missing_ids: list[str] = []
+    missing_names: list[str] = []
+    unpaired: list[tuple[str, str]] = []
+    for level_id, level_name in targets:
+        if level_id not in text:
+            missing_ids.append(level_id)
+        canonical_name = " ".join(level_name.split()) if level_name else ""
+        if canonical_name and canonical_name not in normalized:
+            missing_names.append(level_name)
+        # Pair check: the id and its canonical name must co-occur within a
+        # narrow window somewhere in the doc, so it is not enough that the
+        # doc mentions every id AND every name -- they must be bound
+        # together. This catches the exact "FM2 | Dynamic Semantic Rules"
+        # drift mode where the wrong name is paired with the right id.
+        # Well-formed bindings sit within ~10 chars ("### FM2 Semantic
+        # Graph / Constraint", "FM2 (Semantic Graph / Constraint)"); a
+        # Markdown table that mis-pairs across adjacent rows leaves ~50+
+        # chars between the id and the wrong-row name.
+        if canonical_name and level_id in text and canonical_name in normalized:
+            if not _id_name_paired(normalized, level_id, canonical_name):
+                unpaired.append((level_id, level_name))
+    failures: list[PolicyFailure] = []
+    if missing_ids:
+        failures.append(
+            _fail(
+                drift_rule_id,
+                f"{doc_rel} no longer mentions every canonical level id; missing: {missing_ids}",
+                doc_rel,
+            )
+        )
+    if missing_names:
+        failures.append(
+            _fail(
+                drift_rule_id,
+                f"{doc_rel} no longer mentions every canonical level name; missing: {missing_names}",
+                doc_rel,
+            )
+        )
+    if unpaired:
+        rendered = ", ".join(f"{lid}↔{name!r}" for lid, name in unpaired)
+        failures.append(
+            _fail(
+                drift_rule_id,
+                f"{doc_rel} mentions every canonical id and name, but at least one (id, name) pair is "
+                f"not co-located within a 200-character window — likely id/name drift: {rendered}",
+                doc_rel,
+            )
+        )
+    return failures
+
+
+def _id_name_paired(normalized_text: str, level_id: str, level_name: str, window: int = 40) -> bool:
+    """Return True if `level_id` and `level_name` co-occur within `window` chars in `normalized_text`."""
+    start = 0
+    while True:
+        idx = normalized_text.find(level_id, start)
+        if idx == -1:
+            return False
+        window_start = max(0, idx - window)
+        window_end = idx + len(level_id) + window
+        if level_name in normalized_text[window_start:window_end]:
+            return True
+        start = idx + 1
+
+
+def evaluate_assurance_policy(repo_root: Path) -> list[PolicyFailure]:
+    """Return the list of structural failures for the ASR-505 assurance policy (empty = OK)."""
+    policy_path = repo_root / ASSURANCE_POLICY_RELATIVE_PATH
+    if not policy_path.is_file():
+        return [
+            _fail(
+                "assurance-policy-missing",
+                f"assurance policy not found: {ASSURANCE_POLICY_RELATIVE_PATH}",
+                ASSURANCE_POLICY_RELATIVE_PATH,
+            )
+        ]
+
+    try:
+        raw = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [
+            _fail(
+                "assurance-policy-parse",
+                f"failed to parse {ASSURANCE_POLICY_RELATIVE_PATH}: {exc}",
+                ASSURANCE_POLICY_RELATIVE_PATH,
+            )
+        ]
+
+    if not isinstance(raw, dict):
+        return [
+            _fail(
+                "assurance-policy-shape",
+                f"{ASSURANCE_POLICY_RELATIVE_PATH} must be a YAML mapping at the top level",
+                ASSURANCE_POLICY_RELATIVE_PATH,
+            )
+        ]
+
+    failures: list[PolicyFailure] = []
+    failures.extend(_check_top_level_fields(raw, ASSURANCE_POLICY_RELATIVE_PATH))
+    failures.extend(_check_refs(raw, ASSURANCE_POLICY_RELATIVE_PATH))
+
+    raw_levels = raw.get("levels")
+    levels: list[Any] = raw_levels if isinstance(raw_levels, list) else []
+    # _check_levels runs even when levels is empty or missing, so the
+    # missing-canonical-level failures fire instead of getting silently
+    # skipped.
+    failures.extend(_check_levels(levels, ASSURANCE_POLICY_RELATIVE_PATH))
+
+    # ADR-007 is IMMUTABLE per the ADR README; it must mention the baseline
+    # FM0..FM3 ladder it codifies, and nothing more. Future FM4+ levels flow
+    # through to the mutable docs only.
+    baseline_targets = _baseline_drift_targets(levels)
+    extended_targets = _drift_targets(levels) if levels else baseline_targets
+    if not extended_targets or not any(name for _id, name in extended_targets):
+        extended_targets = baseline_targets
+
+    failures.extend(
+        _check_doc_drift(
+            repo_root,
+            ADR_POLICY_RELATIVE_PATH,
+            "assurance-policy-adr-missing",
+            "assurance-policy-adr-drift",
+            baseline_targets,
+        )
+    )
+    failures.extend(
+        _check_doc_drift(
+            repo_root,
+            CODING_STANDARDS_RELATIVE_PATH,
+            "assurance-policy-coding-standards-missing",
+            "assurance-policy-coding-standards-drift",
+            extended_targets,
+        )
+    )
+    failures.extend(
+        _check_doc_drift(
+            repo_root,
+            FORMAL_OVERVIEW_RELATIVE_PATH,
+            "assurance-policy-formal-overview-missing",
+            "assurance-policy-formal-overview-drift",
+            extended_targets,
+        )
+    )
+
+    # Artifact-keyword drift -- applies only to MUTABLE docs. A doc that drops
+    # mention of an artifact category that the YAML still requires fails the
+    # gate; readers cannot be told a stale story.
+    required_artifacts = _required_artifact_union(levels)
+    failures.extend(
+        _check_artifact_keyword_drift(
+            repo_root,
+            CODING_STANDARDS_RELATIVE_PATH,
+            "assurance-policy-coding-standards-drift",
+            required_artifacts,
+        )
+    )
+    failures.extend(
+        _check_artifact_keyword_drift(
+            repo_root,
+            FORMAL_OVERVIEW_RELATIVE_PATH,
+            "assurance-policy-formal-overview-drift",
+            required_artifacts,
+        )
+    )
+
+    return failures
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate the ASR-505 classification-based assurance policy (ADR-007 / ADR-018)."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to the repo containing this file).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_assurance_policy(args.repo_root)
+    exceptions_file = args.repo_root / "tools" / "policy" / "exceptions.yaml"
+    if exceptions_file.is_file():
+        failures = apply_exceptions(failures, load_exceptions(args.repo_root))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Codifies the FM0/FM1/FM2/FM3 classification ladder ADR-007 defines in prose as a single machine-readable canonical artifact (`specs/formal/assurance-policy.yaml`) governed by a new ADR-018, with a CI-wired structural gate (`tools/check_assurance_policy.py`) that pins YAML shape, per-level required-artifact floor, proportionality, category-to-level binding, and drift across the three downstream docs (immutable ADR-007 by the baseline ladder only; mutable `coding-standards.md` and `docs/specs/formal.md` by the full extended set plus required-artifact keyword presence and paired id↔name co-location). The validator catches the exact drift mode that motivated this work — `docs/specs/formal.md` had previously labeled FM2 "Dynamic Semantic Rules" and FM3 "Cross-System Contracts" while ADR-007 named them "Semantic Graph / Constraint" and "Stateful / Control Semantics" — and the realignment of `formal.md` to ADR-007's level names lands in the same PR. ASR-505 transitions DRAFT → ACTIVE in Ground Control once this merges.

## Requirement UIDs

- `ASR-505`

## Related Issues

Closes #68

## ADR Impact

- ADR-018

## Changes

- Add `specs/formal/assurance-policy.yaml` — canonical machine-readable mapping per ADR-009, naming ASR-505 in `requirement_refs`, ADR-007 and ADR-018 in `adr_refs`, and enumerating each FM level's `id`, `name`, `scope`, `change_categories`, `required_artifacts`, and (for FM0/FM3) `prohibited_artifacts` / `recommended_artifacts`.
- Add `tools/check_assurance_policy.py` — `PolicyFailure`-shaped validator (matches the existing `check_repo_policy.py` / `check_semantic_coverage.py` pattern, supports `--json` and `tools/policy/exceptions.yaml` waivers). Enforces: YAML shape (required keys, strict-string sequence elements, unique level ids), per-level required-artifact floor sourced from ADR-007, required/prohibited disjointness, FM-numbered ordering across the whole ladder (handles future FM4+), consecutive-pair proportionality (FM0 ⊆ FM1 ⊆ FM2 ⊆ FM3 ⊆ …), category-to-level binding pinning each ASR-505 word to its level, and drift guards against ADR-007 (baseline FM0..FM3 only, because ADR-007 is immutable), `coding-standards.md`, and `docs/specs/formal.md` (full extended ladder + required-artifact keyword presence + paired id↔name co-location).
- Add `docs/decisions/adrs/adr-018-classification-based-assurance-policy.md` — the canonical-seam decision; sits alongside (does not supersede) ADR-007. Register ADR-018 in the ADR index.
- Add `implementations/python/tests/test_assurance_policy.py` — 57 pytest cases covering positive case, every failure rule, FM4 extension path, drift modes (id-only, name-only, swapped id↔name pair, artifact keyword missing), and ADR-007 immutability boundary.
- Wire the validator into `noxfile.py`'s `policy` session (and via that into `verify`, `hook-pre-commit` staged-skip, `hook-pre-push`, and `TARGETED_POLICY_TESTS`).
- Realign `docs/specs/formal.md` to ADR-007's canonical level names ('Static Semantic', 'Semantic Graph / Constraint', 'Stateful / Control Semantics'), add the property-based / differential testing required-artifact phrase for FM2, and point at the canonical YAML.
- Update `docs/explain/reference/coding-standards.md` to point at the canonical YAML, fix the pre-existing broken relative ADR link (`../adrs/...` → `../../decisions/adrs/...`), and add the same fix to the new ADR-018 link.
- Update `specs/formal/README.md` to reference the canonical YAML and ADR-018.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `nox -s verify` is green (hygiene, policy including the new `policy / assurance policy ADR` stage, lint, contracts, full pytest sweep, docs).
- `implementations/python/.venv/bin/python tools/check_assurance_policy.py` is clean against the real repo.
- 57 unit tests in `test_assurance_policy.py` exercise the positive case, every failure rule, the FM4 extension path, the four drift modes, and the ADR-007 immutability boundary.
- Pre-push reviews recorded as decision records on the issue thread (see #68): three review cycles surfaced 14 production-readiness findings total across the validator and tests; each was fixed in-PR, and one test-quality cycle surfaced 2 assertion-strength warnings, both fixed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-505 ← specs/formal/assurance-policy.yaml, ASR-505 ← tools/check_assurance_policy.py, ASR-505 ← docs/decisions/adrs/adr-018-classification-based-assurance-policy.md, ASR-505 ← docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md (pre-existing policy decision)
- TESTS: ASR-505 ← implementations/python/tests/test_assurance_policy.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/68.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed