### PR TITLE
added: move asset inventory methodology into ACES docs

### DIFF
--- a/.claude/skills/aces-asset-inventory-capture/SKILL.md
+++ b/.claude/skills/aces-asset-inventory-capture/SKILL.md
@@ -10,10 +10,11 @@ agent entry point for the participant-discoverable asset inventory
 methodology: capture evidence first, map facts to ACES only when the mapping is
 semantically correct, and leave every omission as durable evidence.
 
-The methodology remains the authority. In an APTL checkout, read
-`docs/aces/inventory/asset-inventory-methodology.md` before capture. This
-skill operationalizes that prose; it does not define a second ledger schema or
-a second secret taxonomy.
+The ACES methodology remains the authority. Read
+`docs/aces/inventory/asset-inventory-methodology.md` from the ACES repo before
+capture; when working in a downstream checkout, use that ACES document as the
+canonical source. This skill operationalizes that prose; it does not define a
+second ledger schema or a second secret taxonomy.
 
 For Docker/Compose/container-image captures, start by copying
 `scripts/capture-container-evidence-template.sh` and
@@ -39,13 +40,13 @@ commands that may expose secrets.
 
 ## Bundle Contract
 
-Produce a bundle that validates with the APTL ledger tooling:
+Produce a bundle that validates with the current APTL reference ledger tooling:
 
 - `README.md` that states scope, target identity, verification commands, and
   known limits;
 - `capture-evidence.sh` or equivalent committed capture commands, derived from
   the template for Docker/Compose assets when applicable;
-- `mapping-ledger.yaml` using the canonical APTL schema;
+- `mapping-ledger.yaml` using the current reference ledger schema;
 - `evidence/` with raw or redacted evidence files;
 - `evidence/capture-limits.txt` with one first-class limit for every skipped
   required step, declined useful-optional step, contamination boundary, or

--- a/.codex-skills/aces-asset-inventory-capture/SKILL.md
+++ b/.codex-skills/aces-asset-inventory-capture/SKILL.md
@@ -10,10 +10,11 @@ agent entry point for the participant-discoverable asset inventory
 methodology: capture evidence first, map facts to ACES only when the mapping is
 semantically correct, and leave every omission as durable evidence.
 
-The methodology remains the authority. In an APTL checkout, read
-`docs/aces/inventory/asset-inventory-methodology.md` before capture. This
-skill operationalizes that prose; it does not define a second ledger schema or
-a second secret taxonomy.
+The ACES methodology remains the authority. Read
+`docs/aces/inventory/asset-inventory-methodology.md` from the ACES repo before
+capture; when working in a downstream checkout, use that ACES document as the
+canonical source. This skill operationalizes that prose; it does not define a
+second ledger schema or a second secret taxonomy.
 
 For Docker/Compose/container-image captures, start by copying
 `scripts/capture-container-evidence-template.sh` and
@@ -39,13 +40,13 @@ commands that may expose secrets.
 
 ## Bundle Contract
 
-Produce a bundle that validates with the APTL ledger tooling:
+Produce a bundle that validates with the current APTL reference ledger tooling:
 
 - `README.md` that states scope, target identity, verification commands, and
   known limits;
 - `capture-evidence.sh` or equivalent committed capture commands, derived from
   the template for Docker/Compose assets when applicable;
-- `mapping-ledger.yaml` using the canonical APTL schema;
+- `mapping-ledger.yaml` using the current reference ledger schema;
 - `evidence/` with raw or redacted evidence files;
 - `evidence/capture-limits.txt` with one first-class limit for every skipped
   required step, declined useful-optional step, contamination boundary, or

--- a/changelog.d/411.added.md
+++ b/changelog.d/411.added.md
@@ -1,2 +1,3 @@
-Added deterministic container evidence capture and Syft CycloneDX normalization
-templates to the ACES asset inventory capture skills.
+Added ACES-owned asset inventory methodology docs plus deterministic container
+evidence capture and Syft CycloneDX normalization templates to the ACES asset
+inventory capture skills.

--- a/docs/aces/inventory/ad-preflight.md
+++ b/docs/aces/inventory/ad-preflight.md
@@ -1,0 +1,35 @@
+# AD ACES Inventory Preflight
+
+This is a historical APTL TechVault validation note imported into ACES as a
+reference example. It is not the methodology authority; the canonical ACES
+methodology is `docs/aces/inventory/asset-inventory-methodology.md`.
+
+This note records the local architecture preflight for SCN-010 / issue #332.
+The Ground Control `gc_codex_architecture_preflight` call completed and wrote
+the issue phase marker, but the tool did not create a repo-local note file.
+
+## Binding Guardrails
+
+- Keep this work as an ACES inventory and specification update. Evidence,
+  Docker output, package manifests, scanner output, checksums, and ledgers are
+  proof inputs only; catalogued facts that ACES can express belong in
+  `scenarios/techvault.sdl.yaml`.
+- Do not create an APTL-local schema, parser, validator, Pydantic model, or
+  runtime exception hierarchy for AD inventory facts.
+- Reuse `docs/aces/inventory/asset-inventory-methodology.md`,
+  `src/aptl/core/aces_inventory.py`, `src/aptl/cli/aces_inventory.py`, the
+  existing webapp and db inventory bundles, and `docs/aces/parity-inventory.yaml`.
+- Redact AD administrator credentials, generated flags, Kerberos/Samba secret
+  material, Wazuh client keys, and private key contents from committed evidence.
+- Keep legacy `aptl.core.sdl` and `scenarios/*.yaml` functional until the
+  ADR-035 cutover PR. This issue does not change backend runtime behavior or
+  flip default scenario selection.
+
+## Applied Scope
+
+The implementation captures the realized `aptl-ad` container after a fresh
+`uv run aptl lab stop -v -y && uv run aptl lab start --skip-seed`, then records
+the AD inventory under `docs/aces/inventory/ad/`, maps every catalogued fact in
+`mapping-ledger.yaml`, and encodes the AD host, Samba domain, runtime, network,
+service, identity, vulnerability, content, and relationship facts in
+`scenarios/techvault.sdl.yaml`.

