### PR TITLE
feat(sdl): add runtime software component inventory

### DIFF
--- a/changelog.d/395.added.md
+++ b/changelog.d/395.added.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `runtime.software_components` for node-scoped runtime software component identity below package-manager row granularity.

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -4402,6 +4402,13 @@
           "title": "Processes",
           "type": "array"
         },
+        "software_components": {
+          "items": {
+            "$ref": "#/$defs/RuntimeSoftwareComponent"
+          },
+          "title": "Software Components",
+          "type": "array"
+        },
         "ssh_servers": {
           "items": {
             "$ref": "#/$defs/SshServerConfig"
@@ -6981,6 +6988,167 @@
         "unknown"
       ],
       "title": "RuntimeSensitivityClassification",
+      "type": "string"
+    },
+    "RuntimeSoftwareComponent": {
+      "additionalProperties": false,
+      "description": "A software component observed as part of a runtime node's state.",
+      "properties": {
+        "component_id": {
+          "title": "Component Id",
+          "type": "string"
+        },
+        "component_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeSoftwareComponentType"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Component Type"
+        },
+        "cpe": {
+          "default": "",
+          "title": "Cpe",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "ecosystem": {
+          "default": "",
+          "title": "Ecosystem",
+          "type": "string"
+        },
+        "hashes": {
+          "items": {
+            "$ref": "#/$defs/RuntimeSoftwareComponentHash"
+          },
+          "title": "Hashes",
+          "type": "array"
+        },
+        "installed_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Installed Paths",
+          "type": "array"
+        },
+        "manifest_path": {
+          "default": "",
+          "title": "Manifest Path",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "package_manager": {
+          "default": "",
+          "title": "Package Manager",
+          "type": "string"
+        },
+        "package_name": {
+          "default": "",
+          "title": "Package Name",
+          "type": "string"
+        },
+        "package_version": {
+          "default": "",
+          "title": "Package Version",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeSoftwareComponentProvenance"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Provenance"
+        },
+        "purl": {
+          "default": "",
+          "title": "Purl",
+          "type": "string"
+        },
+        "version": {
+          "default": "",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "component_id",
+        "name"
+      ],
+      "title": "RuntimeSoftwareComponent",
+      "type": "object"
+    },
+    "RuntimeSoftwareComponentHash": {
+      "additionalProperties": false,
+      "description": "Digest attached to an observed runtime software component.",
+      "properties": {
+        "algorithm": {
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "title": "RuntimeSoftwareComponentHash",
+      "type": "object"
+    },
+    "RuntimeSoftwareComponentProvenance": {
+      "description": "Origin class for an observed runtime software component fact.",
+      "enum": [
+        "package_manager",
+        "dependency_manifest",
+        "sbom",
+        "scanner",
+        "image_metadata",
+        "filesystem",
+        "process_inspection",
+        "operator",
+        "self_reported",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeSoftwareComponentProvenance",
+      "type": "string"
+    },
+    "RuntimeSoftwareComponentType": {
+      "description": "Portable type for a software component observed on a runtime node.",
+      "enum": [
+        "application",
+        "framework",
+        "library",
+        "container",
+        "platform",
+        "operating_system",
+        "device",
+        "device_driver",
+        "firmware",
+        "file",
+        "data",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeSoftwareComponentType",
       "type": "string"
     },
     "RuntimeSudoPrincipalKind": {

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -4402,6 +4402,13 @@
           "title": "Processes",
           "type": "array"
         },
+        "software_components": {
+          "items": {
+            "$ref": "#/$defs/RuntimeSoftwareComponent"
+          },
+          "title": "Software Components",
+          "type": "array"
+        },
         "ssh_servers": {
           "items": {
             "$ref": "#/$defs/SshServerConfig"
@@ -6981,6 +6988,167 @@
         "unknown"
       ],
       "title": "RuntimeSensitivityClassification",
+      "type": "string"
+    },
+    "RuntimeSoftwareComponent": {
+      "additionalProperties": false,
+      "description": "A software component observed as part of a runtime node's state.",
+      "properties": {
+        "component_id": {
+          "title": "Component Id",
+          "type": "string"
+        },
+        "component_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeSoftwareComponentType"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Component Type"
+        },
+        "cpe": {
+          "default": "",
+          "title": "Cpe",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        },
+        "ecosystem": {
+          "default": "",
+          "title": "Ecosystem",
+          "type": "string"
+        },
+        "hashes": {
+          "items": {
+            "$ref": "#/$defs/RuntimeSoftwareComponentHash"
+          },
+          "title": "Hashes",
+          "type": "array"
+        },
+        "installed_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Installed Paths",
+          "type": "array"
+        },
+        "manifest_path": {
+          "default": "",
+          "title": "Manifest Path",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "package_manager": {
+          "default": "",
+          "title": "Package Manager",
+          "type": "string"
+        },
+        "package_name": {
+          "default": "",
+          "title": "Package Name",
+          "type": "string"
+        },
+        "package_version": {
+          "default": "",
+          "title": "Package Version",
+          "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RuntimeSoftwareComponentProvenance"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "unknown",
+          "title": "Provenance"
+        },
+        "purl": {
+          "default": "",
+          "title": "Purl",
+          "type": "string"
+        },
+        "version": {
+          "default": "",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "component_id",
+        "name"
+      ],
+      "title": "RuntimeSoftwareComponent",
+      "type": "object"
+    },
+    "RuntimeSoftwareComponentHash": {
+      "additionalProperties": false,
+      "description": "Digest attached to an observed runtime software component.",
+      "properties": {
+        "algorithm": {
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "title": "RuntimeSoftwareComponentHash",
+      "type": "object"
+    },
+    "RuntimeSoftwareComponentProvenance": {
+      "description": "Origin class for an observed runtime software component fact.",
+      "enum": [
+        "package_manager",
+        "dependency_manifest",
+        "sbom",
+        "scanner",
+        "image_metadata",
+        "filesystem",
+        "process_inspection",
+        "operator",
+        "self_reported",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeSoftwareComponentProvenance",
+      "type": "string"
+    },
+    "RuntimeSoftwareComponentType": {
+      "description": "Portable type for a software component observed on a runtime node.",
+      "enum": [
+        "application",
+        "framework",
+        "library",
+        "container",
+        "platform",
+        "operating_system",
+        "device",
+        "device_driver",
+        "firmware",
+        "file",
+        "data",
+        "unknown",
+        "other"
+      ],
+      "title": "RuntimeSoftwareComponentType",
       "type": "string"
     },
     "RuntimeSudoPrincipalKind": {

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -59,3 +59,4 @@ Each ADR includes:
 | [031](adr-031-ssh-server-configuration-surface.md) | SSH Server Configuration Surface | accepted | 2026-05-23 |
 | [032](adr-032-directory-domain-identity-runtime-surface.md) | Directory and Domain Identity Runtime Surface | accepted | 2026-05-24 |
 | [033](adr-033-scenario-delivery-boundary-for-runtime-node-state.md) | Scenario/Delivery Boundary for Runtime Node State | accepted | 2026-05-24 |
+| [034](adr-034-runtime-software-component-inventory.md) | Runtime Software Component Inventory | accepted | 2026-05-25 |

--- a/docs/decisions/adrs/adr-034-runtime-software-component-inventory.md
+++ b/docs/decisions/adrs/adr-034-runtime-software-component-inventory.md
@@ -1,0 +1,93 @@
+# ADR-034: Runtime Software Component Inventory
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-25
+
+## Context
+
+Issue #395 identifies an SDL expressivity gap: a scenario node can contain
+software state that is finer grained than package-manager rows in
+`runtime.packages`. A single package can ship multiple binaries or bundled
+libraries, software can be installed outside a package manager, and the same
+component may need an application/framework/library distinction for analysis or
+inventory parity.
+
+ACES already has adjacent surfaces, but each has a narrower meaning:
+
+- `runtime.packages` records package-manager rows.
+- `runtime.applications` records participant-observable HTTP route/API/UI
+  surface inventory.
+- `runtime.processes` records running process observations.
+- `runtime.dependency_manifests` records manifest-file observations.
+- `source.build` records image build provenance.
+- top-level `features` records authored scenario deployment intent.
+
+Reusing any of those would make component identity ambiguous and would blur the
+existing authored-intent, build-provenance, runtime-state, and observable-surface
+boundaries.
+
+## Decision
+
+Add `Node.runtime.software_components` as a node-scoped runtime inventory
+surface for software identity facts. Each component has a stable
+`component_id`, `name`, optional `version`, bounded `component_type`, bounded
+`provenance`, optional ecosystem identifiers (`purl`, `cpe`, hashes), optional
+package/manifest lineage fields, and optional absolute runtime paths where the
+component is present.
+
+The surface is WHAT-IS state. It does not model invocation, capabilities,
+commands, participant workflows, or scanning. It is declarative inventory only:
+the SDL parser and model validators do not execute binaries, inspect host files,
+query package databases, or import SBOM/scanner payloads.
+
+The component type vocabulary may reuse SBOM-style identity categories such as
+`application`, `framework`, `library`, `container`, `platform`,
+`operating_system`, `device`, `device_driver`, `firmware`, `file`, and `data`.
+ACES owns the SDL shape; raw CycloneDX, SPDX, package-manager, or scanner output
+remains evidence/provenance input rather than the normative schema.
+
+## Guardrails
+
+- Keep `runtime.packages` as package-manager rows. Do not add subcomponent
+  identity there.
+- Keep `runtime.applications` scoped to ADR-026's HTTP route/API/UI inventory.
+- Keep `runtime.processes` scoped to observed running processes.
+- Keep `runtime.dependency_manifests` scoped to manifest files, not resolved
+  component sets.
+- Keep `source.build` scoped to artifact build provenance.
+- Keep top-level `features` scoped to authored deployment intent.
+- Do not name the field `cli_applications` or otherwise revive invocation
+  semantics that issue #395 explicitly retracted.
+- Do not add raw SBOM documents, scanner reports, command output, credentials,
+  private keys, or backend-native inspect payloads to the model.
+
+## Consequences
+
+### Positive
+
+- SDL can normatively declare node software identity below package-manager row
+  granularity.
+- Package rows, component identity, process observations, HTTP surfaces, and
+  build provenance stay distinguishable.
+- APTL and other inventory consumers can map observed component facts into ACES
+  without converting evidence bundles into schema authority.
+
+### Negative
+
+- Authors may need to record both a package row and one or more software
+  components for the same installed artifact when both facts matter.
+- The model intentionally does not resolve component dependency graphs or import
+  full SBOM documents; richer import tooling remains separate work.
+
+### Risks
+
+- Overly broad use of `other` or free-text provenance can erode comparability if
+  inventories skip the bounded fields.
+- Future references from components to packages, manifests, files, or processes
+  must add semantic validation and module-reference support together, rather
+  than publishing dangling string conventions.

--- a/docs/explain/sdl/limitations.md
+++ b/docs/explain/sdl/limitations.md
@@ -18,6 +18,8 @@ parity, including mounts, Linux capabilities, namespace modes, entrypoints,
 image commands, extra hosts, DNS options, security flags, resource limits,
 health status/logs, filesystem inventory, the local identity
 database (`/etc/passwd` users, `/etc/group` groups, and sudo/sudoers grants),
+software component identity below package-manager row granularity
+([ADR-034](../../decisions/adrs/adr-034-runtime-software-component-inventory.md)),
 container network realization (per-network aliases and DNS names,
 hostname/domain identity, endpoint MAC/IP/prefix/gateway, backend network and
 endpoint identifiers with stability classification, host-published port

--- a/docs/explain/sdl/lineage.md
+++ b/docs/explain/sdl/lineage.md
@@ -37,6 +37,13 @@ see [Design Precedents](precedents.md).
 - CyRIS, KYPO, OCR, VSDL, and CRACK are prior scenario-definition systems.
   Their strongest shared lesson is that scenario meaning must be more than a
   deployment script.
+- SBOM standards such as [CycloneDX](https://cyclonedx.org/specification/overview/)
+  and [SPDX](https://spdx.dev/use/specifications/) inform the runtime software
+  component identity vocabulary: component type, version, purl/CPE, hashes, and
+  package or manifest lineage are useful portable facts. ACES adapts those
+  identity concepts under `Node.runtime.software_components`; it does not import
+  raw SBOM documents, scanner output, or invocation/capability semantics into
+  the SDL schema.
 
 ## Directory, Domain, And Identity Authority Semantics
 

--- a/docs/explain/sdl/precedents.md
+++ b/docs/explain/sdl/precedents.md
@@ -244,6 +244,7 @@ taxonomy of container, orchestrator, or host-security concerns.
 | Dockerfile/build execution              | Build executor mechanics are delivery/packaging; observable image/source provenance is an artifact-boundary fact | Backend implementation layer for execution mechanics; `Source.build` provenance when observed; see ADR-023 |
 | Observable container image build provenance | Artifact provenance, not deployment authoring | SDL source-artifact surface; see ADR-023 |
 | Runtime-effective container entrypoints | Backend/runtime state              | `Node.runtime.container` when observed |
+| Runtime software component identity below package-manager rows | Runtime-observed state, not deployment authoring, process execution, or HTTP/API inventory | `Node.runtime.software_components` when observed; see ADR-034 |
 | Local identity database (`/etc/passwd`, `/etc/group`, sudoers) | Runtime-observed state, not deployment authoring | `Node.runtime.local_identity` when observed; see ADR-024 |
 | Container network realization (aliases, DNS names, endpoint metadata, host-published bindings) | Runtime-observed state, not topology authoring | `Node.runtime.network` when observed; see ADR-025 |
 | Application HTTP route/API/UI surface (routes, methods, request inputs, responses, route-specific weakness placement) | Participant-observable application state, not transport-service or vulnerability authoring | `Node.runtime.applications` when observed; see ADR-026 |

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -205,6 +205,23 @@ nodes:
         - manager: apk
           name: musl
           version: 1.2.4-r2
+      software_components:
+        - component_id: shuffle-backend-app
+          name: shuffle-backend
+          version: 1.2.3
+          component_type: application
+          provenance: scanner
+          ecosystem: go
+          purl: "pkg:golang/github.com/frikky/shuffle@1.2.3"
+          cpe: "cpe:2.3:a:shuffle:shuffle:1.2.3:*:*:*:*:*:*:*"
+          package_manager: apk
+          package_name: shuffle-backend
+          package_version: 1.2.3-r0
+          manifest_path: /app/go.mod
+          installed_paths: [/app/shufflebackend, /app/go.mod]
+          hashes:
+            - algorithm: sha256
+              value: abc123
       dependency_manifests:
         - ecosystem: go
           path: /app/go.mod
@@ -432,12 +449,18 @@ posture — `default`, `unconfined`, a named profile, or a profile path) and
 such as `seccomp:unconfined` or `no-new-privileges`); a seccomp posture is a
 distinct security control from `privileged`, so it is recorded separately (see
 [ADR-028](../../decisions/adrs/adr-028-container-seccomp-security-options-surface.md));
-`health` records observed health status and bounded
-healthcheck log facts; `packages` and `dependency_manifests` record runtime
-inventory; and `package_vulnerabilities` records scanner-derived CVE/advisory
-findings tied to an image digest and scan time. These findings are separate
-from the top-level `vulnerabilities` section, which remains the CWE-classified
-scenario vulnerability surface.
+`health` records observed health status and bounded healthcheck log facts;
+`packages` records package-manager rows; `software_components` records
+node-local software identity at component granularity with stable ACES ids,
+component type, version, purl/CPE/hash identifiers, package or manifest
+lineage, and runtime paths when known; `dependency_manifests` records observed
+manifest files; and `package_vulnerabilities` records scanner-derived
+CVE/advisory findings tied to an image digest and scan time. Software
+components are WHAT-IS state, not invocation surfaces, process snapshots, HTTP
+route inventory, build provenance, or authored deployment intent (see
+[ADR-034](../../decisions/adrs/adr-034-runtime-software-component-inventory.md)).
+Package findings are separate from the top-level `vulnerabilities` section,
+which remains the CWE-classified scenario vulnerability surface.
 
 `runtime.local_identity` records the observed local identity database — the
 node-scoped `/etc/passwd`, `/etc/group`, and sudo/sudoers facts. `users` carry

--- a/docs/explain/sdl/validation.md
+++ b/docs/explain/sdl/validation.md
@@ -50,12 +50,15 @@ becoming a validator-only interpretation of the SDL.
 
 Pydantic structural validation also enforces model-local node rules before
 these semantic passes run. Switch nodes reject VM-only fields, including
-`runtime`. Runtime mount and dependency-manifest paths must be absolute paths
-or variable references. Runtime filesystem inventory paths, container masked
-paths, container read-only paths, and device host/container paths must also be
+`runtime`. Runtime mount, dependency-manifest, and software-component manifest
+paths must be absolute paths or variable references. Runtime software-component
+`installed_paths`, filesystem inventory paths, container masked paths,
+container read-only paths, and device host/container paths must also be
 absolute runtime paths or variable references. Runtime local-control interface
 paths and bind sources must be absolute paths, Windows named pipe endpoints, or
 variable references; Windows named pipe endpoints require `kind: named_pipe`.
+Runtime software components must have stable, concrete `component_id` values
+that are unique within the node runtime block.
 Runtime filesystem inventory UID/GID and size fields are non-negative, mode is
 stored as octal permission bits, and content digests must carry both the digest
 algorithm and value. Runtime healthcheck entries marked as redacted must omit
@@ -117,7 +120,8 @@ This also means the validator only enforces what the current SDL syntax can
 actually express. Node `runtime` metadata covers observed VM configuration
 facts such as mounts, path-local control interfaces, process identity, runtime
 filesystem inventory, container host/security configuration, health observations,
-package inventory, dependency manifests, and scanner-derived package findings.
+package inventory, software component identity, dependency manifests, and
+scanner-derived package findings.
 The `source.build` block covers observed container image build provenance:
 base image and digest, layer chain, structured build-recipe instructions, build
 arguments, copied sources, image-default configuration, source-input mapping,

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,7 @@ decisions/adrs/adr-030-process-scoped-linux-capability-policy
 decisions/adrs/adr-031-ssh-server-configuration-surface
 decisions/adrs/adr-032-directory-domain-identity-runtime-surface
 decisions/adrs/adr-033-scenario-delivery-boundary-for-runtime-node-state
+decisions/adrs/adr-034-runtime-software-component-inventory
 decisions/sem-213-temporal-participant-preflight
 ```
 

--- a/implementations/python/packages/aces_sdl/nodes.py
+++ b/implementations/python/packages/aces_sdl/nodes.py
@@ -96,6 +96,10 @@ from .runtime_configuration import (
     RuntimeResourceLimits,
     RuntimeRestartPolicy,
     RuntimeSensitivityClassification,
+    RuntimeSoftwareComponent,
+    RuntimeSoftwareComponentHash,
+    RuntimeSoftwareComponentProvenance,
+    RuntimeSoftwareComponentType,
     RuntimeSudoPrincipalKind,
     RuntimeSudoRule,
     parse_ram,
@@ -227,6 +231,15 @@ __all__ = [
     "ServicePort",
     "parse_ram",
 ]
+
+__all__.extend(
+    [
+        RuntimeSoftwareComponent.__name__,
+        RuntimeSoftwareComponentHash.__name__,
+        RuntimeSoftwareComponentProvenance.__name__,
+        RuntimeSoftwareComponentType.__name__,
+    ]
+)
 
 MAX_NODE_NAME_LENGTH = 35
 

--- a/implementations/python/packages/aces_sdl/runtime_configuration.py
+++ b/implementations/python/packages/aces_sdl/runtime_configuration.py
@@ -83,6 +83,12 @@ from .runtime_network import (
     RuntimeNetworkRealization,
     RuntimePublishedPort,
 )
+from .runtime_software import (
+    RuntimeSoftwareComponent,
+    RuntimeSoftwareComponentHash,
+    RuntimeSoftwareComponentProvenance,
+    RuntimeSoftwareComponentType,
+)
 from .runtime_ssh_server import (
     SshForcedCommand,
     SshForcedCommandKind,
@@ -168,6 +174,10 @@ __all__ = [
     "RuntimeResourceLimits",
     "RuntimeRestartPolicy",
     "RuntimeSensitivityClassification",
+    "RuntimeSoftwareComponent",
+    "RuntimeSoftwareComponentHash",
+    "RuntimeSoftwareComponentProvenance",
+    "RuntimeSoftwareComponentType",
     "RuntimeSudoPrincipalKind",
     "RuntimeSudoRule",
     "SshForcedCommand",
@@ -395,6 +405,7 @@ class RuntimeConfiguration(SDLModel):
     database_services: list[DatabaseService] = Field(default_factory=list)
     ssh_servers: list[SshServerConfig] = Field(default_factory=list)
     packages: list[RuntimePackage] = Field(default_factory=list)
+    software_components: list[RuntimeSoftwareComponent] = Field(default_factory=list)
     dependency_manifests: list[RuntimeDependencyManifest] = Field(default_factory=list)
     package_vulnerabilities: list[RuntimePackageVulnerabilityFinding] = Field(default_factory=list)
 
@@ -409,4 +420,5 @@ class RuntimeConfiguration(SDLModel):
         _reject_duplicate_keys(self.database_services, attr="database_service_id", label="database_service_id")
         _reject_duplicate_keys(self.ssh_servers, attr="server_id", label="ssh_server server_id")
         _reject_duplicate_keys(self.identity_authorities, attr="authority_id", label="identity authority")
+        _reject_duplicate_keys(self.software_components, attr="component_id", label="software component")
         return self

--- a/implementations/python/packages/aces_sdl/runtime_software.py
+++ b/implementations/python/packages/aces_sdl/runtime_software.py
@@ -1,0 +1,125 @@
+"""Observed runtime software component inventory models for SDL nodes."""
+
+from enum import Enum
+
+from pydantic import Field, field_validator
+
+from ._base import SDLModel
+from .runtime_values import (
+    absolute_path_or_var,
+    coerce_string_list,
+    parse_runtime_enum_or_var,
+    require_symbol,
+    validate_absolute_paths,
+)
+
+
+class RuntimeSoftwareComponentType(str, Enum):
+    """Portable type for a software component observed on a runtime node."""
+
+    APPLICATION = "application"
+    FRAMEWORK = "framework"
+    LIBRARY = "library"
+    CONTAINER = "container"
+    PLATFORM = "platform"
+    OPERATING_SYSTEM = "operating_system"
+    DEVICE = "device"
+    DEVICE_DRIVER = "device_driver"
+    FIRMWARE = "firmware"
+    FILE = "file"
+    DATA = "data"
+    UNKNOWN = "unknown"
+    OTHER = "other"
+
+
+class RuntimeSoftwareComponentProvenance(str, Enum):
+    """Origin class for an observed runtime software component fact."""
+
+    PACKAGE_MANAGER = "package_manager"
+    DEPENDENCY_MANIFEST = "dependency_manifest"
+    SBOM = "sbom"
+    SCANNER = "scanner"
+    IMAGE_METADATA = "image_metadata"
+    FILESYSTEM = "filesystem"
+    PROCESS_INSPECTION = "process_inspection"
+    OPERATOR = "operator"
+    SELF_REPORTED = "self_reported"
+    UNKNOWN = "unknown"
+    OTHER = "other"
+
+
+class RuntimeSoftwareComponentHash(SDLModel):
+    """Digest attached to an observed runtime software component."""
+
+    algorithm: str
+    value: str
+
+    @field_validator("algorithm", "value")
+    @classmethod
+    def validate_non_empty(cls, v: str) -> str:
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("software component hash fields must be non-empty strings")
+        return v
+
+
+class RuntimeSoftwareComponent(SDLModel):
+    """A software component observed as part of a runtime node's state."""
+
+    component_id: str
+    name: str
+    version: str = ""
+    component_type: RuntimeSoftwareComponentType | str = RuntimeSoftwareComponentType.UNKNOWN
+    provenance: RuntimeSoftwareComponentProvenance | str = RuntimeSoftwareComponentProvenance.UNKNOWN
+    ecosystem: str = ""
+    purl: str = ""
+    cpe: str = ""
+    package_manager: str = ""
+    package_name: str = ""
+    package_version: str = ""
+    manifest_path: str = ""
+    installed_paths: list[str] = Field(default_factory=list)
+    hashes: list[RuntimeSoftwareComponentHash] = Field(default_factory=list)
+    description: str = ""
+
+    @field_validator("component_id")
+    @classmethod
+    def validate_component_id(cls, v: str) -> str:
+        return require_symbol(v, field_name="component_id")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not isinstance(v, str) or not v.strip():
+            raise ValueError("software component name must be a non-empty string")
+        return v
+
+    @field_validator("component_type", mode="before")
+    @classmethod
+    def normalize_component_type(
+        cls,
+        v: RuntimeSoftwareComponentType | str,
+    ) -> RuntimeSoftwareComponentType | str:
+        return parse_runtime_enum_or_var(v, RuntimeSoftwareComponentType, field_name="component_type")
+
+    @field_validator("provenance", mode="before")
+    @classmethod
+    def normalize_provenance(
+        cls,
+        v: RuntimeSoftwareComponentProvenance | str,
+    ) -> RuntimeSoftwareComponentProvenance | str:
+        return parse_runtime_enum_or_var(v, RuntimeSoftwareComponentProvenance, field_name="provenance")
+
+    @field_validator("manifest_path")
+    @classmethod
+    def validate_manifest_path(cls, v: str) -> str:
+        return absolute_path_or_var(v, field_name="manifest_path") if v else v
+
+    @field_validator("installed_paths", mode="before")
+    @classmethod
+    def coerce_installed_paths(cls, v: object) -> object:
+        return coerce_string_list(v)
+
+    @field_validator("installed_paths")
+    @classmethod
+    def validate_installed_paths(cls, v: list[str]) -> list[str]:
+        return validate_absolute_paths(v, field_name="installed_paths")

--- a/implementations/python/tests/test_runtime_models.py
+++ b/implementations/python/tests/test_runtime_models.py
@@ -175,6 +175,22 @@ nodes:
         - manager: apk
           name: musl
           version: 1.2.4-r2
+      software-components:
+        - component-id: shuffle-backend-app
+          name: shuffle-backend
+          version: 1.2.3
+          component-type: application
+          provenance: scanner
+          ecosystem: go
+          purl: "pkg:golang/github.com/frikky/shuffle@1.2.3"
+          package-manager: apk
+          package-name: shuffle-backend
+          package-version: 1.2.3-r0
+          manifest-path: /app/go.mod
+          installed-paths: [/app/shufflebackend, /app/go.mod]
+          hashes:
+            - algorithm: sha256
+              value: abc123
       dependency-manifests:
         - ecosystem: go
           path: /app/go.mod
@@ -246,6 +262,14 @@ nodes:
         assert runtime["packages"][0]["manager"] == "apk"
         assert runtime["packages"][0]["name"] == "musl"
         assert runtime["packages"][0]["version"] == "1.2.4-r2"
+        assert runtime["software_components"][0]["component_id"] == "shuffle-backend-app"
+        assert runtime["software_components"][0]["name"] == "shuffle-backend"
+        assert runtime["software_components"][0]["component_type"] == "application"
+        assert runtime["software_components"][0]["provenance"] == "scanner"
+        assert runtime["software_components"][0]["package_manager"] == "apk"
+        assert runtime["software_components"][0]["manifest_path"] == "/app/go.mod"
+        assert runtime["software_components"][0]["installed_paths"] == ["/app/shufflebackend", "/app/go.mod"]
+        assert runtime["software_components"][0]["hashes"][0]["algorithm"] == "sha256"
         assert runtime["dependency_manifests"][0]["ecosystem"] == "go"
         assert runtime["dependency_manifests"][0]["path"] == "/app/go.mod"
         assert runtime["dependency_manifests"][0]["format"] == "go-module"

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -83,6 +83,8 @@ from aces.core.sdl.nodes import (
     RuntimePublishedPort,
     RuntimeRestartPolicy,
     RuntimeSensitivityClassification,
+    RuntimeSoftwareComponentProvenance,
+    RuntimeSoftwareComponentType,
     RuntimeSudoPrincipalKind,
     RuntimeSudoRule,
     parse_ram,
@@ -414,6 +416,24 @@ class TestNode:
                         "version": "1.2.4-r2",
                     }
                 ],
+                "software_components": [
+                    {
+                        "component_id": "shuffle-backend-app",
+                        "name": "shuffle-backend",
+                        "version": "1.2.3",
+                        "component_type": "application",
+                        "provenance": "scanner",
+                        "ecosystem": "go",
+                        "purl": "pkg:golang/github.com/frikky/shuffle@1.2.3",
+                        "cpe": "cpe:2.3:a:shuffle:shuffle:1.2.3:*:*:*:*:*:*:*",
+                        "package_manager": "apk",
+                        "package_name": "shuffle-backend",
+                        "package_version": "1.2.3-r0",
+                        "manifest_path": "/app/go.mod",
+                        "installed_paths": ["/app/shufflebackend", "/app/go.mod"],
+                        "hashes": [{"algorithm": "sha256", "value": "abc123"}],
+                    }
+                ],
                 "dependency_manifests": [
                     {
                         "ecosystem": "go",
@@ -456,6 +476,20 @@ class TestNode:
         assert runtime.packages[0].manager == "apk"
         assert runtime.packages[0].name == "musl"
         assert runtime.packages[0].version == "1.2.4-r2"
+        assert runtime.software_components[0].component_id == "shuffle-backend-app"
+        assert runtime.software_components[0].name == "shuffle-backend"
+        assert runtime.software_components[0].version == "1.2.3"
+        assert runtime.software_components[0].component_type == RuntimeSoftwareComponentType.APPLICATION
+        assert runtime.software_components[0].provenance == RuntimeSoftwareComponentProvenance.SCANNER
+        assert runtime.software_components[0].ecosystem == "go"
+        assert runtime.software_components[0].purl == "pkg:golang/github.com/frikky/shuffle@1.2.3"
+        assert runtime.software_components[0].cpe == "cpe:2.3:a:shuffle:shuffle:1.2.3:*:*:*:*:*:*:*"
+        assert runtime.software_components[0].package_manager == "apk"
+        assert runtime.software_components[0].package_name == "shuffle-backend"
+        assert runtime.software_components[0].package_version == "1.2.3-r0"
+        assert runtime.software_components[0].manifest_path == "/app/go.mod"
+        assert runtime.software_components[0].installed_paths == ["/app/shufflebackend", "/app/go.mod"]
+        assert runtime.software_components[0].hashes[0].algorithm == "sha256"
         assert runtime.dependency_manifests[0].ecosystem == "go"
         assert runtime.dependency_manifests[0].path == "/app/go.mod"
         assert runtime.dependency_manifests[0].format == "go-module"
@@ -467,6 +501,33 @@ class TestNode:
         assert runtime.package_vulnerabilities[0].scanner == "trivy"
         assert runtime.package_vulnerabilities[0].image_digest == "sha256:abc123"
         assert runtime.package_vulnerabilities[0].scan_time == "2026-05-20T12:00:00Z"
+
+    def test_vm_runtime_rejects_duplicate_software_component_id(self):
+        with pytest.raises(ValidationError, match="Duplicate runtime software component 'webapp'"):
+            Node(
+                type="vm",
+                runtime={
+                    "software_components": [
+                        {"component_id": "webapp", "name": "web application"},
+                        {"component_id": "webapp", "name": "bundled library"},
+                    ],
+                },
+            )
+
+    def test_vm_runtime_software_component_paths_must_be_absolute(self):
+        with pytest.raises(ValidationError, match="manifest_path must be an absolute path"):
+            Node(
+                type="vm",
+                runtime={
+                    "software_components": [
+                        {
+                            "component_id": "webapp",
+                            "name": "web application",
+                            "manifest_path": "app/package-lock.json",
+                        }
+                    ],
+                },
+            )
 
     def test_vm_runtime_operational_surfaces(self):
         n = Node(

--- a/implementations/python/tests/test_sdl_parser.py
+++ b/implementations/python/tests/test_sdl_parser.py
@@ -357,6 +357,23 @@ nodes:
         - manager: apk
           name: musl
           version: 1.2.4-r2
+      software-components:
+        - component-id: shuffle-backend-app
+          name: shuffle-backend
+          version: 1.2.3
+          component-type: application
+          provenance: scanner
+          ecosystem: go
+          purl: "pkg:golang/github.com/frikky/shuffle@1.2.3"
+          cpe: "cpe:2.3:a:shuffle:shuffle:1.2.3:*:*:*:*:*:*:*"
+          package-manager: apk
+          package-name: shuffle-backend
+          package-version: 1.2.3-r0
+          manifest-path: /app/go.mod
+          installed-paths: [/app/shufflebackend, /app/go.mod]
+          hashes:
+            - algorithm: sha256
+              value: abc123
       dependency-manifests:
         - ecosystem: go
           path: /app/go.mod
@@ -444,6 +461,19 @@ nodes:
         assert node.runtime.packages[0].manager == "apk"
         assert node.runtime.packages[0].name == "musl"
         assert node.runtime.packages[0].version == "1.2.4-r2"
+        assert node.runtime.software_components[0].component_id == "shuffle-backend-app"
+        assert node.runtime.software_components[0].name == "shuffle-backend"
+        assert node.runtime.software_components[0].version == "1.2.3"
+        assert node.runtime.software_components[0].component_type == "application"
+        assert node.runtime.software_components[0].provenance == "scanner"
+        assert node.runtime.software_components[0].ecosystem == "go"
+        assert node.runtime.software_components[0].purl == "pkg:golang/github.com/frikky/shuffle@1.2.3"
+        assert node.runtime.software_components[0].package_manager == "apk"
+        assert node.runtime.software_components[0].package_name == "shuffle-backend"
+        assert node.runtime.software_components[0].package_version == "1.2.3-r0"
+        assert node.runtime.software_components[0].manifest_path == "/app/go.mod"
+        assert node.runtime.software_components[0].installed_paths == ["/app/shufflebackend", "/app/go.mod"]
+        assert node.runtime.software_components[0].hashes[0].value == "abc123"
         assert node.runtime.dependency_manifests[0].ecosystem == "go"
         assert node.runtime.dependency_manifests[0].path == "/app/go.mod"
         assert node.runtime.dependency_manifests[0].format == "go-module"

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -9,6 +9,9 @@ phases:
       - GOV-920
       - GOV-921
       - GOV-922
+  - id: sdl-language
+    patterns:
+      - ^DSL-
   - id: api400-core
     requirements:
       - API-412
@@ -89,6 +92,14 @@ ownership:
     - implementations/python/packages/aces_processor
     - implementations/python/pyproject.toml
     - implementations/python/src/aces
+    - implementations/python/tests
+    - CHANGELOG.md
+  sdl-language:
+    - contracts/schemas/sdl
+    - docs/decisions/adrs
+    - docs/explain/sdl
+    - docs/index.md
+    - implementations/python/packages/aces_sdl
     - implementations/python/tests
     - CHANGELOG.md
   api400-core:


### PR DESCRIPTION
## Summary

Add a node runtime software-component inventory surface for declaring observed software state below package-manager rows without overloading packages, processes, dependency manifests, source build metadata, or top-level features.

## Requirement UIDs

- `DSL-107`

## Related Issues

Closes #395

## ADR Impact

- ADR-034

## Changes

- Added `Node.runtime.software_components` models, schema emission, parser preservation, and runtime compiler preservation.
- Documented the surface in SDL references and ADR-034 with guardrails separating observed runtime software identity from delivery, scanner invocation, and source/build concerns.
- Updated requirement-order policy ownership for SDL language artifacts touched by this issue.

## Test Plan

- [x] Local canonical verification passed: `GC_BASE_URL=http://100.98.28.66:8000 ACES_REQUIREMENT_UID=DSL-107 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`
- [x] GitHub CI `verify` passed.
- [x] GitHub CI `fuzz` passed.
- [x] GitHub CI `sonar` passed.
- [x] SonarCloud quality gate passed.
- [x] GitGuardian security check passed.

## Ground Control Checks

- [x] Repo policy, requirement governance, semantic coverage ADR, assurance policy ADR, authority boundary ADR, agent guidance profile, and example catalog stages passed inside `nox -s verify`.
- [x] PR #408 is linked to `DSL-107` with `IMPLEMENTS` traceability.
- [x] ADR-034 is linked to `DSL-107` with `CONSTRAINS` traceability; stale pre-rebase ADR-033 software-component traceability was removed.
- [x] Final report posted to issue #395 and corrected for traceability accounting.

## Traceability

- IMPLEMENTS: Issue #395, DSL-107, ADR-034, implementations/python/packages/aces_sdl/runtime_software.py, implementations/python/packages/aces_sdl/runtime_configuration.py
- TESTS: implementations/python/tests/test_sdl_models.py, implementations/python/tests/test_sdl_parser.py, implementations/python/tests/test_runtime_models.py, contracts/schemas/sdl/sdl-authoring-input-v1.json, contracts/schemas/sdl/instantiated-scenario-v1.json

## Checklist

- [x] Code follows project coding standards (`docs/explain/reference/coding-standards.md`).
- [x] Changelog fragment added at `changelog.d/395.added.md`.
- [x] Architectural docs and ADR index updated for ADR-034.
- [x] Generated SDL schemas regenerated and checked for drift.
- [x] No scanner execution, package-manager query, host file inspection, binary execution, or raw SBOM import behavior added.