### PR TITLE
added: add temporal participant semantics

### DIFF
--- a/changelog.d/190.added.md
+++ b/changelog.d/190.added.md
@@ -1,0 +1,6 @@
+### Added
+
+- Added SEM-213 temporal participant contracts, runtime temporal-context
+  validation, backend timing disclosures, generated schema publication, and
+  adversarial tests for domain/clock/disclosure and deadline/dwell/timeout
+  state-machine failures.

--- a/contracts/schemas/control-plane/participant-behavior-history-event-stream-v1.json
+++ b/contracts/schemas/control-plane/participant-behavior-history-event-stream-v1.json
@@ -564,6 +564,109 @@
       ],
       "title": "ParticipantPreconditionClass",
       "type": "string"
+    },
+    "ParticipantTemporalEventPoint": {
+      "description": "Named participant event points used by temporal contracts.",
+      "enum": [
+        "submit",
+        "start",
+        "end",
+        "observed",
+        "effective",
+        "deadline",
+        "window_open",
+        "window_close",
+        "reset",
+        "replay"
+      ],
+      "title": "ParticipantTemporalEventPoint",
+      "type": "string"
+    },
+    "ParticipantTemporalRuntimeContextModel": {
+      "additionalProperties": false,
+      "properties": {
+        "backend_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Backend Disclosure Refs",
+          "type": "array"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "event_points": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalEventPoint"
+          },
+          "minItems": 1,
+          "title": "Event Points",
+          "type": "array"
+        },
+        "observation_point": {
+          "minLength": 1,
+          "title": "Observation Point",
+          "type": "string"
+        },
+        "replay_boundary": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Replay Boundary"
+        },
+        "reset_boundary": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reset Boundary"
+        },
+        "temporal_contract_id": {
+          "minLength": 1,
+          "title": "Temporal Contract Id",
+          "type": "string"
+        },
+        "time_domain": {
+          "$ref": "#/$defs/ParticipantTimeDomain"
+        }
+      },
+      "required": [
+        "temporal_contract_id",
+        "time_domain",
+        "clock_authority",
+        "event_points",
+        "observation_point"
+      ],
+      "title": "ParticipantTemporalRuntimeContextModel",
+      "type": "object"
+    },
+    "ParticipantTimeDomain": {
+      "description": "Distinct SEM-213 time domains.",
+      "enum": [
+        "episode_step",
+        "scenario_time",
+        "simulation_time",
+        "backend_time",
+        "wall_clock_time"
+      ],
+      "title": "ParticipantTimeDomain",
+      "type": "string"
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -734,6 +837,13 @@
         ],
         "default": null,
         "title": "State Transition Kind"
+      },
+      "temporal_contexts": {
+        "items": {
+          "$ref": "#/$defs/ParticipantTemporalRuntimeContextModel"
+        },
+        "title": "Temporal Contexts",
+        "type": "array"
       },
       "timestamp": {
         "title": "Timestamp",

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -1492,6 +1492,13 @@
           "title": "Backend Failure Mappings",
           "type": "array"
         },
+        "backend_timing_disclosures": {
+          "items": {
+            "$ref": "#/$defs/ParticipantBackendTimingDisclosure"
+          },
+          "title": "Backend Timing Disclosures",
+          "type": "array"
+        },
         "behavioral_granularity": {
           "$ref": "#/$defs/ParticipantActionGranularity"
         },
@@ -1569,6 +1576,13 @@
             "type": "string"
           },
           "title": "State Transition Effects",
+          "type": "array"
+        },
+        "temporal_contracts": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalContract"
+          },
+          "title": "Temporal Contracts",
           "type": "array"
         }
       },
@@ -1701,6 +1715,62 @@
       ],
       "title": "ParticipantBackendFailureMapping",
       "type": "object"
+    },
+    "ParticipantBackendTimingDisclosure": {
+      "additionalProperties": false,
+      "description": "Backend timing realization disclosure for SEM-213 contracts.",
+      "properties": {
+        "affected_temporal_ids": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Affected Temporal Ids",
+          "type": "array"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "disclosure_id": {
+          "title": "Disclosure Id",
+          "type": "string"
+        },
+        "disclosure_kind": {
+          "$ref": "#/$defs/ParticipantBackendTimingDisclosureKind"
+        },
+        "limitations": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Limitations",
+          "type": "array"
+        },
+        "support_mode": {
+          "$ref": "#/$defs/ParticipantTemporalSupportMode"
+        }
+      },
+      "required": [
+        "disclosure_id",
+        "disclosure_kind",
+        "support_mode",
+        "description",
+        "affected_temporal_ids"
+      ],
+      "title": "ParticipantBackendTimingDisclosure",
+      "type": "object"
+    },
+    "ParticipantBackendTimingDisclosureKind": {
+      "description": "Backend timing realization disclosures.",
+      "enum": [
+        "pacing",
+        "dilation",
+        "synchronization",
+        "serialization",
+        "unsupported_guarantee"
+      ],
+      "title": "ParticipantBackendTimingDisclosureKind",
+      "type": "string"
     },
     "ParticipantEffectClass": {
       "description": "SEM-211 effect classes for participant action results.",
@@ -1898,6 +1968,175 @@
         "realization"
       ],
       "title": "ParticipantPreconditionClass",
+      "type": "string"
+    },
+    "ParticipantTemporalContract": {
+      "additionalProperties": false,
+      "description": "Typed SEM-213 temporal contract for a participant action.",
+      "properties": {
+        "backend_disclosure_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Backend Disclosure Refs",
+          "type": "array"
+        },
+        "clock_authority": {
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "duration_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ref"
+        },
+        "event_points": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalEventPoint"
+          },
+          "minItems": 1,
+          "title": "Event Points",
+          "type": "array"
+        },
+        "ordering_basis": {
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "randomization_basis": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Randomization Basis"
+        },
+        "replay_boundary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Replay Boundary"
+        },
+        "reset_boundary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reset Boundary"
+        },
+        "temporal_id": {
+          "title": "Temporal Id",
+          "type": "string"
+        },
+        "temporal_kind": {
+          "$ref": "#/$defs/ParticipantTemporalContractKind"
+        },
+        "time_domain": {
+          "$ref": "#/$defs/ParticipantTimeDomain"
+        },
+        "window_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Window Ref"
+        }
+      },
+      "required": [
+        "temporal_id",
+        "temporal_kind",
+        "time_domain",
+        "clock_authority",
+        "event_points",
+        "description",
+        "ordering_basis"
+      ],
+      "title": "ParticipantTemporalContract",
+      "type": "object"
+    },
+    "ParticipantTemporalContractKind": {
+      "description": "SEM-213 temporal contract kinds.",
+      "enum": [
+        "schedule",
+        "cadence",
+        "deadline",
+        "dwell",
+        "latency",
+        "time_window",
+        "timeout",
+        "cooldown"
+      ],
+      "title": "ParticipantTemporalContractKind",
+      "type": "string"
+    },
+    "ParticipantTemporalEventPoint": {
+      "description": "Named participant event points used by temporal contracts.",
+      "enum": [
+        "submit",
+        "start",
+        "end",
+        "observed",
+        "effective",
+        "deadline",
+        "window_open",
+        "window_close",
+        "reset",
+        "replay"
+      ],
+      "title": "ParticipantTemporalEventPoint",
+      "type": "string"
+    },
+    "ParticipantTemporalSupportMode": {
+      "description": "How a backend supports a temporal guarantee.",
+      "enum": [
+        "exact",
+        "bounded",
+        "disclosed_limitation",
+        "unsupported"
+      ],
+      "title": "ParticipantTemporalSupportMode",
+      "type": "string"
+    },
+    "ParticipantTimeDomain": {
+      "description": "Distinct SEM-213 time domains.",
+      "enum": [
+        "episode_step",
+        "scenario_time",
+        "simulation_time",
+        "backend_time",
+        "wall_clock_time"
+      ],
+      "title": "ParticipantTimeDomain",
       "type": "string"
     },
     "ParticipantViewDisposition": {

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -1492,6 +1492,13 @@
           "title": "Backend Failure Mappings",
           "type": "array"
         },
+        "backend_timing_disclosures": {
+          "items": {
+            "$ref": "#/$defs/ParticipantBackendTimingDisclosure"
+          },
+          "title": "Backend Timing Disclosures",
+          "type": "array"
+        },
         "behavioral_granularity": {
           "$ref": "#/$defs/ParticipantActionGranularity"
         },
@@ -1569,6 +1576,13 @@
             "type": "string"
           },
           "title": "State Transition Effects",
+          "type": "array"
+        },
+        "temporal_contracts": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalContract"
+          },
+          "title": "Temporal Contracts",
           "type": "array"
         }
       },
@@ -1701,6 +1715,62 @@
       ],
       "title": "ParticipantBackendFailureMapping",
       "type": "object"
+    },
+    "ParticipantBackendTimingDisclosure": {
+      "additionalProperties": false,
+      "description": "Backend timing realization disclosure for SEM-213 contracts.",
+      "properties": {
+        "affected_temporal_ids": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Affected Temporal Ids",
+          "type": "array"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "disclosure_id": {
+          "title": "Disclosure Id",
+          "type": "string"
+        },
+        "disclosure_kind": {
+          "$ref": "#/$defs/ParticipantBackendTimingDisclosureKind"
+        },
+        "limitations": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Limitations",
+          "type": "array"
+        },
+        "support_mode": {
+          "$ref": "#/$defs/ParticipantTemporalSupportMode"
+        }
+      },
+      "required": [
+        "disclosure_id",
+        "disclosure_kind",
+        "support_mode",
+        "description",
+        "affected_temporal_ids"
+      ],
+      "title": "ParticipantBackendTimingDisclosure",
+      "type": "object"
+    },
+    "ParticipantBackendTimingDisclosureKind": {
+      "description": "Backend timing realization disclosures.",
+      "enum": [
+        "pacing",
+        "dilation",
+        "synchronization",
+        "serialization",
+        "unsupported_guarantee"
+      ],
+      "title": "ParticipantBackendTimingDisclosureKind",
+      "type": "string"
     },
     "ParticipantEffectClass": {
       "description": "SEM-211 effect classes for participant action results.",
@@ -1898,6 +1968,175 @@
         "realization"
       ],
       "title": "ParticipantPreconditionClass",
