### PR TITLE
feat: add typed SDL runtime surfaces

### DIFF
--- a/changelog.d/354.added.md
+++ b/changelog.d/354.added.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added typed SDL node runtime metadata for mounts, local control interfaces, process identity, package inventory, dependency manifests, and scanner-derived package vulnerability findings.

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -1250,6 +1250,17 @@
           "title": "Roles",
           "type": "object"
         },
+        "runtime": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "services": {
           "items": {
             "$ref": "#/$defs/ServicePort"
@@ -2244,6 +2255,407 @@
         "username"
       ],
       "title": "Role",
+      "type": "object"
+    },
+    "RuntimeConfiguration": {
+      "additionalProperties": false,
+      "description": "Observed runtime configuration facts attached to a VM node.",
+      "properties": {
+        "dependency_manifests": {
+          "items": {
+            "$ref": "#/$defs/RuntimeDependencyManifest"
+          },
+          "title": "Dependency Manifests",
+          "type": "array"
+        },
+        "local_control_interfaces": {
+          "items": {
+            "$ref": "#/$defs/RuntimeControlInterface"
+          },
+          "title": "Local Control Interfaces",
+          "type": "array"
+        },
+        "mounts": {
+          "items": {
+            "$ref": "#/$defs/RuntimeMount"
+          },
+          "title": "Mounts",
+          "type": "array"
+        },
+        "package_vulnerabilities": {
+          "items": {
+            "$ref": "#/$defs/RuntimePackageVulnerabilityFinding"
+          },
+          "title": "Package Vulnerabilities",
+          "type": "array"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/$defs/RuntimePackage"
+          },
+          "title": "Packages",
+          "type": "array"
+        },
+        "process": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeProcessIdentity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "RuntimeConfiguration",
+      "type": "object"
+    },
+    "RuntimeControlInterface": {
+      "additionalProperties": false,
+      "description": "A non-network local control API exposed inside a runtime node.",
+      "properties": {
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeControlInterfaceAccess"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Access"
+        },
+        "bind_source": {
+          "default": "",
+          "title": "Bind Source",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeControlInterfaceKind"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unix_socket",
+          "title": "Kind"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "protocol": {
+          "default": "",
+          "title": "Protocol",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "RuntimeControlInterface",
+      "type": "object"
+    },
+    "RuntimeControlInterfaceAccess": {
+      "description": "Observed local-control access mode.",
+      "enum": [
+        "read_only",
+        "read_write",
+        "unknown"
+      ],
+      "title": "RuntimeControlInterfaceAccess",
+      "type": "string"
+    },
+    "RuntimeControlInterfaceKind": {
+      "description": "Path-local control interface shape observed at runtime.",
+      "enum": [
+        "unix_socket",
+        "named_pipe",
+        "file",
+        "other"
+      ],
+      "title": "RuntimeControlInterfaceKind",
+      "type": "string"
+    },
+    "RuntimeDependencyManifest": {
+      "additionalProperties": false,
+      "description": "A dependency manifest visible in the realized runtime artifact.",
+      "properties": {
+        "ecosystem": {
+          "title": "Ecosystem",
+          "type": "string"
+        },
+        "format": {
+          "default": "",
+          "title": "Format",
+          "type": "string"
+        },
+        "name": {
+          "default": "",
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "version": {
+          "default": "",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ecosystem",
+        "path"
+      ],
+      "title": "RuntimeDependencyManifest",
+      "type": "object"
+    },
+    "RuntimeMount": {
+      "additionalProperties": false,
+      "description": "A filesystem mount observed on a runtime node.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Options",
+          "type": "array"
+        },
+        "read_only": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "title": "Read Only"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "source_kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeMountSourceKind"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "other",
+          "title": "Source Kind"
+        },
+        "target": {
+          "title": "Target",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "title": "RuntimeMount",
+      "type": "object"
+    },
+    "RuntimeMountSourceKind": {
+      "description": "Portable source kind for a runtime filesystem mount.",
+      "enum": [
+        "volume",
+        "bind",
+        "tmpfs",
+        "image",
+        "other"
+      ],
+      "title": "RuntimeMountSourceKind",
+      "type": "string"
+    },
+    "RuntimePackage": {
+      "additionalProperties": false,
+      "description": "A package observed in a runtime image or node.",
+      "properties": {
+        "architecture": {
+          "default": "",
+          "title": "Architecture",
+          "type": "string"
+        },
+        "manager": {
+          "title": "Manager",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "purl": {
+          "default": "",
+          "title": "Purl",
+          "type": "string"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manager",
+        "name",
+        "version"
+      ],
+      "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageVulnerabilityFinding": {
+      "additionalProperties": false,
+      "description": "A scanner-derived CVE/advisory finding for an observed package.",
+      "properties": {
+        "advisory_url": {
+          "default": "",
+          "title": "Advisory Url",
+          "type": "string"
+        },
+        "fixed_version": {
+          "default": "",
+          "title": "Fixed Version",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "image_digest": {
+          "title": "Image Digest",
+          "type": "string"
+        },
+        "installed_version": {
+          "title": "Installed Version",
+          "type": "string"
+        },
+        "package_name": {
+          "title": "Package Name",
+          "type": "string"
+        },
+        "scan_time": {
+          "title": "Scan Time",
+          "type": "string"
+        },
+        "scanner": {
+          "title": "Scanner",
+          "type": "string"
+        },
+        "scanner_database": {
+          "default": "",
+          "title": "Scanner Database",
+          "type": "string"
+        },
+        "scanner_version": {
+          "default": "",
+          "title": "Scanner Version",
+          "type": "string"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimePackageVulnerabilitySeverity"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Severity"
+        }
+      },
+      "required": [
+        "id",
+        "package_name",
+        "installed_version",
+        "scanner",
+        "image_digest",
+        "scan_time"
+      ],
+      "title": "RuntimePackageVulnerabilityFinding",
+      "type": "object"
+    },
+    "RuntimePackageVulnerabilitySeverity": {
+      "description": "Scanner-derived package finding severity.",
+      "enum": [
+        "unknown",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "title": "RuntimePackageVulnerabilitySeverity",
+      "type": "string"
+    },
+    "RuntimeProcessIdentity": {
+      "additionalProperties": false,
+      "description": "Observed process identity for a runtime node.",
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Command",
+          "type": "array"
+        },
+        "group": {
+          "default": "",
+          "title": "Group",
+          "type": "string"
+        },
+        "pid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pid"
+        },
+        "user": {
+          "default": "",
+          "title": "User",
+          "type": "string"
+        },
+        "working_directory": {
+          "default": "",
+          "title": "Working Directory",
+          "type": "string"
+        }
+      },
+      "title": "RuntimeProcessIdentity",
       "type": "object"
     },
     "Script": {

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -1250,6 +1250,17 @@
           "title": "Roles",
           "type": "object"
         },
+        "runtime": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "services": {
           "items": {
             "$ref": "#/$defs/ServicePort"
@@ -2244,6 +2255,407 @@
         "username"
       ],
       "title": "Role",
+      "type": "object"
+    },
+    "RuntimeConfiguration": {
+      "additionalProperties": false,
+      "description": "Observed runtime configuration facts attached to a VM node.",
+      "properties": {
+        "dependency_manifests": {
+          "items": {
+            "$ref": "#/$defs/RuntimeDependencyManifest"
+          },
+          "title": "Dependency Manifests",
+          "type": "array"
+        },
+        "local_control_interfaces": {
+          "items": {
+            "$ref": "#/$defs/RuntimeControlInterface"
+          },
+          "title": "Local Control Interfaces",
+          "type": "array"
+        },
+        "mounts": {
+          "items": {
+            "$ref": "#/$defs/RuntimeMount"
+          },
+          "title": "Mounts",
+          "type": "array"
+        },
+        "package_vulnerabilities": {
+          "items": {
+            "$ref": "#/$defs/RuntimePackageVulnerabilityFinding"
+          },
+          "title": "Package Vulnerabilities",
+          "type": "array"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/$defs/RuntimePackage"
+          },
+          "title": "Packages",
+          "type": "array"
+        },
+        "process": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeProcessIdentity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "RuntimeConfiguration",
+      "type": "object"
+    },
+    "RuntimeControlInterface": {
+      "additionalProperties": false,
+      "description": "A non-network local control API exposed inside a runtime node.",
+      "properties": {
+        "access": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeControlInterfaceAccess"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Access"
+        },
+        "bind_source": {
+          "default": "",
+          "title": "Bind Source",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeControlInterfaceKind"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unix_socket",
+          "title": "Kind"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "protocol": {
+          "default": "",
+          "title": "Protocol",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "RuntimeControlInterface",
+      "type": "object"
+    },
+    "RuntimeControlInterfaceAccess": {
+      "description": "Observed local-control access mode.",
+      "enum": [
+        "read_only",
+        "read_write",
+        "unknown"
+      ],
+      "title": "RuntimeControlInterfaceAccess",
+      "type": "string"
+    },
+    "RuntimeControlInterfaceKind": {
+      "description": "Path-local control interface shape observed at runtime.",
+      "enum": [
+        "unix_socket",
+        "named_pipe",
+        "file",
+        "other"
+      ],
+      "title": "RuntimeControlInterfaceKind",
+      "type": "string"
+    },
+    "RuntimeDependencyManifest": {
+      "additionalProperties": false,
+      "description": "A dependency manifest visible in the realized runtime artifact.",
+      "properties": {
+        "ecosystem": {
+          "title": "Ecosystem",
+          "type": "string"
+        },
+        "format": {
+          "default": "",
+          "title": "Format",
+          "type": "string"
+        },
+        "name": {
+          "default": "",
+          "title": "Name",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "version": {
+          "default": "",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ecosystem",
+        "path"
+      ],
+      "title": "RuntimeDependencyManifest",
+      "type": "object"
+    },
+    "RuntimeMount": {
+      "additionalProperties": false,
+      "description": "A filesystem mount observed on a runtime node.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Options",
+          "type": "array"
+        },
+        "read_only": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "title": "Read Only"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "source_kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeMountSourceKind"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "other",
+          "title": "Source Kind"
+        },
+        "target": {
+          "title": "Target",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "title": "RuntimeMount",
+      "type": "object"
+    },
+    "RuntimeMountSourceKind": {
+      "description": "Portable source kind for a runtime filesystem mount.",
+      "enum": [
+        "volume",
+        "bind",
+        "tmpfs",
+        "image",
+        "other"
+      ],
+      "title": "RuntimeMountSourceKind",
+      "type": "string"
+    },
+    "RuntimePackage": {
+      "additionalProperties": false,
+      "description": "A package observed in a runtime image or node.",
+      "properties": {
+        "architecture": {
+          "default": "",
+          "title": "Architecture",
+          "type": "string"
+        },
+        "manager": {
+          "title": "Manager",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "purl": {
+          "default": "",
+          "title": "Purl",
+          "type": "string"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "manager",
+        "name",
+        "version"
+      ],
+      "title": "RuntimePackage",
+      "type": "object"
+    },
+    "RuntimePackageVulnerabilityFinding": {
+      "additionalProperties": false,
+      "description": "A scanner-derived CVE/advisory finding for an observed package.",
+      "properties": {
+        "advisory_url": {
+          "default": "",
+          "title": "Advisory Url",
+          "type": "string"
+        },
+        "fixed_version": {
+          "default": "",
+          "title": "Fixed Version",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "image_digest": {
+          "title": "Image Digest",
+          "type": "string"
+        },
+        "installed_version": {
+          "title": "Installed Version",
+          "type": "string"
+        },
+        "package_name": {
+          "title": "Package Name",
+          "type": "string"
+        },
+        "scan_time": {
+          "title": "Scan Time",
+          "type": "string"
+        },
+        "scanner": {
+          "title": "Scanner",
+          "type": "string"
+        },
+        "scanner_database": {
+          "default": "",
+          "title": "Scanner Database",
+          "type": "string"
+        },
+        "scanner_version": {
+          "default": "",
+          "title": "Scanner Version",
+          "type": "string"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimePackageVulnerabilitySeverity"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Severity"
+        }
+      },
+      "required": [
+        "id",
+        "package_name",
+        "installed_version",
+        "scanner",
+        "image_digest",
+        "scan_time"
+      ],
+      "title": "RuntimePackageVulnerabilityFinding",
+      "type": "object"
+    },
+    "RuntimePackageVulnerabilitySeverity": {
+      "description": "Scanner-derived package finding severity.",
+      "enum": [
+        "unknown",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "title": "RuntimePackageVulnerabilitySeverity",
+      "type": "string"
+    },
+    "RuntimeProcessIdentity": {
+      "additionalProperties": false,
+      "description": "Observed process identity for a runtime node.",
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Command",
+          "type": "array"
+        },
+        "group": {
+          "default": "",
+          "title": "Group",
+          "type": "string"
+        },
+        "pid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pid"
+        },
+        "user": {
+          "default": "",
+          "title": "User",
+          "type": "string"
+        },
+        "working_directory": {
+          "default": "",
+          "title": "Working Directory",
+          "type": "string"
+        }
+      },
+      "title": "RuntimeProcessIdentity",
       "type": "object"
     },
     "Script": {

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -85,13 +85,46 @@ nodes:
         name: http
       - port: 443
         name: https
+    runtime:                            # observed runtime configuration facts
+      mounts:
+        - target: /shuffle-database
+          source: aptl_shuffle_data
+          source_kind: volume
+      local_control_interfaces:
+        - path: /run/docker.sock
+          kind: unix_socket
+          protocol: docker
+          bind_source: /var/run/docker.sock
+          access: read_write
+      process:
+        pid: 1
+        command: ./shufflebackend
+        user: root
+        working_directory: /app
+      packages:
+        - manager: apk
+          name: musl
+          version: 1.2.4-r2
+      dependency_manifests:
+        - ecosystem: go
+          path: /app/go.mod
+          format: go-module
+      package_vulnerabilities:
+        - id: CVE-2026-12345
+          package_name: musl
+          installed_version: 1.2.4-r2
+          fixed_version: 1.2.5-r0
+          severity: high
+          scanner: trivy
+          image_digest: sha256:abc123
+          scan_time: "2026-05-20T12:00:00Z"
     asset_value:                        # CIA triad (from CybORG)
       confidentiality: high
       integrity: medium
       availability: critical
 ```
 
-**Switch** nodes are pure connectivity objects. They may define `type` and an optional `description`, but `source`, `resources`, `os`, `os_version`, `features`, `conditions`, `injects`, `vulnerabilities`, `roles`, `services`, and `asset_value` are rejected.
+**Switch** nodes are pure connectivity objects. They may define `type` and an optional `description`, but `source`, `resources`, `os`, `os_version`, `features`, `conditions`, `injects`, `vulnerabilities`, `roles`, `services`, `asset_value`, and `runtime` are rejected.
 
 For **VM** nodes, `resources` remain optional at the SDL layer to preserve abstract specifications, but a VM without `resources` emits a non-fatal advisory because many deployment backends will need explicit sizing or well-defined defaults.
 
@@ -100,6 +133,16 @@ For **VM** nodes, `resources` remain optional at the SDL layer to preserve abstr
 When `features`, `conditions`, or `injects` use the `{name: role}` form, the role must be declared in the node's `roles` map.
 
 Concrete service bindings on a VM must be unique by `protocol` + `port`. Reusing `53/tcp` and `53/udp` is valid; declaring `443/tcp` twice on the same node is rejected. If a service binding also has a `name`, that `name` must be unique within the node and can be targeted directly as `nodes.<node>.services.<service_name>`.
+
+`runtime` captures observed VM/runtime facts that are not authored deployable
+features or exposed network services. Mounts describe realized filesystem
+attachments; `local_control_interfaces` describe path-local control APIs such
+as Unix sockets; `process` records execution identity; `packages` and
+`dependency_manifests` record runtime inventory; and
+`package_vulnerabilities` records scanner-derived CVE/advisory findings tied
+to an image digest and scan time. These findings are separate from the
+top-level `vulnerabilities` section, which remains the CWE-classified scenario
+vulnerability surface.
 
 ---
 

--- a/docs/explain/sdl/validation.md
+++ b/docs/explain/sdl/validation.md
@@ -43,6 +43,13 @@ becoming a validator-only interpretation of the SDL.
 | `verify_workflows` | Workflow `start` and every referenced step must exist. `objective`/`retry` steps must reference declared objectives. Predicate refs must resolve to declared conditions/metrics/evaluations/TLOs/goals/objectives, and step-state refs must resolve to prior executable steps whose state is guaranteed to be known before the predicate runs. Workflow graphs must be acyclic and fully reachable from `start`. Parallel joins must be explicit barriers, every explicit branch path must converge on the declared join, branch-local state remains scoped until the join, and post-join predicates may inspect only branch steps guaranteed on every path within their branch before the join. |
 | `verify_variables` | Checks that full-value `${var}` placeholders reference declared variables. Structural validation of typed defaults and `allowed_values` still happens in the `Variable` model itself. |
 
+Pydantic structural validation also enforces model-local node rules before
+these semantic passes run. Switch nodes reject VM-only fields, including
+`runtime`. Runtime mount and dependency-manifest paths must be absolute paths
+or variable references. Runtime local-control interface paths and bind sources
+must be absolute paths, Windows named pipe endpoints, or variable references;
+Windows named pipe endpoints require `kind: named_pipe`.
+
 When a field contains an unresolved `${var}` placeholder, reference-oriented
 passes treat it as deferred rather than as a broken concrete reference. The
 validator still does not substitute values; the later repo-owned instantiation
@@ -54,9 +61,12 @@ compiler performs additional fail-closed binding checks, including node-local
 feature dependency enforcement and bound-resource reference resolution.
 
 This also means the validator only enforces what the current SDL syntax can
-actually express. Broader ecosystem concerns such as participant-implementation
-manifests, decision-surface exposure policy contracts, augmentation disclosure,
-and full evidence-capture contract surfaces are separate validation domains.
+actually express. Node `runtime` metadata covers observed VM configuration
+facts such as mounts, path-local control interfaces, process identity, runtime
+package inventory, dependency manifests, and scanner-derived package findings.
+Broader ecosystem concerns such as participant-implementation manifests,
+decision-surface exposure policy contracts, augmentation disclosure, and full
+evidence-capture contract surfaces are separate validation domains.
 They should not be retrofitted into validator-only behavior before the authored
 surface or external contracts exist.
 

--- a/implementations/python/packages/aces_sdl/nodes.py
+++ b/implementations/python/packages/aces_sdl/nodes.py
@@ -13,6 +13,7 @@ from ._base import (
     SDLModel,
     is_variable_ref,
     normalize_enum_value,
+    parse_bool_or_var,
     parse_enum_or_var,
     parse_int_or_var,
 )
@@ -36,6 +37,46 @@ _RAM_PATTERN = re.compile(
     r"^\s*(\d+(?:\.\d+)?)\s*(" + "|".join(_BYTE_UNITS) + r")\s*$",
     re.IGNORECASE,
 )
+_WINDOWS_NAMED_PIPE_PREFIXES = ("\\\\.\\pipe\\", "\\\\?\\pipe\\")
+
+
+def _absolute_path_or_var(value: str, *, field_name: str) -> str:
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if not value.startswith("/"):
+        raise ValueError(f"{field_name} must be an absolute path")
+    return value
+
+
+def _is_windows_named_pipe(value: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(_WINDOWS_NAMED_PIPE_PREFIXES)
+
+
+def _control_interface_path_or_var(value: str, *, field_name: str) -> str:
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if value.startswith("/") or _is_windows_named_pipe(value):
+        return value
+    raise ValueError(f"{field_name} must be an absolute path or Windows named pipe")
+
+
+def _parse_runtime_enum_or_var(value, enum_cls: type[Enum], *, field_name: str):
+    if value is None or is_variable_ref(value):
+        return value
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, str):
+        normalized = value.lower().replace("-", "_")
+        try:
+            return enum_cls(normalized)
+        except ValueError as e:
+            allowed = ", ".join(member.value for member in enum_cls)
+            raise ValueError(f"{field_name} must be one of: {allowed}") from e
+    raise ValueError(f"{field_name} must be a string")
 
 
 def parse_ram(value: str | int) -> int | str:
@@ -163,6 +204,199 @@ class ServicePort(SDLModel):
         return parse_int_or_var(v, minimum=1, maximum=65535, field_name="port")
 
 
+class RuntimeMountSourceKind(str, Enum):
+    """Portable source kind for a runtime filesystem mount."""
+
+    VOLUME = "volume"
+    BIND = "bind"
+    TMPFS = "tmpfs"
+    IMAGE = "image"
+    OTHER = "other"
+
+
+class RuntimeControlInterfaceKind(str, Enum):
+    """Path-local control interface shape observed at runtime."""
+
+    UNIX_SOCKET = "unix_socket"
+    NAMED_PIPE = "named_pipe"
+    FILE = "file"
+    OTHER = "other"
+
+
+class RuntimeControlInterfaceAccess(str, Enum):
+    """Observed local-control access mode."""
+
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+    UNKNOWN = "unknown"
+
+
+class RuntimePackageVulnerabilitySeverity(str, Enum):
+    """Scanner-derived package finding severity."""
+
+    UNKNOWN = "unknown"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class RuntimeMount(SDLModel):
+    """A filesystem mount observed on a runtime node."""
+
+    target: str
+    source: str = ""
+    source_kind: RuntimeMountSourceKind | str = RuntimeMountSourceKind.OTHER
+    read_only: bool | str = False
+    options: list[str] = Field(default_factory=list)
+    description: str = ""
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="target")
+
+    @field_validator("source_kind", mode="before")
+    @classmethod
+    def normalize_source_kind(cls, v: RuntimeMountSourceKind | str) -> RuntimeMountSourceKind | str:
+        return _parse_runtime_enum_or_var(v, RuntimeMountSourceKind, field_name="source_kind")
+
+    @field_validator("read_only", mode="before")
+    @classmethod
+    def parse_read_only(cls, v: bool | str) -> bool | str:
+        return parse_bool_or_var(v, field_name="read_only")
+
+
+class RuntimeControlInterface(SDLModel):
+    """A non-network local control API exposed inside a runtime node."""
+
+    path: str
+    kind: RuntimeControlInterfaceKind | str = RuntimeControlInterfaceKind.UNIX_SOCKET
+    protocol: str = ""
+    bind_source: str = ""
+    access: RuntimeControlInterfaceAccess | str = RuntimeControlInterfaceAccess.UNKNOWN
+    description: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        return _control_interface_path_or_var(v, field_name="path")
+
+    @field_validator("bind_source")
+    @classmethod
+    def validate_bind_source(cls, v: str) -> str:
+        return _control_interface_path_or_var(v, field_name="bind_source") if v else v
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def normalize_kind(cls, v: RuntimeControlInterfaceKind | str) -> RuntimeControlInterfaceKind | str:
+        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceKind, field_name="kind")
+
+    @field_validator("access", mode="before")
+    @classmethod
+    def normalize_access(cls, v: RuntimeControlInterfaceAccess | str) -> RuntimeControlInterfaceAccess | str:
+        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceAccess, field_name="access")
+
+    @model_validator(mode="after")
+    def validate_named_pipe_kind(self) -> "RuntimeControlInterface":
+        if is_variable_ref(self.kind):
+            return self
+        has_windows_named_pipe_endpoint = _is_windows_named_pipe(self.path) or _is_windows_named_pipe(self.bind_source)
+        if has_windows_named_pipe_endpoint and self.kind != RuntimeControlInterfaceKind.NAMED_PIPE:
+            raise ValueError("Windows named pipe paths require kind 'named_pipe'")
+        return self
+
+
+class RuntimeProcessIdentity(SDLModel):
+    """Observed process identity for a runtime node."""
+
+    pid: int | str | None = None
+    command: list[str] = Field(default_factory=list)
+    user: str = ""
+    group: str = ""
+    working_directory: str = ""
+
+    @field_validator("pid", mode="before")
+    @classmethod
+    def parse_pid(cls, v: int | str | None) -> int | str | None:
+        return parse_int_or_var(v, minimum=1, field_name="pid") if v is not None else v
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def normalize_command(cls, v: str | list[str] | None) -> list[str]:
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [v]
+        return v
+
+    @field_validator("working_directory")
+    @classmethod
+    def validate_working_directory(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="working_directory") if v else v
+
+
+class RuntimePackage(SDLModel):
+    """A package observed in a runtime image or node."""
+
+    manager: str
+    name: str
+    version: str
+    architecture: str = ""
+    source: str = ""
+    purl: str = ""
+
+
+class RuntimeDependencyManifest(SDLModel):
+    """A dependency manifest visible in the realized runtime artifact."""
+
+    ecosystem: str
+    path: str
+    format: str = ""
+    name: str = ""
+    version: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="path")
+
+
+class RuntimePackageVulnerabilityFinding(SDLModel):
+    """A scanner-derived CVE/advisory finding for an observed package."""
+
+    id: str
+    package_name: str
+    installed_version: str
+    severity: RuntimePackageVulnerabilitySeverity | str = RuntimePackageVulnerabilitySeverity.UNKNOWN
+    scanner: str
+    image_digest: str
+    scan_time: str
+    fixed_version: str = ""
+    advisory_url: str = ""
+    scanner_version: str = ""
+    scanner_database: str = ""
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def normalize_severity(
+        cls,
+        v: RuntimePackageVulnerabilitySeverity | str,
+    ) -> RuntimePackageVulnerabilitySeverity | str:
+        return _parse_runtime_enum_or_var(v, RuntimePackageVulnerabilitySeverity, field_name="severity")
+
+
+class RuntimeConfiguration(SDLModel):
+    """Observed runtime configuration facts attached to a VM node."""
+
+    mounts: list[RuntimeMount] = Field(default_factory=list)
+    local_control_interfaces: list[RuntimeControlInterface] = Field(default_factory=list)
+    process: RuntimeProcessIdentity | None = None
+    packages: list[RuntimePackage] = Field(default_factory=list)
+    dependency_manifests: list[RuntimeDependencyManifest] = Field(default_factory=list)
+    package_vulnerabilities: list[RuntimePackageVulnerabilityFinding] = Field(default_factory=list)
+
+
 class Node(SDLModel):
     """A scenario node — either a VM or a Switch.
 
@@ -189,6 +423,7 @@ class Node(SDLModel):
     roles: dict[str, Role] = Field(default_factory=dict)
     services: list[ServicePort] = Field(default_factory=list)
     asset_value: AssetValue | None = None
+    runtime: RuntimeConfiguration | None = None
 
     @field_validator("os", mode="before")
     @classmethod
@@ -198,33 +433,30 @@ class Node(SDLModel):
     @model_validator(mode="after")
     def validate_type_constraints(self) -> "Node":
         """Switch nodes cannot carry VM-only fields."""
-        if self.type == NodeType.SWITCH:
-            disallowed_fields: list[str] = []
-            if self.source is not None:
-                disallowed_fields.append("source")
-            if self.resources is not None:
-                disallowed_fields.append("resources")
-            if self.os is not None:
-                disallowed_fields.append("os")
-            if self.os_version:
-                disallowed_fields.append("os_version")
-            if self.features:
-                disallowed_fields.append("features")
-            if self.conditions:
-                disallowed_fields.append("conditions")
-            if self.injects:
-                disallowed_fields.append("injects")
-            if self.vulnerabilities:
-                disallowed_fields.append("vulnerabilities")
-            if self.roles:
-                disallowed_fields.append("roles")
-            if self.services:
-                disallowed_fields.append("services")
-            if self.asset_value is not None:
-                disallowed_fields.append("asset_value")
-            if disallowed_fields:
-                raise ValueError("Switch nodes cannot have VM-only fields: " + ", ".join(disallowed_fields))
+        if self.type != NodeType.SWITCH:
+            return self
+
+        disallowed_fields = self._populated_vm_only_fields()
+        if disallowed_fields:
+            raise ValueError("Switch nodes cannot have VM-only fields: " + ", ".join(disallowed_fields))
         return self
+
+    def _populated_vm_only_fields(self) -> list[str]:
+        fields = {
+            "source": self.source is not None,
+            "resources": self.resources is not None,
+            "os": self.os is not None,
+            "os_version": bool(self.os_version),
+            "features": bool(self.features),
+            "conditions": bool(self.conditions),
+            "injects": bool(self.injects),
+            "vulnerabilities": bool(self.vulnerabilities),
+            "roles": bool(self.roles),
+            "services": bool(self.services),
+            "asset_value": self.asset_value is not None,
+            "runtime": self.runtime is not None,
+        }
+        return [field_name for field_name, is_populated in fields.items() if is_populated]
 
     @model_validator(mode="after")
     def validate_unique_service_ports(self) -> "Node":

--- a/implementations/python/packages/aces_sdl/parser.py
+++ b/implementations/python/packages/aces_sdl/parser.py
@@ -184,8 +184,8 @@ def _expand_min_score(value: Any) -> Any:
 
 def _expand_shorthands(data: dict[str, Any]) -> dict[str, Any]:
     """Apply all shorthand expansions to normalized data."""
-    # Sections where "source" is a plain string reference, NOT a Source package.
-    _SOURCE_SKIP_SECTIONS = frozenset({"relationships", "agents", "imports"})
+    # Scopes where "source" is a plain string reference, NOT a Source package.
+    _SOURCE_SKIP_SECTIONS = frozenset({"relationships", "agents", "imports", "runtime"})
 
     def expand_sources_scoped(
         obj: Any,

--- a/implementations/python/tests/test_runtime_models.py
+++ b/implementations/python/tests/test_runtime_models.py
@@ -48,6 +48,60 @@ features:
         assert model.feature_bindings["provision.feature.vm1.nginx"].node_name == "vm1"
         assert model.feature_bindings["provision.feature.vm2.nginx"].node_name == "vm2"
 
+    def test_node_runtime_preserves_runtime_configuration_metadata(self):
+        model = compile_runtime_model(
+            _scenario("""
+name: shuffle-runtime-inventory
+nodes:
+  shuffle-backend:
+    type: vm
+    os: linux
+    runtime:
+      mounts:
+        - target: /shuffle-database
+          source: aptl_shuffle_data
+          source-kind: volume
+      local-control-interfaces:
+        - path: /run/docker.sock
+          kind: unix-socket
+          protocol: docker
+          bind-source: /var/run/docker.sock
+          access: read-write
+      process:
+        pid: 1
+        command: ./shufflebackend
+        user: root
+        working-directory: /app
+      packages:
+        - manager: apk
+          name: musl
+          version: 1.2.4-r2
+      dependency-manifests:
+        - ecosystem: go
+          path: /app/go.mod
+          format: go-module
+      package-vulnerabilities:
+        - id: CVE-2026-12345
+          package-name: musl
+          installed-version: 1.2.4-r2
+          fixed-version: 1.2.5-r0
+          severity: high
+          scanner: trivy
+          image-digest: sha256:abc123
+          scan-time: "2026-05-20T12:00:00Z"
+""")
+        )
+
+        runtime = model.node_deployments["provision.node.shuffle-backend"].spec["node"]["runtime"]
+        assert runtime["mounts"][0]["target"] == "/shuffle-database"
+        assert runtime["local_control_interfaces"][0]["path"] == "/run/docker.sock"
+        assert runtime["process"]["pid"] == 1
+        assert runtime["process"]["command"] == ["./shufflebackend"]
+        assert runtime["packages"][0]["manager"] == "apk"
+        assert runtime["dependency_manifests"][0]["ecosystem"] == "go"
+        assert runtime["package_vulnerabilities"][0]["scanner"] == "trivy"
+        assert not model.diagnostics
+
     def test_feature_binding_tracks_same_node_dependencies(self):
         model = compile_runtime_model(
             _scenario("""

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -8,7 +8,17 @@ from aces.core.sdl.conditions import Condition
 from aces.core.sdl.entities import Entity, ExerciseRole, flatten_entities
 from aces.core.sdl.features import Feature, FeatureType
 from aces.core.sdl.infrastructure import ACLAction, ACLRule, InfraNode, SimpleProperties
-from aces.core.sdl.nodes import Node, NodeType, Resources, Role, parse_ram
+from aces.core.sdl.nodes import (
+    Node,
+    NodeType,
+    Resources,
+    Role,
+    RuntimeControlInterface,
+    RuntimeControlInterfaceAccess,
+    RuntimeControlInterfaceKind,
+    RuntimeMountSourceKind,
+    parse_ram,
+)
 from aces.core.sdl.objectives import Objective, ObjectiveSuccess, ObjectiveWindow
 from aces.core.sdl.orchestration import (
     Inject,
@@ -120,11 +130,112 @@ class TestNode:
             ("roles", {"admin": {"username": "root"}}),
             ("services", [{"port": 80, "name": "http"}]),
             ("asset_value", {"confidentiality": "high"}),
+            ("runtime", {"process": {"pid": 1, "command": "./shufflebackend"}}),
         ],
     )
     def test_switch_rejects_other_vm_only_fields(self, field_name, value):
         with pytest.raises(ValidationError, match=field_name):
             Node(type="switch", **{field_name: value})
+
+    def test_vm_runtime_configuration_surfaces(self):
+        n = Node(
+            type="vm",
+            runtime={
+                "mounts": [
+                    {
+                        "target": "/shuffle-database",
+                        "source": "aptl_shuffle_data",
+                        "source_kind": "volume",
+                    }
+                ],
+                "local_control_interfaces": [
+                    {
+                        "path": "/run/docker.sock",
+                        "kind": "unix_socket",
+                        "protocol": "docker",
+                        "bind_source": "/var/run/docker.sock:/var/run/docker.sock:rw",
+                        "access": "read_write",
+                    }
+                ],
+                "process": {
+                    "pid": 1,
+                    "command": "./shufflebackend",
+                    "user": "root",
+                    "working_directory": "/app",
+                },
+                "packages": [
+                    {
+                        "manager": "apk",
+                        "name": "musl",
+                        "version": "1.2.4-r2",
+                    }
+                ],
+                "dependency_manifests": [
+                    {
+                        "ecosystem": "go",
+                        "path": "/app/go.mod",
+                        "format": "go-module",
+                    }
+                ],
+                "package_vulnerabilities": [
+                    {
+                        "id": "CVE-2026-12345",
+                        "package_name": "musl",
+                        "installed_version": "1.2.4-r2",
+                        "fixed_version": "1.2.5-r0",
+                        "severity": "high",
+                        "scanner": "trivy",
+                        "image_digest": "sha256:abc123",
+                        "scan_time": "2026-05-20T12:00:00Z",
+                    }
+                ],
+            },
+        )
+
+        runtime = n.runtime
+        assert runtime is not None
+        assert runtime.mounts[0].target == "/shuffle-database"
+        assert runtime.mounts[0].source_kind == RuntimeMountSourceKind.VOLUME
+        assert runtime.local_control_interfaces[0].kind == RuntimeControlInterfaceKind.UNIX_SOCKET
+        assert runtime.local_control_interfaces[0].bind_source == "/var/run/docker.sock:/var/run/docker.sock:rw"
+        assert runtime.local_control_interfaces[0].access == RuntimeControlInterfaceAccess.READ_WRITE
+        assert runtime.process is not None
+        assert runtime.process.pid == 1
+        assert runtime.process.command == ["./shufflebackend"]
+        assert runtime.process.user == "root"
+        assert runtime.process.working_directory == "/app"
+        assert runtime.packages[0].manager == "apk"
+        assert runtime.dependency_manifests[0].ecosystem == "go"
+        assert runtime.package_vulnerabilities[0].scanner == "trivy"
+
+    @pytest.mark.parametrize(
+        ("runtime", "message"),
+        [
+            ({"mounts": [{"target": "shuffle-database", "source": "data"}]}, "target"),
+            ({"local_control_interfaces": [{"path": "run/docker.sock"}]}, "path"),
+            ({"process": {"pid": 0, "command": "./shufflebackend"}}, "pid"),
+            ({"process": {"working_directory": "app"}}, "working_directory"),
+            ({"dependency_manifests": [{"ecosystem": "go", "path": "go.mod"}]}, "path"),
+        ],
+    )
+    def test_runtime_configuration_rejects_invalid_runtime_anchors(self, runtime, message):
+        with pytest.raises(ValidationError, match=message):
+            Node(type="vm", runtime=runtime)
+
+    def test_runtime_control_interface_accepts_windows_named_pipe_path(self):
+        interface = RuntimeControlInterface(
+            path=r"\\.\pipe\docker_engine",
+            kind="named-pipe",
+            bind_source=r"\\.\pipe\docker_engine",
+        )
+
+        assert interface.path == r"\\.\pipe\docker_engine"
+        assert interface.kind == RuntimeControlInterfaceKind.NAMED_PIPE
+        assert interface.bind_source == r"\\.\pipe\docker_engine"
+
+    def test_runtime_control_interface_named_pipe_path_requires_named_pipe_kind(self):
+        with pytest.raises(ValidationError, match="named_pipe"):
+            RuntimeControlInterface(path=r"\\.\pipe\docker_engine", kind="unix-socket")
 
 
 class TestRole:

--- a/implementations/python/tests/test_sdl_parser.py
+++ b/implementations/python/tests/test_sdl_parser.py
@@ -220,6 +220,59 @@ nodes:
         s = parse_sdl(sdl)
         assert any("without 'resources'" in advisory for advisory in s.advisories)
 
+    def test_runtime_configuration_parses_without_overloading_other_sections(self):
+        sdl = """
+name: shuffle-runtime-inventory
+nodes:
+  shuffle-backend:
+    type: vm
+    os: linux
+    runtime:
+      mounts:
+        - target: /shuffle-database
+          source: aptl_shuffle_data
+          source-kind: volume
+      local-control-interfaces:
+        - path: /run/docker.sock
+          kind: unix-socket
+          protocol: docker
+          bind-source: /var/run/docker.sock
+          access: read-write
+      process:
+        pid: 1
+        command: ./shufflebackend
+        user: root
+        working-directory: /app
+      packages:
+        - manager: apk
+          name: musl
+          version: 1.2.4-r2
+      dependency-manifests:
+        - ecosystem: go
+          path: /app/go.mod
+          format: go-module
+      package-vulnerabilities:
+        - id: CVE-2026-12345
+          package-name: musl
+          installed-version: 1.2.4-r2
+          fixed-version: 1.2.5-r0
+          severity: high
+          scanner: trivy
+          image-digest: sha256:abc123
+          scan-time: "2026-05-20T12:00:00Z"
+"""
+        scenario = parse_sdl(sdl)
+        node = scenario.nodes["shuffle-backend"]
+
+        assert node.services == []
+        assert scenario.vulnerabilities == {}
+        assert node.runtime is not None
+        assert node.runtime.mounts[0].target == "/shuffle-database"
+        assert node.runtime.local_control_interfaces[0].path == "/run/docker.sock"
+        assert node.runtime.process is not None
+        assert node.runtime.process.command == ["./shufflebackend"]
+        assert node.runtime.package_vulnerabilities[0].id == "CVE-2026-12345"
+
     def test_source_shorthand(self):
         sdl = """
 name: test


### PR DESCRIPTION
## Summary

GAP-354 issue-context: add a typed VM node runtime metadata surface for observed mounts, local control interfaces, process identity, package/dependency inventory, and scanner-derived package findings.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #354

## ADR Impact

- No ADR required

## Changes

- Added closed SDL models for nodes.*.runtime metadata and VM-only switch rejection.
- Scoped source shorthand expansion so runtime mount source values remain plain observed identifiers.
- Added parser/model/compiler tests proving runtime metadata parses cleanly, stays out of services/vulnerabilities, validates runtime anchors, and survives compile into NodeRuntime.spec.
- Regenerated published SDL schemas and updated SDL reference documentation.
- Added changelog fragment changelog.d/354.added.md.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pre-commit run --all-files; targeted pytest for SDL model/parser/runtime tests; tools/check_repo_policy.py; tools/check_requirement_governance.py via unavailable-GC path after default gc-dev timed out; tools/verify_all.py; configured nox verify completion command.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GAP-354 GitHub issue #354 acceptance contract
- TESTS: implementations/python/tests/test_sdl_models.py, implementations/python/tests/test_sdl_parser.py, implementations/python/tests/test_runtime_models.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/354.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
