### PR TITLE
feat: add AUT-806 example library

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ nodes:
 ```
 
 Complete examples live in [`examples/scenarios/`](examples/scenarios/).
+Reusable non-normative templates and patterns are indexed by
+[`examples/library/catalog.yaml`](examples/library/catalog.yaml).
 
 ## Getting Started
 
@@ -118,7 +120,7 @@ uv run aces-mcp
 - `specs/` - normative prose and formal specification material
 - `contracts/` - published schemas, fixtures, manifests, and profiles
 - `implementations/` - reference implementations and their local tooling
-- `examples/` - worked SDL scenario examples
+- `examples/` - worked SDL scenario examples plus reusable authoring templates and patterns
 - `docs/` - explanatory documentation, API docs, and architecture decisions
 - `research/` - supporting literature and reference ecosystem material
 - `tools/` - repository maintenance, policy, and publication tooling
@@ -145,6 +147,7 @@ The documentation source is under [`docs/`](docs/). Important entry points:
 - [`docs/index.md`](docs/index.md) - documentation index
 - [`docs/explain/getting-started.md`](docs/explain/getting-started.md) - use-case and rigor-level entrypoint
 - [`examples/README.md`](examples/README.md) - current worked example inventory
+- [`examples/library/catalog.yaml`](examples/library/catalog.yaml) - template and pattern library catalog
 - [`docs/explain/reference/canonical-reference-map.md`](docs/explain/reference/canonical-reference-map.md) - current reference map
 - [`docs/explain/reference/documentation-style-guide.md`](docs/explain/reference/documentation-style-guide.md) - documentation style and citation rules
 - [`docs/explain/reference/glossary.md`](docs/explain/reference/glossary.md) - current terminology

--- a/changelog.d/227.changed.md
+++ b/changelog.d/227.changed.md
@@ -1,0 +1,1 @@
+Added a validated AUT-806 example, template, and pattern library covering scenarios, workflows, participant behavior, tasks, runs, and studies.

--- a/docs/explain/getting-started.md
+++ b/docs/explain/getting-started.md
@@ -15,19 +15,20 @@ ACES can currently support:
 - parsing and validating SDL through the Python implementation
 - instantiating variables and compiling runtime models in the reference stack
 - checking backend contract fixtures and conformance profiles
+- browsing validated, non-normative examples, templates, and reusable patterns
+  for scenarios, workflows, participant behavior, tasks, runs, and studies
 - reviewing the specifications, ADRs, and examples that define current claims
 
 ACES does not currently provide:
 
 - production range deployment
 - hosted backend operation
-- a general template catalog
-- participant-behavior templates
-- task, run, or study templates
-- a reusable pattern library with versioned catalog metadata
+- first-class SDL sections named `tasks`, `runs`, or `studies`
+- backend-specific deployment recipes for the example library
+- production run storage, study management, or participant-control services
 
-Treat the examples as worked examples, not as conformance fixtures or schema
-authority.
+Treat the examples and library templates as authoring aids, not as conformance
+fixtures or schema authority.
 
 ## Choose A Path
 
@@ -35,6 +36,7 @@ authority.
 |------|------------|---------------|---------------------|
 | Understand the repository | `README.md`, [`docs/index.md`](../index.md), [`docs/explain/reference/canonical-reference-map.md`](reference/canonical-reference-map.md) | Read the referenced docs | The repository layout and current boundaries are understood. |
 | Read a complete scenario | `examples/README.md`, `examples/scenarios/*.sdl.yaml` | `pytest tests/test_scenarios.py` | The checked examples load through the current parser boundary. |
+| Start from a reusable template or pattern | `examples/library/catalog.yaml`, `examples/library/templates/`, `examples/library/patterns/` | `python tools/check_example_library.py` | The catalog covers scenario, workflow, participant behavior, task, run, and study surfaces with parser-validated template bodies. |
 | Author a small SDL file | [`docs/explain/sdl/index.md`](sdl/index.md), [`docs/explain/sdl/sections.md`](sdl/sections.md), [`docs/explain/sdl/validation.md`](sdl/validation.md) | `parse_sdl_file()` or `load_scenario()` | The file is accepted by the current SDL model and semantic validator. |
 | Use an agent-facing authoring surface | `aces-mcp`, then `aces_tool_surface`, `aces_agent_guidance`, and [`docs/explain/sdl/language-service.md`](sdl/language-service.md) | `aces_agent_guidance`, `sdl_completions`, `sdl_apply_edit`, `sdl_diagnostics`, `sdl_format`, `sdl_references`, `sdl_validate`, `sdl_design_assessment`, `sdl_plan`, `sdl_claims_assessment` | The agent can help author, inspect, edit, dry-run, and qualify claims without repository-local code access. |
 | Use variables or imports | [`docs/explain/sdl/parser.md`](sdl/parser.md), [`docs/explain/sdl/sections.md`](sdl/sections.md) | `aces sdl resolve`, `aces sdl verify-imports` | Imports and variable placeholders follow the current parser rules. |
@@ -51,6 +53,7 @@ Use the lowest level that answers the question.
 | Orientation | You need to know what ACES is and is not. | README, docs index, reference map | Current repository scope and entrypoints | SDL validity, backend behavior, or experiment adequacy |
 | SDL parse and validation | You have an SDL file and need current parser feedback. | `parse_sdl_file()`, `load_scenario()`, SDL parser/model/validator tests | Structural and semantic acceptance by the reference implementation | Deployment viability or general domain completeness |
 | Example-backed authoring | You need a worked scenario to study or adapt. | `examples/scenarios/*.sdl.yaml`, `test_scenarios.py` | The example loads from disk without advisories under current tests | Suitability for another range, backend, exercise, or research design |
+| Template and pattern authoring | You need a reusable starting shape for a scenario, workflow, participant behavior, task, run, or study. | `examples/library/catalog.yaml`, `tools/check_example_library.py` | The cataloged template body validates as current SDL and the pattern has stable metadata | New runtime semantics or first-class task, run, or study sections |
 | Runtime and contracts | You need processor or backend integration context. | Runtime compiler/planner, contract schemas, backend profiles, conformance fixtures | Current reference-stack and contract behavior | Production backend correctness or operational reliability |
 | Specification review | You need to evaluate a semantic or authority claim. | `specs/`, ADRs, formal notes, tests | The current reasoning and normative boundary for a claim | Completed implementation when the materialized code/contracts are absent |
 
@@ -130,43 +133,51 @@ Use the Python parser boundary or the test suite for direct validation.
 
 The current positive example corpus is under `examples/scenarios/`. Each file
 is real SDL and is loaded by `implementations/python/tests/test_scenarios.py`.
+The reusable authoring library is under `examples/library/` and indexed by
+`examples/library/catalog.yaml`.
 
 Use examples to:
 
 - inspect large SDL structure
 - see current workflow, objective, relationship, content, and runtime surfaces
 - exercise parser and semantic validation with real files
+- start from validated templates for scenario, workflow, participant behavior,
+  task, run, and study authoring
+- compare reusable patterns against current limitations before claiming support
 - identify authoring friction against current limits
 
 Do not use examples to claim:
 
 - production backend support
 - complete cyber-range domain coverage
-- participant-behavior adequacy
-- task, run, or study provenance support
+- complete participant-behavior adequacy
+- first-class task, run, or study runtime support
 - conformance to any backend beyond published fixtures and tests
 
-## Unsupported Template And Pattern Surfaces
+## Template And Pattern Boundary
 
-Some useful artifacts are not present because the current system lacks the
-syntax, contracts, or validation boundary needed to make them useful now.
+The current library provides validated authoring aids, not new runtime
+authority.
 
 Current status:
 
 - Scenario examples exist as valid SDL files.
-- Workflow examples exist inside scenario files and workflow specs.
-- Participant behavior has architecture and partial contract work, but no
-  reusable authoring template catalog.
-- Tasks, runs, and studies are recognized ecosystem concepts, but no current
-  template or pattern catalog exists for them.
+- Workflow examples exist inside scenario files, workflow specs, and the
+  workflow template.
+- Participant behavior has a reusable action-contract and observation-boundary
+  template validated through current SDL semantics.
+- Tasks, runs, and studies have reusable templates and patterns that map those
+  concepts onto current objectives, workflows, timing, scoring, and evidence
+  references.
 - Evidence and provenance concerns are documented at architecture and
-  limitation surfaces, but not fully materialized as published template
-  artifacts.
+  limitation surfaces, but not fully materialized as published runtime
+  contracts.
 
 When adding an artifact, put it where its current role matches the repository
 authority boundary:
 
 - valid worked SDL examples: `examples/scenarios/*.sdl.yaml`
+- reusable non-normative templates and patterns: `examples/library/`
 - explanatory snippets: `docs/`
 - normative rules: `specs/`
 - published schemas and fixtures: `contracts/`

--- a/docs/explain/reference/canonical-reference-map.md
+++ b/docs/explain/reference/canonical-reference-map.md
@@ -31,6 +31,7 @@ material. It is an index, not a replacement for the linked artifacts.
 |---------|-------------------|
 | Getting started | [`docs/explain/getting-started.md`](../getting-started.md) |
 | Worked examples | `examples/README.md`, `examples/scenarios/*.sdl.yaml` |
+| Template and pattern library | `examples/library/catalog.yaml`, `examples/library/templates/`, `examples/library/patterns/` |
 | SDL guide | [`docs/explain/sdl/index.md`](../sdl/index.md) |
 | SDL sections | [`docs/explain/sdl/sections.md`](../sdl/sections.md) |
 | Parser behavior | [`docs/explain/sdl/parser.md`](../sdl/parser.md) |
@@ -68,7 +69,8 @@ material. It is an index, not a replacement for the linked artifacts.
 ## Current Materialization Notes
 
 - SDL authoring, parsing, validation, instantiation, compilation, planning,
-  control-plane APIs, and published JSON schemas are present in the repository.
+  control-plane APIs, published JSON schemas, and a validated non-normative
+  template/pattern library are present in the repository.
 - Participant-implementation manifests, evidence-capture contracts, and
   provenance contract surfaces are described at the architecture level and are
   not fully materialized as published schemas.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ for advisory in scenario.advisories:
 - **Semantic validation** and formal semantic artifacts
 - **Processor layer** with compiler, planner, and control-plane contracts
 - **Schemas** and backend conformance fixtures
-- **CLI commands**, docs, examples, and tests
+- **CLI commands**, docs, examples, reusable authoring templates, patterns, and tests
 
 ## Reader Map
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,9 @@
 # ACES Examples
 
-This directory contains non-normative worked examples. They are useful for
-reading and testing current SDL behavior. They are not conformance fixtures,
-schemas, deployment recipes, or backend guarantees.
+This directory contains non-normative worked examples, templates, and reusable
+patterns. They are useful for reading, testing, and adapting current SDL
+behavior. They are not conformance fixtures, schemas, deployment recipes, or
+backend guarantees.
 
 ## Current Corpus
 
@@ -15,6 +16,26 @@ schemas, deployment recipes, or backend guarantees.
 
 The tests are in
 [`../implementations/python/tests/test_scenarios.py`](../implementations/python/tests/test_scenarios.py).
+
+## Template And Pattern Library
+
+The AUT-806 library is indexed by
+[`library/catalog.yaml`](library/catalog.yaml). It is a versioned,
+machine-readable catalog for the current non-normative authoring library.
+
+| Surface | Template | Pattern |
+|---------|----------|---------|
+| Scenario | [`library/templates/scenario/minimal-validated-scenario.yaml`](library/templates/scenario/minimal-validated-scenario.yaml) | [`library/patterns/scenario-reference-integrity.yaml`](library/patterns/scenario-reference-integrity.yaml) |
+| Workflow | [`library/templates/workflow/parallel-objective-workflow.yaml`](library/templates/workflow/parallel-objective-workflow.yaml) | [`library/patterns/workflow-explicit-control-graph.yaml`](library/patterns/workflow-explicit-control-graph.yaml) |
+| Participant behavior | [`library/templates/participant_behavior/action-contract-observation-boundary.yaml`](library/templates/participant_behavior/action-contract-observation-boundary.yaml) | [`library/patterns/participant-behavior-contract-binding.yaml`](library/patterns/participant-behavior-contract-binding.yaml) |
+| Task | [`library/templates/task/single-objective-task.yaml`](library/templates/task/single-objective-task.yaml) | [`library/patterns/task-as-objective-contract.yaml`](library/patterns/task-as-objective-contract.yaml) |
+| Run | [`library/templates/run/timed-run-control.yaml`](library/templates/run/timed-run-control.yaml) | [`library/patterns/run-window-with-evidence.yaml`](library/patterns/run-window-with-evidence.yaml) |
+| Study | [`library/templates/study/scored-study-protocol.yaml`](library/templates/study/scored-study-protocol.yaml) | [`library/patterns/study-scoring-chain.yaml`](library/patterns/study-scoring-chain.yaml) |
+
+Each template has metadata plus a complete current-SDL `body`. The
+`tools/check_example_library.py` policy gate validates catalog shape, stable
+IDs, referenced paths, AUT-806 requirement references, and every template body
+through the SDL parser and semantic validator.
 
 ## Validate The Examples
 
@@ -36,6 +57,12 @@ scenario = parse_sdl_file(
     Path("../../examples/scenarios/port-authority-surge-response.sdl.yaml")
 )
 assert scenario.advisories == []
+```
+
+Validate the template and pattern catalog from the repository root:
+
+```shell
+uv run --project implementations/python --frozen python tools/check_example_library.py
 ```
 
 ## How To Use These Files
@@ -62,19 +89,15 @@ Check the section reference and limitations before adapting a file:
 
 There are no placeholder templates in this directory. Files under
 `examples/scenarios/` are positive SDL examples and must load successfully from
-disk.
+disk. Files under `examples/library/templates/` are reusable authoring
+templates with complete SDL bodies; they are validated by the example-library
+policy gate.
 
 Do not add invalid or incomplete SDL files under `examples/scenarios/`.
 Negative-path examples belong in focused parser, model, validator, contract, or
 conformance tests.
 
-Current gaps:
-
-- no reusable participant-behavior template catalog
-- no task template catalog
-- no run template catalog
-- no study template catalog
-- no versioned pattern-library metadata
-
-Those surfaces need current syntax, contracts, or validation rules before a
-repository artifact can make a factual claim about them.
+Task, run, and study templates use current SDL wrappers rather than first-class
+`tasks`, `runs`, or `studies` sections. They show how to express those concepts
+with objectives, workflows, timing, scoring, and evidence-like references that
+the current implementation can validate.

--- a/examples/library/catalog.yaml
+++ b/examples/library/catalog.yaml
@@ -1,0 +1,84 @@
+library: aces-example-pattern-library
+version: 1
+requirement_refs: [AUT-806]
+source_refs:
+  - examples/README.md
+  - docs/explain/getting-started.md
+  - docs/explain/reference/canonical-reference-map.md
+description: >
+  Non-normative, validated authoring library for current ACES examples,
+  templates, and reusable patterns. Template bodies use current SDL so they can
+  be parsed and semantically validated by the Python reference implementation.
+surfaces:
+  scenario:
+    summary: Complete scenario authoring from topology through objective flow.
+    worked_examples:
+      - id: hospital-ransomware-surgery-day
+        path: examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml
+        source_refs: [examples/README.md]
+    templates:
+      - id: minimal-validated-scenario
+        path: examples/library/templates/scenario/minimal-validated-scenario.yaml
+    patterns:
+      - id: scenario-reference-integrity
+        path: examples/library/patterns/scenario-reference-integrity.yaml
+  workflow:
+    summary: Declarative workflow authoring over objectives and branch state.
+    worked_examples:
+      - id: satcom-release-poisoning-workflows
+        path: examples/scenarios/satcom-release-poisoning.sdl.yaml
+        source_refs: [examples/README.md]
+    templates:
+      - id: parallel-objective-workflow
+        path: examples/library/templates/workflow/parallel-objective-workflow.yaml
+    patterns:
+      - id: workflow-explicit-control-graph
+        path: examples/library/patterns/workflow-explicit-control-graph.yaml
+  participant_behavior:
+    summary: Participant action contracts, observation boundaries, and agent bindings.
+    worked_examples:
+      - id: sem-208-participant-behavior
+        path: implementations/python/tests/test_sem_208_participant_behavior.py
+        source_refs: [docs/explain/sdl/validation.md]
+    templates:
+      - id: action-contract-observation-boundary
+        path: examples/library/templates/participant_behavior/action-contract-observation-boundary.yaml
+    patterns:
+      - id: participant-behavior-contract-binding
+        path: examples/library/patterns/participant-behavior-contract-binding.yaml
+  task:
+    summary: Task-oriented authoring using current objectives, conditions, and target refs.
+    worked_examples:
+      - id: port-authority-objective-tasks
+        path: examples/scenarios/port-authority-surge-response.sdl.yaml
+        source_refs: [examples/README.md]
+    templates:
+      - id: single-objective-task
+        path: examples/library/templates/task/single-objective-task.yaml
+    patterns:
+      - id: task-as-objective-contract
+        path: examples/library/patterns/task-as-objective-contract.yaml
+  run:
+    summary: Run-oriented authoring with story, script, event, workflow, and objective windows.
+    worked_examples:
+      - id: hospital-run-story
+        path: examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml
+        source_refs: [examples/README.md]
+    templates:
+      - id: timed-run-control
+        path: examples/library/templates/run/timed-run-control.yaml
+    patterns:
+      - id: run-window-with-evidence
+        path: examples/library/patterns/run-window-with-evidence.yaml
+  study:
+    summary: Study-oriented authoring with metrics, evaluations, TLOs, goals, and workflow protocol.
+    worked_examples:
+      - id: satcom-study-scoring
+        path: examples/scenarios/satcom-release-poisoning.sdl.yaml
+        source_refs: [examples/README.md]
+    templates:
+      - id: scored-study-protocol
+        path: examples/library/templates/study/scored-study-protocol.yaml
+    patterns:
+      - id: study-scoring-chain
+        path: examples/library/patterns/study-scoring-chain.yaml

--- a/examples/library/patterns/participant-behavior-contract-binding.yaml
+++ b/examples/library/patterns/participant-behavior-contract-binding.yaml
@@ -1,0 +1,23 @@
+pattern: aces-library-pattern
+version: 1
+id: participant-behavior-contract-binding
+surface: participant_behavior
+requirement_refs: [AUT-806]
+source_refs:
+  - implementations/python/tests/test_sem_208_participant_behavior.py
+  - docs/explain/sdl/validation.md
+summary: Bind participant actions to governed action contracts and observation boundaries.
+intent: >
+  Make participant behavior examples reusable without treating free-form action
+  names as complete semantics.
+use_when:
+  - An agent action needs declared preconditions, effects, failures, and evidence expectations.
+  - A participant view needs explicit hidden, observable, and evidence-only material.
+authoring_steps:
+  - Add an action-contract entry for each governed action name.
+  - Bind agent actions to the action-contract keys.
+  - Add observation-boundaries and bind each agent boundary reference.
+  - Keep sensitive information in hidden or evidence-only boundary rules.
+validation:
+  - command: parse_sdl_file
+    expected: agent actions and observation boundaries resolve to declared entries.

--- a/examples/library/patterns/run-window-with-evidence.yaml
+++ b/examples/library/patterns/run-window-with-evidence.yaml
@@ -1,0 +1,23 @@
+pattern: aces-library-pattern
+version: 1
+id: run-window-with-evidence
+surface: run
+requirement_refs: [AUT-806]
+source_refs:
+  - examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml
+  - docs/explain/sdl/sections.md
+summary: Represent current run templates with stories, scripts, events, objectives, and workflow windows.
+intent: >
+  Give authors a reusable run shape that connects timed exercise material to
+  objective validation without adding backend-specific run storage.
+use_when:
+  - A run needs a timed story or script window.
+  - Objective success should be scoped to a specific event or story interval.
+authoring_steps:
+  - Define injects and events before scripts reference them.
+  - Put events in scripts, scripts in stories, and stories in objective windows.
+  - Keep workflow steps aligned with the same objective boundaries.
+  - Capture evidence as named content or evidence refs where current surfaces allow it.
+validation:
+  - command: parse_sdl_file
+    expected: story, script, event, objective, and workflow references resolve.

--- a/examples/library/patterns/scenario-reference-integrity.yaml
+++ b/examples/library/patterns/scenario-reference-integrity.yaml
@@ -1,0 +1,24 @@
+pattern: aces-library-pattern
+version: 1
+id: scenario-reference-integrity
+surface: scenario
+requirement_refs: [AUT-806]
+source_refs:
+  - examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml
+  - docs/explain/sdl/validation.md
+summary: Keep scenario examples useful by making every cross-reference resolve through the current SDL validator.
+intent: >
+  Authors can copy a scenario skeleton and replace names while preserving the
+  parser-backed relationship between nodes, entities, agents, objectives, and
+  workflows.
+use_when:
+  - Building a new scenario from a small validated starting point.
+  - Reviewing whether a scenario example is still a positive corpus artifact.
+authoring_steps:
+  - Start with a complete SDL document that parses without semantic errors.
+  - Give every reusable surface a stable identifier before adding references.
+  - Add objective and workflow references only after the target sections exist.
+  - Validate with parse_sdl_file or the example-library policy checker.
+validation:
+  - command: uv run --project implementations/python --frozen python tools/check_example_library.py
+    expected: catalog and template bodies pass with no policy failures.

--- a/examples/library/patterns/study-scoring-chain.yaml
+++ b/examples/library/patterns/study-scoring-chain.yaml
@@ -1,0 +1,23 @@
+pattern: aces-library-pattern
+version: 1
+id: study-scoring-chain
+surface: study
+requirement_refs: [AUT-806]
+source_refs:
+  - examples/scenarios/satcom-release-poisoning.sdl.yaml
+  - docs/explain/reference/assessment-semantics.md
+summary: Represent current study templates with a traceable scoring chain from condition to goal.
+intent: >
+  Make study-like examples reusable by connecting participant activity to
+  metrics, evaluations, TLOs, goals, objectives, and workflow protocol.
+use_when:
+  - A study needs repeatable scoring or interpretation of participant outcomes.
+  - Reviewers need to see how a measured condition contributes to a higher-level goal.
+authoring_steps:
+  - Define the observable condition or manual metric.
+  - Bind metrics into evaluations with explicit thresholds.
+  - Link evaluations to TLOs and TLOs to goals.
+  - Reference the scoring chain from objectives and workflow protocol steps.
+validation:
+  - command: parse_sdl_file
+    expected: metric, evaluation, TLO, goal, objective, and workflow references resolve.

--- a/examples/library/patterns/task-as-objective-contract.yaml
+++ b/examples/library/patterns/task-as-objective-contract.yaml
@@ -1,0 +1,23 @@
+pattern: aces-library-pattern
+version: 1
+id: task-as-objective-contract
+surface: task
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/sdl/limitations.md
+summary: Represent current task templates as objective contracts with explicit actors, targets, and success criteria.
+intent: >
+  Provide a reusable task authoring path using current SDL surfaces while the
+  repository does not expose a first-class tasks section.
+use_when:
+  - A user-facing task can be expressed as one objective with measurable success.
+  - The task target can be named through existing SDL target references.
+authoring_steps:
+  - Create or reuse the participant agent that owns the task.
+  - Define the task target as a targetable SDL reference.
+  - Add a condition, metric, evaluation, TLO, or goal that proves completion.
+  - Place the objective in a workflow when task order matters.
+validation:
+  - command: parse_sdl_file
+    expected: objective actor, target, and success references resolve.

--- a/examples/library/patterns/workflow-explicit-control-graph.yaml
+++ b/examples/library/patterns/workflow-explicit-control-graph.yaml
@@ -1,0 +1,23 @@
+pattern: aces-library-pattern
+version: 1
+id: workflow-explicit-control-graph
+surface: workflow
+requirement_refs: [AUT-806]
+source_refs:
+  - examples/scenarios/satcom-release-poisoning.sdl.yaml
+  - docs/explain/sdl/sections.md
+summary: Model workflow behavior as explicit objective, branch, join, retry, call, and end nodes.
+intent: >
+  Keep workflow templates reusable by relying on named control-flow steps and
+  existing workflow semantic validation instead of prose-only sequencing.
+use_when:
+  - Translating an exercise procedure into workflow steps.
+  - Making branch convergence or terminal states reviewable.
+authoring_steps:
+  - Define the objective names the workflow will execute.
+  - Choose the smallest workflow step type that represents each transition.
+  - Name joins explicitly when using parallel branches.
+  - End every reachable path in an end step or a validated terminal transition.
+validation:
+  - command: parse_sdl_file
+    expected: workflow graph is acyclic and all reachable step references resolve.

--- a/examples/library/templates/participant_behavior/action-contract-observation-boundary.yaml
+++ b/examples/library/templates/participant_behavior/action-contract-observation-boundary.yaml
@@ -1,0 +1,118 @@
+template: aces-library-template
+version: 1
+id: action-contract-observation-boundary
+surface: participant_behavior
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/validation.md
+  - implementations/python/tests/test_sem_208_participant_behavior.py
+summary: Participant behavior template binding an agent action to an action contract and observation boundary.
+body:
+  name: library-participant-behavior-template
+  description: Participant behavior template with governed action and observation semantics.
+  nodes:
+    web:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 80, name: http}
+  entities:
+    red-team:
+      role: red
+  action-contracts:
+    scan:
+      semantic-version: 1.0.0
+      lifecycle-state: active
+      behavioral-granularity: atomic
+      procedure-basis: nmap service discovery
+      realization-profile: backend-declared
+      fidelity-claim: records participant discovery intent and terminal observation
+      preconditions:
+        - precondition-id: authority-in-scope
+          precondition-class: authority
+          description: red participant is authorized to scan the web service
+          support-refs: [agents.red-agent, nodes.web.services.http]
+        - precondition-id: target-service-present
+          precondition-class: target
+          description: target service exists in the participant action scope
+          support-refs: [nodes.web.services.http]
+        - precondition-id: backend-can-realize-scan
+          precondition-class: realization
+          description: backend can realize the scan action contract
+          support-refs: [backend.participant-runtime]
+      effects:
+        - effect-id: discover-network-services
+          effect-class: intended_effect
+          description: discover network services
+          target-refs: [nodes.web.services.http]
+        - effect-id: participant-service-knowledge-update
+          effect-class: side_effect
+          description: participant-local service knowledge changes
+          target-refs: [nodes.web.services.http]
+        - effect-id: terminal-scan-observation
+          effect-class: observation_effect
+          description: terminal scan observation
+          evidence-refs: [evidence.scan-output]
+        - effect-id: participant-view-discovers-node
+          effect-class: visibility_effect
+          description: participant view marks the web node discovered
+          target-refs: [nodes.web]
+        - effect-id: scan-output-evidence
+          effect-class: evidence_effect
+          description: scan output is retained as evidence
+          evidence-refs: [evidence.scan-output]
+        - effect-id: no-hidden-truth-effect
+          effect-class: no_effect
+          description: scan does not disclose hidden adjudication material
+      state-transition-effects: [participant knowledge expands]
+      observation-expectations: [terminal scan result]
+      evidence-expectations: [tool output]
+      failure-classes: [target_unavailable, precondition_unsatisfied, backend_error, unknown]
+      backend-failure-mappings:
+        - backend-error-code: backend.target-unreachable
+          failure-class: target_unavailable
+          diagnostic: backend target unreachable
+  observation-boundaries:
+    red-view:
+      projection-basis: participant-local projection over observed services
+      observable-refs: []
+      hidden-refs: [nodes.web, content.private-answer-key]
+      evidence-refs: [evidence.scan-output]
+      redaction-policy: hidden refs never project without explicit disclosure
+      latency-profile: terminal observation emitted after state transition commit
+      observer-effects: [tool execution may affect telemetry]
+      realized-view-disclosure: backend reports terminal scan output only
+      view-rules:
+        - information-ref: nodes.web
+          boundary-class: observable_resource
+          disposition: hidden
+          visibility-basis: service is not known before terminal scan output
+          latency-profile: terminal observation latency
+        - information-ref: content.private-answer-key
+          boundary-class: private_answer_key
+          disposition: hidden
+          visibility-basis: adjudication-only hidden truth
+        - information-ref: evidence.scan-output
+          boundary-class: archival_evidence
+          disposition: evidence_only
+          visibility-basis: archival run evidence reference
+          evidence-refs: [evidence.scan-output]
+      view-transitions:
+        - transition-id: discover-web-service
+          transition-kind: discovery
+          information-ref: nodes.web
+          trigger: scan terminal observation
+          effective-from: episode-step:scan-0001:terminal-observation
+          effective-order: 30
+          history-event-type: observation_emitted
+          action-instance-id: scan-0001
+          from-disposition: hidden
+          to-disposition: discovered
+          evidence-refs: [evidence.scan-output]
+          certainty: high
+          latency-profile: terminal observation latency
+  agents:
+    red-agent:
+      entity: red-team
+      actions: [scan]
+      observation-boundaries: [red-view]

--- a/examples/library/templates/run/timed-run-control.yaml
+++ b/examples/library/templates/run/timed-run-control.yaml
@@ -1,0 +1,66 @@
+template: aces-library-template
+version: 1
+id: timed-run-control
+surface: run
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/sdl/validation.md
+summary: Run template binding story/script timing to objective and workflow windows.
+body:
+  name: library-run-template
+  description: Run-oriented SDL wrapper with a timed story, script, event, objective, and workflow.
+  nodes:
+    service:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 443, name: https}
+  conditions:
+    telemetry-ready:
+      command: test -f /var/lib/aces/telemetry-ready
+      interval: 30
+  injects:
+    start-run:
+      description: Operator starts the run window.
+  events:
+    run-start:
+      conditions: [telemetry-ready]
+      injects: [start-run]
+  scripts:
+    run-script:
+      start-time: 0
+      end-time: 15 min
+      speed: 1.0
+      events:
+        run-start: 1 min
+  stories:
+    run-story:
+      speed: 1.0
+      scripts: [run-script]
+  entities:
+    operator-team:
+      role: blue
+  agents:
+    run-operator:
+      entity: operator-team
+  objectives:
+    observe-run-telemetry:
+      agent: run-operator
+      targets: [nodes.service.services.https]
+      success:
+        conditions: [telemetry-ready]
+      window:
+        stories: [run-story]
+        scripts: [run-script]
+        events: [run-start]
+  workflows:
+    run-control:
+      start: observe
+      steps:
+        observe:
+          type: objective
+          objective: observe-run-telemetry
+          on-success: done
+        done:
+          type: end

--- a/examples/library/templates/scenario/minimal-validated-scenario.yaml
+++ b/examples/library/templates/scenario/minimal-validated-scenario.yaml
@@ -1,0 +1,44 @@
+template: aces-library-template
+version: 1
+id: minimal-validated-scenario
+surface: scenario
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/sdl/validation.md
+summary: Minimal current-SDL scenario with a target, participant, objective, and workflow.
+body:
+  name: library-scenario-template
+  description: Minimal scenario template exercising identity, target, objective, and workflow refs.
+  nodes:
+    app:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 443, name: https}
+  conditions:
+    app-healthy:
+      command: curl -fsS https://app/health
+      interval: 30
+  entities:
+    blue-team:
+      role: blue
+  agents:
+    operator:
+      entity: blue-team
+  objectives:
+    verify-app-health:
+      agent: operator
+      targets: [nodes.app.services.https]
+      success:
+        conditions: [app-healthy]
+  workflows:
+    baseline-check:
+      start: verify
+      steps:
+        verify:
+          type: objective
+          objective: verify-app-health
+          on-success: done
+        done:
+          type: end

--- a/examples/library/templates/study/scored-study-protocol.yaml
+++ b/examples/library/templates/study/scored-study-protocol.yaml
@@ -1,0 +1,62 @@
+template: aces-library-template
+version: 1
+id: scored-study-protocol
+surface: study
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/reference/assessment-semantics.md
+summary: Study template connecting task outcome, metric, evaluation, TLO, goal, and workflow protocol.
+body:
+  name: library-study-template
+  description: Study-oriented SDL wrapper with objectives mapped into metric, evaluation, TLO, and goal evidence.
+  nodes:
+    study-target:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 443, name: https}
+  conditions:
+    study-task-success:
+      command: test -f /var/lib/aces/study-task-success
+      interval: 30
+  metrics:
+    task-success-score:
+      type: conditional
+      condition: study-task-success
+      max-score: 100
+  evaluations:
+    study-evaluation:
+      metrics: [task-success-score]
+      min-score: {percentage: 80}
+  tlos:
+    study-learning-objective:
+      evaluation: study-evaluation
+  goals:
+    study-goal:
+      tlos: [study-learning-objective]
+  entities:
+    participant-team:
+      role: blue
+  agents:
+    study-participant:
+      entity: participant-team
+  objectives:
+    complete-study-task:
+      agent: study-participant
+      targets: [nodes.study-target.services.https]
+      success:
+        metrics: [task-success-score]
+        evaluations: [study-evaluation]
+        tlos: [study-learning-objective]
+        goals: [study-goal]
+  workflows:
+    study-protocol:
+      start: complete-task
+      steps:
+        complete-task:
+          type: objective
+          objective: complete-study-task
+          on-success: done
+        done:
+          type: end

--- a/examples/library/templates/task/single-objective-task.yaml
+++ b/examples/library/templates/task/single-objective-task.yaml
@@ -1,0 +1,44 @@
+template: aces-library-template
+version: 1
+id: single-objective-task
+surface: task
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/sdl/limitations.md
+summary: Task template using current SDL objectives and conditions as the materialized task boundary.
+body:
+  name: library-task-template
+  description: Task-oriented SDL wrapper using a single objective and success condition.
+  nodes:
+    target:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 22, name: ssh}
+  conditions:
+    task-complete:
+      command: test -f /tmp/aces-task-complete
+      interval: 15
+  entities:
+    participant:
+      role: blue
+  agents:
+    task-agent:
+      entity: participant
+  objectives:
+    complete-service-check-task:
+      agent: task-agent
+      targets: [nodes.target.services.ssh]
+      success:
+        conditions: [task-complete]
+  workflows:
+    task-flow:
+      start: perform-task
+      steps:
+        perform-task:
+          type: objective
+          objective: complete-service-check-task
+          on-success: done
+        done:
+          type: end

--- a/examples/library/templates/workflow/parallel-objective-workflow.yaml
+++ b/examples/library/templates/workflow/parallel-objective-workflow.yaml
@@ -1,0 +1,63 @@
+template: aces-library-template
+version: 1
+id: parallel-objective-workflow
+surface: workflow
+requirement_refs: [AUT-806]
+source_refs:
+  - docs/explain/sdl/sections.md
+  - docs/explain/sdl/validation.md
+summary: Parallel workflow template with explicit branch convergence through a join step.
+body:
+  name: library-workflow-template
+  description: Workflow template showing parallel objective branches converging at an explicit join.
+  nodes:
+    service:
+      type: VM
+      resources: {ram: 1 GiB, cpu: 1}
+      services:
+        - {port: 443, name: https}
+  conditions:
+    patch-applied:
+      command: test -f /var/lib/aces/patch-applied
+      interval: 30
+    service-verified:
+      command: curl -fsS https://service/health
+      interval: 30
+  entities:
+    blue-team:
+      role: blue
+  agents:
+    operator:
+      entity: blue-team
+  objectives:
+    apply-patch:
+      agent: operator
+      targets: [nodes.service]
+      success:
+        conditions: [patch-applied]
+    verify-service:
+      agent: operator
+      targets: [nodes.service.services.https]
+      success:
+        conditions: [service-verified]
+  workflows:
+    parallel-remediation:
+      start: fan-out
+      steps:
+        fan-out:
+          type: parallel
+          branches: [patch-step, verify-step]
+          join: converge
+        patch-step:
+          type: objective
+          objective: apply-patch
+          on-success: converge
+        verify-step:
+          type: objective
+          objective: verify-service
+          on-success: converge
+        converge:
+          type: join
+          next: done
+        done:
+          type: end

--- a/implementations/python/tests/test_example_library_policy.py
+++ b/implementations/python/tests/test_example_library_policy.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.check_example_library import (  # noqa: E402
+    CATALOG_RELATIVE_PATH,
+    REQUIRED_SURFACES,
+    REQUIREMENT_REF,
+    evaluate_example_library,
+)
+
+_VALID_BODY = {
+    "name": "library-policy-test",
+    "nodes": {
+        "app": {
+            "type": "VM",
+            "resources": {"ram": "1 GiB", "cpu": 1},
+            "services": [{"port": 443, "name": "https"}],
+        }
+    },
+    "conditions": {
+        "app-healthy": {
+            "command": "curl -fsS https://app/health",
+            "interval": 30,
+        }
+    },
+    "entities": {"blue-team": {"role": "blue"}},
+    "agents": {"operator": {"entity": "blue-team"}},
+    "objectives": {
+        "verify-app-health": {
+            "agent": "operator",
+            "targets": ["nodes.app.services.https"],
+            "success": {"conditions": ["app-healthy"]},
+        }
+    },
+    "workflows": {
+        "baseline-check": {
+            "start": "verify",
+            "steps": {
+                "verify": {
+                    "type": "objective",
+                    "objective": "verify-app-health",
+                    "on-success": "done",
+                },
+                "done": {"type": "end"},
+            },
+        }
+    },
+}
+
+
+def _write_yaml(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+
+
+def _seed_repo(tmp_path: Path) -> Path:
+    catalog: dict[str, Any] = {
+        "library": "aces-example-pattern-library",
+        "version": 1,
+        "requirement_refs": [REQUIREMENT_REF],
+        "source_refs": ["examples/README.md"],
+        "surfaces": {},
+    }
+    for surface in REQUIRED_SURFACES:
+        worked_path = f"examples/library/worked/{surface}.txt"
+        template_path = f"examples/library/templates/{surface}/template.yaml"
+        pattern_path = f"examples/library/patterns/{surface}.yaml"
+        catalog["surfaces"][surface] = {
+            "summary": f"{surface} surface with enough detail for the policy checker.",
+            "worked_examples": [
+                {
+                    "id": f"{surface}-worked",
+                    "path": worked_path,
+                    "source_refs": ["examples/README.md"],
+                }
+            ],
+            "templates": [{"id": f"{surface}-template", "path": template_path}],
+            "patterns": [{"id": f"{surface}-pattern", "path": pattern_path}],
+        }
+        worked_file = tmp_path / worked_path
+        worked_file.parent.mkdir(parents=True, exist_ok=True)
+        worked_file.write_text("worked example\n", encoding="utf-8")
+        _write_yaml(
+            tmp_path / template_path,
+            {
+                "template": "aces-library-template",
+                "version": 1,
+                "id": f"{surface}-template",
+                "surface": surface,
+                "requirement_refs": [REQUIREMENT_REF],
+                "source_refs": ["docs/explain/sdl/sections.md"],
+                "summary": f"Reusable {surface} template for policy tests.",
+                "body": dict(_VALID_BODY, name=f"{surface}-template"),
+            },
+        )
+        _write_yaml(
+            tmp_path / pattern_path,
+            {
+                "pattern": "aces-library-pattern",
+                "version": 1,
+                "id": f"{surface}-pattern",
+                "surface": surface,
+                "requirement_refs": [REQUIREMENT_REF],
+                "source_refs": ["docs/explain/sdl/validation.md"],
+                "summary": f"Reusable {surface} pattern for policy tests.",
+                "intent": "Exercise the policy checker with a substantive reusable pattern.",
+                "authoring_steps": ["Start from a valid SDL body."],
+                "validation": [{"command": "parse_sdl_file", "expected": "valid SDL"}],
+            },
+        )
+    _write_yaml(tmp_path / CATALOG_RELATIVE_PATH, catalog)
+    return tmp_path
+
+
+def _catalog_path(repo_root: Path) -> Path:
+    return repo_root / CATALOG_RELATIVE_PATH
+
+
+def _read_catalog(repo_root: Path) -> dict[str, Any]:
+    return yaml.safe_load(_catalog_path(repo_root).read_text(encoding="utf-8"))
+
+
+def _write_catalog(repo_root: Path, catalog: dict[str, Any]) -> None:
+    _write_yaml(_catalog_path(repo_root), catalog)
+
+
+def _flagged(failures, marker: str) -> bool:
+    needle = marker.lower()
+    return any(failure.rule_id == marker or needle in failure.render().lower() for failure in failures)
+
+
+def test_good_example_library_has_no_failures(tmp_path: Path) -> None:
+    assert evaluate_example_library(_seed_repo(tmp_path)) == []
+
+
+def test_requirement_ref_is_aut_806() -> None:
+    assert REQUIREMENT_REF == "AUT-806"
+
+
+def test_required_surfaces_cover_aut_806_clauses() -> None:
+    assert REQUIRED_SURFACES == (
+        "scenario",
+        "workflow",
+        "participant_behavior",
+        "task",
+        "run",
+        "study",
+    )
+
+
+def test_missing_surface_is_flagged(tmp_path: Path) -> None:
+    repo_root = _seed_repo(tmp_path)
+    catalog = _read_catalog(repo_root)
+    del catalog["surfaces"]["study"]
+    _write_catalog(repo_root, catalog)
+
+    failures = evaluate_example_library(repo_root)
+
+    assert _flagged(failures, "example-library-surface")
+
+
+def test_top_level_requirement_ref_is_flagged(tmp_path: Path) -> None:
+    repo_root = _seed_repo(tmp_path)
+    catalog = _read_catalog(repo_root)
+    catalog["requirement_refs"] = ["OTHER-001"]
+    _write_catalog(repo_root, catalog)
+
+    failures = evaluate_example_library(repo_root)
+
+    assert _flagged(failures, "example-library-requirement-ref")
+
+
+def test_template_body_must_parse_as_sdl(tmp_path: Path) -> None:
+    repo_root = _seed_repo(tmp_path)
+    template_path = repo_root / "examples/library/templates/scenario/template.yaml"
+    template = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+    del template["body"]["name"]
+    _write_yaml(template_path, template)
+
+    failures = evaluate_example_library(repo_root)
+
+    assert _flagged(failures, "example-library-template-body")
+
+
+def test_pattern_surface_must_match_catalog(tmp_path: Path) -> None:
+    repo_root = _seed_repo(tmp_path)
+    pattern_path = repo_root / "examples/library/patterns/scenario.yaml"
+    pattern = yaml.safe_load(pattern_path.read_text(encoding="utf-8"))
+    pattern["surface"] = "workflow"
+    _write_yaml(pattern_path, pattern)
+
+    failures = evaluate_example_library(repo_root)
+
+    assert _flagged(failures, "example-library-pattern-surface")

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ TARGETED_POLICY_TESTS = [
     "implementations/python/tests/test_assurance_policy.py",
     "implementations/python/tests/test_authority_boundary.py",
     "implementations/python/tests/test_agent_guidance_policy.py",
+    "implementations/python/tests/test_example_library_policy.py",
 ]
 CONTRACT_TRIGGER_PREFIXES = (
     "contracts/",
@@ -514,6 +515,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
             "policy / agent guidance profile",
             "skipped on staged check; runs on push and verify",
         )
+        reporter.skip(
+            "policy / example library catalog",
+            "skipped on staged check; runs on push and verify",
+        )
     else:
         reporter.run(
             "policy / semantic coverage ADR",
@@ -530,6 +535,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         reporter.run(
             "policy / agent guidance profile",
             lambda: _run_project_python(session, "tools/check_agent_guidance.py"),
+        )
+        reporter.run(
+            "policy / example library catalog",
+            lambda: _run_project_python(session, "tools/check_example_library.py"),
         )
 
 

--- a/tools/check_example_library.py
+++ b/tools/check_example_library.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Structural and SDL-validation gate for the AUT-806 example library."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import yaml
+
+from tools.policy.common import PolicyFailure, apply_exceptions, failures_to_json, load_exceptions
+
+CATALOG_RELATIVE_PATH = "examples/library/catalog.yaml"
+LIBRARY_VALUE = "aces-example-pattern-library"
+TEMPLATE_VALUE = "aces-library-template"
+PATTERN_VALUE = "aces-library-pattern"
+REQUIREMENT_REF = "AUT-806"
+REQUIRED_SURFACES: tuple[str, ...] = (
+    "scenario",
+    "workflow",
+    "participant_behavior",
+    "task",
+    "run",
+    "study",
+)
+REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = (
+    "library",
+    "version",
+    "requirement_refs",
+    "source_refs",
+    "surfaces",
+)
+REQUIRED_SURFACE_FIELDS: tuple[str, ...] = (
+    "summary",
+    "worked_examples",
+    "templates",
+    "patterns",
+)
+REQUIRED_REFERENCE_ENTRY_FIELDS: tuple[str, ...] = (
+    "id",
+    "path",
+)
+REQUIRED_TEMPLATE_FIELDS: tuple[str, ...] = (
+    "template",
+    "version",
+    "id",
+    "surface",
+    "requirement_refs",
+    "source_refs",
+    "summary",
+    "body",
+)
+REQUIRED_PATTERN_FIELDS: tuple[str, ...] = (
+    "pattern",
+    "version",
+    "id",
+    "surface",
+    "requirement_refs",
+    "source_refs",
+    "summary",
+    "intent",
+    "authoring_steps",
+    "validation",
+)
+
+
+def _fail(rule_id: str, message: str, path: str | None = CATALOG_RELATIVE_PATH) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _str_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    if not all(isinstance(item, str) and item for item in value):
+        return None
+    return list(value)
+
+
+def _load_yaml_file(path: Path, relative_path: str) -> tuple[dict[str, Any] | None, list[PolicyFailure]]:
+    if not path.is_file():
+        return None, [_fail("example-library-missing", f"missing {relative_path}", relative_path)]
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return None, [_fail("example-library-parse", f"failed to parse {relative_path}: {exc}", relative_path)]
+    if not isinstance(raw, dict):
+        return None, [
+            _fail(
+                "example-library-shape",
+                f"{relative_path} must be a YAML mapping at the top level",
+                relative_path,
+            )
+        ]
+    return raw, []
+
+
+def _repo_relative_path(
+    value: Any, *, repo_root: Path, owner: str
+) -> tuple[Path | None, str | None, PolicyFailure | None]:
+    if not isinstance(value, str) or not value:
+        return None, None, _fail("example-library-path", f"{owner} path must be a non-empty string")
+    raw_path = Path(value)
+    if raw_path.is_absolute() or ".." in raw_path.parts:
+        return None, value, _fail("example-library-path", f"{owner} path must be repo-relative: {value}", value)
+    return repo_root / raw_path, value, None
+
+
+def _check_top_level(raw: dict[str, Any]) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in raw:
+            failures.append(_fail("example-library-field", f"missing required top-level field: {field}"))
+
+    if "library" in raw and raw["library"] != LIBRARY_VALUE:
+        failures.append(_fail("example-library-name", f"library must be {LIBRARY_VALUE!r}; got {raw['library']!r}"))
+    if "version" in raw and (not isinstance(raw["version"], int) or raw["version"] < 1):
+        failures.append(_fail("example-library-version", "version must be a positive integer"))
+
+    for field in ("requirement_refs", "source_refs"):
+        if field in raw and _str_list(raw[field]) is None:
+            failures.append(_fail("example-library-field-type", f"{field} must be a list of non-empty strings"))
+
+    requirement_refs = _str_list(raw.get("requirement_refs"))
+    if requirement_refs is not None and REQUIREMENT_REF not in requirement_refs:
+        failures.append(_fail("example-library-requirement-ref", f"requirement_refs must include {REQUIREMENT_REF}"))
+
+    if "surfaces" in raw and not isinstance(raw["surfaces"], dict):
+        failures.append(_fail("example-library-field-type", "surfaces must be a mapping"))
+    return failures
+
+
+def _check_surfaces(raw: dict[str, Any], *, repo_root: Path) -> list[PolicyFailure]:
+    surfaces = raw.get("surfaces")
+    if not isinstance(surfaces, dict):
+        return []
+
+    failures: list[PolicyFailure] = []
+    seen_ids: set[str] = set()
+    for surface in REQUIRED_SURFACES:
+        value = surfaces.get(surface)
+        if not isinstance(value, dict):
+            failures.append(_fail("example-library-surface", f"surfaces.{surface} must be a mapping"))
+            continue
+        failures.extend(_check_surface(surface, value, repo_root=repo_root, seen_ids=seen_ids))
+
+    extras = sorted(set(surfaces) - set(REQUIRED_SURFACES))
+    for surface in extras:
+        failures.append(_fail("example-library-surface-extra", f"unexpected surface: {surface}"))
+    return failures
+
+
+def _check_surface(
+    surface: str,
+    value: dict[str, Any],
+    *,
+    repo_root: Path,
+    seen_ids: set[str],
+) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    for field in REQUIRED_SURFACE_FIELDS:
+        if field not in value:
+            failures.append(_fail("example-library-surface-field", f"surfaces.{surface} missing {field}"))
+
+    summary = value.get("summary")
+    if not isinstance(summary, str) or len(summary.strip()) < 20:
+        failures.append(_fail("example-library-surface-summary", f"surfaces.{surface}.summary must be substantive"))
+
+    failures.extend(
+        _check_reference_entries(
+            surface,
+            "worked_examples",
+            value.get("worked_examples"),
+            repo_root=repo_root,
+            seen_ids=seen_ids,
+        )
+    )
+    failures.extend(
+        _check_artifact_entries(
+            surface,
+            "templates",
+            value.get("templates"),
+            repo_root=repo_root,
+            seen_ids=seen_ids,
+            artifact_kind="template",
+        )
+    )
+    failures.extend(
+        _check_artifact_entries(
+            surface,
+            "patterns",
+            value.get("patterns"),
+            repo_root=repo_root,
+            seen_ids=seen_ids,
+            artifact_kind="pattern",
+        )
+    )
+    return failures
+
+
+def _check_reference_entries(
+    surface: str,
+    field: str,
+    entries: Any,
+    *,
+    repo_root: Path,
+    seen_ids: set[str],
+) -> list[PolicyFailure]:
+    if not isinstance(entries, list) or not entries:
+        return [_fail("example-library-surface-entry", f"surfaces.{surface}.{field} must be a non-empty list")]
+
+    failures: list[PolicyFailure] = []
+    for index, entry in enumerate(entries):
+        failures.extend(
+            _check_reference_entry(
+                surface,
+                field,
+                index,
+                entry,
+                repo_root=repo_root,
+                seen_ids=seen_ids,
+            )
+        )
+    return failures
+
+
+def _check_reference_entry(
+    surface: str,
+    field: str,
+    index: int,
+    entry: Any,
+    *,
+    repo_root: Path,
+    seen_ids: set[str],
+) -> list[PolicyFailure]:
+    if not isinstance(entry, dict):
+        return [
+            _fail(
+                "example-library-entry-shape",
+                f"surfaces.{surface}.{field}[{index}] must be a mapping; got {type(entry).__name__}",
+            )
+        ]
+
+    failures: list[PolicyFailure] = []
+    for required_field in REQUIRED_REFERENCE_ENTRY_FIELDS:
+        if required_field not in entry:
+            failures.append(
+                _fail("example-library-entry-field", f"surfaces.{surface}.{field}[{index}] missing {required_field}")
+            )
+
+    failures.extend(_check_unique_id(entry.get("id"), f"surfaces.{surface}.{field}[{index}]", seen_ids))
+    absolute, relative, path_failure = _repo_relative_path(
+        entry.get("path"),
+        repo_root=repo_root,
+        owner=f"surfaces.{surface}.{field}[{index}]",
+    )
+    if path_failure is not None:
+        failures.append(path_failure)
+    elif absolute is not None and relative is not None and not absolute.is_file():
+        failures.append(_fail("example-library-path-missing", f"referenced path does not exist: {relative}", relative))
+
+    if "source_refs" in entry and _str_list(entry["source_refs"]) is None:
+        failures.append(
+            _fail("example-library-entry-field-type", f"surfaces.{surface}.{field}[{index}].source_refs must be a list")
+        )
+    return failures
+
+
+def _check_artifact_entries(
+    surface: str,
+    field: str,
+    entries: Any,
+    *,
+    repo_root: Path,
+    seen_ids: set[str],
+    artifact_kind: str,
+) -> list[PolicyFailure]:
+    if not isinstance(entries, list) or not entries:
+        return [_fail("example-library-surface-entry", f"surfaces.{surface}.{field} must be a non-empty list")]
+
+    failures: list[PolicyFailure] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            failures.append(
+                _fail(
+                    "example-library-entry-shape",
+                    f"surfaces.{surface}.{field}[{index}] must be a mapping; got {type(entry).__name__}",
+                )
+            )
+            continue
+        for required_field in REQUIRED_REFERENCE_ENTRY_FIELDS:
+            if required_field not in entry:
+                failures.append(
+                    _fail(
+                        "example-library-entry-field",
+                        f"surfaces.{surface}.{field}[{index}] missing {required_field}",
+                    )
+                )
+        entry_id = entry.get("id")
+        failures.extend(_check_unique_id(entry_id, f"surfaces.{surface}.{field}[{index}]", seen_ids))
+        absolute, relative, path_failure = _repo_relative_path(
+            entry.get("path"),
+            repo_root=repo_root,
+            owner=f"surfaces.{surface}.{field}[{index}]",
+        )
+        if path_failure is not None:
+            failures.append(path_failure)
+            continue
+        if absolute is None or relative is None:
+            continue
+        if not absolute.is_file():
+            failures.append(
+                _fail("example-library-path-missing", f"referenced path does not exist: {relative}", relative)
+            )
+            continue
+        if artifact_kind == "template":
+            failures.extend(_check_template_file(absolute, relative, surface=surface, catalog_id=entry_id))
+        else:
+            failures.extend(_check_pattern_file(absolute, relative, surface=surface, catalog_id=entry_id))
+    return failures
+
+
+def _check_unique_id(value: Any, owner: str, seen_ids: set[str]) -> list[PolicyFailure]:
+    if not isinstance(value, str) or not value:
+        return [_fail("example-library-entry-id", f"{owner}.id must be a non-empty string")]
+    if value in seen_ids:
+        return [_fail("example-library-entry-duplicate", f"duplicate library id: {value}")]
+    seen_ids.add(value)
+    return []
+
+
+def _check_template_file(path: Path, relative_path: str, *, surface: str, catalog_id: Any) -> list[PolicyFailure]:
+    raw, failures = _load_yaml_file(path, relative_path)
+    if raw is None:
+        return failures
+    failures.extend(_check_artifact_common(raw, relative_path, surface=surface, catalog_id=catalog_id, kind="template"))
+
+    if "template" in raw and raw["template"] != TEMPLATE_VALUE:
+        failures.append(_fail("example-library-template-kind", f"template must be {TEMPLATE_VALUE!r}", relative_path))
+    for field in REQUIRED_TEMPLATE_FIELDS:
+        if field not in raw:
+            failures.append(
+                _fail("example-library-template-field", f"missing required template field: {field}", relative_path)
+            )
+
+    body = raw.get("body")
+    if not isinstance(body, dict):
+        failures.append(_fail("example-library-template-body", "template body must be a mapping", relative_path))
+        return failures
+    failures.extend(_check_template_body(body, relative_path))
+    return failures
+
+
+def _check_pattern_file(path: Path, relative_path: str, *, surface: str, catalog_id: Any) -> list[PolicyFailure]:
+    raw, failures = _load_yaml_file(path, relative_path)
+    if raw is None:
+        return failures
+    failures.extend(_check_artifact_common(raw, relative_path, surface=surface, catalog_id=catalog_id, kind="pattern"))
+
+    if "pattern" in raw and raw["pattern"] != PATTERN_VALUE:
+        failures.append(_fail("example-library-pattern-kind", f"pattern must be {PATTERN_VALUE!r}", relative_path))
+    for field in REQUIRED_PATTERN_FIELDS:
+        if field not in raw:
+            failures.append(
+                _fail("example-library-pattern-field", f"missing required pattern field: {field}", relative_path)
+            )
+
+    for field in ("use_when", "authoring_steps", "validation"):
+        if field in raw and not isinstance(raw[field], list):
+            failures.append(_fail("example-library-pattern-field-type", f"{field} must be a list", relative_path))
+    return failures
+
+
+def _check_artifact_common(
+    raw: dict[str, Any],
+    relative_path: str,
+    *,
+    surface: str,
+    catalog_id: Any,
+    kind: str,
+) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    artifact_id = raw.get("id")
+    if artifact_id != catalog_id:
+        failures.append(
+            _fail(
+                f"example-library-{kind}-id",
+                f"{kind} id must match catalog id {catalog_id!r}; got {artifact_id!r}",
+                relative_path,
+            )
+        )
+    if raw.get("surface") != surface:
+        failures.append(
+            _fail(
+                f"example-library-{kind}-surface",
+                f"{kind} surface must match catalog surface {surface!r}; got {raw.get('surface')!r}",
+                relative_path,
+            )
+        )
+    if "version" in raw and (not isinstance(raw["version"], int) or raw["version"] < 1):
+        failures.append(_fail(f"example-library-{kind}-version", "version must be a positive integer", relative_path))
+    for field in ("requirement_refs", "source_refs"):
+        if field in raw and _str_list(raw[field]) is None:
+            failures.append(
+                _fail(f"example-library-{kind}-field-type", f"{field} must be a string list", relative_path)
+            )
+    requirement_refs = _str_list(raw.get("requirement_refs"))
+    if requirement_refs is not None and REQUIREMENT_REF not in requirement_refs:
+        failures.append(
+            _fail(
+                f"example-library-{kind}-requirement-ref",
+                f"requirement_refs must include {REQUIREMENT_REF}",
+                relative_path,
+            )
+        )
+    summary = raw.get("summary")
+    if not isinstance(summary, str) or len(summary.strip()) < 20:
+        failures.append(_fail(f"example-library-{kind}-summary", "summary must be substantive", relative_path))
+    return failures
+
+
+def _check_template_body(body: dict[str, Any], relative_path: str) -> list[PolicyFailure]:
+    try:
+        from aces_sdl import parse_sdl
+    except ImportError as exc:  # pragma: no cover - policy runs inside the project environment
+        return [_fail("example-library-template-import", f"could not import aces_sdl: {exc}", relative_path)]
+
+    try:
+        scenario = parse_sdl(yaml.safe_dump(body, sort_keys=False))
+    except Exception as exc:  # noqa: BLE001 - render parser/validator failures as policy failures
+        return [_fail("example-library-template-body", f"template body is not valid SDL: {exc}", relative_path)]
+    if scenario.advisories:
+        return [
+            _fail(
+                "example-library-template-advisory",
+                "template body produced advisories: " + "; ".join(scenario.advisories),
+                relative_path,
+            )
+        ]
+    return []
+
+
+def evaluate_example_library(repo_root: Path = REPO_ROOT) -> list[PolicyFailure]:
+    raw, failures = _load_yaml_file(repo_root / CATALOG_RELATIVE_PATH, CATALOG_RELATIVE_PATH)
+    if raw is None:
+        return failures
+    failures.extend(_check_top_level(raw))
+    failures.extend(_check_surfaces(raw, repo_root=repo_root))
+    return failures
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate the AUT-806 example template and pattern library.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to the repo containing this file).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_example_library(args.repo_root)
+    exceptions_file = args.repo_root / "tools" / "policy" / "exceptions.yaml"
+    if exceptions_file.is_file():
+        failures = apply_exceptions(failures, load_exceptions(args.repo_root))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a validated AUT-806 example, template, and pattern library covering scenarios, workflows, participant behavior, tasks, runs, and studies.

## Requirement UIDs

- `AUT-806`

## Related Issues

Closes #227

## ADR Impact

- No ADR required

## Changes

- Add examples/library/catalog.yaml as the versioned non-normative library index for AUT-806 surfaces.
- Add parser-validated SDL template bodies for scenario, workflow, participant behavior, task, run, and study authoring.
- Add reusable pattern entries for the same six surfaces with source references and validation guidance.
- Add tools/check_example_library.py and policy tests, and wire the checker into nox policy.
- Update README, docs, and examples guidance to point users to the validated library boundary.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Passed focused example-library checker/tests, nox policy, exact repo policy commands, full tools/verify_all.py --requirement-uid AUT-806, pre-commit run --all-files, commit pre-commit hook, and authorized Codex pre-push review cycle 2. Local requirement governance exited 0 via the repo's Ground Control timeout skip.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: examples/library/catalog.yaml, examples/library/templates/, examples/library/patterns/, tools/check_example_library.py, noxfile.py
- TESTS: implementations/python/tests/test_example_library_policy.py, tools/check_example_library.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/227.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
