### PR TITLE
feat: express container seccomp profile and security_opt posture in SDL

### DIFF
--- a/changelog.d/385.added.md
+++ b/changelog.d/385.added.md
@@ -1,0 +1,4 @@
+Added `seccomp_profile` and `security_opt` fields to
+`RuntimeContainerConfiguration`, letting the SDL express a container's seccomp
+posture and backend-native security options without conflating them with
+`privileged` (see ADR-028).

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -4017,6 +4017,18 @@
           "title": "Runtime Name",
           "type": "string"
         },
+        "seccomp_profile": {
+          "default": "",
+          "title": "Seccomp Profile",
+          "type": "string"
+        },
+        "security_opt": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Security Opt",
+          "type": "array"
+        },
         "shm_size": {
           "anyOf": [
             {

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -4017,6 +4017,18 @@
           "title": "Runtime Name",
           "type": "string"
         },
+        "seccomp_profile": {
+          "default": "",
+          "title": "Seccomp Profile",
+          "type": "string"
+        },
+        "security_opt": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Security Opt",
+          "type": "array"
+        },
         "shm_size": {
           "anyOf": [
             {

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -53,3 +53,4 @@ Each ADR includes:
 | [025](adr-025-container-network-realization-surface.md) | Container Network Realization Surface | accepted | 2026-05-21 |
 | [026](adr-026-application-http-surface-inventory.md) | Application HTTP Surface Inventory | accepted | 2026-05-22 |
 | [027](adr-027-container-init-reaper-runtime-surface.md) | Container Init/Reaper Runtime Surface | accepted | 2026-05-22 |
+| [028](adr-028-container-seccomp-security-options-surface.md) | Container Seccomp and Security Options Surface | accepted | 2026-05-22 |

--- a/docs/decisions/adrs/adr-028-container-seccomp-security-options-surface.md
+++ b/docs/decisions/adrs/adr-028-container-seccomp-security-options-surface.md
@@ -1,0 +1,196 @@
+# ADR-028: Container Seccomp and Security Options Surface
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-22
+
+## Context
+
+Issue #385 requires SDL expressivity for a container runtime security fact:
+the seccomp profile, and the backend-native `security_opt` posture that can
+carry seccomp and adjacent Linux security options. The motivating evidence is
+a Docker container with `HostConfig.SecurityOpt: ["seccomp:unconfined"]`.
+That posture disables Docker's default seccomp syscall filter and materially
+widens the syscall attack surface.
+
+The repository already has nearby runtime security surfaces:
+
+- `Node.runtime.container.privileged`
+- `Node.runtime.container.namespaces`
+- `Node.runtime.container.masked_paths` and `read_only_paths`
+- `Node.runtime.container.device_cgroup_rules`
+- `Node.runtime.linux_capabilities`
+
+None of those fields owns seccomp profile state or arbitrary engine security
+options. Treating `seccomp:unconfined` as `privileged`, a namespace mode, a
+capability, a device rule, or a raw Docker inspect payload would conflate
+distinct security controls and make downstream security review unreliable.
+
+## Decision
+
+### 1. Model seccomp posture under runtime container configuration
+
+Seccomp and backend-native security options belong under the existing
+node-scoped runtime container surface:
+
+`Node.runtime.container`
+
+They are observed runtime container host/security facts. They must not become
+new top-level SDL sections, image build-provenance fields, infrastructure
+properties, Linux capability fields, or backend-specific Docker dialects.
+
+### 2. Preserve portable seccomp posture and native options separately
+
+The SDL surface should preserve two related but distinct meanings:
+
+- `seccomp_profile`: a first-class portable seccomp posture/profile value,
+  such as `default`, `unconfined`, a named profile, a profile path, or a
+  variable placeholder.
+- `security_opt`: a list of backend-native security option strings observed
+  from the runtime engine, such as `seccomp:unconfined`,
+  `apparmor=profile-name`, or `no-new-privileges`.
+
+`seccomp_profile` is the portable fact consumers can compare without parsing a
+Docker option list. `security_opt` is the bounded native-option seam that
+preserves adjacent engine options without pretending ACES has typed every
+container security control.
+
+When both fields are present and concrete, and `security_opt` contains a
+recognized seccomp option form, the values must agree. Known Docker and
+Compose spelling variants may be recognized for this consistency check, but
+that parsing must not turn Docker inspect JSON into the SDL authority boundary.
+
+### 3. Reuse existing SDL and contract gates
+
+The implementation must reuse the repository's existing cross-cutting gates:
+
+- `SDLModel` closed-world Pydantic validation.
+- shared runtime parsing helpers such as `coerce_string_list()` and
+  variable-placeholder helpers.
+- parser key normalization, source-shorthand behavior, hashmap-key
+  preservation, and variable-placeholder key rejection.
+- `SemanticValidator` and `SDLValidationError` only if future seccomp or
+  security-option facts introduce cross-reference or cross-field authoring
+  semantics that do not belong in the local Pydantic model.
+- `instantiate_scenario()` and `SDLInstantiationError` for substitution and
+  concrete revalidation.
+- `schema_bundle()`, `tools/generate_contract_schemas.py`, and
+  `tools/check_generated_schemas.py`; generated schemas under
+  `contracts/schemas/` must not be edited directly.
+- existing runtime/control-plane diagnostics and envelopes if these facts later
+  flow through snapshots, backend reports, or API responses.
+
+No new parser, schema registry, validation framework, exception hierarchy,
+logging stack, persistence mechanism, or raw backend-payload contract is
+justified for this issue.
+
+### 4. Validate shape without inventing policy claims
+
+The model should validate portable shape and internal consistency:
+
+- `security_opt` accepts a scalar string or list of strings through the
+  existing list-coercion pattern.
+- empty option entries and exact duplicate option entries should be rejected.
+- `seccomp_profile` should not be inferred from absence unless the scenario
+  explicitly records the posture.
+- validation errors should identify the field and rule without echoing full
+  backend-native payloads.
+
+The SDL should record the observed security posture. It should not claim that
+an omitted `security_opt` list proves Docker default seccomp was active, unless
+the profile is explicitly recorded as such.
+
+### 5. Keep the extensibility seam container-scoped
+
+The extension seam remains `RuntimeContainerConfiguration`. Future typed
+security controls such as AppArmor profile, SELinux label policy,
+`no-new-privileges`, Landlock, or Kubernetes security context projections
+should extend this container-scoped runtime security posture and, where they
+overlap with `security_opt`, define consistency rules between the typed field
+and the native option list.
+
+## Security and Validation Gates
+
+- Parser gate: hyphenated field names such as `security-opt` should normalize
+  through the existing parser. Option values must remain literal strings; no
+  nested hashmap preservation is needed for a list field.
+- SDL model gate: closed-world validation must reject unknown fields, malformed
+  list shapes, empty option strings, duplicate exact options, and concrete
+  `seccomp_profile`/`security_opt` disagreement.
+- Semantic validation gate: this issue should not add semantic cross-reference
+  logic unless seccomp profiles become named SDL artifacts later.
+- Instantiation gate: variable placeholders may stand in value fields, but not
+  mapping keys; instantiated scenarios must revalidate consistency after
+  substitution.
+- Contract/schema gate: schema changes come from Python model sources and
+  regeneration, never direct edits under `contracts/schemas/`.
+- Runtime/control-plane gate: if these facts are exposed through snapshots or
+  APIs, use existing `aces_processor.models.Diagnostic` and published envelope
+  shapes plus existing authentication, authorization, audit, request-size,
+  idempotency, and redacted error handling.
+- Host/OS exposure gate: `seccomp:unconfined` is increased syscall exposure.
+  It must remain visible as runtime container security posture and must not be
+  normalized away as merely non-privileged.
+- Secret and environment gate: this surface is not an environment-binding or
+  secret-value surface. Do not store raw inspect payloads, credentials, tokens,
+  or command output as security options or diagnostics.
+
+## Guardrails
+
+- Do not collapse seccomp posture into `privileged`; non-privileged containers
+  can still be seccomp-unconfined.
+- Do not use `linux_capabilities` for seccomp. Capabilities and syscall filters
+  are different controls.
+- Do not put seccomp or `security_opt` into `namespaces`, path masks, device
+  cgroup rules, network realization, image provenance, or infrastructure.
+- Do not embed raw Docker, Compose, Podman, Kubernetes, or harness inspect
+  payloads into SDL as the portable model.
+- Do not create duplicate schemas, parser branches, exception hierarchies, or
+  logging paths for this field.
+- Do not edit generated JSON schemas by hand.
+- Do not treat an empty or absent `security_opt` field as proof of a secure
+  default. Record `seccomp_profile` explicitly when that posture matters.
+
+## Non-Goals
+
+- Implementing issue #385.
+- Updating `examples/scenarios/techvault.sdl.yaml`.
+- Building a Docker, Compose, Podman, Kubernetes, or harness inspector.
+- Defining backend provisioning behavior for seccomp profiles or security
+  options.
+- Defining a comprehensive Linux security module policy model.
+- Changing runtime snapshot, control-plane, backend manifest, or processor
+  capability contracts unless a later implementation explicitly routes these
+  facts through those surfaces.
+
+## Consequences
+
+### Positive
+
+- Seccomp posture becomes a first-class runtime security fact without
+  overloading `privileged`.
+- Adjacent backend-native security options can be preserved without making
+  Docker inspect JSON normative.
+- Existing SDL parsing, validation, instantiation, schema generation,
+  diagnostics, and control-plane envelopes remain authoritative.
+
+### Negative
+
+- The model intentionally allows overlap between a typed `seccomp_profile` and
+  native `security_opt` entries, so consistency validation is needed when both
+  are present.
+- Consumers that only understand `security_opt` may need to learn the typed
+  `seccomp_profile` field for portable comparison.
+
+### Risks
+
+- A loose native-option list could become a dumping ground if future typed
+  security controls are not promoted deliberately.
+- Inferring defaults from missing data would make inventory evidence look more
+  complete than it is.
+- Echoing raw backend payloads in diagnostics could leak paths, labels, or
+  unrelated sensitive runtime details.

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -180,6 +180,8 @@ nodes:
             container_path: /dev/null
             permissions: rwm
         device_cgroup_rules: [c 1:3 rwm]
+        seccomp_profile: unconfined
+        security_opt: [seccomp:unconfined, no-new-privileges]
         extra_hosts:
           - hostname: wazuh-manager
             address: 172.20.0.10
@@ -340,7 +342,13 @@ identity; `processes` records a supervised or load-bearing process set;
 and redaction classification; `linux_capabilities` records container/Linux
 capability policy; `operational_policy` records restart policy and observed
 resource limits; `container` records observed host/container configuration and
-namespace/security facts; `health` records observed health status and bounded
+namespace/security facts, including `seccomp_profile` (the portable seccomp
+posture — `default`, `unconfined`, a named profile, or a profile path) and
+`security_opt` (the bounded list of backend-native engine security options
+such as `seccomp:unconfined` or `no-new-privileges`); a seccomp posture is a
+distinct security control from `privileged`, so it is recorded separately (see
+[ADR-028](../../decisions/adrs/adr-028-container-seccomp-security-options-surface.md));
+`health` records observed health status and bounded
 healthcheck log facts; `packages` and `dependency_manifests` record runtime
 inventory; and `package_vulnerabilities` records scanner-derived CVE/advisory
 findings tied to an image digest and scan time. These findings are separate

--- a/implementations/python/packages/aces_sdl/runtime_container.py
+++ b/implementations/python/packages/aces_sdl/runtime_container.py
@@ -1,11 +1,12 @@
 """Observed container runtime host/security and health models for SDL nodes."""
 
+import re
 from enum import Enum
 from typing import Any
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 
-from ._base import SDLModel, parse_bool_or_var, parse_int_or_var
+from ._base import SDLModel, is_variable_ref, parse_bool_or_var, parse_int_or_var
 from .runtime_values import (
     absolute_path_or_var,
     coerce_string_list,
@@ -112,6 +113,22 @@ class RuntimeInitProcess(SDLModel):
         return self
 
 
+# Recognized Docker/Compose spellings of a seccomp security option (`seccomp:value`
+# or `seccomp=value`). Used only for the seccomp_profile/security_opt consistency
+# check; it does not turn the option list into a typed Docker dialect.
+_SECCOMP_OPTION_RE = re.compile(r"^seccomp[:=](.+)$", re.IGNORECASE)
+
+
+def _seccomp_values_from_security_opt(security_opt: list[str]) -> list[str]:
+    """Extract seccomp profile values from recognized ``security_opt`` entries."""
+    values: list[str] = []
+    for option in security_opt:
+        match = _SECCOMP_OPTION_RE.match(option)
+        if match:
+            values.append(match.group(1).strip())
+    return values
+
+
 class RuntimeContainerConfiguration(SDLModel):
     """Observed container runtime host and security configuration facts."""
 
@@ -132,6 +149,8 @@ class RuntimeContainerConfiguration(SDLModel):
     init_process: RuntimeInitProcess | None = None
     devices: list[RuntimeDeviceMapping] = Field(default_factory=list)
     device_cgroup_rules: list[str] = Field(default_factory=list)
+    seccomp_profile: str = ""
+    security_opt: list[str] = Field(default_factory=list)
     extra_hosts: list[RuntimeExtraHost] = Field(default_factory=list)
     dns: list[str] = Field(default_factory=list)
     dns_options: list[str] = Field(default_factory=list)
@@ -148,6 +167,7 @@ class RuntimeContainerConfiguration(SDLModel):
         "masked_paths",
         "read_only_paths",
         "device_cgroup_rules",
+        "security_opt",
         "dns",
         "dns_options",
         "dns_search",
@@ -172,6 +192,32 @@ class RuntimeContainerConfiguration(SDLModel):
     @classmethod
     def validate_path_lists(cls, v: list[str], info: ValidationInfo) -> list[str]:
         return validate_absolute_paths(v, field_name=info.field_name)
+
+    @field_validator("security_opt")
+    @classmethod
+    def validate_security_opt(cls, v: list[str]) -> list[str]:
+        seen: set[str] = set()
+        for option in v:
+            if not isinstance(option, str) or not option.strip():
+                raise ValueError("security_opt entries must be non-empty strings")
+            if option in seen:
+                raise ValueError(f"Duplicate runtime security option '{option}'")
+            seen.add(option)
+        return v
+
+    @model_validator(mode="after")
+    def validate_seccomp_consistency(self) -> "RuntimeContainerConfiguration":
+        observed: set[str] = set()
+        if self.seccomp_profile and not is_variable_ref(self.seccomp_profile):
+            observed.add(self.seccomp_profile)
+        for value in _seccomp_values_from_security_opt(self.security_opt):
+            if value and not is_variable_ref(value):
+                observed.add(value)
+        if len(observed) > 1:
+            raise ValueError(
+                "seccomp_profile and security_opt seccomp entries disagree: " + ", ".join(sorted(observed))
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_unique_container_entries(self) -> "RuntimeContainerConfiguration":

--- a/implementations/python/tests/test_runtime_models.py
+++ b/implementations/python/tests/test_runtime_models.py
@@ -152,6 +152,8 @@ nodes:
             container-path: /dev/null
             permissions: rwm
         device-cgroup-rules: c 1:3 rwm
+        seccomp-profile: unconfined
+        security-opt: [seccomp:unconfined, no-new-privileges]
         extra-hosts:
           - hostname: wazuh-manager
             address: 172.20.0.10
@@ -228,6 +230,8 @@ nodes:
         assert runtime["container"]["read_only_paths"] == ["/proc/sys"]
         assert runtime["container"]["devices"][0]["container_path"] == "/dev/null"
         assert runtime["container"]["device_cgroup_rules"] == ["c 1:3 rwm"]
+        assert runtime["container"]["seccomp_profile"] == "unconfined"
+        assert runtime["container"]["security_opt"] == ["seccomp:unconfined", "no-new-privileges"]
         assert runtime["container"]["extra_hosts"][0]["hostname"] == "wazuh-manager"
         assert runtime["container"]["dns_options"] == ["ndots:0"]
         assert runtime["container"]["group_add"] == ["adm", "101"]

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -35,6 +35,7 @@ from aces.core.sdl.nodes import (
     RuntimeApplicationResponse,
     RuntimeApplicationRoute,
     RuntimeApplicationSurface,
+    RuntimeContainerConfiguration,
     RuntimeControlInterface,
     RuntimeControlInterfaceAccess,
     RuntimeControlInterfaceKind,
@@ -734,6 +735,15 @@ class TestNode:
                 },
                 "Duplicate runtime extra host",
             ),
+            ({"container": {"security_opt": ["seccomp:unconfined", ""]}}, "security_opt"),
+            (
+                {"container": {"security_opt": ["seccomp:unconfined", "seccomp:unconfined"]}},
+                "Duplicate runtime security option",
+            ),
+            (
+                {"container": {"seccomp_profile": "default", "security_opt": ["seccomp:unconfined"]}},
+                "seccomp_profile",
+            ),
             ({"health": {"log": [{"output": "secret", "output_redacted": True}]}}, "redacted healthcheck output"),
             (
                 {
@@ -830,6 +840,40 @@ class TestNode:
         assert init.argv_redacted is True
         assert init.argv == []
         assert init.description == "backend-injected reaper"
+
+    def test_runtime_container_records_seccomp_and_security_opt(self):
+        container = RuntimeContainerConfiguration(
+            seccomp_profile="unconfined",
+            security_opt=["seccomp:unconfined", "apparmor=unconfined", "no-new-privileges"],
+        )
+
+        assert container.seccomp_profile == "unconfined"
+        assert container.security_opt == ["seccomp:unconfined", "apparmor=unconfined", "no-new-privileges"]
+
+    def test_runtime_container_security_opt_coerces_scalar_string(self):
+        container = RuntimeContainerConfiguration(security_opt="seccomp:unconfined")
+
+        assert container.security_opt == ["seccomp:unconfined"]
+
+    def test_runtime_container_seccomp_consistency_accepts_agreeing_values(self):
+        container = RuntimeContainerConfiguration(
+            seccomp_profile="unconfined",
+            security_opt=["label=disable", "seccomp=unconfined"],
+        )
+
+        assert container.seccomp_profile == "unconfined"
+
+    def test_runtime_container_seccomp_consistency_allows_variable_placeholder(self):
+        container = RuntimeContainerConfiguration(
+            seccomp_profile="${SECCOMP}",
+            security_opt=["seccomp:unconfined"],
+        )
+
+        assert container.seccomp_profile == "${SECCOMP}"
+
+    def test_runtime_container_seccomp_rejects_disagreeing_security_opt_entries(self):
+        with pytest.raises(ValidationError, match="seccomp_profile"):
+            RuntimeContainerConfiguration(security_opt=["seccomp:unconfined", "seccomp=default"])
 
     def test_runtime_control_interface_accepts_windows_named_pipe_path(self):
         interface = RuntimeControlInterface(


### PR DESCRIPTION
## Summary

Adds `seccomp_profile` and `security_opt` fields to `RuntimeContainerConfiguration` so the SDL can express a container's seccomp posture and backend-native security options — a first-class container security fact distinct from `privileged`. Implements ADR-028 (Container Seccomp and Security Options Surface), produced by the architecture preflight for this issue.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #385

## ADR Impact

- ADR-028
- ADR-021

## Changes

- Add `seccomp_profile: str` (portable seccomp posture) and `security_opt: list[str]` (bounded native engine security options) to `RuntimeContainerConfiguration`
- `security_opt` joins the existing `normalize_string_lists` validator so a scalar string coerces to a one-element list
- New `security_opt` shape validator rejects empty/whitespace-only entries and exact-duplicate options
- New seccomp-consistency model validator: when `seccomp_profile` is concrete and `security_opt` carries a recognized `seccomp:`/`seccomp=` entry, the values must agree; `${var}` placeholders skip the check
- Regenerate `contracts/schemas/sdl/` JSON schema bundles from the Python models
- Document the new fields in `docs/explain/sdl/sections.md`
- Add ADR-028 and its README index row; changelog fragment under `changelog.d/385.added.md`

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full `nox -s verify` (hygiene, policy, lint, contracts, pytest, integration, docs) passes locally with `--skip-requirement` (requirement-free run). New tests cover field round-trip through the parser, scalar coercion, empty/duplicate rejection, seccomp consistency pass/fail, and `${var}` placeholder skip.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-028 ← implementations/python/packages/aces_sdl/runtime_container.py
- TESTS: implementations/python/tests/test_sdl_models.py ← RuntimeContainerConfiguration seccomp/security_opt validation, implementations/python/tests/test_runtime_models.py ← container seccomp/security_opt round-trip

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/385.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