+      "type": "string"
+    },
+    "ParticipantTemporalContract": {
+      "additionalProperties": false,
+      "description": "Typed SEM-213 temporal contract for a participant action.",
+      "properties": {
+        "backend_disclosure_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Backend Disclosure Refs",
+          "type": "array"
+        },
+        "clock_authority": {
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "duration_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration Ref"
+        },
+        "event_points": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalEventPoint"
+          },
+          "minItems": 1,
+          "title": "Event Points",
+          "type": "array"
+        },
+        "ordering_basis": {
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "randomization_basis": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Randomization Basis"
+        },
+        "replay_boundary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Replay Boundary"
+        },
+        "reset_boundary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reset Boundary"
+        },
+        "temporal_id": {
+          "title": "Temporal Id",
+          "type": "string"
+        },
+        "temporal_kind": {
+          "$ref": "#/$defs/ParticipantTemporalContractKind"
+        },
+        "time_domain": {
+          "$ref": "#/$defs/ParticipantTimeDomain"
+        },
+        "window_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Window Ref"
+        }
+      },
+      "required": [
+        "temporal_id",
+        "temporal_kind",
+        "time_domain",
+        "clock_authority",
+        "event_points",
+        "description",
+        "ordering_basis"
+      ],
+      "title": "ParticipantTemporalContract",
+      "type": "object"
+    },
+    "ParticipantTemporalContractKind": {
+      "description": "SEM-213 temporal contract kinds.",
+      "enum": [
+        "schedule",
+        "cadence",
+        "deadline",
+        "dwell",
+        "latency",
+        "time_window",
+        "timeout",
+        "cooldown"
+      ],
+      "title": "ParticipantTemporalContractKind",
+      "type": "string"
+    },
+    "ParticipantTemporalEventPoint": {
+      "description": "Named participant event points used by temporal contracts.",
+      "enum": [
+        "submit",
+        "start",
+        "end",
+        "observed",
+        "effective",
+        "deadline",
+        "window_open",
+        "window_close",
+        "reset",
+        "replay"
+      ],
+      "title": "ParticipantTemporalEventPoint",
+      "type": "string"
+    },
+    "ParticipantTemporalSupportMode": {
+      "description": "How a backend supports a temporal guarantee.",
+      "enum": [
+        "exact",
+        "bounded",
+        "disclosed_limitation",
+        "unsupported"
+      ],
+      "title": "ParticipantTemporalSupportMode",
+      "type": "string"
+    },
+    "ParticipantTimeDomain": {
+      "description": "Distinct SEM-213 time domains.",
+      "enum": [
+        "episode_step",
+        "scenario_time",
+        "simulation_time",
+        "backend_time",
+        "wall_clock_time"
+      ],
+      "title": "ParticipantTimeDomain",
       "type": "string"
     },
     "ParticipantViewDisposition": {

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -827,6 +827,13 @@
           "default": null,
           "title": "State Transition Kind"
         },
+        "temporal_contexts": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalRuntimeContextModel"
+          },
+          "title": "Temporal Contexts",
+          "type": "array"
+        },
         "timestamp": {
           "title": "Timestamp",
           "type": "string"
@@ -1080,6 +1087,109 @@
         "realization"
       ],
       "title": "ParticipantPreconditionClass",
