### PR TITLE
added: expose container runtime configuration surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,14 @@ jobs:
         env:
           ACES_REQUIREMENT_UID: ${{ steps.requirement.outputs.uid }}
           GC_BASE_URL: ${{ vars.GC_BASE_URL }}
-        run: >
-          uv tool run --from 'nox[uv]==2026.4.10'
-          nox -f noxfile.py -s verify --
-          --base-rev "${{ steps.base.outputs.base_rev }}"
+        run: |
+          verify_args=(--base-rev "${{ steps.base.outputs.base_rev }}")
+          if [ -n "${{ steps.requirement.outputs.uid }}" ]; then
+            verify_args+=(--requirement-uid "${{ steps.requirement.outputs.uid }}")
+          else
+            verify_args+=(--skip-requirement)
+          fi
+          uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify -- "${verify_args[@]}"
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/changelog.d/358.added.md
+++ b/changelog.d/358.added.md
@@ -1,0 +1,1 @@
+Add typed SDL runtime surfaces for observed process sets, runtime environment variables, Linux capability policy, restart policy, and container resource limits.

--- a/changelog.d/358.added.md
+++ b/changelog.d/358.added.md
@@ -1,1 +1,1 @@
-Add typed SDL runtime surfaces for observed process sets, runtime environment variables, Linux capability policy, restart policy, and container resource limits.
+Add typed SDL runtime surfaces for observed process sets, runtime environment variables, Linux capability policy, restart policy, and container resource limits; support issue-only CI verification for no-requirement implementation branches.

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -2257,6 +2257,47 @@
       "title": "Role",
       "type": "object"
     },
+    "RuntimeCapabilityPolicy": {
+      "additionalProperties": false,
+      "description": "Linux/container capability policy observed for a runtime node.",
+      "properties": {
+        "add": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Add",
+          "type": "array"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "drop": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Drop",
+          "type": "array"
+        },
+        "effective": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Effective",
+          "type": "array"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        }
+      },
+      "title": "RuntimeCapabilityPolicy",
+      "type": "object"
+    },
     "RuntimeConfiguration": {
       "additionalProperties": false,
       "description": "Observed runtime configuration facts attached to a VM node.",
@@ -2267,6 +2308,24 @@
           },
           "title": "Dependency Manifests",
           "type": "array"
+        },
+        "environment": {
+          "items": {
+            "$ref": "#/$defs/RuntimeEnvironmentVariable"
+          },
+          "title": "Environment",
+          "type": "array"
+        },
+        "linux_capabilities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeCapabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "local_control_interfaces": {
           "items": {
@@ -2281,6 +2340,17 @@
           },
           "title": "Mounts",
           "type": "array"
+        },
+        "operational_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeOperationalPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "package_vulnerabilities": {
           "items": {
@@ -2306,6 +2376,13 @@
             }
           ],
           "default": null
+        },
+        "processes": {
+          "items": {
+            "$ref": "#/$defs/RuntimeProcessIdentity"
+          },
+          "title": "Processes",
+          "type": "array"
         }
       },
       "title": "RuntimeConfiguration",
@@ -2421,6 +2498,85 @@
       "title": "RuntimeDependencyManifest",
       "type": "object"
     },
+    "RuntimeEnvironmentValueClassification": {
+      "description": "Sensitivity classification for an observed runtime environment value.",
+      "enum": [
+        "plain",
+        "redacted",
+        "secret_fixture",
+        "unknown"
+      ],
+      "title": "RuntimeEnvironmentValueClassification",
+      "type": "string"
+    },
+    "RuntimeEnvironmentVariable": {
+      "additionalProperties": false,
+      "description": "Observed runtime environment variable with provenance and sensitivity.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeEnvironmentVariableProvenance"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Provenance"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "value": {
+          "default": "",
+          "title": "Value",
+          "type": "string"
+        },
+        "value_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeEnvironmentValueClassification"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Value Classification"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "RuntimeEnvironmentVariable",
+      "type": "object"
+    },
+    "RuntimeEnvironmentVariableProvenance": {
+      "description": "Origin class for an observed runtime environment variable.",
+      "enum": [
+        "compose",
+        "image",
+        "operator",
+        "container",
+        "runtime",
+        "other",
+        "unknown"
+      ],
+      "title": "RuntimeEnvironmentVariableProvenance",
+      "type": "string"
+    },
     "RuntimeMount": {
       "additionalProperties": false,
       "description": "A filesystem mount observed on a runtime node.",
@@ -2488,6 +2644,42 @@
       ],
       "title": "RuntimeMountSourceKind",
       "type": "string"
+    },
+    "RuntimeOperationalPolicy": {
+      "additionalProperties": false,
+      "description": "Observed restart and resource-limit policy for a runtime node.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "resource_limits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeResourceLimits"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "restart": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeRestartPolicy"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Restart"
+        }
+      },
+      "title": "RuntimeOperationalPolicy",
+      "type": "object"
     },
     "RuntimePackage": {
       "additionalProperties": false,
@@ -2624,10 +2816,47 @@
           "title": "Command",
           "type": "array"
         },
+        "command_redacted": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "title": "Command Redacted"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
         "group": {
           "default": "",
           "title": "Group",
           "type": "string"
+        },
+        "name": {
+          "default": "",
+          "title": "Name",
+          "type": "string"
+        },
+        "parent_pid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Pid"
         },
         "pid": {
           "anyOf": [
@@ -2644,6 +2873,18 @@
           "default": null,
           "title": "Pid"
         },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeProcessRole"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "other",
+          "title": "Role"
+        },
         "user": {
           "default": "",
           "title": "User",
@@ -2657,6 +2898,120 @@
       },
       "title": "RuntimeProcessIdentity",
       "type": "object"
+    },
+    "RuntimeProcessRole": {
+      "description": "Observed role of a process in a runtime process set.",
+      "enum": [
+        "primary",
+        "supervisor",
+        "worker",
+        "sidecar",
+        "agent",
+        "other"
+      ],
+      "title": "RuntimeProcessRole",
+      "type": "string"
+    },
+    "RuntimeResourceLimits": {
+      "additionalProperties": false,
+      "description": "Observed runtime/cgroup resource limits for a node.",
+      "properties": {
+        "cpu": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cpu"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "memory": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Memory"
+        },
+        "memory_swap": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Memory Swap"
+        },
+        "open_files": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Open Files"
+        },
+        "pids": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pids"
+        }
+      },
+      "title": "RuntimeResourceLimits",
+      "type": "object"
+    },
+    "RuntimeRestartPolicy": {
+      "description": "Portable restart policy classification observed at runtime.",
+      "enum": [
+        "no",
+        "always",
+        "on_failure",
+        "unless_stopped",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeRestartPolicy",
+      "type": "string"
     },
     "Script": {
       "additionalProperties": false,

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -2257,6 +2257,47 @@
       "title": "Role",
       "type": "object"
     },
+    "RuntimeCapabilityPolicy": {
+      "additionalProperties": false,
+      "description": "Linux/container capability policy observed for a runtime node.",
+      "properties": {
+        "add": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Add",
+          "type": "array"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "drop": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Drop",
+          "type": "array"
+        },
+        "effective": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Effective",
+          "type": "array"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Required",
+          "type": "array"
+        }
+      },
+      "title": "RuntimeCapabilityPolicy",
+      "type": "object"
+    },
     "RuntimeConfiguration": {
       "additionalProperties": false,
       "description": "Observed runtime configuration facts attached to a VM node.",
@@ -2267,6 +2308,24 @@
           },
           "title": "Dependency Manifests",
           "type": "array"
+        },
+        "environment": {
+          "items": {
+            "$ref": "#/$defs/RuntimeEnvironmentVariable"
+          },
+          "title": "Environment",
+          "type": "array"
+        },
+        "linux_capabilities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeCapabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "local_control_interfaces": {
           "items": {
@@ -2281,6 +2340,17 @@
           },
           "title": "Mounts",
           "type": "array"
+        },
+        "operational_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeOperationalPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "package_vulnerabilities": {
           "items": {
@@ -2306,6 +2376,13 @@
             }
           ],
           "default": null
+        },
+        "processes": {
+          "items": {
+            "$ref": "#/$defs/RuntimeProcessIdentity"
+          },
+          "title": "Processes",
+          "type": "array"
         }
       },
       "title": "RuntimeConfiguration",
@@ -2421,6 +2498,85 @@
       "title": "RuntimeDependencyManifest",
       "type": "object"
     },
+    "RuntimeEnvironmentValueClassification": {
+      "description": "Sensitivity classification for an observed runtime environment value.",
+      "enum": [
+        "plain",
+        "redacted",
+        "secret_fixture",
+        "unknown"
+      ],
+      "title": "RuntimeEnvironmentValueClassification",
+      "type": "string"
+    },
+    "RuntimeEnvironmentVariable": {
+      "additionalProperties": false,
+      "description": "Observed runtime environment variable with provenance and sensitivity.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeEnvironmentVariableProvenance"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Provenance"
+        },
+        "source": {
+          "default": "",
+          "title": "Source",
+          "type": "string"
+        },
+        "value": {
+          "default": "",
+          "title": "Value",
+          "type": "string"
+        },
+        "value_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeEnvironmentValueClassification"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Value Classification"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "RuntimeEnvironmentVariable",
+      "type": "object"
+    },
+    "RuntimeEnvironmentVariableProvenance": {
+      "description": "Origin class for an observed runtime environment variable.",
+      "enum": [
+        "compose",
+        "image",
+        "operator",
+        "container",
+        "runtime",
+        "other",
+        "unknown"
+      ],
+      "title": "RuntimeEnvironmentVariableProvenance",
+      "type": "string"
+    },
     "RuntimeMount": {
       "additionalProperties": false,
       "description": "A filesystem mount observed on a runtime node.",
@@ -2488,6 +2644,42 @@
       ],
       "title": "RuntimeMountSourceKind",
       "type": "string"
