### PR TITLE
added: add agent guidance profile

### DIFF
--- a/changelog.d/225.added.md
+++ b/changelog.d/225.added.md
@@ -1,0 +1,1 @@
+Add a canonical AUT-811 agent guidance profile, checker, MCP tool, tests, and docs for machine-readable scope boundaries, invariants, review priorities, and safe-operating expectations.

--- a/changelog.d/225.fixed.md
+++ b/changelog.d/225.fixed.md
@@ -1,0 +1,1 @@
+Avoided unnecessary iterable materialization in the agent guidance helper.

--- a/docs/api/sdl.rst
+++ b/docs/api/sdl.rst
@@ -44,6 +44,12 @@ Language Service
 .. automodule:: aces_sdl.language_service
    :members:
 
+Agent Guidance
+--------------
+
+.. automodule:: aces_sdl.agent_guidance
+   :members:
+
 Composition
 -----------
 

--- a/docs/explain/getting-started.md
+++ b/docs/explain/getting-started.md
@@ -36,7 +36,7 @@ authority.
 | Understand the repository | `README.md`, [`docs/index.md`](../index.md), [`docs/explain/reference/canonical-reference-map.md`](reference/canonical-reference-map.md) | Read the referenced docs | The repository layout and current boundaries are understood. |
 | Read a complete scenario | `examples/README.md`, `examples/scenarios/*.sdl.yaml` | `pytest tests/test_scenarios.py` | The checked examples load through the current parser boundary. |
 | Author a small SDL file | [`docs/explain/sdl/index.md`](sdl/index.md), [`docs/explain/sdl/sections.md`](sdl/sections.md), [`docs/explain/sdl/validation.md`](sdl/validation.md) | `parse_sdl_file()` or `load_scenario()` | The file is accepted by the current SDL model and semantic validator. |
-| Use an agent-facing authoring surface | `aces-mcp`, then `aces_tool_surface` and [`docs/explain/sdl/language-service.md`](sdl/language-service.md) | `sdl_completions`, `sdl_apply_edit`, `sdl_diagnostics`, `sdl_format`, `sdl_references`, `sdl_validate`, `sdl_design_assessment`, `sdl_plan`, `sdl_claims_assessment` | The agent can help author, inspect, edit, dry-run, and qualify claims without repository-local code access. |
+| Use an agent-facing authoring surface | `aces-mcp`, then `aces_tool_surface`, `aces_agent_guidance`, and [`docs/explain/sdl/language-service.md`](sdl/language-service.md) | `aces_agent_guidance`, `sdl_completions`, `sdl_apply_edit`, `sdl_diagnostics`, `sdl_format`, `sdl_references`, `sdl_validate`, `sdl_design_assessment`, `sdl_plan`, `sdl_claims_assessment` | The agent can help author, inspect, edit, dry-run, and qualify claims without repository-local code access. |
 | Use variables or imports | [`docs/explain/sdl/parser.md`](sdl/parser.md), [`docs/explain/sdl/sections.md`](sdl/sections.md) | `aces sdl resolve`, `aces sdl verify-imports` | Imports and variable placeholders follow the current parser rules. |
 | Inspect current limits | [`docs/explain/sdl/limitations.md`](sdl/limitations.md), [`docs/explain/sdl/testing.md`](sdl/testing.md) | Compare the use case to the listed materialized surfaces | Unsupported or partial surfaces are identified before authoring. |
 | Work on backend conformance | [`docs/explain/sdl/runtime-architecture.md`](sdl/runtime-architecture.md), `contracts/README.md`, [`docs/explain/reference/backend-conformance.md`](reference/backend-conformance.md) | `aces conformance --help` and the conformance tests | The backend work is aligned with published contracts and fixtures. |