--- a/docs/aces/inventory/asset-inventory-methodology.md
+++ b/docs/aces/inventory/asset-inventory-methodology.md
@@ -1,0 +1,353 @@
+# Participant-Discoverable Asset Inventory Methodology
+
+This is the ACES-owned methodology for participant-discoverable asset
+inventory capture. It was first validated against the TechVault
+`shuffle-backend` asset during APTL issue #353, with later APTL asset
+captures used as downstream proof work. The companion assurance report
+`docs/aces/inventory/methodology-assurance-report.md` records the DevOps,
+supply-chain, reproducible-research, and verification/validation basis for the
+methodology. The method has one inclusion rule:
+
+> If a participant or agent could discover a fact from inside the range,
+> capture it and attempt to specify it in ACES.
+
+There is no relevance filter during capture, no accidental-versus-deliberate
+filter, and no early split that sends facts to backend evidence merely because
+they came from Docker or another realization layer. ACES is the methodology and
+specification authority. A downstream runtime such as APTL can provide
+reference reality for a proof pass, but it does not own the inclusion rule.
+The participant-discoverable rule is the evidence boundary for inventory
+capture; it is not the semantic frame for extending the SDL. Backend and
+provenance evidence explain how the configuration was realized and how the
+claim was captured; they do not shrink the set of facts that must be attempted
+in ACES.
+
+## Scope and Claim Boundary
+
+The method captures steady-state asset configuration facts within the
+participant-discoverable boundary: network facts, services, versions, packages,
+files, data, connections, processes, mounts, credentials, configuration, trust
+surfaces, and any other fact an in-range participant or agent could discover.
+It also captures provenance and assurance artifacts so the discovery claim can
+be audited.
+
+It does not claim byte-identical rebuildability, independent replication of
+scenario outcomes, or dynamic behavior coverage. For the first TechVault
+validation pass, this was best described as an asset configuration inventory
+plus a reproducible evidence bundle. In digital twin terms, it is a digital
+model or digital shadow. It is not a live digital twin because the inventory is
+not continuously synchronized with the running system and does not provide a
+closed feedback loop.
+
+The practical reproducibility standard is therefore:
+
+- another maintainer can identify every captured participant-discoverable
+  fact, its discovery vantage, and the evidence that supports it;
+- every captured fact has either an ACES specification mapping or an ACES
+  issue for the expressivity gap;
+- the capture can be rerun with non-commercial tooling on a local lab;
+- limits, time-sensitive scanner output, mutable tags, redactions, and
+  skipped steps are recorded plainly.
+
+This follows the computational reproducibility framing in Peng (2011),
+Goodman, Fanelli, and Ioannidis (2016), and Boettiger (2015): preserve
+the code, environment, parameters, and artifacts needed to assess a
+computational claim, without overstating that the result is an independent
+scientific replication.
+
+## Evidence Model
+
+Each asset is described across five layers:
+
+| Layer | Meaning | Typical evidence |
+| --- | --- | --- |
+| Discovery vantage | Where an in-range participant or agent could learn the fact. | Kali/red-agent shell, compromised app shell, blue console, service API, filesystem, network scan. |
+| Captured configuration fact | The discovered fact itself, with no intent/relevance filtering. | IPs, DNS names, routes, ports, banners, versions, files, packages, env names/values visible in-range, processes, mounts, data, credentials. |
+| ACES specification mapping | The SDL element or ACES contract that represents the fact. | `nodes`, `infrastructure`, `services`, `features`, `content`, `accounts`, `relationships`, `agents`, `objectives`, variables, or a cited ACES issue. |
+| Provenance | Where the realized artifact came from and which immutable identifiers were observed. | Image digest, image history, Dockerfile or upstream absence, source lockfiles, scanner/tool versions. |
+| Assurance products | Derived artifacts used for audit, comparison, and gap filing. | CycloneDX or SPDX SBOM, vulnerability JSON, package list, filesystem hashes, evidence checksums. |
+
+This mirrors the W3C PROV separation between entities, activities, and
+agents: a document should not merely say "shuffle-backend exists"; it
+should identify the authored source, the capture activity, the tool agent,
+and the resulting evidence artifacts.
+
+## Capture and Specification Recipe
+
+Skip a step only when it does not make sense for the asset class, and
+record the skip in the per-asset note. For example, an upstream image with
+no in-repo Dockerfile should record the image digest and image history
+instead of pretending a local build recipe exists.
+
+1. Define in-range discovery vantage points.
+
+   Identify the participant and agent positions that can discover facts:
+   red-agent host, blue console, compromised container shell, exposed service
+   API, web UI, database session, directory service, SIEM/SOAR console, and
+   any other in-range position the scenario makes possible. Host-side Docker
+   commands are supporting evidence, not the primary inclusion criterion.
+
+2. Capture every participant-discoverable fact.
+
+   From the relevant vantage points, capture network topology, IPs, DNS,
+   routes, ARP/neighbors, open ports, banners, TLS certificates, HTTP
+   headers, service versions, application pages, API metadata, auth behavior,
+   files, directories, package versions, OS details, processes, listeners,
+   mounts, environment variables, readable secrets, data stores, workflows,
+   logs, relationships, credentials, trust surfaces, and connections.
+   Capture first; do not filter for intent, portability, elegance, or
+   accidentalness.
+
+3. Classify the asset for provenance and rerun support.
+
+   Record service name, container name, source class, owning profile or
+   family target, upstream/custom status, expected network identity, data
+   volumes, secrets policy, and steady-state boundary. Classify source as
+   `custom-build`, `upstream-image`, or `runtime-composed`.
+
+4. Capture source provenance.
+
+   Preserve the Compose service slice, relevant downstream runtime
+   configuration references, Dockerfile or source package paths when present,
+   image ID, repo digest,
+   rootfs layers, image history, build labels, and language lockfiles.
+   Mutable tags such as `latest` are never enough; pair them with the
+   observed digest. For container images, also check for registry-visible
+   attestations and record the result in the ledger provenance block. For
+   first-party custom builds, prefer BuildKit/Docker build attestations that
+   emit SBOM and provenance at build time, and preserve in-toto/SLSA predicate
+   type, builder identity, and verification result when available.
+
+5. Capture realized runtime state.
+
+   Preserve container inspect, network inspect, volume inspect, process
+   list, listeners, mounts, OS release, users/groups, working directory,
+   command/entrypoint, exposed ports, restart policy, resource limits, and
+   bind mounts. Redact secret values before evidence enters git unless the
+   scenario explicitly requires a participant-visible secret fixture to be
+   specified; in that case, store it through the repo's approved secret-fixture
+   mechanism rather than leaking live local secrets.
+
+6. Capture package and dependency inventory.
+
+   Prefer a standards-backed SBOM. CycloneDX JSON is the default for this
+   spike because Trivy can emit it directly; SPDX is acceptable when a
+   downstream consumer needs SPDX profiles. Also capture OS package-manager
+   output and language manifests or lockfiles visible inside the container.
+   Any SBOM minification or normalization must be deterministic, scripted in
+   the bundle, and recorded in `capture-limits.txt`. For Syft CycloneDX output,
+   a repository-size-safe package/component SBOM may disable file catalogers and
+   strip `syft:location:*` component properties only when the package/component
+   identity fields remain intact and separate filesystem evidence is captured
+   or explicitly declined. The exact command and jq transform are part of the
+   reproducibility record, not an analyst-only cleanup step.
+
+7. Capture patch and vulnerability state.
+
+   Run an open vulnerability scanner such as Trivy or Grype against the
+   immutable image digest. Store full machine-readable results, a severity
+   count summary, scanner version, and any scanner image digest. Treat
+   vulnerability data as time-sensitive evidence, not as a permanent truth
+   about the asset.
+
+8. Capture filesystem integrity for load-bearing paths.
+
+   Hash application and configuration paths that matter to scenario
+   behavior. Exclude virtual filesystems and high-churn paths such as
+   `/proc`, `/sys`, `/dev`, `/run`, caches, logs, and temp directories.
+   For larger assets, replace ad hoc `sha256sum` output with a stable
+   manifest tool such as `mtree`, AIDE, or Tripwire.
+
+9. Capture relationships and trust surfaces.
+
+   Record inbound consumers, outbound dependencies, trust boundaries,
+   authentication surfaces, privileged binds, exposed listeners, data
+   volumes, and implicit backend requirements. This is where Docker socket
+   binds, service DNS names, static IPs, and healthcheck dependencies
+   become visible.
+
+10. Attempt maximal ACES specification.
+
+   For every participant-discoverable fact, attempt to represent it in ACES.
+   Use the most specific existing SDL surface available: nodes,
+   infrastructure, services, features, content, accounts, relationships,
+   agents, objectives, workflows, variables, or a contract surface if one
+   already exists. The question at this stage is not "should we specify
+   less?" It is "can ACES fully specify this discovered world fact?"
+   Record the result in `mapping-ledger.yaml` instead of relying on prose.
+   Each captured fact must have one of these dispositions:
+
+   - `encoded` when current ACES can represent the fact directly;
+   - `encoded_with_caveat` when current ACES can represent the fact but the
+     later encoding issue must preserve a stated limitation;
+   - `blocked_by_aces_gap` when ACES lacks a semantically correct surface;
+   - `blocked_by_aptl_gap` when ACES can express the fact but APTL cannot yet
+     realize or consume that SDL;
+   - `needs_gap_triage` only as a temporary local state before filing or
+     linking the required issue.
+
+   The ledger itself is a schema-governed artifact. The current reference
+   implementation is APTL's `aptl aces-inventory` CLI: `aptl aces-inventory
+   schema` prints the current JSON Schema generated from the Pydantic model,
+   and `aptl aces-inventory validate <asset-dir>` fails schema, evidence-path,
+   and mapping-accountability violations.
+
+11. Handle ACES gaps immediately.
+
+   When a captured participant-discoverable fact cannot be fully expressed in
+   ACES, search the ACES issue tracker for an existing issue that covers the
+   missing expressivity. If an issue exists, record the evidence path and
+   stop for discussion. If none exists, create a new ACES issue with:
+
+   - the discovered fact or class of facts;
+   - the in-range vantage point that can discover it;
+   - the evidence path in the downstream bundle;
+   - the ACES surfaces that were checked;
+   - why those surfaces are insufficient;
+   - the proposed ACES expressivity requirement.
+
+   After linking or creating the issue, stop and discuss before continuing
+   with additional gaps.
+
+12. Publish a reproducibility bundle.
+
+    The per-asset directory should include a README, `mapping-ledger.yaml`,
+    raw evidence, the capture commands or script used to produce it, evidence
+    checksums, focused tests that parse the evidence, and explicit notes on
+    skipped or normalized steps. This supports ACM-style artifact review
+    thinking: make the artifact available and evaluable, then be precise about
+    which result claims it validates.
+
+13. Plan correspondence checks.
+
+    Methodology issues do not have to finish the ACES encoding, but they must
+    define how later issues will prove correspondence between encoded ACES
+    surfaces and realized downstream state. Record these checks in the
+    ledger's `correspondence_checks` section. A check names the source surface,
+    captured
+    evidence, ledger fact IDs, method, status, and limit. Later encoding issues
+    should turn planned checks into implemented checks that compare the encoded
+    SDL/source package against fresh runtime evidence with explicit tolerances.
+    This is the verification-and-validation layer for the inventory method: the
+    ledger verifies evidence and mappings now, while later checks validate that
+    the encoded model corresponds to the realized scenario asset.
+
+## Tooling Baseline
+
+The baseline intentionally avoids commercial and cloud-provider services.
+
+Required local tools:
+
+- Docker and Docker Compose for image, container, network, and volume
+  inspection.
+- `jq` and `yq` for structured JSON/YAML extraction.
+- `sha256sum` or equivalent coreutils for evidence checksums.
+- Trivy for image scanning, CycloneDX SBOM output, and vulnerability JSON.
+- A downstream ledger validator. The current reference implementation is
+  `aptl aces-inventory validate <asset-dir>` to validate the mapping ledger
+  and its evidence references.
+- `aptl aces-inventory gaps <asset-dir>` to list the ACES and downstream
+  implementation issues later encoding work must resolve or consume.
+- `aptl aces-inventory schema` to inspect the reference ledger schema.
+- Docker Buildx `imagetools inspect`, build-time `--sbom`, and `--provenance`
+  or equivalent in-toto/SLSA attestation tooling for provenance capture.
+
+Useful optional tools:
+
+- Syft for SBOM generation and Grype for an independent vulnerability scan.
+- CycloneDX CLI or SPDX tooling for validating or converting SBOMs.
+- Digest-pinned scanner container images when host binaries are absent or when
+  a capture needs rerunnable tool identity independent of local package state.
+- Cosign, notation, Rekor, or registry-native signature tooling when upstream
+  images publish verifiable signatures/attestations.
+- `osquery` for richer live asset inventory when containers include enough
+  host support.
+- `mtree`, AIDE, or Tripwire for stable filesystem manifests on larger
+  assets.
+- SCAP/OVAL tooling when the asset needs policy compliance checks instead
+  of only package and vulnerability inventory.
+- Reactor's citation MCP and Zotero translation-server for resolving
+  primary literature by DOI during methodology work.
+
+## Tested TechVault Validation Pass
+
+The first proof pass captured `aptl-shuffle-backend` under
+APTL's `docs/aces/inventory/shuffle-backend/`. It used an already-running
+local lab rather than a destructive clean lab reset, so the output is method
+evidence, not final SCN-010 acceptance evidence.
+
+The pass proved that the method can capture an upstream-image asset with:
+
+- immutable image identity and rootfs layer evidence;
+- Compose service intent, static network identity, volume and bind-mount
+  surfaces, and runtime process/listener baseline;
+- OS package inventory and Go module manifests visible in the image;
+- CycloneDX SBOM and Trivy vulnerability output;
+- evidence checksums and pytest validation for redaction, digest identity,
+  SBOM structure, and severity-count consistency.
+
+This proof pass is not yet a full maximal-discovery pass because it mostly
+uses host-side Docker evidence plus a container runtime baseline. The next
+pass must add in-range participant/agent discovery commands and then attempt
+maximal ACES specification from the discovered facts.
+
+Known limits are first-class methodology data, not prose footnotes. The
+shuffle-backend ledger records that registry-visible in-toto/SLSA provenance
+was captured but not cryptographically verified, that scanner output is
+time-sensitive, and that correspondence checks are planned rather than
+implemented in this methodology issue.
+
+## Issue Breakdown Implication
+
+APTL #330, #331, #332, and #353 were useful as a downstream per-asset
+validation queue, but they should not define ACES methodology ownership or
+drive cloning/spec/capture order by themselves. The method should land in ACES
+first, then one upstream-image asset and one custom-build asset should exercise
+it before a wave of ACES or downstream implementation gap issues is filed.
+
+In practice:
+
+- APTL #353 (`shuffle-backend`) is the first upstream-image proof case.
+- APTL #331 (`db`) is a second upstream-image comparison point.
+- APTL #330 (`webapp`) and #332 (`ad`) are custom-build cases that should
+  decide whether source package capture needs more structure.
+- ACES SDL encoding should happen as soon as a participant-discoverable fact
+  is captured. Where ACES cannot express the fact, create or link the ACES
+  gap issue and stop for discussion.
+
+If those captures show that cloning/spec/capture need a different split,
+the correction should be discussed before filing many downstream gap
+issues.
+
+## References
+
+Primary literature:
+
+- Yamin, Katt, and Gkioulos, "Cyber ranges and security testbeds:
+  Scenarios, functions, tools and architecture", Computers & Security,
+  2020. https://doi.org/10.1016/j.cose.2019.101636
+- Peng, "Reproducible Research in Computational Science", Science, 2011.
+  https://doi.org/10.1126/science.1213847
+- Goodman, Fanelli, and Ioannidis, "What does research reproducibility
+  mean?", Science Translational Medicine, 2016.
+  https://doi.org/10.1126/scitranslmed.aaf5027
+- Boettiger, "An introduction to Docker for reproducible research",
+  ACM SIGOPS Operating Systems Review, 2015.
+  https://doi.org/10.1145/2723872.2723882
+- Grieves and Vickers, "Digital Twin: Mitigating Unpredictable,
+  Undesirable Emergent Behavior in Complex Systems", 2017.
+  https://doi.org/10.1007/978-3-319-38756-7_4
+- Kritzinger et al., "Digital Twin in manufacturing: A categorical
+  literature review and classification", IFAC-PapersOnLine, 2018.
+  https://doi.org/10.1016/j.ifacol.2018.08.474
+
+Open specifications and tool references:
+
+- W3C PROV-DM: https://www.w3.org/TR/prov-dm/
+- CycloneDX 1.6 JSON reference: https://cyclonedx.org/docs/1.6/json/
+- SPDX specifications: https://spdx.dev/use/specifications/
+- SLSA specification: https://slsa.dev/spec/latest/
+- in-toto specification: https://github.com/in-toto/specification
+- NIST SCAP releases and SP 800-126: https://csrc.nist.gov/projects/security-content-automation-protocol/scap-releases
+- Trivy SBOM documentation: https://trivy.dev/docs/latest/guide/target/sbom/
+- ACM artifact review and badging: https://www.acm.org/publications/policies/artifact-review-and-badging-current

--- a/docs/aces/inventory/index.md
+++ b/docs/aces/inventory/index.md
@@ -1,0 +1,32 @@
+# ACES Asset Inventory Methodology
+
+ACES owns the participant-discoverable asset inventory methodology. Downstream
+projects can implement capture tooling and evidence ledgers, but the inclusion
+rule, semantic gates, and capture-to-specification workflow live here.
+
+Use these documents as the ACES authority:
+
+- [Participant-discoverable asset inventory methodology](asset-inventory-methodology.md)
+  defines the canonical capture workflow, evidence boundary, ACES mapping
+  dispositions, and gap-handling rules.
+- [Methodology assurance report](methodology-assurance-report.md) records the
+  DevOps, supply-chain, reproducible-research, and verification/validation
+  basis for the method.
+- The preflight notes are imported validation records from the APTL TechVault
+  proof work. They are useful implementation examples for downstream asset
+  captures, but they do not replace the methodology.
+
+The original TechVault proof bundles remain in APTL as downstream evidence
+artifacts. ACES keeps the methodology and reusable agent entry points so later
+range implementations can consume the same rules without making APTL the
+methodology owner.
+
+```{toctree}
+:maxdepth: 1
+
+asset-inventory-methodology
+methodology-assurance-report
+webapp-preflight
+kali-preflight
+ad-preflight
+```

--- a/docs/aces/inventory/kali-preflight.md
+++ b/docs/aces/inventory/kali-preflight.md
@@ -1,0 +1,150 @@
+# Kali ACES Inventory Preflight
+
+This is a historical APTL TechVault validation note imported into ACES as a
+reference example. It is not the methodology authority; the canonical ACES
+methodology is `docs/aces/inventory/asset-inventory-methodology.md`.
+
+This note is the architecture preflight for SCN-010 / issue #339. It is a
+binding guardrail for the Kali steady-state inventory, not a replacement for
+ADR-035, ADR-033, ADR-029, or the ACES asset-inventorying methodology.
+
+## Architecture Decisions
+
+- The completion artifact is an ACES inventory bundle under
+  `docs/aces/inventory/kali/`, using the existing `mapping-ledger.yaml`
+  schema, `aptl aces-inventory validate`, and the evidence/checksum shape
+  already used by `shuffle-backend` and `webapp`.
+- The inventory describes the realized `aptl-kali` container at one
+  post-`aptl lab start` steady-state snapshot. If the capture is not from a
+  destructive clean reset, record that boundary explicitly and do not claim
+  clean-lab reproducibility or byte-identical rebuildability.
+- `scenarios/techvault.sdl.yaml` remains an ACES SDL document whose authority
+  is the sibling ACES parser and runtime compiler. Do not validate Kali
+  additions through `aptl.core.sdl`, `aptl.core.scenarios`, or a local mirror
+  of ACES models.
+- Keep three concepts separate: the ACES red-side node/agent surface, the APTL
+  Docker Compose realization, and ADR-033 experimental capture/runstore data.
+  Participant-visible Kali facts must be captured and mapped; run archive and
+  harvest mechanics stay owned by ADR-033, `LocalRunStore`, and the MCP common
+  capture boundary.
+- Kali is not a target host for declared scenario weaknesses. Scanner CVEs and
+  patch state belong in runtime/package inventory evidence unless ACES has a
+  more specific non-target weakness surface.
+- Missing ACES expressivity must be represented as an upstream ACES blocker.
+  APTL backend consumption gaps do not justify leaving an observable fact as
+  evidence-only for this inventory issue.
+
+## Cross-Cutting Concerns To Reuse
+
+- Inventory methodology and ledger validation:
+  `docs/aces/inventory/asset-inventory-methodology.md`,
+  `src/aptl/core/aces_inventory.py`, `src/aptl/cli/aces_inventory.py`, and
+  `tests/test_aces_inventory_methodology.py`.
+- Prior asset patterns:
+  `docs/aces/inventory/shuffle-backend/`,
+  `docs/aces/inventory/webapp/`,
+  `docs/aces/inventory/webapp-preflight.md`, and
+  `tests/test_webapp_inventory.py`.
+- ACES adoption and parity routing:
+  ADR-035, `docs/aces/parity-inventory.yaml`,
+  `docs/aces/parity-inventory.md`, and `tests/test_parity_inventory.py`.
+- Kali realization owners:
+  `docker-compose.yml` service `kali`, `containers/kali/Dockerfile`,
+  `containers/kali/entrypoint.sh`, `containers/kali/healthcheck.sh`,
+  `containers/kali/scripts/aptl-wrap-shell.sh`,
+  `containers/kali/audit/aptl.rules`, and
+  `docs/components/kali-redteam.md`.
+- Runtime/control-plane owners:
+  `AptlConfig`, `ContainerSettings.enabled_profiles()`, `EnvVars`,
+  `_LAB_START_STEPS`, `DeploymentBackend`, `LabResult`,
+  `StartupDiagnostic`, `RangeSnapshot.to_dict()`, `LocalRunStore`, and the
+  MCP run/capture helpers mirrored under `mcp/aptl-mcp-common`.
+- Shared safety helpers and policies: ADR-028, ADR-029, ADR-033, ADR-036,
+  ADR-037, `aptl.utils.redaction.redact`, and `aptl.utils.curl_safe` when
+  commands would otherwise put credentials in process argv.
+
+## Security And Validation Layers
+
+- **ACES SDL shape:** Kali SDL additions must parse with
+  `aces_sdl.parse_sdl_file` and compile through the ACES runtime compiler.
+  Do not add local structural validators for ACES fields.
+- **Inventory ledger:** every captured fact needs an existing
+  `AcesSurface` mapping, caveat, or linked ACES issue in
+  `mapping-ledger.yaml`. No `needs_gap_triage` rows should remain at review.
+- **Secret classification:** ADR-029 is canonical. Operator secrets, private
+  SSH keys, bearer tokens, cookies, generated service config, and arbitrary
+  prior run transcripts must not be committed unredacted. Intentional target
+  fixture credentials may be encoded only when they are participant-visible
+  scenario facts with an explicit `secret_fixture`-style classification.
+- **Kali capture data:** ADR-033 capture surfaces can contain full argv, hidden
+  PTY input, raw pcap bytes, and prior experiment data. A non-empty
+  `kali_captures` volume is evidence to account for, but it is not safe to
+  commit wholesale. Prefer fresh-volume capture for this inventory; otherwise
+  record contamination and redact or checksum sensitive content.
+- **Config and env binding:** durable toggles remain in strict `AptlConfig`.
+  `.env` parsing and placeholder rejection remain in `EnvVars` /
+  `find_placeholder_env_values`. Do not add ACES-specific environment parsing
+  for Kali. Compose `VICTIM_IP` and SSH `APTL_*` session env vars are
+  different surfaces and must not be collapsed.
+- **OS/process exposure:** inventory capture commands must not place private
+  keys, passwords, hashes, tokens, or replayable IDs in argv, logs, or
+  exception text. Store command provenance, not secret-bearing command lines.
+- **Runtime isolation:** preserve ADR-033 non-contamination. No Wazuh agent,
+  rsyslog forwarding, or red-to-SIEM pipe belongs in Kali evidence or future
+  fixes unless a later ADR explicitly overrides ADR-033.
+- **Container security shape:** encode the difference between Compose
+  `cap_add`, `seccomp:unconfined`, Docker `init: true`, the entrypoint's
+  `capsh --drop=cap_audit_control` behavior, and healthcheck degraded
+  subsystem reporting. Do not flatten them into one generic privilege flag.
+- **Error envelopes and observability:** any new CLI/test helper must report
+  narrow diagnostics and reuse redaction. Raw Docker, scanner, SSH, or ACES
+  exception payloads must not cross CLI, log, API, snapshot, or runstore
+  boundaries unfiltered.
+
+## Extensibility Seam
+
+The seam is the versioned inventory ledger plus ACES runtime fields for one
+asset id, source class, and Compose service. A future red-side asset or custom
+build should reuse the same schema and test fixture pattern by changing asset
+parameters, not by extending the validator with Kali-specific branches.
+
+For the SDL, parameterization belongs in ACES-native node, source, runtime,
+agent, relationship, content, and account fields. Backend realization remains
+behind the ACES backend profile and existing APTL owners.
+
+## Gotchas And Anti-Patterns
+
+- Do not reuse a "representative paths only" filesystem claim silently. This
+  issue asks for participant/agent-observable steady-state facts, including
+  logs, caches, generated state, and volume contents. If a full enumeration is
+  not done, record the exact claim boundary and leave remaining facts encoded
+  later or blocked by ACES expressivity.
+- Do not encode stale public SSH port assumptions. Current Compose declares no
+  host port for `kali`; the control plane reaches it by container IP.
+- Do not treat `kalilinux/kali-last-release:latest` as immutable. Pair the
+  mutable base tag and local image tag with observed digests, layers, package
+  manifests, and scanner versions.
+- Do not confuse scanner findings with authored vulnerabilities on a target
+  host.
+- Do not model auditd/procacct as fully available unless the readiness marker
+  and health log show those subsystems as `ok`; healthy Kali can still be
+  capture-degraded.
+- Do not hide missing ACES expressivity in `metadata`, `x-aptl-*`, comments,
+  evidence-only ledgers, or TechVault-name dispatch.
+- Do not create a second scenario schema, second inventory validator, second
+  secret taxonomy, second readiness taxonomy, or new exception hierarchy.
+- Do not repair Kali inventory findings by changing Docker Compose,
+  container startup, capture plumbing, or red/blue visibility in this issue.
+
+## Non-Goals
+
+- Do not implement the inventory, capture evidence, edit TechVault SDL, or add
+  tests from this preflight.
+- Do not run `aptl lab stop -v && aptl lab start` unless the user explicitly
+  authorizes destroying the current lab state.
+- Do not implement the ACES backend interpreter, default-scenario flip,
+  legacy SDL deletion, scenario archive move, or Phase B cutover.
+- Do not redesign ADR-033 capture ownership, close the Kali tamper-resistance
+  follow-up, redesign run archives, or add a red-to-SIEM path.
+- Do not use APTL runtime consumption gaps as a substitute for ACES SDL
+  expression or ACES expressivity blockers.

--- a/docs/aces/inventory/methodology-assurance-report.md
+++ b/docs/aces/inventory/methodology-assurance-report.md
@@ -1,0 +1,123 @@
+# ACES Inventory Methodology Assurance Report
+
+This report reviews the ACES asset-inventory methodology for defensibility
+under DevOps/security practice, supply-chain evidence practice,
+reproducible-research expectations, and verification/validation thinking. The
+method was first exercised through APTL #353, but ACES owns the methodology and
+semantic gates. This report is not a final TechVault asset specification; it
+exists to keep the methodology itself from drifting while downstream asset
+captures and later ACES/downstream gap issues do the full encoding work.
+
+## Current Position
+
+The methodology is defensible as a capture-to-specification workflow if it is
+used with explicit ledger gates. The current reference implementation is APTL's
+`aptl aces-inventory` CLI:
+
+- `mapping-ledger.yaml` is the accountability artifact for every captured fact.
+- `aptl aces-inventory validate <asset-dir>` validates the ledger schema,
+  evidence references, and mapping disposition requirements.
+- `aptl aces-inventory gaps <asset-dir>` emits the actionable gap list later
+  issues must consume or fix.
+- `aptl aces-inventory schema` emits the current JSON Schema generated from the
+  Pydantic ledger model.
+
+The methodology is not yet sufficient to claim final equivalence between a
+future ACES encoding and any realized downstream deployment. That requires the
+planned correspondence checks in the ledger to become implemented checks after
+the encoding exists.
+
+## Practice Alignment
+
+| Concern | Methodology position | Basis |
+| --- | --- | --- |
+| Configuration management | Captures realized runtime configuration, evidence paths, mutable-tag limits, redactions, and disposition of each fact. | NIST SP 800-128 treats security-focused configuration management as an explicit lifecycle concern for establishing and monitoring configuration state. |
+| Container security | Captures immutable image digest, runtime configuration, mounts, socket exposure, package inventory, and vulnerability scan state. | NIST SP 800-190 identifies container images, registries, orchestrators, runtime isolation, and host interactions as security-relevant surfaces. |
+| SBOM practice | Captures CycloneDX SBOM and package inventory; accepts SPDX/CycloneDX as standards-backed formats. | NTIA/CISA SBOM guidance defines minimum SBOM transparency expectations; CycloneDX and SPDX are standard SBOM formats. |
+| Provenance and attestations | Captures registry-visible Docker/OCI attestation manifests when available; requires first-party custom builds to prefer build-time SBOM/provenance attestations. | Docker Build attestations, SLSA provenance, and in-toto provide established supply-chain attestation patterns. |
+| Evidence provenance | Separates captured facts, evidence paths, tool output, and provenance metadata. | W3C PROV distinguishes entities, activities, and agents for auditable provenance. |
+| Reproducible research | Preserves enough artifact, tool, environment, and parameter evidence to rerun and challenge the claim. | Peng, Goodman et al., and ACM artifact-review guidance frame reproducibility as artifact-backed evaluation, not narrative alone. |
+| Cyber-range scenario rigor | Treats scenario assets, services, topology, and evidence as explicit artifacts rather than backend lore. | Cyber-range literature emphasizes scenario definition, infrastructure, tooling, monitoring, and evaluation as separable concerns. |
+| V&V / correspondence | Adds planned correspondence checks tying future ACES surfaces to realized evidence. | NASA model/simulation assurance guidance and IEEE-style V&V practice emphasize evidence that the model satisfies requirements and corresponds to intended use. |
+
+## Improvements Made In This Pass
+
+The first APTL validation proof captured useful evidence but left several
+methodology risks too implicit. The ACES methodology closes the visible
+problems now:
+
+- The ledger is now schema-governed by Pydantic models, with a schema CLI.
+- The ledger now has an explicit provenance block, including attestation status,
+  predicate types, evidence paths, verification status, and limits.
+- The shuffle-backend proof now captures Docker Buildx image-index evidence and
+  the amd64 attestation manifest showing an in-toto layer with SLSA provenance
+  predicate type.
+- The ledger now has explicit correspondence-check records. They are planned,
+  not implemented, because the first validation pass covered methodology and
+  tooling rather than final ACES encoding.
+- The docs state scanner limits, attestation-verification limits, and
+  correspondence limits directly.
+
+## Remaining Limits
+
+These limits were acceptable for the first APTL #353 validation scope, but
+later issues must not silently carry them into final claims:
+
+- The shuffle-backend capture came from an already-running local lab, not a
+  clean `aptl lab stop -v && aptl lab start` capture.
+- Registry-visible upstream attestations were captured but not
+  cryptographically verified for signature, transparency-log inclusion, or
+  builder identity.
+- The Trivy SBOM and vulnerability outputs are scanner state tied to tool,
+  database, advisory, and capture time. They are not permanent ground truth.
+- The ledger proves mapping accountability, not semantic completeness of ACES.
+  ACES #354 remains a blocker for typed runtime configuration surfaces.
+- Correspondence checks are planned. Final encoding issues must implement them
+  by comparing ACES/source-package content against fresh realized evidence.
+
+## Required Bar For Later Asset Issues
+
+Each follow-on asset issue should meet this minimum:
+
+1. Capture evidence from a clean steady-state lab unless the issue explicitly
+   records why that is impossible.
+2. Use digest-pinned image references; mutable tags are never sufficient.
+3. Check for registry-visible attestations on upstream images.
+4. For custom builds, emit or capture build-time SBOM/provenance attestations
+   using Docker Buildx `--sbom` and `--provenance` or equivalent in-toto/SLSA
+   tooling.
+5. Validate the mapping ledger with `aptl aces-inventory validate`.
+6. Run `aptl aces-inventory gaps` and file/link gap issues before encoding
+   unsupported facts through semantically wrong ACES fields.
+7. Add or update correspondence checks so the future ACES encoding can be
+   verified against realized evidence.
+
+## References
+
+- NIST SP 800-128, *Guide for Security-Focused Configuration Management of
+  Information Systems*. https://csrc.nist.gov/pubs/sp/800/128/upd1/final
+- NIST SP 800-190, *Application Container Security Guide*.
+  https://csrc.nist.gov/pubs/sp/800/190/final
+- NTIA, *The Minimum Elements For a Software Bill of Materials*.
+  https://www.ntia.gov/report/2021/minimum-elements-software-bill-materials-sbom
+- CISA, *Software Bill of Materials*. https://www.cisa.gov/sbom
+- CycloneDX specification overview. https://cyclonedx.org/specification/overview/
+- SPDX specifications. https://spdx.dev/use/specifications/
+- Docker Build attestations. https://docs.docker.com/build/metadata/attestations/
+- SLSA specification v1.2. https://slsa.dev/spec/v1.2/
+- in-toto project. https://in-toto.io/
+- W3C PROV-DM. https://www.w3.org/TR/prov-dm/
+- ACM Artifact Review and Badging. https://www.acm.org/publications/policies/artifact-review-and-badging-current
+- Peng, "Reproducible Research in Computational Science", *Science*, 2011.
+  https://doi.org/10.1126/science.1213847
+- Goodman, Fanelli, and Ioannidis, "What does research reproducibility mean?",
+  *Science Translational Medicine*, 2016.
+  https://doi.org/10.1126/scitranslmed.aaf5027
+- Boettiger, "An introduction to Docker for reproducible research",
+  *ACM SIGOPS Operating Systems Review*, 2015.
+  https://doi.org/10.1145/2723872.2723882
+- Yamin, Katt, and Gkioulos, "Cyber ranges and security testbeds: Scenarios,
+  functions, tools and architecture", *Computers & Security*, 2020.
+  https://doi.org/10.1016/j.cose.2019.101636
+- NASA-STD-7009, *Standard for Models and Simulations*.
+  https://standards.nasa.gov/standard/nasa/nasa-std-7009

--- a/docs/aces/inventory/webapp-preflight.md
+++ b/docs/aces/inventory/webapp-preflight.md
@@ -1,0 +1,93 @@
+# Webapp ACES Inventory Preflight
+
+This is a historical APTL TechVault validation note imported into ACES as a
+reference example. It is not the methodology authority; the canonical ACES
+methodology is `docs/aces/inventory/asset-inventory-methodology.md`.
+
+This note is the local architecture preflight for SCN-010 / issue #330 after
+`gc_codex_architecture_preflight` timed out twice on 2026-05-21. It is a
+binding implementation guardrail for the webapp steady-state inventory, not a
+replacement for ADR-035 or the ACES asset-inventorying methodology.
+
+## Architecture Decisions
+
+- The completion artifact is an ACES inventory bundle under
+  `docs/aces/inventory/webapp/`, using the same ledger schema and validation
+  CLI as the existing `shuffle-backend` proof pass.
+- The inventory captures the realized `aptl-webapp` container at one
+  steady-state point. It does not claim byte-identical rebuildability, dynamic
+  attack-state coverage, or clean-lab proof unless the evidence says that was
+  performed.
+- Current ACES SDL can express webapp node identity, OS, source, resources,
+  network service, runtime mounts, process identity, package inventory,
+  dependency manifests, scanner findings, and declared CWE weaknesses. These
+  fields belong in `scenarios/techvault.sdl.yaml`.
+- APTL-specific realization and public start-path interpretation are outside
+  this issue. This issue records ACES expressivity gaps only when the webapp
+  ACES SDL/spec inventory cannot express an observed fact. It must not
+  implement a TechVault-only backend shortcut.
+- `docs/aces/parity-inventory.yaml` remains the audit router for SCN-010.
+  Update rows only to point at the new webapp inventory/SDL evidence; do not
+  turn the parity inventory into a runtime input schema.
+
+## Cross-Cutting Concerns To Reuse
+
+- Inventory methodology and ledger validator:
+  `docs/aces/inventory/asset-inventory-methodology.md`,
+  `src/aptl/core/aces_inventory.py`, and
+  `tests/test_aces_inventory_methodology.py`.
+- Existing evidence-bundle shape:
+  `docs/aces/inventory/shuffle-backend/README.md`,
+  `docs/aces/inventory/shuffle-backend/mapping-ledger.yaml`, and the
+  `evidence/` manifest/checksum pattern.
+- Webapp realization owners:
+  `docker-compose.yml` service `webapp`, `containers/webapp/Dockerfile`,
+  `containers/webapp/entrypoint.sh`, `containers/webapp/supervisord.conf`,
+  `containers/webapp/requirements.txt`, and `containers/webapp/app/`.
+- ACES SDL authority: sibling `../aces-sdl` parser/model documentation and
+  the closed ACES #354 runtime-surface gap. Do not parse
+  `techvault.sdl.yaml` with `aptl.core.sdl`.
+- Secret and evidence safety: ADR-029, `aptl.utils.redaction`, the existing
+  test pattern that blocks raw secret assignments, and redacted evidence files.
+
+## Security And Validation Gates
+
+- Evidence committed to git must redact operator/control-plane secrets. The
+  webapp's intentional participant-visible fixture secrets are allowed only
+  when they are scenario facts already present in checked-in source or Compose
+  configuration.
+- Runtime evidence must cite the command/source that produced each claim:
+  Docker inspect/history/network/volume/top, in-container runtime baseline,
+  package manifests, filesystem hashes, and scanner output when available.
+- `mapping-ledger.yaml` must validate through `aptl aces-inventory validate`
+  with every captured fact assigned an ACES/APTL disposition and no temporary
+  `needs_gap_triage` rows.
+- Tests must fail if the webapp bundle omits required evidence, if evidence
+  checksums drift, if raw secret assignments leak, if the ledger loses ACES gap
+  accountability, or if `scenarios/techvault.sdl.yaml` stops declaring the
+  ACES-expressible webapp runtime fields.
+- The issue changes executable tests and YAML artifacts, so the documentation
+  carve-out does not apply. The documentation carve-out does not apply. Run
+  focused pytest while iterating, then the
+  required `pytest` and `pre-commit run --all-files` gates.
+
+## Extensibility Seam
+
+The seam is the versioned inventory ledger plus ACES runtime fields on the
+TechVault SDL node. Later per-asset inventory issues should be able to add
+their own bundle by reusing the same validator and tests with a different asset
+fixture, without adding new parser branches or a second inventory schema.
+
+When APTL later consumes these ACES fields, that work must land behind the ACES
+backend boundary, not in this evidence pass.
+
+## Non-Goals
+
+- Do not run a destructive `aptl lab stop -v && aptl lab start` unless the user
+  explicitly authorizes resetting the current lab.
+- Do not implement the ACES backend interpreter, default-scenario flip, legacy
+  SDL deletion, scenario archive move, or public start-path routing.
+- Do not add a second scenario model, second inventory validator, or
+  TechVault-name-dispatch shortcut.
+- Do not edit `CHANGELOG.md`; if this becomes user-visible executable source
+  work, add a towncrier fragment instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,13 @@ explain/sdl/runtime-architecture
 
 ```{toctree}
 :maxdepth: 2