+    },
+    "RuntimeOperationalPolicy": {
+      "additionalProperties": false,
+      "description": "Observed restart and resource-limit policy for a runtime node.",
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "resource_limits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeResourceLimits"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "restart": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeRestartPolicy"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Restart"
+        }
+      },
+      "title": "RuntimeOperationalPolicy",
+      "type": "object"
     },
     "RuntimePackage": {
       "additionalProperties": false,
@@ -2624,10 +2816,47 @@
           "title": "Command",
           "type": "array"
         },
+        "command_redacted": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "title": "Command Redacted"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
         "group": {
           "default": "",
           "title": "Group",
           "type": "string"
+        },
+        "name": {
+          "default": "",
+          "title": "Name",
+          "type": "string"
+        },
+        "parent_pid": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Pid"
         },
         "pid": {
           "anyOf": [
@@ -2644,6 +2873,18 @@
           "default": null,
           "title": "Pid"
         },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeProcessRole"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "other",
+          "title": "Role"
+        },
         "user": {
           "default": "",
           "title": "User",
@@ -2657,6 +2898,120 @@
       },
       "title": "RuntimeProcessIdentity",
       "type": "object"
+    },
+    "RuntimeProcessRole": {
+      "description": "Observed role of a process in a runtime process set.",
+      "enum": [
+        "primary",
+        "supervisor",
+        "worker",
+        "sidecar",
+        "agent",
+        "other"
+      ],
+      "title": "RuntimeProcessRole",
+      "type": "string"
+    },
+    "RuntimeResourceLimits": {
+      "additionalProperties": false,
+      "description": "Observed runtime/cgroup resource limits for a node.",
+      "properties": {
+        "cpu": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cpu"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "memory": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Memory"
+        },
+        "memory_swap": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Memory Swap"
+        },
+        "open_files": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Open Files"
+        },
+        "pids": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pids"
+        }
+      },
+      "title": "RuntimeResourceLimits",
+      "type": "object"
+    },
+    "RuntimeRestartPolicy": {
+      "description": "Portable restart policy classification observed at runtime.",
+      "enum": [
+        "no",
+        "always",
+        "on_failure",
+        "unless_stopped",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeRestartPolicy",
+      "type": "string"
     },
     "Script": {
       "additionalProperties": false,

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -101,6 +101,32 @@ nodes:
         command: ./shufflebackend
         user: root
         working_directory: /app
+      processes:
+        - name: supervisord
+          pid: 1
+          command: supervisord -n
+          role: supervisor
+        - name: gunicorn
+          parent_pid: 1
+          command: [gunicorn, app:app]
+          role: worker
+      environment:
+        - name: TECHVAULT_ADMIN_PASSWORD
+          value_classification: redacted
+          provenance: operator
+        - name: SCENARIO_FIXTURE_TOKEN
+          value: fixture-token
+          value_classification: secret_fixture
+          provenance: compose
+      linux_capabilities:
+        required: [CAP_NET_ADMIN]
+        effective: CAP_NET_ADMIN
+      operational_policy:
+        restart: unless_stopped
+        resource_limits:
+          memory: 512 MiB
+          cpu: 0.5
+          pids: 128
       packages:
         - manager: apk
           name: musl
@@ -137,8 +163,12 @@ Concrete service bindings on a VM must be unique by `protocol` + `port`. Reusing
 `runtime` captures observed VM/runtime facts that are not authored deployable
 features or exposed network services. Mounts describe realized filesystem
 attachments; `local_control_interfaces` describe path-local control APIs such
-as Unix sockets; `process` records execution identity; `packages` and
-`dependency_manifests` record runtime inventory; and
+as Unix sockets; `process` records primary execution identity; `processes`
+records a supervised or load-bearing process set; `environment` records
+observed runtime environment variables with provenance and redaction
+classification; `linux_capabilities` records container/Linux capability policy;
+`operational_policy` records restart policy and observed resource limits;
+`packages` and `dependency_manifests` record runtime inventory; and
 `package_vulnerabilities` records scanner-derived CVE/advisory findings tied
 to an image digest and scan time. These findings are separate from the
 top-level `vulnerabilities` section, which remains the CWE-classified scenario

--- a/implementations/python/packages/aces_sdl/nodes.py
+++ b/implementations/python/packages/aces_sdl/nodes.py
@@ -4,7 +4,6 @@ Ports the OCR SDL Node/VM/Switch/Resources/Role structs with
 backend-agnostic Source references.
 """
 
-import re
 from enum import Enum
 
 from pydantic import Field, field_validator, model_validator
@@ -13,101 +12,64 @@ from ._base import (
     SDLModel,
     is_variable_ref,
     normalize_enum_value,
-    parse_bool_or_var,
     parse_enum_or_var,
     parse_int_or_var,
 )
 from ._source import Source
+from .runtime_configuration import (
+    RuntimeCapabilityPolicy,
+    RuntimeConfiguration,
+    RuntimeControlInterface,
+    RuntimeControlInterfaceAccess,
+    RuntimeControlInterfaceKind,
+    RuntimeEnvironmentValueClassification,
+    RuntimeEnvironmentVariable,
+    RuntimeEnvironmentVariableProvenance,
+    RuntimeMount,
+    RuntimeMountSourceKind,
+    RuntimeOperationalPolicy,
+    RuntimePackage,
+    RuntimePackageVulnerabilityFinding,
+    RuntimePackageVulnerabilitySeverity,
+    RuntimeProcessIdentity,
+    RuntimeProcessRole,
+    RuntimeResourceLimits,
+    RuntimeRestartPolicy,
+    parse_ram,
+)
+
+__all__ = [
+    "AssetValue",
+    "AssetValueLevel",
+    "MAX_NODE_NAME_LENGTH",
+    "Node",
+    "NodeType",
+    "OSFamily",
+    "Resources",
+    "Role",
+    "RuntimeCapabilityPolicy",
+    "RuntimeConfiguration",
+    "RuntimeControlInterface",
+    "RuntimeControlInterfaceAccess",
+    "RuntimeControlInterfaceKind",
+    "RuntimeEnvironmentValueClassification",
+    "RuntimeEnvironmentVariable",
+    "RuntimeEnvironmentVariableProvenance",
+    "RuntimeMount",
+    "RuntimeMountSourceKind",
+    "RuntimeOperationalPolicy",
+    "RuntimePackage",
+    "RuntimePackageVulnerabilityFinding",
+    "RuntimePackageVulnerabilitySeverity",
+    "RuntimeProcessIdentity",
+    "RuntimeProcessRole",
+    "RuntimeResourceLimits",
+    "RuntimeRestartPolicy",
+    "ServicePort",
+    "parse_ram",
+]
 
 MAX_NODE_NAME_LENGTH = 35
-
-_BYTE_UNITS = {
-    "b": 1,
-    "kb": 1_000,
-    "kib": 1_024,
-    "mb": 1_000_000,
-    "mib": 1_048_576,
-    "gb": 1_000_000_000,
-    "gib": 1_073_741_824,
-    "tb": 1_000_000_000_000,
-    "tib": 1_099_511_627_776,
-}
-
-_RAM_PATTERN = re.compile(
-    r"^\s*(\d+(?:\.\d+)?)\s*(" + "|".join(_BYTE_UNITS) + r")\s*$",
-    re.IGNORECASE,
-)
-_WINDOWS_NAMED_PIPE_PREFIXES = ("\\\\.\\pipe\\", "\\\\?\\pipe\\")
-
-
-def _absolute_path_or_var(value: str, *, field_name: str) -> str:
-    if is_variable_ref(value):
-        return value
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string")
-    if not value.startswith("/"):
-        raise ValueError(f"{field_name} must be an absolute path")
-    return value
-
-
-def _is_windows_named_pipe(value: str) -> bool:
-    return isinstance(value, str) and value.lower().startswith(_WINDOWS_NAMED_PIPE_PREFIXES)
-
-
-def _control_interface_path_or_var(value: str, *, field_name: str) -> str:
-    if is_variable_ref(value):
-        return value
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string")
-    if value.startswith("/") or _is_windows_named_pipe(value):
-        return value
-    raise ValueError(f"{field_name} must be an absolute path or Windows named pipe")
-
-
-def _parse_runtime_enum_or_var(value, enum_cls: type[Enum], *, field_name: str):
-    if value is None or is_variable_ref(value):
-        return value
-    if isinstance(value, enum_cls):
-        return value
-    if isinstance(value, str):
-        normalized = value.lower().replace("-", "_")
-        try:
-            return enum_cls(normalized)
-        except ValueError as e:
-            allowed = ", ".join(member.value for member in enum_cls)
-            raise ValueError(f"{field_name} must be one of: {allowed}") from e
-    raise ValueError(f"{field_name} must be a string")
-
-
-def parse_ram(value: str | int) -> int | str:
-    """Parse a human-readable RAM string to bytes.
-
-    Accepts bare integers (treated as bytes) or strings like
-    ``"4 GiB"``, ``"2048 MiB"``, ``"512mb"``.
-    """
-    if is_variable_ref(value):
-        return value
-    if isinstance(value, bool):
-        raise ValueError("RAM must be a positive integer or human-readable size")
-    if isinstance(value, int):
-        if value < 1:
-            raise ValueError("RAM must be >= 1 byte")
-        return value
-    value_str = str(value).strip()
-    if value_str.isdigit():
-        parsed = int(value_str)
-        if parsed < 1:
-            raise ValueError("RAM must be >= 1 byte")
-        return parsed
-    match = _RAM_PATTERN.match(value_str)
-    if not match:
-        raise ValueError(f"Invalid RAM value: {value_str!r}. Use a number with a unit (e.g., '4 GiB', '2048 MiB').")
-    amount = float(match.group(1))
-    unit = match.group(2).lower()
-    parsed = int(amount * _BYTE_UNITS[unit])
-    if parsed < 1:
-        raise ValueError("RAM must be >= 1 byte")
-    return parsed
 
 
 class NodeType(str, Enum):
@@ -202,199 +164,6 @@ class ServicePort(SDLModel):
     @classmethod
     def parse_port_value(cls, v: int | str) -> int | str:
         return parse_int_or_var(v, minimum=1, maximum=65535, field_name="port")
-
-
-class RuntimeMountSourceKind(str, Enum):
-    """Portable source kind for a runtime filesystem mount."""
-
-    VOLUME = "volume"
-    BIND = "bind"
-    TMPFS = "tmpfs"
-    IMAGE = "image"
-    OTHER = "other"
-
-
-class RuntimeControlInterfaceKind(str, Enum):
-    """Path-local control interface shape observed at runtime."""
-
-    UNIX_SOCKET = "unix_socket"
-    NAMED_PIPE = "named_pipe"
-    FILE = "file"
-    OTHER = "other"
-
-
-class RuntimeControlInterfaceAccess(str, Enum):
-    """Observed local-control access mode."""
-
-    READ_ONLY = "read_only"
-    READ_WRITE = "read_write"
-    UNKNOWN = "unknown"
-
-
-class RuntimePackageVulnerabilitySeverity(str, Enum):
-    """Scanner-derived package finding severity."""
-
-    UNKNOWN = "unknown"
-    LOW = "low"
-    MEDIUM = "medium"
-    HIGH = "high"
-    CRITICAL = "critical"
-
-
-class RuntimeMount(SDLModel):
-    """A filesystem mount observed on a runtime node."""
-
-    target: str
-    source: str = ""
-    source_kind: RuntimeMountSourceKind | str = RuntimeMountSourceKind.OTHER
-    read_only: bool | str = False
-    options: list[str] = Field(default_factory=list)
-    description: str = ""
-
-    @field_validator("target")
-    @classmethod
-    def validate_target(cls, v: str) -> str:
-        return _absolute_path_or_var(v, field_name="target")
-
-    @field_validator("source_kind", mode="before")
-    @classmethod
-    def normalize_source_kind(cls, v: RuntimeMountSourceKind | str) -> RuntimeMountSourceKind | str:
-        return _parse_runtime_enum_or_var(v, RuntimeMountSourceKind, field_name="source_kind")
-
-    @field_validator("read_only", mode="before")
-    @classmethod
-    def parse_read_only(cls, v: bool | str) -> bool | str:
-        return parse_bool_or_var(v, field_name="read_only")
-
-
-class RuntimeControlInterface(SDLModel):
-    """A non-network local control API exposed inside a runtime node."""
-
-    path: str
-    kind: RuntimeControlInterfaceKind | str = RuntimeControlInterfaceKind.UNIX_SOCKET
-    protocol: str = ""
-    bind_source: str = ""
-    access: RuntimeControlInterfaceAccess | str = RuntimeControlInterfaceAccess.UNKNOWN
-    description: str = ""
-
-    @field_validator("path")
-    @classmethod
-    def validate_path(cls, v: str) -> str:
-        return _control_interface_path_or_var(v, field_name="path")
-
-    @field_validator("bind_source")
-    @classmethod
-    def validate_bind_source(cls, v: str) -> str:
-        return _control_interface_path_or_var(v, field_name="bind_source") if v else v
-
-    @field_validator("kind", mode="before")
-    @classmethod
-    def normalize_kind(cls, v: RuntimeControlInterfaceKind | str) -> RuntimeControlInterfaceKind | str:
-        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceKind, field_name="kind")
-
-    @field_validator("access", mode="before")
-    @classmethod
-    def normalize_access(cls, v: RuntimeControlInterfaceAccess | str) -> RuntimeControlInterfaceAccess | str:
-        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceAccess, field_name="access")
-
-    @model_validator(mode="after")
-    def validate_named_pipe_kind(self) -> "RuntimeControlInterface":
-        if is_variable_ref(self.kind):
-            return self
-        has_windows_named_pipe_endpoint = _is_windows_named_pipe(self.path) or _is_windows_named_pipe(self.bind_source)
-        if has_windows_named_pipe_endpoint and self.kind != RuntimeControlInterfaceKind.NAMED_PIPE:
-            raise ValueError("Windows named pipe paths require kind 'named_pipe'")
-        return self
-
-
-class RuntimeProcessIdentity(SDLModel):
-    """Observed process identity for a runtime node."""
-
-    pid: int | str | None = None
-    command: list[str] = Field(default_factory=list)
-    user: str = ""
-    group: str = ""
-    working_directory: str = ""
-
-    @field_validator("pid", mode="before")
-    @classmethod
-    def parse_pid(cls, v: int | str | None) -> int | str | None:
-        return parse_int_or_var(v, minimum=1, field_name="pid") if v is not None else v
-
-    @field_validator("command", mode="before")
-    @classmethod
-    def normalize_command(cls, v: str | list[str] | None) -> list[str]:
-        if v is None:
-            return []
-        if isinstance(v, str):
-            return [v]
-        return v
-
-    @field_validator("working_directory")
-    @classmethod
-    def validate_working_directory(cls, v: str) -> str:
-        return _absolute_path_or_var(v, field_name="working_directory") if v else v
-
-
-class RuntimePackage(SDLModel):
-    """A package observed in a runtime image or node."""
-
-    manager: str
-    name: str
-    version: str
-    architecture: str = ""
-    source: str = ""
-    purl: str = ""
-
-
-class RuntimeDependencyManifest(SDLModel):
-    """A dependency manifest visible in the realized runtime artifact."""
-
-    ecosystem: str
-    path: str
-    format: str = ""
-    name: str = ""
-    version: str = ""
-
-    @field_validator("path")
-    @classmethod
-    def validate_path(cls, v: str) -> str:
-        return _absolute_path_or_var(v, field_name="path")
-
-
-class RuntimePackageVulnerabilityFinding(SDLModel):
-    """A scanner-derived CVE/advisory finding for an observed package."""
-
-    id: str
-    package_name: str
-    installed_version: str
-    severity: RuntimePackageVulnerabilitySeverity | str = RuntimePackageVulnerabilitySeverity.UNKNOWN
-    scanner: str
-    image_digest: str
-    scan_time: str
-    fixed_version: str = ""
-    advisory_url: str = ""
-    scanner_version: str = ""
-    scanner_database: str = ""
-
-    @field_validator("severity", mode="before")
-    @classmethod
-    def normalize_severity(
-        cls,
-        v: RuntimePackageVulnerabilitySeverity | str,
-    ) -> RuntimePackageVulnerabilitySeverity | str:
-        return _parse_runtime_enum_or_var(v, RuntimePackageVulnerabilitySeverity, field_name="severity")
-
-
-class RuntimeConfiguration(SDLModel):
-    """Observed runtime configuration facts attached to a VM node."""
-
-    mounts: list[RuntimeMount] = Field(default_factory=list)
-    local_control_interfaces: list[RuntimeControlInterface] = Field(default_factory=list)
-    process: RuntimeProcessIdentity | None = None
-    packages: list[RuntimePackage] = Field(default_factory=list)
-    dependency_manifests: list[RuntimeDependencyManifest] = Field(default_factory=list)
-    package_vulnerabilities: list[RuntimePackageVulnerabilityFinding] = Field(default_factory=list)
 
 
 class Node(SDLModel):

--- a/implementations/python/packages/aces_sdl/runtime_configuration.py
+++ b/implementations/python/packages/aces_sdl/runtime_configuration.py
@@ -29,6 +29,7 @@ _RAM_PATTERN = re.compile(
     r"^\s*(\d+(?:\.\d+)?)\s*(" + "|".join(_BYTE_UNITS) + r")\s*$",
     re.IGNORECASE,
 )
+_RAM_MIN_BYTES_ERROR = "RAM must be >= 1 byte"
 _WINDOWS_NAMED_PIPE_PREFIXES = ("\\\\.\\pipe\\", "\\\\?\\pipe\\")
 
 
@@ -83,13 +84,13 @@ def parse_ram(value: str | int) -> int | str:
         raise ValueError("RAM must be a positive integer or human-readable size")
     if isinstance(value, int):
         if value < 1:
-            raise ValueError("RAM must be >= 1 byte")
+            raise ValueError(_RAM_MIN_BYTES_ERROR)
         return value
     value_str = str(value).strip()
     if value_str.isdigit():
         parsed = int(value_str)
         if parsed < 1:
-            raise ValueError("RAM must be >= 1 byte")
+            raise ValueError(_RAM_MIN_BYTES_ERROR)
         return parsed
     match = _RAM_PATTERN.match(value_str)
     if not match:
@@ -98,7 +99,7 @@ def parse_ram(value: str | int) -> int | str:
     unit = match.group(2).lower()
     parsed = int(amount * _BYTE_UNITS[unit])
     if parsed < 1:
-        raise ValueError("RAM must be >= 1 byte")
+        raise ValueError(_RAM_MIN_BYTES_ERROR)
     return parsed
 
 
@@ -155,7 +156,7 @@ class RuntimeEnvironmentValueClassification(str, Enum):
 
     PLAIN = "plain"
     REDACTED = "redacted"
-    SECRET_FIXTURE = "secret_fixture"  # noqa: S105 - classification label, not a credential value.
+    SECRET_FIXTURE = "secret_fixture"  # noqa: S105
     UNKNOWN = "unknown"
 
 

--- a/implementations/python/packages/aces_sdl/runtime_configuration.py
+++ b/implementations/python/packages/aces_sdl/runtime_configuration.py
@@ -1,0 +1,517 @@
+"""Observed runtime configuration models for SDL nodes."""
+
+import re
+from enum import Enum
+
+from pydantic import Field, ValidationInfo, field_validator, model_validator
+
+from ._base import (
+    SDLModel,
+    is_variable_ref,
+    parse_bool_or_var,
+    parse_float_or_var,
+    parse_int_or_var,
+)
+
+_BYTE_UNITS = {
+    "b": 1,
+    "kb": 1_000,
+    "kib": 1_024,
+    "mb": 1_000_000,
+    "mib": 1_048_576,
+    "gb": 1_000_000_000,
+    "gib": 1_073_741_824,
+    "tb": 1_000_000_000_000,
+    "tib": 1_099_511_627_776,
+}
+
+_RAM_PATTERN = re.compile(
+    r"^\s*(\d+(?:\.\d+)?)\s*(" + "|".join(_BYTE_UNITS) + r")\s*$",
+    re.IGNORECASE,
+)
+_WINDOWS_NAMED_PIPE_PREFIXES = ("\\\\.\\pipe\\", "\\\\?\\pipe\\")
+
+
+def _absolute_path_or_var(value: str, *, field_name: str) -> str:
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if not value.startswith("/"):
+        raise ValueError(f"{field_name} must be an absolute path")
+    return value
+
+
+def _is_windows_named_pipe(value: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(_WINDOWS_NAMED_PIPE_PREFIXES)
+
+
+def _control_interface_path_or_var(value: str, *, field_name: str) -> str:
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    if value.startswith("/") or _is_windows_named_pipe(value):
+        return value
+    raise ValueError(f"{field_name} must be an absolute path or Windows named pipe")
+
+
+def _parse_runtime_enum_or_var(value, enum_cls: type[Enum], *, field_name: str):
+    if value is None or is_variable_ref(value):
+        return value
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, str):
+        normalized = value.lower().replace("-", "_")
+        try:
+            return enum_cls(normalized)
+        except ValueError as e:
+            allowed = ", ".join(member.value for member in enum_cls)
+            raise ValueError(f"{field_name} must be one of: {allowed}") from e
+    raise ValueError(f"{field_name} must be a string")
+
+
+def parse_ram(value: str | int) -> int | str:
+    """Parse a human-readable RAM string to bytes.
+
+    Accepts bare integers (treated as bytes) or strings like
+    ``"4 GiB"``, ``"2048 MiB"``, ``"512mb"``.
+    """
+    if is_variable_ref(value):
+        return value
+    if isinstance(value, bool):
+        raise ValueError("RAM must be a positive integer or human-readable size")
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError("RAM must be >= 1 byte")
+        return value
+    value_str = str(value).strip()
+    if value_str.isdigit():
+        parsed = int(value_str)
+        if parsed < 1:
+            raise ValueError("RAM must be >= 1 byte")
+        return parsed
+    match = _RAM_PATTERN.match(value_str)
+    if not match:
+        raise ValueError(f"Invalid RAM value: {value_str!r}. Use a number with a unit (e.g., '4 GiB', '2048 MiB').")
+    amount = float(match.group(1))
+    unit = match.group(2).lower()
+    parsed = int(amount * _BYTE_UNITS[unit])
+    if parsed < 1:
+        raise ValueError("RAM must be >= 1 byte")
+    return parsed
+
+
+class RuntimeMountSourceKind(str, Enum):
+    """Portable source kind for a runtime filesystem mount."""
+
+    VOLUME = "volume"
+    BIND = "bind"
+    TMPFS = "tmpfs"
+    IMAGE = "image"
+    OTHER = "other"
+
+
+class RuntimeControlInterfaceKind(str, Enum):
+    """Path-local control interface shape observed at runtime."""
+
+    UNIX_SOCKET = "unix_socket"
+    NAMED_PIPE = "named_pipe"
+    FILE = "file"
+    OTHER = "other"
+
+
+class RuntimeControlInterfaceAccess(str, Enum):
+    """Observed local-control access mode."""
+
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+    UNKNOWN = "unknown"
+
+
+class RuntimePackageVulnerabilitySeverity(str, Enum):
+    """Scanner-derived package finding severity."""
+
+    UNKNOWN = "unknown"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class RuntimeProcessRole(str, Enum):
+    """Observed role of a process in a runtime process set."""
+
+    PRIMARY = "primary"
+    SUPERVISOR = "supervisor"
+    WORKER = "worker"
+    SIDECAR = "sidecar"
+    AGENT = "agent"
+    OTHER = "other"
+
+
+class RuntimeEnvironmentValueClassification(str, Enum):
+    """Sensitivity classification for an observed runtime environment value."""
+
+    PLAIN = "plain"
+    REDACTED = "redacted"
+    SECRET_FIXTURE = "secret_fixture"  # noqa: S105 - classification label, not a credential value.
+    UNKNOWN = "unknown"
+
+
+class RuntimeEnvironmentVariableProvenance(str, Enum):
+    """Origin class for an observed runtime environment variable."""
+
+    COMPOSE = "compose"
+    IMAGE = "image"
+    OPERATOR = "operator"
+    CONTAINER = "container"
+    RUNTIME = "runtime"
+    OTHER = "other"
+    UNKNOWN = "unknown"
+
+
+class RuntimeRestartPolicy(str, Enum):
+    """Portable restart policy classification observed at runtime."""
+
+    NO = "no"
+    ALWAYS = "always"
+    ON_FAILURE = "on_failure"
+    UNLESS_STOPPED = "unless_stopped"
+    UNKNOWN = "unknown"
+    OTHER = "other"
+
+
+def _coerce_string_list(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return value
+
+
+def _normalize_capability_name(value: str) -> str:
+    if is_variable_ref(value):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("capability names must be non-empty strings")
+    normalized = value.strip().upper().replace("-", "_")
+    if not re.fullmatch(r"CAP_[A-Z0-9_]+", normalized):
+        raise ValueError("capability names must use Linux CAP_* form")
+    return normalized
+
+
+class RuntimeMount(SDLModel):
+    """A filesystem mount observed on a runtime node."""
+
+    target: str
+    source: str = ""
+    source_kind: RuntimeMountSourceKind | str = RuntimeMountSourceKind.OTHER
+    read_only: bool | str = False
+    options: list[str] = Field(default_factory=list)
+    description: str = ""
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="target")
+
+    @field_validator("source_kind", mode="before")
+    @classmethod
+    def normalize_source_kind(cls, v: RuntimeMountSourceKind | str) -> RuntimeMountSourceKind | str:
+        return _parse_runtime_enum_or_var(v, RuntimeMountSourceKind, field_name="source_kind")
+
+    @field_validator("read_only", mode="before")
+    @classmethod
+    def parse_read_only(cls, v: bool | str) -> bool | str:
+        return parse_bool_or_var(v, field_name="read_only")
+
+
+class RuntimeControlInterface(SDLModel):
+    """A non-network local control API exposed inside a runtime node."""
+
+    path: str
+    kind: RuntimeControlInterfaceKind | str = RuntimeControlInterfaceKind.UNIX_SOCKET
+    protocol: str = ""
+    bind_source: str = ""
+    access: RuntimeControlInterfaceAccess | str = RuntimeControlInterfaceAccess.UNKNOWN
+    description: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        return _control_interface_path_or_var(v, field_name="path")
+
+    @field_validator("bind_source")
+    @classmethod
+    def validate_bind_source(cls, v: str) -> str:
+        return _control_interface_path_or_var(v, field_name="bind_source") if v else v
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def normalize_kind(cls, v: RuntimeControlInterfaceKind | str) -> RuntimeControlInterfaceKind | str:
+        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceKind, field_name="kind")
+
+    @field_validator("access", mode="before")
+    @classmethod
+    def normalize_access(cls, v: RuntimeControlInterfaceAccess | str) -> RuntimeControlInterfaceAccess | str:
+        return _parse_runtime_enum_or_var(v, RuntimeControlInterfaceAccess, field_name="access")
+
+    @model_validator(mode="after")
+    def validate_named_pipe_kind(self) -> "RuntimeControlInterface":
+        if is_variable_ref(self.kind):
+            return self
+        has_windows_named_pipe_endpoint = _is_windows_named_pipe(self.path) or _is_windows_named_pipe(self.bind_source)
+        if has_windows_named_pipe_endpoint and self.kind != RuntimeControlInterfaceKind.NAMED_PIPE:
+            raise ValueError("Windows named pipe paths require kind 'named_pipe'")
+        return self
+
+
+class RuntimeProcessIdentity(SDLModel):
+    """Observed process identity for a runtime node."""
+
+    name: str = ""
+    pid: int | str | None = None
+    parent_pid: int | str | None = None
+    command: list[str] = Field(default_factory=list)
+    command_redacted: bool | str = False
+    role: RuntimeProcessRole | str = RuntimeProcessRole.OTHER
+    user: str = ""
+    group: str = ""
+    working_directory: str = ""
+    description: str = ""
+
+    @field_validator("pid", mode="before")
+    @classmethod
+    def parse_pid(cls, v: int | str | None) -> int | str | None:
+        return parse_int_or_var(v, minimum=1, field_name="pid") if v is not None else v
+
+    @field_validator("parent_pid", mode="before")
+    @classmethod
+    def parse_parent_pid(cls, v: int | str | None) -> int | str | None:
+        return parse_int_or_var(v, minimum=1, field_name="parent_pid") if v is not None else v
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def normalize_command(cls, v: str | list[str] | None) -> list[str]:
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [v]
+        return v
+
+    @field_validator("command_redacted", mode="before")
+    @classmethod
+    def parse_command_redacted(cls, v: bool | str) -> bool | str:
+        return parse_bool_or_var(v, field_name="command_redacted")
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def normalize_role(cls, v: RuntimeProcessRole | str) -> RuntimeProcessRole | str:
+        return _parse_runtime_enum_or_var(v, RuntimeProcessRole, field_name="role")
+
+    @field_validator("working_directory")
+    @classmethod
+    def validate_working_directory(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="working_directory") if v else v
+
+
+class RuntimeEnvironmentVariable(SDLModel):
+    """Observed runtime environment variable with provenance and sensitivity."""
+
+    name: str
+    value: str = ""
+    value_classification: RuntimeEnvironmentValueClassification | str = RuntimeEnvironmentValueClassification.UNKNOWN
+    provenance: RuntimeEnvironmentVariableProvenance | str = RuntimeEnvironmentVariableProvenance.UNKNOWN
+    source: str = ""
+    description: str = ""
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("environment variable name must be a non-empty string")
+        if "=" in v:
+            raise ValueError("environment variable name must not contain '='")
+        return v
+
+    @field_validator("value_classification", mode="before")
+    @classmethod
+    def normalize_value_classification(
+        cls,
+        v: RuntimeEnvironmentValueClassification | str,
+    ) -> RuntimeEnvironmentValueClassification | str:
+        return _parse_runtime_enum_or_var(
+            v,
+            RuntimeEnvironmentValueClassification,
+            field_name="value_classification",
+        )
+
+    @field_validator("provenance", mode="before")
+    @classmethod
+    def normalize_provenance(
+        cls,
+        v: RuntimeEnvironmentVariableProvenance | str,
+    ) -> RuntimeEnvironmentVariableProvenance | str:
+        return _parse_runtime_enum_or_var(v, RuntimeEnvironmentVariableProvenance, field_name="provenance")
+
+    @model_validator(mode="after")
+    def validate_redacted_value(self) -> "RuntimeEnvironmentVariable":
+        if self.value_classification == RuntimeEnvironmentValueClassification.REDACTED and self.value:
+            raise ValueError("redacted runtime environment variables must omit value")
+        return self
+
+
+class RuntimeCapabilityPolicy(SDLModel):
+    """Linux/container capability policy observed for a runtime node."""
+
+    required: list[str] = Field(default_factory=list)
+    effective: list[str] = Field(default_factory=list)
+    add: list[str] = Field(default_factory=list)
+    drop: list[str] = Field(default_factory=list)
+    description: str = ""
+
+    @field_validator("required", "effective", "add", "drop", mode="before")
+    @classmethod
+    def coerce_capability_lists(cls, v):
+        return _coerce_string_list(v)
+
+    @field_validator("required", "effective", "add", "drop")
+    @classmethod
+    def validate_capability_names(cls, v: list[str]) -> list[str]:
+        return [_normalize_capability_name(item) for item in v]
+
+    @model_validator(mode="after")
+    def validate_unique_capabilities(self) -> "RuntimeCapabilityPolicy":
+        for field_name in ("required", "effective", "add", "drop"):
+            values = getattr(self, field_name)
+            if len(values) != len(set(values)):
+                raise ValueError(f"Duplicate runtime capability in {field_name}")
+        return self
+
+
+class RuntimeResourceLimits(SDLModel):
+    """Observed runtime/cgroup resource limits for a node."""
+
+    memory: int | str | None = None
+    memory_swap: int | str | None = None
+    cpu: float | str | None = None
+    pids: int | str | None = None
+    open_files: int | str | None = None
+    description: str = ""
+
+    @field_validator("memory", "memory_swap", mode="before")
+    @classmethod
+    def parse_memory_limit(cls, v: int | str | None) -> int | str | None:
+        return parse_ram(v) if v is not None else v
+
+    @field_validator("cpu", mode="before")
+    @classmethod
+    def parse_cpu_limit(cls, v: float | str | None) -> float | str | None:
+        return parse_float_or_var(v, minimum=0, field_name="cpu") if v is not None else v
+
+    @field_validator("pids", "open_files", mode="before")
+    @classmethod
+    def parse_count_limit(cls, v: int | str | None, info: ValidationInfo) -> int | str | None:
+        return parse_int_or_var(v, minimum=1, field_name=info.field_name) if v is not None else v
+
+
+class RuntimeOperationalPolicy(SDLModel):
+    """Observed restart and resource-limit policy for a runtime node."""
+
+    restart: RuntimeRestartPolicy | str = RuntimeRestartPolicy.UNKNOWN
+    resource_limits: RuntimeResourceLimits | None = None
+    description: str = ""
+
+    @field_validator("restart", mode="before")
+    @classmethod
+    def normalize_restart(cls, v: RuntimeRestartPolicy | str | bool) -> RuntimeRestartPolicy | str:
+        if v is False:
+            return RuntimeRestartPolicy.NO
+        return _parse_runtime_enum_or_var(v, RuntimeRestartPolicy, field_name="restart")
+
+
+class RuntimePackage(SDLModel):
+    """A package observed in a runtime image or node."""
+
+    manager: str
+    name: str
+    version: str
+    architecture: str = ""
+    source: str = ""
+    purl: str = ""
+
+
+class RuntimeDependencyManifest(SDLModel):
+    """A dependency manifest visible in the realized runtime artifact."""
+
+    ecosystem: str
+    path: str
+    format: str = ""
+    name: str = ""
+    version: str = ""
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v: str) -> str:
+        return _absolute_path_or_var(v, field_name="path")
+
+
+class RuntimePackageVulnerabilityFinding(SDLModel):
+    """A scanner-derived CVE/advisory finding for an observed package."""
+
+    id: str
+    package_name: str
+    installed_version: str
+    severity: RuntimePackageVulnerabilitySeverity | str = RuntimePackageVulnerabilitySeverity.UNKNOWN
+    scanner: str
+    image_digest: str
+    scan_time: str
+    fixed_version: str = ""
+    advisory_url: str = ""
+    scanner_version: str = ""
+    scanner_database: str = ""
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def normalize_severity(
+        cls,
+        v: RuntimePackageVulnerabilitySeverity | str,
+    ) -> RuntimePackageVulnerabilitySeverity | str:
+        return _parse_runtime_enum_or_var(v, RuntimePackageVulnerabilitySeverity, field_name="severity")
+
+
+class RuntimeConfiguration(SDLModel):
+    """Observed runtime configuration facts attached to a VM node."""
+
+    mounts: list[RuntimeMount] = Field(default_factory=list)
+    local_control_interfaces: list[RuntimeControlInterface] = Field(default_factory=list)
+    process: RuntimeProcessIdentity | None = None
+    processes: list[RuntimeProcessIdentity] = Field(default_factory=list)
+    environment: list[RuntimeEnvironmentVariable] = Field(default_factory=list)
+    linux_capabilities: RuntimeCapabilityPolicy | None = None
+    operational_policy: RuntimeOperationalPolicy | None = None
+    packages: list[RuntimePackage] = Field(default_factory=list)
+    dependency_manifests: list[RuntimeDependencyManifest] = Field(default_factory=list)
+    package_vulnerabilities: list[RuntimePackageVulnerabilityFinding] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_unique_runtime_entries(self) -> "RuntimeConfiguration":
+        seen_env_names: set[str] = set()
+        for variable in self.environment:
+            if variable.name in seen_env_names:
+                raise ValueError(f"Duplicate runtime environment variable '{variable.name}'")
+            seen_env_names.add(variable.name)
+
+        seen_process_names: set[str] = set()
+        seen_process_pids: set[int | str] = set()
+        for process in self.processes:
+            if process.name:
+                if process.name in seen_process_names:
+                    raise ValueError(f"Duplicate runtime process name '{process.name}'")
+                seen_process_names.add(process.name)
+            if process.pid is not None:
+                if process.pid in seen_process_pids:
+                    raise ValueError(f"Duplicate runtime process pid '{process.pid}'")
+                seen_process_pids.add(process.pid)
+        return self

--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import sys
 import types
@@ -17,6 +18,33 @@ from tools.check_schema_publication import validate_schema_publication_manifest
 from tools.gitleaks_tool import _checksums_asset_name, _release_asset_name, gitleaks_binary_path
 from tools.policy.common import PolicyFailure
 from tools.policy.repo_policy import evaluate_repo_policy
+
+
+def load_noxfile_with_fake_nox(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    class FakeOptions:
+        default_venv_backend = ""
+        reuse_existing_virtualenvs = False
+        sessions: list[str] = []
+
+    def session(*args: object, **_kwargs: object) -> object:
+        if args and callable(args[0]):
+            return args[0]
+
+        def decorate(function: object) -> object:
+            return function
+
+        return decorate
+
+    fake_nox = types.SimpleNamespace(options=FakeOptions(), Session=object, session=session)
+    monkeypatch.setitem(sys.modules, "nox", fake_nox)
+
+    spec = importlib.util.spec_from_file_location("_aces_test_noxfile", REPO_ROOT / "noxfile.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "_aces_test_noxfile", module)
+    spec.loader.exec_module(module)
+    return module
 
 
 def write_text(path: Path, content: str) -> None:
@@ -51,6 +79,35 @@ def setup_policy_repo(tmp_path: Path) -> Path:
 
 def structural_runner_stub(_: dict) -> list[PolicyFailure]:
     return []
+
+
+def test_hygiene_parser_ignores_policy_only_verify_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    noxfile = load_noxfile_with_fake_nox(monkeypatch)
+    calls: list[dict[str, object]] = []
+
+    def fake_changed_paths(*, staged: bool = False, base_rev: str | None = None) -> list[str]:
+        calls.append({"staged": staged, "base_rev": base_rev})
+        return ["noxfile.py"]
+
+    monkeypatch.setattr(noxfile, "_changed_paths", fake_changed_paths)
+
+    skip_selection = noxfile._parse_hygiene_posargs(
+        ["--base-rev", "origin/dev", "--skip-requirement"],
+        default_all_files=False,
+    )
+    uid_selection = noxfile._parse_hygiene_posargs(
+        ["--base-rev", "origin/dev", "--requirement-uid", "GOV-918"],
+        default_all_files=False,
+    )
+
+    assert skip_selection.paths == ["noxfile.py"]
+    assert skip_selection.source == "changes since origin/dev"
+    assert uid_selection.paths == ["noxfile.py"]
+    assert uid_selection.source == "changes since origin/dev"
+    assert calls == [
+        {"staged": False, "base_rev": "origin/dev"},
+        {"staged": False, "base_rev": "origin/dev"},
+    ]
 
 
 def test_structural_policy_runner_receives_policy_input(tmp_path: Path) -> None:

--- a/implementations/python/tests/test_runtime_models.py
+++ b/implementations/python/tests/test_runtime_models.py
@@ -72,6 +72,32 @@ nodes:
         command: ./shufflebackend
         user: root
         working-directory: /app
+      processes:
+        - name: supervisord
+          pid: 1
+          command: supervisord -n
+          role: supervisor
+        - name: gunicorn
+          parent-pid: 1
+          command: [gunicorn, app:app]
+          role: worker
+      environment:
+        - name: TECHVAULT_ADMIN_PASSWORD
+          value-classification: redacted
+          provenance: operator
+        - name: SCENARIO_FIXTURE_TOKEN
+          value: fixture-token
+          value-classification: secret-fixture
+          provenance: compose
+      linux-capabilities:
+        required: [CAP_NET_ADMIN]
+        effective: CAP_NET_ADMIN
+      operational-policy:
+        restart: unless-stopped
+        resource-limits:
+          memory: 512 MiB
+          cpu: 0.5
+          pids: 128
       packages:
         - manager: apk
           name: musl
@@ -97,9 +123,31 @@ nodes:
         assert runtime["local_control_interfaces"][0]["path"] == "/run/docker.sock"
         assert runtime["process"]["pid"] == 1
         assert runtime["process"]["command"] == ["./shufflebackend"]
+        assert runtime["processes"][0]["name"] == "supervisord"
+        assert runtime["processes"][1]["parent_pid"] == 1
+        assert runtime["environment"][0]["name"] == "TECHVAULT_ADMIN_PASSWORD"
+        assert runtime["environment"][0]["value_classification"] == "redacted"
+        assert runtime["environment"][1]["value_classification"] == "secret_fixture"
+        assert runtime["linux_capabilities"]["required"] == ["CAP_NET_ADMIN"]
+        assert runtime["linux_capabilities"]["effective"] == ["CAP_NET_ADMIN"]
+        assert runtime["operational_policy"]["restart"] == "unless_stopped"
+        assert runtime["operational_policy"]["resource_limits"]["memory"] == 512 * 1048576
+        assert runtime["operational_policy"]["resource_limits"]["cpu"] == 0.5
+        assert runtime["operational_policy"]["resource_limits"]["pids"] == 128
         assert runtime["packages"][0]["manager"] == "apk"
+        assert runtime["packages"][0]["name"] == "musl"
+        assert runtime["packages"][0]["version"] == "1.2.4-r2"
         assert runtime["dependency_manifests"][0]["ecosystem"] == "go"
+        assert runtime["dependency_manifests"][0]["path"] == "/app/go.mod"
+        assert runtime["dependency_manifests"][0]["format"] == "go-module"
+        assert runtime["package_vulnerabilities"][0]["id"] == "CVE-2026-12345"
+        assert runtime["package_vulnerabilities"][0]["package_name"] == "musl"
+        assert runtime["package_vulnerabilities"][0]["installed_version"] == "1.2.4-r2"
+        assert runtime["package_vulnerabilities"][0]["fixed_version"] == "1.2.5-r0"
+        assert runtime["package_vulnerabilities"][0]["severity"] == "high"
         assert runtime["package_vulnerabilities"][0]["scanner"] == "trivy"
+        assert runtime["package_vulnerabilities"][0]["image_digest"] == "sha256:abc123"
+        assert runtime["package_vulnerabilities"][0]["scan_time"] == "2026-05-20T12:00:00Z"
         assert not model.diagnostics
 
     def test_feature_binding_tracks_same_node_dependencies(self):
@@ -689,9 +737,14 @@ imports:
         expanded_model = compile_runtime_model(parse_sdl_file(root))
         flat_model = compile_runtime_model(flat)
 
+        assert not expanded_model.diagnostics
+        assert not flat_model.diagnostics
         assert expanded_model.workflows.keys() == flat_model.workflows.keys()
         assert expanded_model.objectives.keys() == flat_model.objectives.keys()
         assert expanded_model.condition_bindings.keys() == flat_model.condition_bindings.keys()
+        workflow = expanded_model.workflows["orchestration.workflow.shared.response"]
+        assert workflow.referenced_objective_addresses == ("evaluation.objective.shared.validate",)
+        assert workflow.control_steps["run"].objective_address == "evaluation.objective.shared.validate"
 
     def test_workflow_switch_call_and_timeout_compile_to_explicit_contracts(self):
         model = compile_runtime_model(

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -16,7 +16,12 @@ from aces.core.sdl.nodes import (
     RuntimeControlInterface,
     RuntimeControlInterfaceAccess,
     RuntimeControlInterfaceKind,
+    RuntimeEnvironmentValueClassification,
+    RuntimeEnvironmentVariableProvenance,
     RuntimeMountSourceKind,
+    RuntimePackageVulnerabilitySeverity,
+    RuntimeProcessRole,
+    RuntimeRestartPolicy,
     parse_ram,
 )
 from aces.core.sdl.objectives import Objective, ObjectiveSuccess, ObjectiveWindow
@@ -205,8 +210,98 @@ class TestNode:
         assert runtime.process.user == "root"
         assert runtime.process.working_directory == "/app"
         assert runtime.packages[0].manager == "apk"
+        assert runtime.packages[0].name == "musl"
+        assert runtime.packages[0].version == "1.2.4-r2"
         assert runtime.dependency_manifests[0].ecosystem == "go"
+        assert runtime.dependency_manifests[0].path == "/app/go.mod"
+        assert runtime.dependency_manifests[0].format == "go-module"
+        assert runtime.package_vulnerabilities[0].id == "CVE-2026-12345"
+        assert runtime.package_vulnerabilities[0].package_name == "musl"
+        assert runtime.package_vulnerabilities[0].installed_version == "1.2.4-r2"
+        assert runtime.package_vulnerabilities[0].fixed_version == "1.2.5-r0"
+        assert runtime.package_vulnerabilities[0].severity == RuntimePackageVulnerabilitySeverity.HIGH
         assert runtime.package_vulnerabilities[0].scanner == "trivy"
+        assert runtime.package_vulnerabilities[0].image_digest == "sha256:abc123"
+        assert runtime.package_vulnerabilities[0].scan_time == "2026-05-20T12:00:00Z"
+
+    def test_vm_runtime_operational_surfaces(self):
+        n = Node(
+            type="vm",
+            runtime={
+                "processes": [
+                    {
+                        "name": "supervisord",
+                        "pid": 1,
+                        "command": "supervisord -n",
+                        "role": "supervisor",
+                    },
+                    {
+                        "name": "gunicorn",
+                        "pid": 42,
+                        "parent_pid": 1,
+                        "command": ["gunicorn", "app:app"],
+                        "role": "worker",
+                    },
+                    {
+                        "name": "wazuh-agentd",
+                        "parent_pid": 1,
+                        "command_redacted": True,
+                        "role": "agent",
+                    },
+                ],
+                "environment": [
+                    {
+                        "name": "DJANGO_SETTINGS_MODULE",
+                        "value": "techvault.settings",
+                        "value_classification": "plain",
+                        "provenance": "compose",
+                    },
+                    {
+                        "name": "TECHVAULT_ADMIN_PASSWORD",
+                        "value_classification": "redacted",
+                        "provenance": "operator",
+                    },
+                    {
+                        "name": "SCENARIO_FIXTURE_TOKEN",
+                        "value": "fixture-token",
+                        "value_classification": "secret_fixture",
+                        "provenance": "compose",
+                    },
+                ],
+                "linux_capabilities": {
+                    "required": ["CAP_NET_ADMIN"],
+                    "effective": "CAP_NET_ADMIN",
+                },
+                "operational_policy": {
+                    "restart": "unless-stopped",
+                    "resource_limits": {
+                        "memory": "512 MiB",
+                        "cpu": "0.5",
+                        "pids": "128",
+                    },
+                },
+            },
+        )
+
+        runtime = n.runtime
+        assert runtime is not None
+        assert runtime.processes[0].role == RuntimeProcessRole.SUPERVISOR
+        assert runtime.processes[1].parent_pid == 1
+        assert runtime.processes[1].command == ["gunicorn", "app:app"]
+        assert runtime.processes[2].command_redacted is True
+        assert runtime.environment[1].value == ""
+        assert runtime.environment[1].value_classification == RuntimeEnvironmentValueClassification.REDACTED
+        assert runtime.environment[1].provenance == RuntimeEnvironmentVariableProvenance.OPERATOR
+        assert runtime.environment[2].value_classification == RuntimeEnvironmentValueClassification.SECRET_FIXTURE
+        assert runtime.linux_capabilities is not None
+        assert runtime.linux_capabilities.required == ["CAP_NET_ADMIN"]
+        assert runtime.linux_capabilities.effective == ["CAP_NET_ADMIN"]
+        assert runtime.operational_policy is not None
+        assert runtime.operational_policy.restart == RuntimeRestartPolicy.UNLESS_STOPPED
+        assert runtime.operational_policy.resource_limits is not None
+        assert runtime.operational_policy.resource_limits.memory == 512 * 1048576
+        assert runtime.operational_policy.resource_limits.cpu == 0.5
+        assert runtime.operational_policy.resource_limits.pids == 128
 
     @pytest.mark.parametrize(
         ("runtime", "message"),
@@ -216,6 +311,22 @@ class TestNode:
             ({"process": {"pid": 0, "command": "./shufflebackend"}}, "pid"),
             ({"process": {"working_directory": "app"}}, "working_directory"),
             ({"dependency_manifests": [{"ecosystem": "go", "path": "go.mod"}]}, "path"),
+            (
+                {
+                    "environment": [
+                        {"name": "TECHVAULT_ADMIN_PASSWORD", "value_classification": "redacted"},
+                        {"name": "TECHVAULT_ADMIN_PASSWORD", "value_classification": "redacted"},
+                    ]
+                },
+                "Duplicate runtime environment variable",
+            ),
+            ({"environment": [{"name": "BAD=NAME"}]}, "environment variable name"),
+            (
+                {"processes": [{"name": "gunicorn"}, {"name": "gunicorn"}]},
+                "Duplicate runtime process name",
+            ),
+            ({"linux_capabilities": {"required": [""]}}, "capability"),
+            ({"operational_policy": {"resource_limits": {"pids": 0}}}, "pids"),
         ],
     )
     def test_runtime_configuration_rejects_invalid_runtime_anchors(self, runtime, message):

--- a/implementations/python/tests/test_sdl_parser.py
+++ b/implementations/python/tests/test_sdl_parser.py
@@ -243,6 +243,32 @@ nodes:
         command: ./shufflebackend
         user: root
         working-directory: /app
+      processes:
+        - name: supervisord
+          pid: 1
+          command: supervisord -n
+          role: supervisor
+        - name: gunicorn
+          parent-pid: 1
+          command: [gunicorn, app:app]
+          role: worker
+      environment:
+        - name: TECHVAULT_ADMIN_PASSWORD
+          value-classification: redacted
+          provenance: operator
+        - name: SCENARIO_FIXTURE_TOKEN
+          value: fixture-token
+          value-classification: secret-fixture
+          provenance: compose
+      linux-capabilities:
+        required: [CAP_NET_ADMIN]
+        effective: CAP_NET_ADMIN
+      operational-policy:
+        restart: unless-stopped
+        resource-limits:
+          memory: 512 MiB
+          cpu: 0.5
+          pids: 128
       packages:
         - manager: apk
           name: musl
@@ -271,7 +297,31 @@ nodes:
         assert node.runtime.local_control_interfaces[0].path == "/run/docker.sock"
         assert node.runtime.process is not None
         assert node.runtime.process.command == ["./shufflebackend"]
+        assert node.runtime.processes[0].name == "supervisord"
+        assert node.runtime.processes[1].parent_pid == 1
+        assert node.runtime.environment[0].name == "TECHVAULT_ADMIN_PASSWORD"
+        assert node.runtime.environment[0].value_classification == "redacted"
+        assert node.runtime.environment[1].value_classification == "secret_fixture"
+        assert node.runtime.linux_capabilities.required == ["CAP_NET_ADMIN"]
+        assert node.runtime.linux_capabilities.effective == ["CAP_NET_ADMIN"]
+        assert node.runtime.operational_policy.restart == "unless_stopped"
+        assert node.runtime.operational_policy.resource_limits.memory == 512 * 1048576
+        assert node.runtime.operational_policy.resource_limits.cpu == 0.5
+        assert node.runtime.operational_policy.resource_limits.pids == 128
+        assert node.runtime.packages[0].manager == "apk"
+        assert node.runtime.packages[0].name == "musl"
+        assert node.runtime.packages[0].version == "1.2.4-r2"
+        assert node.runtime.dependency_manifests[0].ecosystem == "go"
+        assert node.runtime.dependency_manifests[0].path == "/app/go.mod"
+        assert node.runtime.dependency_manifests[0].format == "go-module"
         assert node.runtime.package_vulnerabilities[0].id == "CVE-2026-12345"
+        assert node.runtime.package_vulnerabilities[0].package_name == "musl"
+        assert node.runtime.package_vulnerabilities[0].installed_version == "1.2.4-r2"
+        assert node.runtime.package_vulnerabilities[0].fixed_version == "1.2.5-r0"
+        assert node.runtime.package_vulnerabilities[0].severity == "high"
+        assert node.runtime.package_vulnerabilities[0].scanner == "trivy"
+        assert node.runtime.package_vulnerabilities[0].image_digest == "sha256:abc123"
+        assert node.runtime.package_vulnerabilities[0].scan_time == "2026-05-20T12:00:00Z"
 
     def test_source_shorthand(self):
         sdl = """
@@ -629,7 +679,7 @@ variables:
     default: hello
 """,
         }
-        with pytest.raises(SDLParseError):
+        with pytest.raises(SDLParseError, match=rf"{field_name}[\s\S]*Input should be"):
             parse_sdl(sdl_by_field[field_name], skip_semantic_validation=True)
 
     @pytest.mark.parametrize(

--- a/noxfile.py
+++ b/noxfile.py
@@ -129,7 +129,15 @@ def _changed_paths(*, staged: bool = False, base_rev: str | None = None) -> list
 
 
 def _sync_project(session: nox.Session) -> None:
-    _run(session, "uv", "sync", "--project", str(PROJECT_ROOT), "--all-extras", "--frozen")
+    _run(
+        session,
+        "uv",
+        "sync",
+        "--project",
+        str(PROJECT_ROOT),
+        "--all-extras",
+        "--frozen",
+    )
 
 
 def _run_project_python(session: nox.Session, script: str, *args: str) -> None:
@@ -192,9 +200,27 @@ def _run_pytest(session: nox.Session, *args: str, coverage: bool = False) -> Non
     if coverage:
         with session.chdir(PROJECT_ROOT):
             _run(session, "uv", "run", "--frozen", "coverage", "erase")
-            _run(session, "uv", "run", "--frozen", "coverage", "run", "-m", "pytest", *normalized_args)
+            _run(
+                session,
+                "uv",
+                "run",
+                "--frozen",
+                "coverage",
+                "run",
+                "-m",
+                "pytest",
+                *normalized_args,
+            )
             _run(session, "uv", "run", "--frozen", "coverage", "xml")
-            _run(session, "uv", "run", "--frozen", "coverage", "report", "--fail-under=50")
+            _run(
+                session,
+                "uv",
+                "run",
+                "--frozen",
+                "coverage",
+                "report",
+                "--fail-under=50",
+            )
         return
     with session.chdir(PROJECT_ROOT):
         _run(session, "uv", "run", "--frozen", "python", "-m", "pytest", *normalized_args)
@@ -249,6 +275,12 @@ def _parse_hygiene_posargs(posargs: Sequence[str], *, default_all_files: bool) -
         if arg == "--base-rev":
             base_rev = values[index + 1]
             all_files = False
+            index += 2
+            continue
+        if arg == "--skip-requirement":
+            index += 1
+            continue
+        if arg == "--requirement-uid":
             index += 2
             continue
         explicit_paths.append(arg)
@@ -322,7 +354,16 @@ def _paths_trigger(paths: Iterable[str], prefixes: tuple[str, ...]) -> bool:
 
 def _run_pre_commit_hook(_session: nox.Session, command: str, *args: str, paths: list[str]) -> None:
     for batch in _chunked(paths):
-        _run_external_subprocess("uv", "tool", "run", "--from", PRE_COMMIT_HOOKS_TOOL_SPEC, command, *args, *batch)
+        _run_external_subprocess(
+            "uv",
+            "tool",
+            "run",
+            "--from",
+            PRE_COMMIT_HOOKS_TOOL_SPEC,
+            command,
+            *args,
+            *batch,
+        )
 
 
 def _run_gitleaks_dir_scan(session: nox.Session, paths: list[str]) -> None:
@@ -348,13 +389,20 @@ def _run_gitleaks_dir_scan(session: nox.Session, paths: list[str]) -> None:
 
 
 def _run_hygiene(
-    session: nox.Session, reporter: SessionReporter, *, posargs: Sequence[str], default_all_files: bool
+    session: nox.Session,
+    reporter: SessionReporter,
+    *,
+    posargs: Sequence[str],
+    default_all_files: bool,
 ) -> None:
     selection = _parse_hygiene_posargs(posargs, default_all_files=default_all_files)
     paths = selection.paths
     detail = f"{len(paths)} files from {selection.source}"
     if not paths:
-        reporter.skip("hygiene / candidate path resolution", f"no files selected from {selection.source}")
+        reporter.skip(
+            "hygiene / candidate path resolution",
+            f"no files selected from {selection.source}",
+        )
         return
 
     text_paths = _text_paths(paths)
@@ -388,7 +436,13 @@ def _run_hygiene(
 
     reporter.run(
         "hygiene / added large files",
-        lambda: _run_pre_commit_hook(session, "check-added-large-files", "--maxkb", MAX_LARGE_FILE_KB, paths=paths),
+        lambda: _run_pre_commit_hook(
+            session,
+            "check-added-large-files",
+            "--maxkb",
+            MAX_LARGE_FILE_KB,
+            paths=paths,
+        ),
         detail=detail,
     )
 
@@ -443,9 +497,18 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
     # snapshot, so it is meaningless (and misleading) under --staged. It runs in
     # the working-tree policy invocations (`policy`, `hook-pre-push`, `verify`).
     if "--staged" in args:
-        reporter.skip("policy / semantic coverage ADR", "skipped on staged check; runs on push and verify")
-        reporter.skip("policy / assurance policy ADR", "skipped on staged check; runs on push and verify")
-        reporter.skip("policy / authority boundary ADR", "skipped on staged check; runs on push and verify")
+        reporter.skip(
+            "policy / semantic coverage ADR",
+            "skipped on staged check; runs on push and verify",
+        )
+        reporter.skip(
+            "policy / assurance policy ADR",
+            "skipped on staged check; runs on push and verify",
+        )
+        reporter.skip(
+            "policy / authority boundary ADR",
+            "skipped on staged check; runs on push and verify",
+        )
     else:
         reporter.run(
             "policy / semantic coverage ADR",
@@ -514,8 +577,14 @@ def _run_changed_lint(session: nox.Session, reporter: SessionReporter, paths: li
             detail=f"{len(project_paths)} files",
         )
     else:
-        reporter.skip("lint / ruff format (changed project files)", "no changed project Python files")
-        reporter.skip("lint / ruff check (changed project files)", "no changed project Python files")
+        reporter.skip(
+            "lint / ruff format (changed project files)",
+            "no changed project Python files",
+        )
+        reporter.skip(
+            "lint / ruff check (changed project files)",
+            "no changed project Python files",
+        )
 
     tooling_paths = [
         path for path in paths if (path.startswith("tools/") or path == "noxfile.py") and path.endswith(".py")
@@ -532,8 +601,14 @@ def _run_changed_lint(session: nox.Session, reporter: SessionReporter, paths: li
             detail=f"{len(tooling_paths)} files",
         )
     else:
-        reporter.skip("lint / ruff format (changed tooling files)", "no changed tooling Python files")
-        reporter.skip("lint / ruff check (changed tooling files)", "no changed tooling Python files")
+        reporter.skip(
+            "lint / ruff format (changed tooling files)",
+            "no changed tooling Python files",
+        )
+        reporter.skip(
+            "lint / ruff check (changed tooling files)",
+            "no changed tooling Python files",
+        )
 
 
 def _run_tests(session: nox.Session, reporter: SessionReporter, posargs: list[str] | None = None) -> None:
@@ -675,7 +750,11 @@ def hook_pre_commit(session: nox.Session) -> None:
             reporter.skip("contracts / generated schema drift", "no contract-bearing changes")
             reporter.skip("contracts / json artifact validation", "no contract-bearing changes")
         if _paths_trigger(changed, FULL_TEST_TRIGGER_PREFIXES):
-            reporter.run("tests / pytest", lambda: _run_pytest(session, "-q"), detail="full implementation test sweep")
+            reporter.run(
+                "tests / pytest",
+                lambda: _run_pytest(session, "-q"),
+                detail="full implementation test sweep",
+            )
         elif _paths_trigger(changed, TOOLING_TEST_TRIGGER_PREFIXES):
             reporter.run(
                 "tests / targeted tooling tests",
@@ -683,7 +762,10 @@ def hook_pre_commit(session: nox.Session) -> None:
                 detail=" ".join(TARGETED_POLICY_TESTS),
             )
         else:
-            reporter.skip("tests / pytest", "no implementation or tooling test trigger paths changed")
+            reporter.skip(
+                "tests / pytest",
+                "no implementation or tooling test trigger paths changed",
+            )
     finally:
         reporter.summary()
 
@@ -706,7 +788,12 @@ def hook_pre_push(session: nox.Session) -> None:
 def verify(session: nox.Session) -> None:
     reporter = SessionReporter(session, "verify")
     try:
-        _run_hygiene(session, reporter, posargs=session.posargs or ["--all-files"], default_all_files=True)
+        _run_hygiene(
+            session,
+            reporter,
+            posargs=session.posargs or ["--all-files"],
+            default_all_files=True,
+        )
         _run_policy(session, reporter, *session.posargs)
         _run_lint(session, reporter)
         _run_contracts(session, reporter)


### PR DESCRIPTION
## Summary

Adds SDL authoring surfaces for observed container runtime configuration, including process identity, environment provenance, Linux capabilities, resource limits, and operational restart policy metadata. Also fixes the issue-only CI verification path needed for no-requirement implementation branches.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #358

## ADR Impact

- ADR-021

## Changes

- Move runtime configuration models out of nodes.py into a focused runtime_configuration module while preserving nodes.py re-exports.
- Add process, environment, Linux capability, resource-limit, and operational-policy runtime model surfaces with validation.
- Update SDL explanatory docs, generated JSON schemas, and changelog coverage for the new runtime metadata.
- Expand SDL model, parser, runtime compiler, and repo-policy tests to assert the new runtime fields and CI argument handling.
- Allow CI no-requirement issue branches to use the existing requirement-governance skip path without skipping hygiene checks.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local validation: `ACES_REQUIREMENT_UID=ISSUE-358 implementations/python/.venv/bin/python tools/verify_all.py`; `uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify -- --base-rev 66a1a8ee7589ed6b0b07cb0ca3606cb0aeacfba1 --skip-requirement`; `ACES_REQUIREMENT_UID=ISSUE-358 pre-commit run nox-pre-commit --files .github/workflows/ci.yml noxfile.py implementations/python/tests/test_repo_policy_tools.py`. `pre-commit run --all-files` hit Ground-Control#949, a chunking false failure in the global schema drift hook; the nox hygiene parser issue was logged as Ground-Control#950.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ISSUE-358 <- implementations/python/packages/aces_sdl/runtime_configuration.py, ISSUE-358 <- implementations/python/packages/aces_sdl/nodes.py, ISSUE-358 <- contracts/schemas/sdl/sdl-authoring-input-v1.json, ISSUE-358 <- contracts/schemas/sdl/instantiated-scenario-v1.json, ISSUE-358 <- docs/explain/sdl/sections.md, ISSUE-358 <- .github/workflows/ci.yml, ISSUE-358 <- noxfile.py
- TESTS: ISSUE-358 <- implementations/python/tests/test_sdl_models.py, ISSUE-358 <- implementations/python/tests/test_sdl_parser.py, ISSUE-358 <- implementations/python/tests/test_runtime_models.py, ISSUE-358 <- implementations/python/tests/test_repo_policy_tools.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/358.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