@@ -101,9 +101,11 @@ cd implementations/python
 uv run aces-mcp
 ```
 
-Start with `aces_tool_surface`; use `sdl_claims_assessment` before making
-research or range-readiness claims. These tools do not execute participant
-actions or start a live range.
+Start with `aces_tool_surface`, then call `aces_agent_guidance` for
+machine-readable scope boundaries, invariants, review priorities, and
+safe-operating expectations. Use `sdl_claims_assessment` before making research
+or range-readiness claims. These tools do not execute participant actions or
+start a live range.
 
 When an agent is authoring SDL, use the language-service tools before and
 after text changes:
@@ -117,6 +119,9 @@ after text changes:
 
 See [SDL Language-Service Tools](sdl/language-service.md) for concrete request
 and response shapes.
+
+See [Agent Guidance Profile](sdl/agent-guidance.md) for the structured guidance
+payload agents can cite in plans and reviews.
 
 The CLI does not expose a separate general-purpose `validate` command today.
 Use the Python parser boundary or the test suite for direct validation.

--- a/docs/explain/sdl/agent-guidance.md
+++ b/docs/explain/sdl/agent-guidance.md
@@ -1,0 +1,98 @@
+# Agent Guidance Profile
+
+ACES exposes a machine-readable guidance profile for agents and operators. The
+profile gives agents stable rule ids for scope boundaries, invariants, review
+priorities, and safe-operating expectations.
+
+The canonical artifact is
+`specs/agent-guidance/agent-guidance.yaml`. The MCP tool
+`aces_agent_guidance` returns that profile as JSON so an agent can consume it
+without scraping prose.
+
+## What Users Get
+
+Before this profile, agent guidance was split across repository instructions,
+MCP tool descriptions, ADRs, policy files, and explanatory docs. An agent could
+read those sources, but it had no single structured payload that said what
+boundaries and review rules apply before authoring or operating against ACES
+SDL.
+
+With the guidance profile, users get:
+
+- stable ids for scope and safety rules agents can cite in plans or reviews
+- a shared contributor/operator vocabulary for what ACES tools can and cannot
+  do
+- source references back to the docs, ADRs, policy files, and code that ground
+  each rule
+- an audience filter for contributor-focused and operator-focused guidance
+
+The profile is not a permission system and does not execute SDL. It is a
+read-only guidance surface.
+
+## MCP Tool
+
+Call `aces_agent_guidance` after `aces_tool_surface` and before an agent starts
+authoring, dry-run planning, or making claims about a scenario.
+
+The tool accepts:
+
+- `audience`: `all`, `contributor`, or `operator`
+
+It returns JSON with:
+
+- `scope_boundaries`
+- `invariants`
+- `review_priorities`
+- `safe_operating_expectations`
+
+Each entry has a stable `id`, an `audience`, a list of `surfaces`, a
+`statement`, and `source_refs`.
+
+Example response shape:
+
+```json
+{
+  "status": "ok",
+  "audience": "operator",
+  "profile": "aces-agent-guidance",
+  "version": 1,
+  "requirement_refs": ["AUT-811"],
+  "guidance": {
+    "scope_boundaries": [
+      {
+        "id": "sdl-authoring-not-execution",
+        "audience": ["contributor", "operator"],
+        "surfaces": ["mcp", "sdl", "processor"],
+        "statement": "...",
+        "source_refs": ["..."]
+      }
+    ]
+  }
+}
+```
+
+## Operating Loop
+
+A conservative agent workflow is:
+
+1. Call `aces_tool_surface` to discover the available tool families.
+2. Call `aces_agent_guidance` for current boundaries and review priorities.
+3. Use `sdl_overview` and `sdl_section_reference` for SDL structure.
+4. Use language-service tools for small edits and diagnostics.
+5. Use `sdl_validate`, `sdl_design_assessment`, `sdl_plan`, and
+   `sdl_claims_assessment` before returning claims about readiness,
+   portability, execution, or evidence.
+
+The guidance profile keeps the "what should I check?" part of that loop
+machine-readable, while the existing SDL tools perform parsing, validation,
+formatting, dry-run planning, and claim assessment.
+
+## Validation
+
+`tools/check_agent_guidance.py` validates the profile shape. The policy gate
+runs it through the nox policy graph, so CI fails if the profile drops a
+required category, uses an unknown audience, duplicates an id, or omits source
+references.
+
+This checker is structural. It does not prove every rule is complete. It keeps
+the profile consumable and prevents prompt-only guidance drift.

--- a/docs/explain/sdl/index.md
+++ b/docs/explain/sdl/index.md
@@ -139,6 +139,7 @@ accounts:
 - [SDL Sections Reference](sections.md) — Complete reference for all 21 sections
 - [Parser Behavior](parser.md) — Key normalization, shorthand expansion, SDL-only parsing
 - [Language-Service Tools](language-service.md) — Agent-facing completions, references, formatting, diagnostics, and structured edits
+- [Agent Guidance Profile](agent-guidance.md) — Machine-readable scope boundaries, invariants, review priorities, and safe-operating expectations
 - [Semantic Validation](validation.md) — Cross-reference checks and what the validator enforces
 - [Design Precedents](precedents.md) — Where each SDL element comes from
 - [Academic Lineage](lineage.md) — Primary-source lineage for SDL semantics

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ explain/sdl/index
 explain/sdl/sections
 explain/sdl/parser
 explain/sdl/language-service
+explain/sdl/agent-guidance
 explain/sdl/validation
 explain/sdl/precedents
 explain/sdl/lineage

--- a/implementations/python/packages/aces_mcp/server.py
+++ b/implementations/python/packages/aces_mcp/server.py
@@ -26,9 +26,11 @@ semantics (objectives, scoring, conditions, relationships, workflows, \
 variables).
 
 Start with `aces_tool_surface` to understand the available tool families, \
-then use `sdl_overview` to orient yourself. Use `sdl_section_reference` \
-for any section you need to understand. Use `sdl_get_example` to see \
-real-world annotated scenarios. Use `sdl_completions`, `sdl_references`, \
+then use `aces_agent_guidance` for scope boundaries, invariants, review \
+priorities, and safe-operating expectations. Use `sdl_overview` to orient \
+yourself. Use `sdl_section_reference` for any section you need to understand. \
+Use `sdl_get_example` to see real-world annotated scenarios. Use \
+`sdl_completions`, `sdl_references`, \
 `sdl_format`, `sdl_diagnostics`, and `sdl_apply_edit` for language-service \
 workflows. Use `sdl_validate`, `sdl_design_assessment`, `sdl_plan`, and \
 `sdl_claims_assessment` to check SDL YAML and avoid overstating what a \

--- a/implementations/python/packages/aces_mcp/tools/operations.py
+++ b/implementations/python/packages/aces_mcp/tools/operations.py
@@ -46,6 +46,7 @@ def register(mcp: FastMCP) -> None:
                 ),
                 "recommended_workflow": [
                     "sdl_overview",
+                    "aces_agent_guidance",
                     "sdl_section_reference",
                     "sdl_scaffold or user-authored SDL",
                     "sdl_completions / sdl_diagnostics / sdl_apply_edit while authoring",
@@ -94,6 +95,9 @@ def register(mcp: FastMCP) -> None:
                         "sdl_design_assessment",
                         "sdl_claims_assessment",
                     ],
+                    "guidance": [
+                        "aces_agent_guidance",
+                    ],
                 },
                 "boundaries": [
                     (
@@ -113,6 +117,20 @@ def register(mcp: FastMCP) -> None:
                 ],
             }
         )
+
+    @mcp.tool(
+        name="aces_agent_guidance",
+        description=(
+            "Return the AUT-811 machine-readable guidance profile for ACES "
+            "agents and operators. Includes scope boundaries, invariants, "
+            "review priorities, safe-operating expectations, source refs, and "
+            "an optional audience filter: all, contributor, or operator."
+        ),
+    )
+    def aces_agent_guidance(audience: str = "all") -> str:
+        from aces_sdl.agent_guidance import agent_guidance
+
+        return json_response(agent_guidance(audience=audience))
 
     @mcp.tool(
         name="sdl_parse",

--- a/implementations/python/packages/aces_sdl/agent_guidance.py
+++ b/implementations/python/packages/aces_sdl/agent_guidance.py
@@ -1,0 +1,68 @@
+"""Machine-readable ACES agent guidance profile."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_GUIDANCE_RELATIVE_PATH = Path("specs") / "agent-guidance" / "agent-guidance.yaml"
+_ALLOWED_AUDIENCES = frozenset({"all", "contributor", "operator"})
+
+
+def agent_guidance(*, audience: str = "all") -> dict[str, Any]:
+    """Return the AUT-811 guidance profile, optionally filtered by audience."""
+    audience_key = audience.strip().lower() if audience else "all"
+    if audience_key not in _ALLOWED_AUDIENCES:
+        return {
+            "status": "invalid",
+            "stage": "guidance_filter",
+            "diagnostics": [
+                {
+                    "stage": "guidance_filter",
+                    "severity": "error",
+                    "code": "agent_guidance.audience",
+                    "message": "audience must be one of: all, contributor, operator",
+                }
+            ],
+        }
+
+    profile = _load_profile()
+    filtered = _filter_profile(profile, audience_key)
+    return {"status": "ok", "audience": audience_key, **filtered}
+
+
+def _load_profile() -> dict[str, Any]:
+    path = _find_repo_root(Path(__file__).resolve().parent) / _GUIDANCE_RELATIVE_PATH
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def _filter_profile(profile: dict[str, Any], audience: str) -> dict[str, Any]:
+    data = deepcopy(profile)
+    if audience == "all":
+        return data
+
+    guidance = data.get("guidance")
+    if not isinstance(guidance, dict):
+        return data
+    for category, entries in list(guidance.items()):
+        if not isinstance(entries, list):
+            continue
+        guidance[category] = [
+            entry
+            for entry in entries
+            if isinstance(entry, dict) and audience in {str(item) for item in entry.get("audience", [])}
+        ]
+    return data
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / ".ground-control.yaml").exists() or (candidate / ".git").exists():
+            return candidate
+    raise RuntimeError(f"could not locate aces-sdl repo root from {start}")

--- a/implementations/python/packages/aces_sdl/agent_guidance.py
+++ b/implementations/python/packages/aces_sdl/agent_guidance.py
@@ -50,7 +50,7 @@ def _filter_profile(profile: dict[str, Any], audience: str) -> dict[str, Any]:
     guidance = data.get("guidance")
     if not isinstance(guidance, dict):
         return data
-    for category, entries in list(guidance.items()):
+    for category, entries in guidance.items():
         if not isinstance(entries, list):
             continue
         guidance[category] = [

--- a/implementations/python/tests/test_agent_guidance.py
+++ b/implementations/python/tests/test_agent_guidance.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from aces_sdl.agent_guidance import agent_guidance
+
+
+def test_agent_guidance_exposes_required_categories() -> None:
+    payload = agent_guidance()
+
+    assert payload["status"] == "ok"
+    assert payload["profile"] == "aces-agent-guidance"
+    assert "AUT-811" in payload["requirement_refs"]
+    assert set(payload["guidance"]) == {
+        "scope_boundaries",
+        "invariants",
+        "review_priorities",
+        "safe_operating_expectations",
+    }
+
+
+def test_agent_guidance_filters_operator_entries() -> None:
+    payload = agent_guidance(audience="operator")
+
+    assert payload["status"] == "ok"
+    assert payload["audience"] == "operator"
+    for entries in payload["guidance"].values():
+        assert entries
+        assert all("operator" in entry["audience"] for entry in entries)
+
+
+def test_agent_guidance_rejects_unknown_audience() -> None:
+    payload = agent_guidance(audience="auditor")
+
+    assert payload["status"] == "invalid"
+    assert payload["diagnostics"][0]["code"] == "agent_guidance.audience"

--- a/implementations/python/tests/test_agent_guidance_policy.py
+++ b/implementations/python/tests/test_agent_guidance_policy.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.check_agent_guidance import (  # noqa: E402
+    AGENT_GUIDANCE_RELATIVE_PATH,
+    ALLOWED_AUDIENCES,
+    REQUIRED_CATEGORIES,
+    REQUIREMENT_REF,
+    evaluate_agent_guidance,
+)
+
+_GOOD_GUIDANCE = """profile: aces-agent-guidance
+version: 1
+requirement_refs: [AUT-811]
+source_refs: [AGENTS.md]
+recommended_workflow: [aces_tool_surface, aces_agent_guidance]
+guidance:
+  scope_boundaries:
+    - id: scope
+      audience: [contributor, operator]
+      surfaces: [mcp]
+      statement: This entry describes a substantive scope boundary for agents.
+      source_refs: [AGENTS.md]
+  invariants:
+    - id: invariant
+      audience: [contributor]
+      surfaces: [policy]
+      statement: This entry describes a substantive invariant for contributors.
+      source_refs: [.gc/plan-rules.md]
+  review_priorities:
+    - id: review
+      audience: [contributor]
+      surfaces: [tests]
+      statement: This entry describes a substantive review priority for work.
+      source_refs: [docs/explain/reference/coding-standards.md]
+  safe_operating_expectations:
+    - id: safe
+      audience: [operator]
+      surfaces: [mcp]
+      statement: This entry describes a substantive safe operating expectation.
+      source_refs: [docs/explain/getting-started.md]
+"""
+
+
+def _seed_repo(tmp_path: Path, body: str = _GOOD_GUIDANCE) -> Path:
+    path = tmp_path / AGENT_GUIDANCE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def _flagged(failures, marker: str) -> bool:
+    needle = marker.lower()
+    return any(failure.rule_id == marker or needle in failure.render().lower() for failure in failures)
+
+
+def test_good_guidance_has_no_failures(tmp_path: Path) -> None:
+    assert evaluate_agent_guidance(_seed_repo(tmp_path)) == []
+
+
+def test_requirement_ref_is_aut_811() -> None:
+    assert REQUIREMENT_REF == "AUT-811"
+
+
+def test_allowed_audiences_are_contributor_and_operator() -> None:
+    assert {"contributor", "operator"} == ALLOWED_AUDIENCES
+
+
+def test_required_categories_cover_aut_811_clauses() -> None:
+    assert REQUIRED_CATEGORIES == (
+        "scope_boundaries",
+        "invariants",
+        "review_priorities",
+        "safe_operating_expectations",
+    )
+
+
+def test_missing_category_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_GUIDANCE.replace(
+        """  invariants:
+    - id: invariant
+      audience: [contributor]
+      surfaces: [policy]
+      statement: This entry describes a substantive invariant for contributors.
+      source_refs: [.gc/plan-rules.md]
+""",
+        "  invariants: []\n",
+    )
+    failures = evaluate_agent_guidance(_seed_repo(tmp_path, body))
+    assert _flagged(failures, "agent-guidance-category")
+
+
+def test_invalid_audience_is_flagged(tmp_path: Path) -> None:
+    body = _GOOD_GUIDANCE.replace("audience: [operator]", "audience: [auditor]", 1)
+    failures = evaluate_agent_guidance(_seed_repo(tmp_path, body))
+    assert _flagged(failures, "agent-guidance-entry-audience")
+
+
+def test_duplicate_entry_ids_are_flagged(tmp_path: Path) -> None:
+    body = _GOOD_GUIDANCE.replace("id: invariant", "id: scope", 1)
+    failures = evaluate_agent_guidance(_seed_repo(tmp_path, body))
+    assert _flagged(failures, "agent-guidance-entry-duplicate")

--- a/implementations/python/tests/test_mcp_server.py
+++ b/implementations/python/tests/test_mcp_server.py
@@ -616,9 +616,32 @@ class TestOperationTools:
     def test_tool_surface_self_describes_boundaries(self, server):
         payload = _json_call(server, "aces_tool_surface")
         assert payload["surface"] == "aces-sdl"
+        assert "aces_agent_guidance" in payload["recommended_workflow"]
         assert "sdl_claims_assessment" in payload["recommended_workflow"]
         assert "sdl_completions" in payload["tool_families"]["language_service"]
+        assert "aces_agent_guidance" in payload["tool_families"]["guidance"]
         assert any("does not expose participant cyber actions" in item for item in payload["boundaries"])
+
+    def test_agent_guidance_returns_machine_usable_profile(self, server):
+        payload = _json_call(server, "aces_agent_guidance")
+        assert payload["status"] == "ok"
+        assert payload["profile"] == "aces-agent-guidance"
+        assert "AUT-811" in payload["requirement_refs"]
+        assert set(payload["guidance"]) == {
+            "scope_boundaries",
+            "invariants",
+            "review_priorities",
+            "safe_operating_expectations",
+        }
+        assert payload["guidance"]["scope_boundaries"][0]["id"]
+        assert payload["guidance"]["scope_boundaries"][0]["source_refs"]
+
+    def test_agent_guidance_filters_by_audience(self, server):
+        payload = _json_call(server, "aces_agent_guidance", {"audience": "operator"})
+        assert payload["status"] == "ok"
+        for entries in payload["guidance"].values():
+            assert entries
+            assert all("operator" in entry["audience"] for entry in entries)
 
     def test_parse_returns_machine_readable_summary(self, server):
         payload = _json_call(server, "sdl_parse", {"sdl_content": MINIMAL_SDL})
@@ -733,9 +756,13 @@ class TestExampleScenarios:
 class TestServerConstruction:
     def test_server_has_all_tools(self):
         server = create_server()
-        tool_names = [t.name for t in server._tool_manager._tools.values()]
+        payload = _json_call(server, "aces_tool_surface")
+        tool_names = {"aces_tool_surface"}
+        for family in payload["tool_families"].values():
+            tool_names.update(family)
         expected = {
             "aces_tool_surface",
+            "aces_agent_guidance",
             "aces_reference_manifests",
             "sdl_overview",
             "sdl_section_reference",
@@ -762,7 +789,7 @@ class TestServerConstruction:
             "sdl_design_assessment",
             "sdl_claims_assessment",
         }
-        assert set(tool_names) == expected
+        assert tool_names == expected
 
     def test_server_has_instructions(self):
         server = create_server()

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,7 @@ TARGETED_POLICY_TESTS = [
     "implementations/python/tests/test_semantic_coverage.py",
     "implementations/python/tests/test_assurance_policy.py",
     "implementations/python/tests/test_authority_boundary.py",
+    "implementations/python/tests/test_agent_guidance_policy.py",
 ]
 CONTRACT_TRIGGER_PREFIXES = (
     "contracts/",
@@ -509,6 +510,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
             "policy / authority boundary ADR",
             "skipped on staged check; runs on push and verify",
         )
+        reporter.skip(
+            "policy / agent guidance profile",
+            "skipped on staged check; runs on push and verify",
+        )
     else:
         reporter.run(
             "policy / semantic coverage ADR",
@@ -521,6 +526,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         reporter.run(
             "policy / authority boundary ADR",
             lambda: _run_project_python(session, "tools/check_authority_boundary.py"),
+        )
+        reporter.run(
+            "policy / agent guidance profile",
+            lambda: _run_project_python(session, "tools/check_agent_guidance.py"),
         )
 
 

--- a/specs/agent-guidance/agent-guidance.yaml
+++ b/specs/agent-guidance/agent-guidance.yaml
@@ -1,0 +1,207 @@
+# Agent-Usable Guidance Profile (AUT-811)
+#
+# Canonical machine-readable guidance for agentic contributors and operators.
+# The profile is intentionally static data: MCP tools and docs may expose or
+# explain it, but this YAML is the source of truth for the rule ids.
+
+profile: aces-agent-guidance
+version: 1
+
+requirement_refs:
+  - AUT-811
+
+source_refs:
+  - AGENTS.md
+  - .gc/plan-rules.md
+  - docs/decisions/adrs/adr-009-normative-artifact-authority-and-repository-structure.md
+  - docs/decisions/adrs/adr-014-nox-as-canonical-verification-graph.md
+  - docs/decisions/adrs/adr-018-classification-based-assurance-policy.md
+  - docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+  - docs/explain/reference/coding-standards.md
+  - docs/explain/reference/documentation-style-guide.md
+  - docs/explain/reference/normative-artifact-authority.md
+  - docs/explain/sdl/language-service.md
+
+recommended_workflow:
+  - aces_tool_surface
+  - aces_agent_guidance
+  - sdl_overview
+  - sdl_section_reference
+  - sdl_completions
+  - sdl_apply_edit
+  - sdl_diagnostics
+  - sdl_format
+  - sdl_validate
+  - sdl_design_assessment
+  - sdl_plan
+  - sdl_claims_assessment
+
+guidance:
+  scope_boundaries:
+    - id: sdl-authoring-not-execution
+      audience: [contributor, operator]
+      surfaces: [mcp, sdl, processor]
+      statement: >-
+        ACES authoring and MCP tools describe, validate, inspect, compile, and
+        dry-run SDL scenarios. They do not execute participant cyber actions or
+        start a live range.
+      source_refs:
+        - implementations/python/packages/aces_mcp/tools/operations.py
+        - docs/explain/getting-started.md
+        - docs/explain/sdl/language-service.md
+
+    - id: reference-implementation-not-authority
+      audience: [contributor]
+      surfaces: [repository, specs, contracts, implementations]
+      statement: >-
+        Reference Python packages realize the ecosystem; they do not define
+        normative meaning when a spec, schema, fixture, profile, or
+        concept-authority artifact exists.
+      source_refs:
+        - docs/decisions/adrs/adr-009-normative-artifact-authority-and-repository-structure.md
+        - docs/explain/reference/normative-artifact-authority.md
+        - specs/authority/authority-boundary.yaml
+
+    - id: dry-run-not-runtime-evidence
+      audience: [operator]
+      surfaces: [processor, backend, assessment]
+      statement: >-
+        Planning against the reference stub backend can support capability and
+        planning claims. It is not evidence that a live range ran or that a
+        participant demonstrated skill.
+      source_refs:
+        - implementations/python/packages/aces_mcp/tools/operations.py
+        - docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+
+  invariants:
+    - id: validate-before-return
+      audience: [contributor, operator]
+      surfaces: [mcp, sdl]
+      statement: >-
+        SDL content returned by an agent must be checked with parser,
+        diagnostic, format, and semantic-validation tools appropriate to the
+        edit size.
+      source_refs:
+        - docs/explain/sdl/language-service.md
+        - docs/explain/sdl/validation.md
+
+    - id: preserve-authority-boundaries
+      audience: [contributor]
+      surfaces: [specs, contracts, implementations, docs]
+      statement: >-
+        New ecosystem authority belongs in approved authority roots. Do not
+        hand-edit generated schemas or add implementation-owned normative
+        contracts.
+      source_refs:
+        - .gc/plan-rules.md
+        - specs/authority/authority-boundary.yaml
+        - docs/explain/reference/normative-artifact-authority.md
+
+    - id: claim-evidence-boundary
+      audience: [contributor, operator]
+      surfaces: [assessment, docs, releases]
+      statement: >-
+        Major maturity, portability, backend, provenance, participant-skill, or
+        run-success claims require explicit evidence. Internal consistency
+        alone is not enough.
+      source_refs:
+        - docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+        - implementations/python/packages/aces_mcp/tools/operation_support.py
+
+    - id: requirement-traceability-aligned
+      audience: [contributor]
+      surfaces: [ground-control, repository]
+      statement: >-
+        Code, tests, docs, and requirements must remain traceable through
+        Ground Control when implementation work changes requirement coverage.
+      source_refs:
+        - AGENTS.md
+        - .gc/plan-rules.md
+
+  review_priorities:
+    - id: semantic-correctness-first
+      audience: [contributor]
+      surfaces: [sdl, processor, tests]
+      statement: >-
+        Review semantic changes for parser behavior, reference resolution,
+        validation invariants, runtime model effects, and negative tests before
+        style or cleanup concerns.
+      source_refs:
+        - docs/decisions/adrs/adr-018-classification-based-assurance-policy.md
+        - docs/explain/reference/coding-standards.md
+
+    - id: security-and-secret-exposure
+      audience: [contributor, operator]
+      surfaces: [mcp, cli, control-plane, docs]
+      statement: >-
+        Prioritize auth boundaries, secret exposure, command examples, error
+        payload leakage, process argv, generated diagnostics, and examples that
+        might normalize unsafe behavior.
+      source_refs:
+        - .gc/plan-rules.md
+        - docs/explain/reference/documentation-style-guide.md
+
+    - id: claim-discipline
+      audience: [contributor, operator]
+      surfaces: [assessment, docs, releases]
+      statement: >-
+        Review whether every supported claim is backed by current source,
+        tests, contracts, or evidence, and whether unsupported claims are named
+        as unsupported.
+      source_refs:
+        - docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+        - docs/explain/sdl/limitations.md
+
+    - id: canonical-verification-graph
+      audience: [contributor]
+      surfaces: [ci, local-tools, policy]
+      statement: >-
+        Treat nox as the canonical verification graph. Local checks, hooks, and
+        CI must not drift into separate command definitions.
+      source_refs:
+        - docs/decisions/adrs/adr-014-nox-as-canonical-verification-graph.md
+        - noxfile.py
+
+  safe_operating_expectations:
+    - id: small-structured-edits
+      audience: [contributor, operator]
+      surfaces: [mcp, sdl]
+      statement: >-
+        Prefer small structured edits, completion checks, reference lookup, and
+        diagnostics over broad YAML rewrites when modifying SDL.
+      source_refs:
+        - docs/explain/sdl/language-service.md
+        - implementations/python/packages/aces_sdl/language_service.py
+
+    - id: no-participant-actions-through-guidance
+      audience: [operator]
+      surfaces: [mcp, backend]
+      statement: >-
+        Guidance and authoring tools must not be used as a route to scan,
+        exploit, SSH, execute commands, reveal hidden state, or bypass backend
+        controls.
+      source_refs:
+        - implementations/python/packages/aces_mcp/tools/operations.py
+        - docs/explain/getting-started.md
+
+    - id: do-not-carry-secrets
+      audience: [contributor, operator]
+      surfaces: [docs, examples, diagnostics, logs]
+      statement: >-
+        Do not place real credentials, bearer tokens, private keys, customer
+        data, environment dumps, or live infrastructure identifiers in SDL,
+        docs, examples, diagnostics, logs, or issue comments.
+      source_refs:
+        - .gc/plan-rules.md
+        - docs/explain/reference/documentation-style-guide.md
+
+    - id: qualify-before-claiming
+      audience: [operator]
+      surfaces: [assessment, reports]
+      statement: >-
+        Use design assessment, dry-run planning, and claims assessment before
+        presenting an SDL scenario as ready, portable, executed, or evidence
+        backed.
+      source_refs:
+        - implementations/python/packages/aces_mcp/tools/operations.py
+        - docs/explain/getting-started.md

--- a/tools/check_agent_guidance.py
+++ b/tools/check_agent_guidance.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Structural gate for the AUT-811 agent guidance profile."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import yaml
+
+from tools.policy.common import PolicyFailure, apply_exceptions, failures_to_json, load_exceptions
+
+AGENT_GUIDANCE_RELATIVE_PATH = "specs/agent-guidance/agent-guidance.yaml"
+POLICY_VALUE = "aces-agent-guidance"
+REQUIREMENT_REF = "AUT-811"
+REQUIRED_CATEGORIES: tuple[str, ...] = (
+    "scope_boundaries",
+    "invariants",
+    "review_priorities",
+    "safe_operating_expectations",
+)
+ALLOWED_AUDIENCES: frozenset[str] = frozenset({"contributor", "operator"})
+REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = (
+    "profile",
+    "version",
+    "requirement_refs",
+    "source_refs",
+    "recommended_workflow",
+    "guidance",
+)
+REQUIRED_ENTRY_FIELDS: tuple[str, ...] = (
+    "id",
+    "audience",
+    "surfaces",
+    "statement",
+    "source_refs",
+)
+
+
+def _fail(rule_id: str, message: str, path: str | None = AGENT_GUIDANCE_RELATIVE_PATH) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _str_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    if not all(isinstance(item, str) and item for item in value):
+        return None
+    return list(value)
+
+
+def _load_yaml(path: Path) -> tuple[dict[str, Any] | None, list[PolicyFailure]]:
+    if not path.is_file():
+        return None, [_fail("agent-guidance-missing", f"missing {AGENT_GUIDANCE_RELATIVE_PATH}")]
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return None, [_fail("agent-guidance-parse", f"failed to parse {AGENT_GUIDANCE_RELATIVE_PATH}: {exc}")]
+    if not isinstance(raw, dict):
+        return None, [
+            _fail(
+                "agent-guidance-shape",
+                f"{AGENT_GUIDANCE_RELATIVE_PATH} must be a YAML mapping at the top level",
+            )
+        ]
+    return raw, []
+
+
+def _check_top_level(raw: dict[str, Any]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in raw:
+            failures.append(_fail("agent-guidance-field", f"missing required top-level field: {field}"))
+
+    if "profile" in raw and raw["profile"] != POLICY_VALUE:
+        failures.append(_fail("agent-guidance-profile", f"profile must be {POLICY_VALUE!r}; got {raw['profile']!r}"))
+    if "version" in raw and (not isinstance(raw["version"], int) or raw["version"] < 1):
+        failures.append(_fail("agent-guidance-version", "version must be a positive integer"))
+
+    for field in ("requirement_refs", "source_refs", "recommended_workflow"):
+        if field in raw and _str_list(raw[field]) is None:
+            failures.append(_fail("agent-guidance-field-type", f"{field} must be a list of non-empty strings"))
+
+    requirement_refs = _str_list(raw.get("requirement_refs"))
+    if requirement_refs is not None and REQUIREMENT_REF not in requirement_refs:
+        failures.append(_fail("agent-guidance-requirement-ref", f"requirement_refs must include {REQUIREMENT_REF}"))
+
+    if "guidance" in raw and not isinstance(raw["guidance"], dict):
+        failures.append(_fail("agent-guidance-field-type", "guidance must be a mapping"))
+    return failures
+
+
+def _check_guidance(raw: dict[str, Any]) -> list[PolicyFailure]:
+    guidance = raw.get("guidance")
+    if not isinstance(guidance, dict):
+        return []
+
+    failures: list[PolicyFailure] = []
+    seen_ids: set[str] = set()
+    for category in REQUIRED_CATEGORIES:
+        entries = guidance.get(category)
+        if not isinstance(entries, list) or not entries:
+            failures.append(_fail("agent-guidance-category", f"guidance.{category} must be a non-empty list"))
+            continue
+        for index, entry in enumerate(entries):
+            failures.extend(_check_entry(category, index, entry, seen_ids))
+    return failures
+
+
+def _check_entry(category: str, index: int, entry: Any, seen_ids: set[str]) -> list[PolicyFailure]:
+    if not isinstance(entry, dict):
+        return [
+            _fail(
+                "agent-guidance-entry-shape",
+                f"guidance.{category}[{index}] must be a mapping; got {type(entry).__name__}",
+            )
+        ]
+
+    failures: list[PolicyFailure] = []
+    for field in REQUIRED_ENTRY_FIELDS:
+        if field not in entry:
+            failures.append(_fail("agent-guidance-entry-field", f"guidance.{category}[{index}] missing {field}"))
+
+    entry_id = entry.get("id")
+    if not isinstance(entry_id, str) or not entry_id:
+        failures.append(_fail("agent-guidance-entry-id", f"guidance.{category}[{index}].id must be a non-empty string"))
+    elif entry_id in seen_ids:
+        failures.append(_fail("agent-guidance-entry-duplicate", f"duplicate guidance id: {entry_id}"))
+    else:
+        seen_ids.add(entry_id)
+
+    audience = _str_list(entry.get("audience"))
+    if audience is None:
+        failures.append(
+            _fail("agent-guidance-entry-audience", f"{entry_id or category} audience must be a string list")
+        )
+    elif not set(audience) <= ALLOWED_AUDIENCES:
+        failures.append(
+            _fail(
+                "agent-guidance-entry-audience",
+                f"{entry_id or category} audience must be within {sorted(ALLOWED_AUDIENCES)}; got {audience}",
+            )
+        )
+
+    for field in ("surfaces", "source_refs"):
+        if _str_list(entry.get(field)) is None:
+            failures.append(
+                _fail("agent-guidance-entry-field-type", f"{entry_id or category} {field} must be a string list")
+            )
+
+    statement = entry.get("statement")
+    if not isinstance(statement, str) or len(statement.strip()) < 20:
+        failures.append(
+            _fail("agent-guidance-entry-statement", f"{entry_id or category} statement must be a substantive string")
+        )
+    return failures
+
+
+def evaluate_agent_guidance(repo_root: Path = REPO_ROOT) -> list[PolicyFailure]:
+    raw, failures = _load_yaml(repo_root / AGENT_GUIDANCE_RELATIVE_PATH)
+    if raw is None:
+        return failures
+    failures.extend(_check_top_level(raw))
+    failures.extend(_check_guidance(raw))
+    return failures
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate the AUT-811 agent guidance profile.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to the repo containing this file).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_agent_guidance(args.repo_root)
+    exceptions_file = args.repo_root / "tools" / "policy" / "exceptions.yaml"
+    if exceptions_file.is_file():
+        failures = apply_exceptions(failures, load_exceptions(args.repo_root))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a validated agent guidance profile for ACES SDL so agents and operators can retrieve scope boundaries, invariants, review priorities, and safe-operating expectations through a stable machine-readable surface.

## Requirement UIDs

- `AUT-811`

## Related Issues

Closes #225

## ADR Impact

- ADR-021

## Changes

- Add the canonical `aces-agent-guidance` profile under `specs/agent-guidance/` with AUT-811 scope, invariant, review, and safe-operating guidance.
- Expose the profile through `aces_sdl.agent_guidance` and the `aces_agent_guidance` MCP tool, including audience filtering for contributors and operators.
- Wire the guidance profile into MCP tool-surface discovery, server instructions, nox policy, documentation, API docs, and changelog.
- Add structural policy checks plus focused unit and MCP tests for profile validity, audience filtering, and public tool discovery.
- Remove unnecessary iterable materialization reported by SonarCloud.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification passed: `ACES_REQUIREMENT_UID=AUT-811 pre-commit run --all-files`; `ACES_REQUIREMENT_UID=AUT-811 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify` (1569 passed, 1 skipped, 7 deselected). Pre-push Codex review was clean. Test-quality review found one warning about private FastMCP test registry access; the test now uses the public `aces_tool_surface` contract, and verification passed after the fix. PR CI is green on commit `229ff5b`, and SonarCloud reports quality gate `OK`, open issues `0`, and hotspots `0`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: AUT-811 ← specs/agent-guidance/agent-guidance.yaml, AUT-811 ← implementations/python/packages/aces_sdl/agent_guidance.py, AUT-811 ← implementations/python/packages/aces_mcp/tools/operations.py, AUT-811 ← docs/explain/sdl/agent-guidance.md
- TESTS: AUT-811 ← tools/check_agent_guidance.py, AUT-811 ← implementations/python/tests/test_agent_guidance.py, AUT-811 ← implementations/python/tests/test_agent_guidance_policy.py, AUT-811 ← implementations/python/tests/test_mcp_server.py, AUT-811 ← noxfile.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragments added at `changelog.d/225.added.md` and `changelog.d/225.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