+      "type": "string"
+    },
+    "ParticipantTemporalEventPoint": {
+      "description": "Named participant event points used by temporal contracts.",
+      "enum": [
+        "submit",
+        "start",
+        "end",
+        "observed",
+        "effective",
+        "deadline",
+        "window_open",
+        "window_close",
+        "reset",
+        "replay"
+      ],
+      "title": "ParticipantTemporalEventPoint",
+      "type": "string"
+    },
+    "ParticipantTemporalRuntimeContextModel": {
+      "additionalProperties": false,
+      "properties": {
+        "backend_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Backend Disclosure Refs",
+          "type": "array"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "event_points": {
+          "items": {
+            "$ref": "#/$defs/ParticipantTemporalEventPoint"
+          },
+          "minItems": 1,
+          "title": "Event Points",
+          "type": "array"
+        },
+        "observation_point": {
+          "minLength": 1,
+          "title": "Observation Point",
+          "type": "string"
+        },
+        "replay_boundary": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Replay Boundary"
+        },
+        "reset_boundary": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reset Boundary"
+        },
+        "temporal_contract_id": {
+          "minLength": 1,
+          "title": "Temporal Contract Id",
+          "type": "string"
+        },
+        "time_domain": {
+          "$ref": "#/$defs/ParticipantTimeDomain"
+        }
+      },
+      "required": [
+        "temporal_contract_id",
+        "time_domain",
+        "clock_authority",
+        "event_points",
+        "observation_point"
+      ],
+      "title": "ParticipantTemporalRuntimeContextModel",
+      "type": "object"
+    },
+    "ParticipantTimeDomain": {
+      "description": "Distinct SEM-213 time domains.",
+      "enum": [
+        "episode_step",
+        "scenario_time",
+        "simulation_time",
+        "backend_time",
+        "wall_clock_time"
+      ],
+      "title": "ParticipantTimeDomain",
       "type": "string"
     },
     "SnapshotEntryModel": {

--- a/docs/decisions/sem-213-temporal-participant-preflight.md
+++ b/docs/decisions/sem-213-temporal-participant-preflight.md
@@ -1,0 +1,64 @@
+# SEM-213 Temporal Participant Preflight
+
+Issue: #190
+Requirement: SEM-213
+Date: 2026-05-21
+
+This note records the architecture preflight guardrails for implementing
+temporal participant semantics. It is guidance for the implementation and does
+not itself implement SEM-213.
+
+## Binding Sources
+
+- ADR-022 separates timestamps from ordering, causality, pacing,
+  synchronization, and clock authority.
+- `specs/formal/participant-semantics/README.md` states that episode step,
+  scenario time, simulation time, backend time, and wall-clock time are
+  distinct time domains.
+- The SEM-213 formal section requires schedules, cadence, deadlines, dwell,
+  latency, time windows, reset and replay boundaries, and backend pacing /
+  synchronization limitation disclosure.
+- SEM-211 already owns controlled failure classes, including timeout. SEM-212
+  already owns causality and attribution support. SEM-213 must link to those
+  surfaces without collapsing into them.
+
+## Guardrails
+
+- Add typed temporal contract fields to governed participant action contracts.
+  Raw `agents.*.actions` names must remain an authoring affordance only.
+- Every temporal contract must name a time domain and clock authority. A raw
+  timestamp alone must not be accepted as schedule, cadence, deadline, dwell,
+  latency, or time-window semantics.
+- Carry temporal contract metadata into compiled runtime action contracts and
+  published behavior-history schemas so backend adapters and conformance tools
+  can inspect the same fields.
+- Runtime participant behavior history may report realized temporal context,
+  but it must match the compiled action contract's temporal id, domain, clock
+  authority, event points, and backend disclosure references.
+- Deadline, dwell, timeout, cadence, reset, and replay interactions need an
+  explicit state-machine check. Terminal missed-deadline / timeout states must
+  not be silently reused across reset or replay boundaries.
+- Backend pacing, dilation, synchronization, serialization, and unsupported
+  timing guarantees must be represented as disclosure objects, not prose-only
+  caveats.
+
+## Reuse
+
+- Reuse the existing participant behavior contract module for the authoring
+  surface and the existing compiler path that already carries SEM-208 through
+  SEM-212 metadata into `ParticipantActionContractRuntime`.
+- Reuse `ParticipantPreconditionClass.TEMPORAL` and
+  `ParticipantFailureClass.TIMEOUT`; do not create duplicate vocabularies for
+  action applicability or failure.
+- Reuse `ParticipantAttributionOrderingBasis` for causal and attribution
+  claims; SEM-213 should not make timestamp adjacency causal.
+- Reuse `iter_participant_behavior_history_violations` for runtime conformance
+  so participant-local temporal context is checked next to visibility,
+  attribution, and action-result checks.
+
+## Non-Goals
+
+- Do not implement the broader SEM-227 / SEM-228 / SEM-229 ACES time model.
+- Do not add new schema files under `contracts/schemas/` by hand; change the
+  Python contract models and regenerate.
+- Do not add compatibility implementation under `implementations/python/src/aces`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ decisions/adrs/adr-019-normative-authority-boundary-manifest
 decisions/adrs/adr-020-declarative-participant-framing-boundaries
 decisions/adrs/adr-021-falsification-first-claim-evidence-gate
 decisions/adrs/adr-022-participant-behavior-and-interaction-semantics
+decisions/sem-213-temporal-participant-preflight
 ```
 
 ```{toctree}

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -19,6 +19,10 @@ from aces_sdl.participant_behavior import (
     ParticipantInteractionClass,
     ParticipantPreconditionClass,
 )
+from aces_sdl.participant_temporal_semantics import (
+    ParticipantTemporalEventPoint,
+    ParticipantTimeDomain,
+)
 from aces_sdl.scenario import InstantiatedScenario, Scenario
 from pydantic import BaseModel, ConfigDict, Field, GetJsonSchemaHandler, model_validator
 from pydantic.json_schema import JsonSchemaValue
@@ -247,6 +251,17 @@ class ParticipantActionResultModel(ContractModel):
     diagnostics: list[NonEmptyString] = Field(default_factory=list)
 
 
+class ParticipantTemporalRuntimeContextModel(ContractModel):
+    temporal_contract_id: NonEmptyString
+    time_domain: ParticipantTimeDomain
+    clock_authority: NonEmptyString
+    event_points: list[ParticipantTemporalEventPoint] = Field(min_length=1)
+    observation_point: NonEmptyString
+    backend_disclosure_refs: list[NonEmptyString] = Field(default_factory=list)
+    reset_boundary: NonEmptyString | None = None
+    replay_boundary: NonEmptyString | None = None
+
+
 class ParticipantAttributionCandidateModel(ContractModel):
     candidate_kind: ParticipantAttributionCandidateKind
     ref: NonEmptyString
@@ -304,6 +319,7 @@ class ParticipantBehaviorHistoryEventModel(ContractModel):
     shared_state_refs: list[NonEmptyString] = Field(default_factory=list)
     action_result: ParticipantActionResultModel | None = None
     attribution_edges: list[ParticipantAttributionEdgeModel] = Field(default_factory=list)
+    temporal_contexts: list[ParticipantTemporalRuntimeContextModel] = Field(default_factory=list)
     details: ParticipantObservationDetailsModel = Field(default_factory=ParticipantObservationDetailsModel)
 
 
@@ -1378,6 +1394,7 @@ __all__ = [
     "ParticipantEpisodeHistoryEventModel",
     "ParticipantEpisodeStateModel",
     "ParticipantRuntimeCapabilitiesModel",
+    "ParticipantTemporalRuntimeContextModel",
     "PlanOperationModel",
     "ProcessorFeature",
     "PROCESSOR_MANIFEST_V2_SCHEMA_VERSION",

--- a/implementations/python/packages/aces_processor/compiler.py
+++ b/implementations/python/packages/aces_processor/compiler.py
@@ -952,6 +952,7 @@ def _compile_action_contracts(scenario: InstantiatedScenario) -> dict[str, Parti
     for name, contract in scenario.action_contracts.items():
         contract_spec = _dump(contract)
         interactions = contract_spec.get("interactions", [])
+        temporal_contracts = contract_spec.get("temporal_contracts", [])
         interaction_classes = _dedupe(
             [
                 str(interaction.get("interaction_class", ""))
@@ -991,6 +992,48 @@ def _compile_action_contracts(scenario: InstantiatedScenario) -> dict[str, Parti
             for mapping in contract_spec.get("backend_failure_mappings", [])
             if isinstance(mapping, dict)
         )
+        temporal_contract_ids = _dedupe(
+            [
+                str(temporal_contract.get("temporal_id", ""))
+                for temporal_contract in temporal_contracts
+                if isinstance(temporal_contract, dict) and temporal_contract.get("temporal_id")
+            ]
+        )
+        temporal_kinds = _dedupe(
+            [
+                str(temporal_contract.get("temporal_kind", ""))
+                for temporal_contract in temporal_contracts
+                if isinstance(temporal_contract, dict) and temporal_contract.get("temporal_kind")
+            ]
+        )
+        time_domains = _dedupe(
+            [
+                str(temporal_contract.get("time_domain", ""))
+                for temporal_contract in temporal_contracts
+                if isinstance(temporal_contract, dict) and temporal_contract.get("time_domain")
+            ]
+        )
+        clock_authorities = _dedupe(
+            [
+                str(temporal_contract.get("clock_authority", ""))
+                for temporal_contract in temporal_contracts
+                if isinstance(temporal_contract, dict) and temporal_contract.get("clock_authority")
+            ]
+        )
+        backend_timing_disclosures = tuple(
+            {
+                "disclosure_id": str(disclosure.get("disclosure_id", "")),
+                "disclosure_kind": str(disclosure.get("disclosure_kind", "")),
+                "support_mode": str(disclosure.get("support_mode", "")),
+                "description": str(disclosure.get("description", "")),
+                "affected_temporal_ids": [
+                    str(temporal_id) for temporal_id in disclosure.get("affected_temporal_ids", [])
+                ],
+                "limitations": [str(limitation) for limitation in disclosure.get("limitations", [])],
+            }
+            for disclosure in contract_spec.get("backend_timing_disclosures", [])
+            if isinstance(disclosure, dict)
+        )
         action_contracts[_action_contract_address(name)] = ParticipantActionContractRuntime(
             address=_action_contract_address(name),
             name=name,
@@ -1004,6 +1047,11 @@ def _compile_action_contracts(scenario: InstantiatedScenario) -> dict[str, Parti
             backend_failure_mappings=backend_failure_mappings,
             interaction_classes=interaction_classes,
             shared_state_refs=shared_state_refs,
+            temporal_contract_ids=temporal_contract_ids,
+            temporal_kinds=temporal_kinds,
+            time_domains=time_domains,
+            clock_authorities=clock_authorities,
+            backend_timing_disclosures=backend_timing_disclosures,
             spec=contract_spec,
         )
     return action_contracts

--- a/implementations/python/packages/aces_processor/models.py
+++ b/implementations/python/packages/aces_processor/models.py
@@ -41,6 +41,11 @@ from aces_sdl.participant_behavior import (
     ParticipantInteractionClass,
     ParticipantPreconditionClass,
 )
+from aces_sdl.participant_temporal_semantics import (
+    ParticipantTemporalEventPoint,
+    ParticipantTemporalState,
+    ParticipantTimeDomain,
+)
 from aces_sdl.semantics.workflow import WorkflowStepSemanticContract
 
 _PARTICIPANT_ACTION_CONTRACT_PREFIX = "participant.action-contract."
@@ -385,6 +390,11 @@ class ParticipantActionContractRuntime(ResolvedResource):
     backend_failure_mappings: tuple[dict[str, str], ...] = ()
     interaction_classes: tuple[str, ...] = ()
     shared_state_refs: tuple[str, ...] = ()
+    temporal_contract_ids: tuple[str, ...] = ()
+    temporal_kinds: tuple[str, ...] = ()
+    time_domains: tuple[str, ...] = ()
+    clock_authorities: tuple[str, ...] = ()
+    backend_timing_disclosures: tuple[dict[str, Any], ...] = ()
 
 
 def map_backend_diagnostic_to_participant_failure(
@@ -2473,6 +2483,234 @@ class ParticipantAttributionEdge:
             raise ValueError("downstream outcome attribution requires interpretation_rule_ref")
 
 
+def _participant_time_domain_from_payload(value: Any) -> ParticipantTimeDomain:
+    if isinstance(value, ParticipantTimeDomain):
+        return value
+    return ParticipantTimeDomain(str(value))
+
+
+def _participant_temporal_event_point_from_payload(value: Any) -> ParticipantTemporalEventPoint:
+    if isinstance(value, ParticipantTemporalEventPoint):
+        return value
+    return ParticipantTemporalEventPoint(str(value))
+
+
+def _participant_temporal_state_from_payload(value: Any) -> ParticipantTemporalState:
+    if isinstance(value, ParticipantTemporalState):
+        return value
+    return ParticipantTemporalState(str(value))
+
+
+def _participant_temporal_event_points_from_payload(value: Any) -> tuple[ParticipantTemporalEventPoint, ...]:
+    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Iterable):
+        raise TypeError("temporal event_points must be a list of event-point strings")
+    points = tuple(_participant_temporal_event_point_from_payload(item) for item in value)
+    if not points:
+        raise ValueError("temporal event_points must be non-empty")
+    if len(set(points)) != len(points):
+        raise ValueError("temporal event_points must be unique")
+    return points
+
+
+@dataclass(frozen=True)
+class ParticipantTemporalRuntimeContext:
+    """Realized SEM-213 temporal context on a participant behavior event."""
+
+    temporal_contract_id: str
+    time_domain: ParticipantTimeDomain
+    clock_authority: str
+    event_points: tuple[ParticipantTemporalEventPoint, ...]
+    observation_point: str
+    backend_disclosure_refs: tuple[str, ...] = ()
+    reset_boundary: str | None = None
+    replay_boundary: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ParticipantTemporalRuntimeContext":
+        if not isinstance(payload, Mapping):
+            raise TypeError("participant temporal runtime context must be a mapping")
+        missing = [
+            key
+            for key in (
+                "temporal_contract_id",
+                "time_domain",
+                "clock_authority",
+                "event_points",
+                "observation_point",
+            )
+            if key not in payload
+        ]
+        if missing:
+            raise ValueError("participant temporal runtime context is missing required fields: " + ", ".join(missing))
+        return cls(
+            temporal_contract_id=str(payload.get("temporal_contract_id")),
+            time_domain=_participant_time_domain_from_payload(payload.get("time_domain")),
+            clock_authority=str(payload.get("clock_authority")),
+            event_points=_participant_temporal_event_points_from_payload(payload.get("event_points")),
+            observation_point=str(payload.get("observation_point")),
+            backend_disclosure_refs=_tuple_of_non_empty_strings(
+                payload.get("backend_disclosure_refs", ()),
+                field_name="backend_disclosure_refs",
+            ),
+            reset_boundary=_optional_payload_string(payload, "reset_boundary"),
+            replay_boundary=_optional_payload_string(payload, "replay_boundary"),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "temporal_contract_id": self.temporal_contract_id,
+            "time_domain": self.time_domain.value,
+            "clock_authority": self.clock_authority,
+            "event_points": [point.value for point in self.event_points],
+            "observation_point": self.observation_point,
+            "backend_disclosure_refs": list(self.backend_disclosure_refs),
+            "reset_boundary": self.reset_boundary,
+            "replay_boundary": self.replay_boundary,
+        }
+
+    def __post_init__(self) -> None:
+        _validate_required_string(
+            self.temporal_contract_id,
+            "participant temporal temporal_contract_id must be a non-empty string",
+        )
+        if not isinstance(self.time_domain, ParticipantTimeDomain):
+            raise TypeError("time_domain must be a ParticipantTimeDomain")
+        _validate_required_string(self.clock_authority, "participant temporal clock_authority must be non-empty")
+        if not isinstance(self.event_points, tuple):
+            raise TypeError("event_points must be a tuple")
+        if not self.event_points:
+            raise ValueError("participant temporal event_points must be non-empty")
+        if any(not isinstance(point, ParticipantTemporalEventPoint) for point in self.event_points):
+            raise TypeError("event_points must contain ParticipantTemporalEventPoint values")
+        if len(set(self.event_points)) != len(self.event_points):
+            raise ValueError("participant temporal event_points must be unique")
+        _validate_required_string(self.observation_point, "participant temporal observation_point must be non-empty")
+        _tuple_of_non_empty_strings(self.backend_disclosure_refs, field_name="backend_disclosure_refs")
+        _validate_optional_string(self.reset_boundary, "reset_boundary must be a non-empty string or None")
+        _validate_optional_string(self.replay_boundary, "replay_boundary must be a non-empty string or None")
+
+
+@dataclass(frozen=True)
+class ParticipantTemporalStateTransition:
+    """Abstract SEM-213 deadline / dwell / timeout state transition."""
+
+    temporal_contract_id: str
+    from_state: ParticipantTemporalState
+    to_state: ParticipantTemporalState
+    event_point: ParticipantTemporalEventPoint
+    time_domain: ParticipantTimeDomain
+    clock_authority: str
+    boundary_ref: str
+    evidence_refs: tuple[str, ...]
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ParticipantTemporalStateTransition":
+        if not isinstance(payload, Mapping):
+            raise TypeError("participant temporal state transition must be a mapping")
+        missing = [
+            key
+            for key in (
+                "temporal_contract_id",
+                "from_state",
+                "to_state",
+                "event_point",
+                "time_domain",
+                "clock_authority",
+                "boundary_ref",
+                "evidence_refs",
+            )
+            if key not in payload
+        ]
+        if missing:
+            raise ValueError("participant temporal state transition is missing required fields: " + ", ".join(missing))
+        return cls(
+            temporal_contract_id=str(payload.get("temporal_contract_id")),
+            from_state=_participant_temporal_state_from_payload(payload.get("from_state")),
+            to_state=_participant_temporal_state_from_payload(payload.get("to_state")),
+            event_point=_participant_temporal_event_point_from_payload(payload.get("event_point")),
+            time_domain=_participant_time_domain_from_payload(payload.get("time_domain")),
+            clock_authority=str(payload.get("clock_authority")),
+            boundary_ref=str(payload.get("boundary_ref")),
+            evidence_refs=_tuple_of_non_empty_strings(payload.get("evidence_refs"), field_name="evidence_refs"),
+        )
+
+    def __post_init__(self) -> None:
+        _validate_required_string(
+            self.temporal_contract_id,
+            "participant temporal temporal_contract_id must be a non-empty string",
+        )
+        if not isinstance(self.from_state, ParticipantTemporalState):
+            raise TypeError("from_state must be a ParticipantTemporalState")
+        if not isinstance(self.to_state, ParticipantTemporalState):
+            raise TypeError("to_state must be a ParticipantTemporalState")
+        if not isinstance(self.event_point, ParticipantTemporalEventPoint):
+            raise TypeError("event_point must be a ParticipantTemporalEventPoint")
+        if not isinstance(self.time_domain, ParticipantTimeDomain):
+            raise TypeError("time_domain must be a ParticipantTimeDomain")
+        _validate_required_string(self.clock_authority, "participant temporal clock_authority must be non-empty")
+        _validate_required_string(self.boundary_ref, "participant temporal boundary_ref must be non-empty")
+        evidence_refs = _tuple_of_non_empty_strings(self.evidence_refs, field_name="evidence_refs")
+        if not evidence_refs:
+            raise ValueError("participant temporal state transitions require evidence_refs")
+
+
+def _participant_temporal_state_transition_from_payload(
+    value: ParticipantTemporalStateTransition | Mapping[str, Any],
+) -> ParticipantTemporalStateTransition:
+    if isinstance(value, ParticipantTemporalStateTransition):
+        return value
+    return ParticipantTemporalStateTransition.from_payload(value)
+
+
+def iter_participant_temporal_state_machine_violations(
+    transitions: Iterable[ParticipantTemporalStateTransition | Mapping[str, Any]],
+) -> Iterator[tuple[str, str]]:
+    """Yield SEM-213 abstract state-machine violations."""
+
+    prior_state: dict[str, ParticipantTemporalState] = {}
+    domain_authority: dict[str, tuple[ParticipantTimeDomain, str]] = {}
+    terminal_states = {ParticipantTemporalState.DEADLINE_MISSED, ParticipantTemporalState.TIMEOUT}
+    boundary_events = {ParticipantTemporalEventPoint.RESET, ParticipantTemporalEventPoint.REPLAY}
+    boundary_states = {ParticipantTemporalState.RESET, ParticipantTemporalState.REPLAY_BOUNDARY}
+
+    for index, raw_transition in enumerate(transitions):
+        locator = f"participant temporal state transition[{index}]"
+        try:
+            transition = _participant_temporal_state_transition_from_payload(raw_transition)
+        except (TypeError, ValueError) as exc:
+            yield (locator, f"participant temporal state transition is invalid: {exc}")
+            continue
+
+        key = transition.temporal_contract_id
+        observed_domain_authority = (transition.time_domain, transition.clock_authority)
+        if key in domain_authority and domain_authority[key] != observed_domain_authority:
+            expected_domain, expected_authority = domain_authority[key]
+            yield (
+                locator,
+                f"temporal contract {key!r} changed time domain or clock authority from "
+                f"{expected_domain.value}/{expected_authority!r} to "
+                f"{transition.time_domain.value}/{transition.clock_authority!r}",
+            )
+        else:
+            domain_authority[key] = observed_domain_authority
+
+        if (
+            transition.to_state == ParticipantTemporalState.DWELL_SATISFIED
+            and transition.from_state != ParticipantTemporalState.DWELL_ACTIVE
+            and prior_state.get(key) != ParticipantTemporalState.DWELL_ACTIVE
+        ):
+            yield (locator, "dwell_satisfied requires prior dwell_active state in the same temporal segment")
+
+        if (
+            transition.from_state in terminal_states
+            and transition.event_point not in boundary_events
+            and transition.to_state not in boundary_states
+        ):
+            yield (locator, "terminal temporal state requires reset or replay boundary before reuse")
+
+        prior_state[key] = transition.to_state
+
+
 def _optional_payload_string(payload: Mapping[str, Any], key: str) -> str | None:
     value = payload.get(key)
     return str(value) if value is not None else None
@@ -2519,6 +2757,19 @@ def _participant_attribution_edges_from_payload(value: Any) -> tuple[Participant
     )
 
 
+def _participant_temporal_contexts_from_payload(value: Any) -> tuple[ParticipantTemporalRuntimeContext, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes, Mapping)) or not isinstance(value, Iterable):
+        raise TypeError("temporal_contexts must be a list of participant temporal runtime contexts")
+    return tuple(
+        context
+        if isinstance(context, ParticipantTemporalRuntimeContext)
+        else ParticipantTemporalRuntimeContext.from_payload(context)
+        for context in value
+    )
+
+
 def _participant_behavior_details_from_payload(value: Any) -> dict[str, Any]:
     if value is None:
         value = {}
@@ -2560,6 +2811,7 @@ class ParticipantBehaviorHistoryEvent:
     shared_state_refs: tuple[str, ...] = ()
     action_result: ParticipantActionResult | None = None
     attribution_edges: tuple[ParticipantAttributionEdge, ...] = ()
+    temporal_contexts: tuple[ParticipantTemporalRuntimeContext, ...] = ()
     details: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -2605,6 +2857,7 @@ class ParticipantBehaviorHistoryEvent:
             ),
             action_result=_participant_action_result_from_payload(payload.get("action_result")),
             attribution_edges=_participant_attribution_edges_from_payload(payload.get("attribution_edges", ())),
+            temporal_contexts=_participant_temporal_contexts_from_payload(payload.get("temporal_contexts", ())),
             details=_participant_behavior_details_from_payload(payload.get("details", {})),
         )
 
@@ -2628,6 +2881,7 @@ class ParticipantBehaviorHistoryEvent:
             "shared_state_refs": list(self.shared_state_refs),
             "action_result": self.action_result.to_payload() if self.action_result is not None else None,
             "attribution_edges": [edge.to_payload() for edge in self.attribution_edges],
+            "temporal_contexts": [context.to_payload() for context in self.temporal_contexts],
             "details": dict(self.details),
         }
 
@@ -2673,6 +2927,7 @@ class ParticipantBehaviorHistoryEvent:
         self._validate_interaction_fields()
         self._validate_action_result_type()
         self._validate_attribution_edge_types()
+        self._validate_temporal_context_types()
         if not isinstance(self.details, dict):
             raise TypeError("participant behavior details must be a dict")
 
@@ -2711,6 +2966,14 @@ class ParticipantBehaviorHistoryEvent:
             raise ValueError("participant attribution edge_id values must be unique per event")
         if self.attribution_edges and self.event_type != ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED:
             raise ValueError("participant attribution edges are only allowed on observation_emitted events")
+
+    def _validate_temporal_context_types(self) -> None:
+        if not isinstance(self.temporal_contexts, tuple):
+            raise TypeError("temporal_contexts must be a tuple")
+        if any(not isinstance(context, ParticipantTemporalRuntimeContext) for context in self.temporal_contexts):
+            raise TypeError("temporal_contexts must contain ParticipantTemporalRuntimeContext values")
+        if len({context.temporal_contract_id for context in self.temporal_contexts}) != len(self.temporal_contexts):
+            raise ValueError("participant temporal_contract_id values must be unique per event")
 
     @staticmethod
     def _validate_required_string(value: Any, message: str) -> None:
@@ -3639,6 +3902,110 @@ def _participant_behavior_address_violations(
     return violations
 
 
+def _contract_sem213_temporal_contracts(
+    contract: ParticipantActionContractRuntime,
+) -> dict[str, Mapping[str, Any]]:
+    temporal_contracts = contract.spec.get("temporal_contracts", ())
+    if isinstance(temporal_contracts, (str, bytes, Mapping)) or not isinstance(temporal_contracts, Iterable):
+        return {}
+    return {
+        str(temporal_contract.get("temporal_id")): temporal_contract
+        for temporal_contract in temporal_contracts
+        if isinstance(temporal_contract, Mapping) and temporal_contract.get("temporal_id")
+    }
+
+
+def _contract_sem213_backend_disclosure_ids(contract: ParticipantActionContractRuntime) -> set[str]:
+    disclosures = contract.spec.get("backend_timing_disclosures", ())
+    if isinstance(disclosures, (str, bytes, Mapping)) or not isinstance(disclosures, Iterable):
+        return set()
+    return {
+        str(disclosure.get("disclosure_id"))
+        for disclosure in disclosures
+        if isinstance(disclosure, Mapping) and disclosure.get("disclosure_id")
+    }
+
+
+def _participant_temporal_context_contract_violations(
+    context: ParticipantTemporalRuntimeContext,
+    *,
+    contract: ParticipantActionContractRuntime,
+) -> list[str]:
+    violations: list[str] = []
+    temporal_contracts = _contract_sem213_temporal_contracts(contract)
+    temporal_contract = temporal_contracts.get(context.temporal_contract_id)
+    if temporal_contract is None:
+        return [f"temporal context references undeclared temporal_contract_id {context.temporal_contract_id!r}"]
+
+    declared_time_domain = str(temporal_contract.get("time_domain", ""))
+    if context.time_domain.value != declared_time_domain:
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} time_domain {context.time_domain.value!r} "
+            f"does not match compiled contract {declared_time_domain!r}"
+        )
+
+    declared_clock_authority = str(temporal_contract.get("clock_authority", ""))
+    if context.clock_authority != declared_clock_authority:
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} clock_authority {context.clock_authority!r} "
+            f"does not match compiled contract {declared_clock_authority!r}"
+        )
+
+    declared_event_points = tuple(str(point) for point in temporal_contract.get("event_points", ()))
+    observed_event_points = tuple(point.value for point in context.event_points)
+    if observed_event_points != declared_event_points:
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} event_points {observed_event_points!r} "
+            f"do not match compiled contract {declared_event_points!r}"
+        )
+
+    declared_contract_disclosures = set(str(ref) for ref in temporal_contract.get("backend_disclosure_refs", ()))
+    declared_disclosures = _contract_sem213_backend_disclosure_ids(contract)
+    for ref in sorted(set(context.backend_disclosure_refs) - declared_contract_disclosures):
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} reports backend_disclosure_ref {ref!r} "
+            "not declared by the temporal contract"
+        )
+    for ref in sorted(set(context.backend_disclosure_refs) - declared_disclosures):
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} reports unknown backend_disclosure_ref {ref!r}"
+        )
+
+    declared_reset_boundary = temporal_contract.get("reset_boundary")
+    if declared_reset_boundary is not None and context.reset_boundary != str(declared_reset_boundary):
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} reset_boundary {context.reset_boundary!r} "
+            f"does not match compiled contract {str(declared_reset_boundary)!r}"
+        )
+    declared_replay_boundary = temporal_contract.get("replay_boundary")
+    if declared_replay_boundary is not None and context.replay_boundary != str(declared_replay_boundary):
+        violations.append(
+            f"temporal context {context.temporal_contract_id!r} replay_boundary {context.replay_boundary!r} "
+            f"does not match compiled contract {str(declared_replay_boundary)!r}"
+        )
+
+    return violations
+
+
+def _participant_behavior_temporal_contract_violations(
+    events: Iterable[ParticipantBehaviorHistoryEvent],
+    *,
+    action_contracts: Mapping[str, ParticipantActionContractRuntime],
+) -> Iterator[tuple[str, str]]:
+    for index, event in enumerate(events):
+        if not event.temporal_contexts:
+            continue
+        action_contract_address = event.action_contract_address or ""
+        contract = action_contracts.get(action_contract_address)
+        locator = f"{_PARTICIPANT_BEHAVIOR_HISTORY_KEY}[{index}]"
+        if contract is None:
+            yield (locator, f"temporal context cannot resolve action contract {action_contract_address!r}")
+            continue
+        for context in event.temporal_contexts:
+            for violation in _participant_temporal_context_contract_violations(context, contract=contract):
+                yield (locator, violation)
+
+
 def _participant_behavior_action_result_contract_violations(
     events: Iterable[ParticipantBehaviorHistoryEvent],
     *,
@@ -3796,9 +4163,9 @@ def _participant_behavior_joint_action_order_violations(
 def iter_participant_behavior_history_violations(
     participant_behavior_history: Any,
     *,
-    action_contract_addresses: set[str] | frozenset[str] | None,
+    action_contract_addresses: set[str] | frozenset[str] | None = None,
     action_contracts: Mapping[str, ParticipantActionContractRuntime] | None = None,
-    observation_boundary_addresses: set[str] | frozenset[str] | None,
+    observation_boundary_addresses: set[str] | frozenset[str] | None = None,
     observation_boundaries: Mapping[str, ParticipantObservationBoundaryRuntime] | None = None,
     participant_episode_history: Any = None,
     expected_participant_address: str | None = None,
@@ -3816,6 +4183,8 @@ def iter_participant_behavior_history_violations(
     if not isinstance(participant_behavior_history, list):
         yield (_PARTICIPANT_BEHAVIOR_HISTORY_KEY, "participant behavior history must be a list of events")
         return
+    if action_contracts is not None and action_contract_addresses is None:
+        action_contract_addresses = frozenset(action_contracts.keys())
     if observation_boundaries is not None and observation_boundary_addresses is None:
         observation_boundary_addresses = frozenset(observation_boundaries.keys())
 
@@ -3834,6 +4203,10 @@ def iter_participant_behavior_history_violations(
     yield from _participant_behavior_joint_action_order_violations(normalized_events)
     if action_contracts is not None:
         yield from _participant_behavior_action_result_contract_violations(
+            normalized_events,
+            action_contracts=action_contracts,
+        )
+        yield from _participant_behavior_temporal_contract_violations(
             normalized_events,
             action_contracts=action_contracts,
         )

--- a/implementations/python/packages/aces_sdl/participant_behavior.py
+++ b/implementations/python/packages/aces_sdl/participant_behavior.py
@@ -18,6 +18,11 @@ from .participant_action_semantics import (
     ParticipantFailureClass,
     ParticipantPreconditionClass,  # noqa: F401 - re-exported for existing participant behavior imports
 )
+from .participant_temporal_semantics import (
+    ParticipantBackendTimingDisclosure,
+    ParticipantTemporalContract,
+    validate_action_contract_temporal_payload,
+)
 
 
 class ParticipantActionLifecycle(str, Enum):
@@ -209,6 +214,8 @@ class ParticipantActionContract(SDLModel):
     backend_failure_mappings: list[ParticipantBackendFailureMapping] = Field(default_factory=list)
     interactions: list[ParticipantInteractionDeclaration] = Field(default_factory=list)
     external_mappings: list[ExternalMappingLoss] = Field(default_factory=list)
+    temporal_contracts: list[ParticipantTemporalContract] = Field(default_factory=list)
+    backend_timing_disclosures: list[ParticipantBackendTimingDisclosure] = Field(default_factory=list)
 
     @field_validator(
         "semantic_version",
@@ -262,6 +269,11 @@ class ParticipantActionContract(SDLModel):
                     f"backend failure mapping {mapping.backend_error_code!r} "
                     f"uses undeclared failure_class {mapping.failure_class.value!r}"
                 )
+        validate_action_contract_temporal_payload(
+            preconditions=self.preconditions,
+            temporal_contracts=self.temporal_contracts,
+            backend_timing_disclosures=self.backend_timing_disclosures,
+        )
         return self
 
 

--- a/implementations/python/packages/aces_sdl/participant_temporal_semantics.py
+++ b/implementations/python/packages/aces_sdl/participant_temporal_semantics.py
@@ -1,0 +1,281 @@
+"""Typed participant temporal semantics (SEM-213)."""
+
+from enum import Enum
+
+from pydantic import Field, field_validator, model_validator
+
+from ._base import SDLModel
+
+
+class ParticipantTimeDomain(str, Enum):
+    """Distinct SEM-213 time domains."""
+
+    EPISODE_STEP = "episode_step"
+    SCENARIO_TIME = "scenario_time"
+    SIMULATION_TIME = "simulation_time"
+    BACKEND_TIME = "backend_time"
+    WALL_CLOCK_TIME = "wall_clock_time"
+
+
+class ParticipantTemporalEventPoint(str, Enum):
+    """Named participant event points used by temporal contracts."""
+
+    SUBMIT = "submit"
+    START = "start"
+    END = "end"
+    OBSERVED = "observed"
+    EFFECTIVE = "effective"
+    DEADLINE = "deadline"
+    WINDOW_OPEN = "window_open"
+    WINDOW_CLOSE = "window_close"
+    RESET = "reset"
+    REPLAY = "replay"
+
+
+class ParticipantTemporalContractKind(str, Enum):
+    """SEM-213 temporal contract kinds."""
+
+    SCHEDULE = "schedule"
+    CADENCE = "cadence"
+    DEADLINE = "deadline"
+    DWELL = "dwell"
+    LATENCY = "latency"
+    TIME_WINDOW = "time_window"
+    TIMEOUT = "timeout"
+    COOLDOWN = "cooldown"
+
+
+class ParticipantBackendTimingDisclosureKind(str, Enum):
+    """Backend timing realization disclosures."""
+
+    PACING = "pacing"
+    DILATION = "dilation"
+    SYNCHRONIZATION = "synchronization"
+    SERIALIZATION = "serialization"
+    UNSUPPORTED_GUARANTEE = "unsupported_guarantee"
+
+
+class ParticipantTemporalSupportMode(str, Enum):
+    """How a backend supports a temporal guarantee."""
+
+    EXACT = "exact"
+    BOUNDED = "bounded"
+    DISCLOSED_LIMITATION = "disclosed_limitation"
+    UNSUPPORTED = "unsupported"
+
+
+class ParticipantTemporalState(str, Enum):
+    """Abstract SEM-213 temporal state-machine states."""
+
+    ELIGIBLE = "eligible"
+    INELIGIBLE = "ineligible"
+    DWELL_ACTIVE = "dwell_active"
+    DWELL_SATISFIED = "dwell_satisfied"
+    DEADLINE_OPEN = "deadline_open"
+    DEADLINE_MET = "deadline_met"
+    DEADLINE_MISSED = "deadline_missed"
+    TIMEOUT = "timeout"
+    RESET = "reset"
+    REPLAY_BOUNDARY = "replay_boundary"
+
+
+_DURATION_KINDS = frozenset(
+    {
+        ParticipantTemporalContractKind.CADENCE,
+        ParticipantTemporalContractKind.DEADLINE,
+        ParticipantTemporalContractKind.DWELL,
+        ParticipantTemporalContractKind.LATENCY,
+        ParticipantTemporalContractKind.TIMEOUT,
+        ParticipantTemporalContractKind.COOLDOWN,
+    }
+)
+
+_WINDOW_KINDS = frozenset(
+    {
+        ParticipantTemporalContractKind.SCHEDULE,
+        ParticipantTemporalContractKind.TIME_WINDOW,
+        ParticipantTemporalContractKind.DWELL,
+    }
+)
+
+_BOUNDARY_KINDS = frozenset(
+    {
+        ParticipantTemporalContractKind.CADENCE,
+        ParticipantTemporalContractKind.DEADLINE,
+        ParticipantTemporalContractKind.DWELL,
+        ParticipantTemporalContractKind.LATENCY,
+        ParticipantTemporalContractKind.TIMEOUT,
+        ParticipantTemporalContractKind.COOLDOWN,
+        ParticipantTemporalContractKind.TIME_WINDOW,
+    }
+)
+
+
+class ParticipantTemporalContract(SDLModel):
+    """Typed SEM-213 temporal contract for a participant action."""
+
+    temporal_id: str
+    temporal_kind: ParticipantTemporalContractKind
+    time_domain: ParticipantTimeDomain
+    clock_authority: str
+    event_points: list[ParticipantTemporalEventPoint] = Field(min_length=1)
+    description: str
+    window_ref: str | None = None
+    duration_ref: str | None = None
+    reset_boundary: str | None = None
+    replay_boundary: str | None = None
+    randomization_basis: str | None = None
+    ordering_basis: str
+    backend_disclosure_refs: list[str] = Field(default_factory=list)
+
+    @field_validator(
+        "temporal_id",
+        "clock_authority",
+        "description",
+        "ordering_basis",
+    )
+    @classmethod
+    def _require_non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("participant temporal contract fields must be non-empty")
+        return value
+
+    @field_validator(
+        "window_ref",
+        "duration_ref",
+        "reset_boundary",
+        "replay_boundary",
+        "randomization_basis",
+    )
+    @classmethod
+    def _require_optional_non_empty(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("participant temporal contract optional fields must be non-empty when provided")
+        return value
+
+    @field_validator("event_points")
+    @classmethod
+    def _require_unique_event_points(
+        cls,
+        values: list[ParticipantTemporalEventPoint],
+    ) -> list[ParticipantTemporalEventPoint]:
+        if len(set(values)) != len(values):
+            raise ValueError("participant temporal contract event_points must be unique")
+        return values
+
+    @field_validator("backend_disclosure_refs")
+    @classmethod
+    def _require_non_empty_disclosure_refs(cls, values: list[str]) -> list[str]:
+        for value in values:
+            if not value.strip():
+                raise ValueError("participant temporal contract backend_disclosure_refs must be non-empty")
+        if len(set(values)) != len(values):
+            raise ValueError("participant temporal contract backend_disclosure_refs must be unique")
+        return values
+
+    @model_validator(mode="after")
+    def _validate_sem213_contract_shape(self) -> "ParticipantTemporalContract":
+        if self.temporal_kind in _WINDOW_KINDS and self.window_ref is None:
+            raise ValueError(f"{self.temporal_kind.value} temporal contracts require window_ref")
+        if self.temporal_kind in _DURATION_KINDS and self.duration_ref is None:
+            raise ValueError(f"{self.temporal_kind.value} temporal contracts require duration_ref")
+        if self.temporal_kind in _BOUNDARY_KINDS:
+            if self.reset_boundary is None:
+                raise ValueError(f"{self.temporal_kind.value} temporal contracts require reset_boundary")
+            if self.replay_boundary is None:
+                raise ValueError(f"{self.temporal_kind.value} temporal contracts require replay_boundary")
+        if self.temporal_kind == ParticipantTemporalContractKind.LATENCY and len(self.event_points) < 2:
+            raise ValueError("latency temporal contracts require at least two event_points")
+        return self
+
+
+class ParticipantBackendTimingDisclosure(SDLModel):
+    """Backend timing realization disclosure for SEM-213 contracts."""
+
+    disclosure_id: str
+    disclosure_kind: ParticipantBackendTimingDisclosureKind
+    support_mode: ParticipantTemporalSupportMode
+    description: str
+    affected_temporal_ids: list[str] = Field(min_length=1)
+    limitations: list[str] = Field(default_factory=list)
+
+    @field_validator("disclosure_id", "description")
+    @classmethod
+    def _require_non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("participant backend timing disclosure fields must be non-empty")
+        return value
+
+    @field_validator("affected_temporal_ids", "limitations")
+    @classmethod
+    def _require_non_empty_items(cls, values: list[str]) -> list[str]:
+        for value in values:
+            if not value.strip():
+                raise ValueError("participant backend timing disclosure list entries must be non-empty")
+        if len(set(values)) != len(values):
+            raise ValueError("participant backend timing disclosure list entries must be unique")
+        return values
+
+    @model_validator(mode="after")
+    def _validate_limitations(self) -> "ParticipantBackendTimingDisclosure":
+        if (
+            self.support_mode
+            in {
+                ParticipantTemporalSupportMode.DISCLOSED_LIMITATION,
+                ParticipantTemporalSupportMode.UNSUPPORTED,
+            }
+            and not self.limitations
+        ):
+            raise ValueError(f"{self.support_mode.value} timing disclosures require limitations")
+        return self
+
+
+def validate_action_contract_temporal_payload(
+    *,
+    preconditions: list[object],
+    temporal_contracts: list[ParticipantTemporalContract],
+    backend_timing_disclosures: list[ParticipantBackendTimingDisclosure],
+) -> None:
+    """Validate SEM-213 cross-field references on a participant action contract."""
+
+    temporal_ids = [contract.temporal_id for contract in temporal_contracts]
+    duplicate_temporal_ids = sorted(
+        {temporal_id for temporal_id in temporal_ids if temporal_ids.count(temporal_id) > 1}
+    )
+    if duplicate_temporal_ids:
+        joined = ", ".join(duplicate_temporal_ids)
+        raise ValueError(f"participant temporal_contracts require unique temporal_id values: {joined}")
+
+    disclosure_ids = [disclosure.disclosure_id for disclosure in backend_timing_disclosures]
+    duplicate_disclosure_ids = sorted(
+        {disclosure_id for disclosure_id in disclosure_ids if disclosure_ids.count(disclosure_id) > 1}
+    )
+    if duplicate_disclosure_ids:
+        joined = ", ".join(duplicate_disclosure_ids)
+        raise ValueError(f"participant backend_timing_disclosures require unique disclosure_id values: {joined}")
+
+    if backend_timing_disclosures and not temporal_contracts:
+        raise ValueError("backend_timing_disclosures require temporal_contracts")
+
+    if any(str(getattr(precondition.precondition_class, "value", "")) == "temporal" for precondition in preconditions):
+        if not temporal_contracts:
+            raise ValueError("temporal preconditions require temporal_contracts")
+
+    known_disclosures = set(disclosure_ids)
+    for contract in temporal_contracts:
+        unknown_disclosures = sorted(set(contract.backend_disclosure_refs) - known_disclosures)
+        if unknown_disclosures:
+            joined = ", ".join(unknown_disclosures)
+            raise ValueError(
+                f"temporal_contract {contract.temporal_id!r} references unknown backend_timing_disclosures: {joined}"
+            )
+
+    known_temporal_ids = set(temporal_ids)
+    for disclosure in backend_timing_disclosures:
+        unknown_temporal_ids = sorted(set(disclosure.affected_temporal_ids) - known_temporal_ids)
+        if unknown_temporal_ids:
+            joined = ", ".join(unknown_temporal_ids)
+            raise ValueError(
+                f"backend_timing_disclosure {disclosure.disclosure_id!r} references unknown "
+                f"temporal_contracts: {joined}"
+            )

--- a/implementations/python/tests/test_sem_213_temporal_participant_semantics.py
+++ b/implementations/python/tests/test_sem_213_temporal_participant_semantics.py
@@ -1,0 +1,422 @@
+"""SEM-213 temporal participant semantics."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from aces_contracts.contracts import ParticipantBehaviorHistoryEventModel
+from aces_processor.compiler import compile_runtime_model
+from aces_processor.models import (
+    ParticipantActionEffectResult,
+    ParticipantActionPreconditionResult,
+    ParticipantActionPreconditionStatus,
+    ParticipantActionResult,
+    ParticipantActionResultStatus,
+    ParticipantBehaviorHistoryEvent,
+    ParticipantBehaviorHistoryEventType,
+    ParticipantObservationStatus,
+    ParticipantTemporalRuntimeContext,
+    ParticipantTemporalState,
+    ParticipantTemporalStateTransition,
+    iter_participant_behavior_history_violations,
+    iter_participant_temporal_state_machine_violations,
+)
+from aces_sdl._errors import SDLParseError
+from aces_sdl.parser import parse_sdl
+from aces_sdl.participant_behavior import ParticipantEffectClass, ParticipantPreconditionClass
+from aces_sdl.participant_temporal_semantics import (
+    ParticipantTemporalContractKind,
+    ParticipantTemporalEventPoint,
+    ParticipantTimeDomain,
+)
+
+T0 = "2026-05-21T04:00:00Z"
+PARTICIPANT_ADDRESS = "participant.behavior.red-agent"
+ACTION_ADDRESS = "participant.action-contract.scan"
+OBSERVATION_ADDRESS = "participant.observation-boundary.red-view"
+ACTION_INSTANCE = "scan-0001"
+EPISODE_ID = "episode-1"
+
+
+def _scenario_yaml() -> str:
+    return textwrap.dedent(
+        """
+        name: sem-213
+        nodes:
+          web:
+            type: VM
+            resources: {ram: 1 GiB, cpu: 1}
+            services: [{port: 80, name: http}]
+        entities:
+          red-team:
+            role: red
+        action-contracts:
+          scan:
+            semantic-version: 1.0.0
+            lifecycle-state: active
+            behavioral-granularity: atomic
+            procedure-basis: nmap service discovery
+            realization-profile: backend-declared
+            fidelity-claim: records participant discovery timing without claiming portable wall-clock fidelity
+            preconditions:
+              - precondition-id: scheduled-window-open
+                precondition-class: temporal
+                description: scan may start only inside the scenario maintenance window
+                support-refs: [windows.maintenance]
+              - precondition-id: backend-can-realize-scan
+                precondition-class: realization
+                description: backend can realize the scan action contract
+                support-refs: [backend.participant-runtime]
+            effects:
+              - effect-id: terminal-scan-observation
+                effect-class: observation_effect
+                description: terminal scan observation is emitted for the participant
+                evidence-refs: [evidence.scan-output]
+            failure-classes: [precondition_unsatisfied, timeout, backend_error, unknown]
+            temporal-contracts:
+              - temporal-id: scan-schedule
+                temporal-kind: schedule
+                time-domain: scenario_time
+                clock-authority: scenario.author.clock
+                event-points: [submit, start]
+                description: scan is eligible only during the authored maintenance window
+                window-ref: windows.maintenance
+                ordering-basis: participant schedule relation, not raw timestamp causality
+                backend-disclosure-refs: [timing.remote-pacing]
+              - temporal-id: scan-cadence
+                temporal-kind: cadence
+                time-domain: episode_step
+                clock-authority: processor.episode-sequence
+                event-points: [submit]
+                description: scan attempts are rate-limited per participant episode
+                duration-ref: cadence.scan.per-episode
+                reset-boundary: participant episode reset starts a new cadence segment
+                replay-boundary: replay preserves the original cadence segment id
+                ordering-basis: participant episode sequence
+                backend-disclosure-refs: [timing.remote-pacing]
+              - temporal-id: scan-deadline
+                temporal-kind: deadline
+                time-domain: backend_time
+                clock-authority: backend.adapter.clock
+                event-points: [submit, end]
+                description: backend must realize the scan before the participant timeout
+                duration-ref: duration.scan.deadline
+                reset-boundary: participant episode reset clears the deadline state
+                replay-boundary: replay reports the original deadline state
+                ordering-basis: backend event order relation
+                backend-disclosure-refs: [timing.remote-pacing, timing.serialization]
+              - temporal-id: scan-dwell
+                temporal-kind: dwell
+                time-domain: scenario_time
+                clock-authority: scenario.author.clock
+                event-points: [start, end]
+                description: target service must remain in scope for the scan dwell window
+                window-ref: windows.maintenance
+                duration-ref: duration.scan.dwell
+                reset-boundary: participant episode reset clears dwell accumulation
+                replay-boundary: replay reports original dwell evidence
+                ordering-basis: scenario window relation
+                backend-disclosure-refs: [timing.serialization]
+              - temporal-id: scan-latency
+                temporal-kind: latency
+                time-domain: backend_time
+                clock-authority: backend.adapter.clock
+                event-points: [submit, observed]
+                description: terminal observation latency is measured from submit to observation delivery
+                duration-ref: duration.scan.observation-latency
+                reset-boundary: participant episode reset closes the latency segment
+                replay-boundary: replay reports original latency evidence
+                ordering-basis: backend delivery order relation
+                backend-disclosure-refs: [timing.remote-pacing]
+              - temporal-id: scan-window
+                temporal-kind: time_window
+                time-domain: wall_clock_time
+                clock-authority: study.coordinator.clock
+                event-points: [window_open, window_close]
+                description: study-level collection window for participant attempts
+                window-ref: study.collection-window
+                reset-boundary: participant episode reset does not change the study window
+                replay-boundary: replay reports the original study window
+                ordering-basis: study coordinator window relation
+                backend-disclosure-refs: [timing.remote-pacing]
+            backend-timing-disclosures:
+              - disclosure-id: timing.remote-pacing
+                disclosure-kind: pacing
+                support-mode: disclosed_limitation
+                description: remote backend pacing is best-effort and not portable semantic time
+                affected-temporal-ids:
+                  - scan-schedule
+                  - scan-cadence
+                  - scan-deadline
+                  - scan-latency
+                  - scan-window
+                limitations: [wall-clock pacing may lag backend event time]
+              - disclosure-id: timing.serialization
+                disclosure-kind: serialization
+                support-mode: disclosed_limitation
+                description: backend serializes scan realization before emitting terminal observation
+                affected-temporal-ids: [scan-deadline, scan-dwell]
+                limitations: [serialized order is disclosed as realized order, not simultaneity]
+        agents:
+          red-agent:
+            entity: red-team
+            actions: [scan]
+            observation-boundaries: [red-view]
+        observation-boundaries:
+          red-view:
+            projection-basis: participant-local projection
+            observable-refs: [nodes.web.services.http]
+            hidden-refs: []
+            evidence-refs: [evidence.scan-output]
+            redaction-policy: no hidden refs in this SEM-213 fixture
+            latency-profile: terminal observation emitted after backend realization
+        """
+    )
+
+
+def test_temporal_action_contract_declares_sem_213_and_compiles_it() -> None:
+    scenario = parse_sdl(_scenario_yaml())
+
+    contract = scenario.action_contracts["scan"]
+    assert [item.temporal_kind for item in contract.temporal_contracts] == [
+        ParticipantTemporalContractKind.SCHEDULE,
+        ParticipantTemporalContractKind.CADENCE,
+        ParticipantTemporalContractKind.DEADLINE,
+        ParticipantTemporalContractKind.DWELL,
+        ParticipantTemporalContractKind.LATENCY,
+        ParticipantTemporalContractKind.TIME_WINDOW,
+    ]
+    assert contract.temporal_contracts[0].time_domain == ParticipantTimeDomain.SCENARIO_TIME
+    assert contract.temporal_contracts[2].clock_authority == "backend.adapter.clock"
+
+    model = compile_runtime_model(scenario)
+    compiled = model.action_contracts[ACTION_ADDRESS]
+
+    assert compiled.temporal_contract_ids == (
+        "scan-schedule",
+        "scan-cadence",
+        "scan-deadline",
+        "scan-dwell",
+        "scan-latency",
+        "scan-window",
+    )
+    assert compiled.temporal_kinds == (
+        "schedule",
+        "cadence",
+        "deadline",
+        "dwell",
+        "latency",
+        "time_window",
+    )
+    assert compiled.time_domains == ("scenario_time", "episode_step", "backend_time", "wall_clock_time")
+    assert compiled.clock_authorities == (
+        "scenario.author.clock",
+        "processor.episode-sequence",
+        "backend.adapter.clock",
+        "study.coordinator.clock",
+    )
+    assert compiled.backend_timing_disclosures[0]["disclosure_id"] == "timing.remote-pacing"
+    assert compiled.backend_timing_disclosures[0]["disclosure_kind"] == "pacing"
+
+
+def test_temporal_claims_require_time_domain_and_clock_authority() -> None:
+    missing_clock_authority = _scenario_yaml().replace(
+        "        clock-authority: scenario.author.clock\n",
+        "",
+        1,
+    )
+
+    with pytest.raises(SDLParseError, match="clock_authority"):
+        parse_sdl(missing_clock_authority)
+
+
+def test_temporal_backend_disclosure_refs_fail_closed() -> None:
+    unknown_backend_disclosure = _scenario_yaml().replace(
+        "backend-disclosure-refs: [timing.remote-pacing]",
+        "backend-disclosure-refs: [timing.unknown]",
+        1,
+    )
+
+    with pytest.raises(SDLParseError, match="unknown backend_timing_disclosures"):
+        parse_sdl(unknown_backend_disclosure)
+
+
+def _history_payloads(*, temporal_context: ParticipantTemporalRuntimeContext) -> list[dict[str, object]]:
+    action_result = ParticipantActionResult(
+        status=ParticipantActionResultStatus.SUCCEEDED,
+        participant_address=PARTICIPANT_ADDRESS,
+        episode_id=EPISODE_ID,
+        action_instance_id=ACTION_INSTANCE,
+        action_contract_address=ACTION_ADDRESS,
+        observation_point="episode-step:scan-0001:terminal-observation",
+        preconditions=(
+            ParticipantActionPreconditionResult(
+                precondition_id="scheduled-window-open",
+                precondition_class=ParticipantPreconditionClass.TEMPORAL,
+                status=ParticipantActionPreconditionStatus.SATISFIED,
+                participant_address=PARTICIPANT_ADDRESS,
+                episode_id=EPISODE_ID,
+                action_contract_address=ACTION_ADDRESS,
+                observation_point="episode-step:scan-0001:attempt",
+                support_refs=("windows.maintenance",),
+            ),
+            ParticipantActionPreconditionResult(
+                precondition_id="backend-can-realize-scan",
+                precondition_class=ParticipantPreconditionClass.REALIZATION,
+                status=ParticipantActionPreconditionStatus.SATISFIED,
+                participant_address=PARTICIPANT_ADDRESS,
+                episode_id=EPISODE_ID,
+                action_contract_address=ACTION_ADDRESS,
+                observation_point="episode-step:scan-0001:attempt",
+                support_refs=("backend.participant-runtime",),
+            ),
+        ),
+        effects=(
+            ParticipantActionEffectResult(
+                effect_id="terminal-scan-observation",
+                effect_class=ParticipantEffectClass.OBSERVATION_EFFECT,
+                description="terminal scan observation emitted",
+                evidence_refs=("evidence.scan-output",),
+            ),
+        ),
+        evidence_refs=("evidence.scan-output",),
+    )
+    observation = ParticipantBehaviorHistoryEvent(
+        event_type=ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED,
+        timestamp=T0,
+        participant_address=PARTICIPANT_ADDRESS,
+        episode_id=EPISODE_ID,
+        action_instance_id=ACTION_INSTANCE,
+        action_contract_address=ACTION_ADDRESS,
+        observation_boundary_address=OBSERVATION_ADDRESS,
+        observation_status=ParticipantObservationStatus.TERMINAL,
+        post_state_digest="sha256:scan",
+        action_result=action_result,
+        temporal_contexts=(temporal_context,),
+    )
+    return [
+        {
+            "event_type": "action_attempted",
+            "timestamp": T0,
+            "participant_address": PARTICIPANT_ADDRESS,
+            "episode_id": EPISODE_ID,
+            "action_instance_id": ACTION_INSTANCE,
+            "action_contract_address": ACTION_ADDRESS,
+            "actor_provenance": "participant:red-agent",
+            "details": {},
+        },
+        {
+            "event_type": "state_transition_recorded",
+            "timestamp": T0,
+            "participant_address": PARTICIPANT_ADDRESS,
+            "episode_id": EPISODE_ID,
+            "action_instance_id": ACTION_INSTANCE,
+            "action_contract_address": ACTION_ADDRESS,
+            "state_transition_kind": "participant_scan_realized",
+            "post_state_digest": "sha256:scan",
+            "details": {},
+        },
+        observation.to_payload(),
+    ]
+
+
+def test_runtime_temporal_context_must_match_compiled_contract() -> None:
+    model = compile_runtime_model(parse_sdl(_scenario_yaml()))
+    context = ParticipantTemporalRuntimeContext(
+        temporal_contract_id="scan-latency",
+        time_domain=ParticipantTimeDomain.BACKEND_TIME,
+        clock_authority="backend.adapter.clock",
+        event_points=(ParticipantTemporalEventPoint.SUBMIT, ParticipantTemporalEventPoint.OBSERVED),
+        observation_point="episode-step:scan-0001:terminal-observation",
+        backend_disclosure_refs=("timing.remote-pacing",),
+        reset_boundary="participant episode reset closes the latency segment",
+        replay_boundary="replay reports original latency evidence",
+    )
+
+    assert (
+        list(
+            iter_participant_behavior_history_violations(
+                _history_payloads(temporal_context=context),
+                action_contracts=model.action_contracts,
+            )
+        )
+        == []
+    )
+
+    mismatched = ParticipantTemporalRuntimeContext(
+        temporal_contract_id="scan-latency",
+        time_domain=ParticipantTimeDomain.WALL_CLOCK_TIME,
+        clock_authority="backend.adapter.clock",
+        event_points=(ParticipantTemporalEventPoint.SUBMIT, ParticipantTemporalEventPoint.OBSERVED),
+        observation_point="episode-step:scan-0001:terminal-observation",
+        backend_disclosure_refs=("timing.remote-pacing",),
+        reset_boundary="participant episode reset closes the latency segment",
+        replay_boundary="replay reports original latency evidence",
+    )
+
+    violations = list(
+        iter_participant_behavior_history_violations(
+            _history_payloads(temporal_context=mismatched),
+            action_contracts=model.action_contracts,
+        )
+    )
+
+    assert any(
+        "temporal context 'scan-latency' time_domain 'wall_clock_time' does not match compiled contract "
+        "'backend_time'" in message
+        for _, message in violations
+    )
+
+
+def test_temporal_state_machine_rejects_invalid_deadline_dwell_timeout_sequences() -> None:
+    dwell_without_active = [
+        ParticipantTemporalStateTransition(
+            temporal_contract_id="scan-dwell",
+            from_state=ParticipantTemporalState.ELIGIBLE,
+            to_state=ParticipantTemporalState.DWELL_SATISFIED,
+            event_point=ParticipantTemporalEventPoint.END,
+            time_domain=ParticipantTimeDomain.SCENARIO_TIME,
+            clock_authority="scenario.author.clock",
+            boundary_ref="episode:episode-1",
+            evidence_refs=("evidence.scan-output",),
+        )
+    ]
+    deadline_reuse_without_boundary = [
+        ParticipantTemporalStateTransition(
+            temporal_contract_id="scan-deadline",
+            from_state=ParticipantTemporalState.ELIGIBLE,
+            to_state=ParticipantTemporalState.DEADLINE_MISSED,
+            event_point=ParticipantTemporalEventPoint.END,
+            time_domain=ParticipantTimeDomain.BACKEND_TIME,
+            clock_authority="backend.adapter.clock",
+            boundary_ref="episode:episode-1",
+            evidence_refs=("evidence.scan-timeout",),
+        ),
+        ParticipantTemporalStateTransition(
+            temporal_contract_id="scan-deadline",
+            from_state=ParticipantTemporalState.DEADLINE_MISSED,
+            to_state=ParticipantTemporalState.ELIGIBLE,
+            event_point=ParticipantTemporalEventPoint.START,
+            time_domain=ParticipantTimeDomain.BACKEND_TIME,
+            clock_authority="backend.adapter.clock",
+            boundary_ref="episode:episode-1",
+            evidence_refs=("evidence.scan-retry",),
+        ),
+    ]
+
+    violations = [
+        *iter_participant_temporal_state_machine_violations(dwell_without_active),
+        *iter_participant_temporal_state_machine_violations(deadline_reuse_without_boundary),
+    ]
+
+    assert any("dwell_satisfied requires prior dwell_active" in message for _, message in violations)
+    assert any("terminal temporal state requires reset or replay boundary" in message for _, message in violations)
+
+
+def test_contract_schema_publishes_temporal_context_payload() -> None:
+    schema = ParticipantBehaviorHistoryEventModel.model_json_schema()
+
+    assert "temporal_contexts" in schema["properties"]
+    temporal_ref = schema["properties"]["temporal_contexts"]["items"]["$ref"]
+    assert temporal_ref.endswith("/ParticipantTemporalRuntimeContextModel")

--- a/specs/formal/participant-semantics/README.md
+++ b/specs/formal/participant-semantics/README.md
@@ -855,6 +855,35 @@ Minimum future implementation artifacts:
 - abstract state-machine model for deadlines, dwell, and timeout interaction;
 - tests for ordering, delayed observation, and deadline/cadence edge cases.
 
+Current implementation artifacts for the first `SEM-213` slice:
+
+- `implementations/python/packages/aces_sdl/participant_temporal_semantics.py`
+  defines typed time domains, temporal event points, schedule/cadence/deadline/
+  dwell/latency/time-window contract kinds, backend timing disclosure kinds,
+  support modes, and abstract temporal states;
+- `implementations/python/packages/aces_sdl/participant_behavior.py` embeds
+  temporal contracts and backend timing disclosures in governed participant
+  action contracts, requires temporal preconditions to resolve to typed
+  temporal contracts, and fails closed on unknown backend disclosure refs;
+- `implementations/python/packages/aces_processor/compiler.py` carries temporal
+  contract ids, kinds, time domains, clock authorities, and backend timing
+  disclosures into compiled participant action contracts;
+- `implementations/python/packages/aces_processor/models.py` defines runtime
+  temporal context on participant behavior-history events, validates it
+  against the compiled action contract, and exposes an abstract state-machine
+  checker for deadline, dwell, timeout, reset, and replay interactions;
+- `implementations/python/packages/aces_contracts/contracts.py` publishes the
+  runtime temporal-context payload in participant behavior-history and runtime
+  snapshot schemas;
+- `implementations/python/tests/test_sem_213_temporal_participant_semantics.py`
+  covers positive SDL-to-runtime compilation, missing clock authority, unknown
+  backend disclosure refs, runtime contract mismatches, and invalid deadline /
+  dwell / timeout state-machine transitions.
+
+This slice implements participant-local temporal contracts and conformance
+checks. It does not claim the broader ACES clock/time-model work owned by
+`SEM-227`, `SEM-228`, and `SEM-229`.
+
 ## SEM-215 - Participant Outcome Interpretation Semantics
 
 `SEM-215` requires semantics for interpreting participant-local outcomes and


### PR DESCRIPTION
## Summary

Implements SEM-213 participant-local temporal semantics by adding typed temporal contracts, backend timing disclosures, runtime temporal context validation, abstract deadline/dwell/timeout state-machine checks, published contract schemas, documentation, and coverage for SDL-to-runtime behavior.

## Requirement UIDs

- `SEM-213`

## Related Issues

Closes #190

## ADR Impact

- ADR-022

## Changes

- Added typed SEM-213 time domains, event points, temporal contract kinds, backend timing disclosure kinds, support modes, and temporal state enums for participant action contracts.
- Embedded temporal contracts and backend timing disclosures into governed participant action contracts with fail-closed reference validation.
- Carried temporal contract ids, kinds, time domains, clock authorities, and backend timing disclosures into compiled runtime action contracts.
- Added runtime temporal context payloads on participant behavior history events, validation against compiled action contracts, and abstract state-machine checks for deadline, dwell, timeout, reset, and replay interactions.
- Published regenerated SDL, runtime snapshot, and participant behavior-history JSON schemas, and documented the implemented SEM-213 slice.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local gates passed after the test-quality cycle 1 finding was fixed: focused SEM-213/SEM-212 pytest suite reported 20 passed; full verify reported 1205 passed, 1 skipped, 7 deselected; serialized pre-commit all-files passed. Test-quality cycle 1 found one schema-publication test gap, which is fixed in this PR. User instructed Codex to continue without invoking over-cap test-quality cycle 2.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SEM-213 ← implementations/python/packages/aces_sdl/participant_temporal_semantics.py, SEM-213 ← implementations/python/packages/aces_sdl/participant_behavior.py, SEM-213 ← implementations/python/packages/aces_processor/compiler.py, SEM-213 ← implementations/python/packages/aces_processor/models.py, SEM-213 ← implementations/python/packages/aces_contracts/contracts.py, SEM-213 ← contracts/schemas/sdl/instantiated-scenario-v1.json, SEM-213 ← contracts/schemas/sdl/sdl-authoring-input-v1.json, SEM-213 ← contracts/schemas/control-plane/participant-behavior-history-event-stream-v1.json, SEM-213 ← contracts/schemas/snapshots/runtime-snapshot-v1.json, SEM-213 ← specs/formal/participant-semantics/README.md
- TESTS: SEM-213 ← implementations/python/tests/test_sem_213_temporal_participant_semantics.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/190.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