+:caption: Asset Inventory
+
+aces/inventory/index
+```
+
+```{toctree}
+:maxdepth: 2
 :caption: Architecture Decisions
 
 decisions/adrs/README


### PR DESCRIPTION
## Summary

Move the canonical participant-discoverable asset inventory methodology into ACES docs and update the reusable agent skills to treat ACES, not APTL, as the methodology authority.

## Requirement UIDs

- `AUT-807`

## Related Issues

Closes #411

## ADR Impact

- No ADR required

## Changes

- Added `docs/aces/inventory/` with the canonical methodology, assurance report, docs index, and historical APTL validation preflight notes.
- Reframed imported methodology prose so ACES owns the inclusion rule, semantic gates, and capture-to-specification workflow while APTL remains downstream validation/reference tooling.
- Updated the Claude and Codex asset-inventory skills plus the changelog fragment to point at the ACES-local methodology authority.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

- `python3 /home/atomik/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex-skills/aces-asset-inventory-capture`
- `python3 /home/atomik/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/aces-asset-inventory-capture`
- `bash -n .codex-skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh`
- `bash -n .claude/skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh`
- `implementations/python/.venv/bin/python -m pytest implementations/python/tests/test_agent_inventory_skill.py`
- `uv run --project implementations/python --frozen sphinx-build -b html docs docs/_build/html`
- `env ACES_REQUIREMENT_UID=AUT-807 GC_BASE_URL=http://127.0.0.1:1 implementations/python/.venv/bin/python tools/verify_all.py`
- `env ACES_REQUIREMENT_UID=AUT-807 GC_BASE_URL=http://127.0.0.1:1 pre-commit run --all-files`

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: docs/aces/inventory/asset-inventory-methodology.md, docs/aces/inventory/index.md, .codex-skills/aces-asset-inventory-capture/SKILL.md, .claude/skills/aces-asset-inventory-capture/SKILL.md
- TESTS: implementations/python/tests/test_agent_inventory_skill.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
