### PR TITLE
feat: add ADR amendment policy and acceptance-content pin gate (GOV-941)

### DIFF
--- a/changelog.d/481.added.md
+++ b/changelog.d/481.added.md
@@ -1,0 +1,2 @@
+### Added
+- Add an ADR amendment policy (ADR-059) and an acceptance-content pin gate: `docs/decisions/adrs/adr-index.yaml` pins every accepted ADR's canonical-content `sha256`, and `tools/check_adr_immutability.py` (wired into the `policy` nox session) fails when an accepted ADR changes without a recorded `## Amendments` entry or a superseding ADR. Reconciled the already-amended ADRs (025, 029, 032, 038, 041, 048, 050, 052) with honest amendment records so the gate starts green.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -16,8 +16,19 @@ Each ADR includes:
 
 ## Principles
 
-- ADRs are **immutable** once accepted. To reverse a decision, create a new ADR
-  that supersedes it.
+- An **accepted** ADR's content is **pinned** and citable. Its acceptance (or
+  last-amendment) content hash is recorded in
+  [`adr-index.yaml`](adr-index.yaml) and enforced by the `policy` nox session
+  (`tools/check_adr_immutability.py`). A substantive change to an accepted ADR
+  is legitimate only as a new **superseding** ADR, or as a recorded **amendment**
+  (a `## Amendments` row plus an updated pin, in the same change). Editorial-only
+  fixes (typos, formatting) also record a one-line amendment row — the gate
+  cannot tell editorial from substantive, so every canonical-content change is
+  recorded. See
+  [ADR-059](adr-059-adr-amendment-policy-and-pin-gate.md) for the full policy.
+- `proposed` ADRs are still being decided and may change freely;
+  `superseded`/`deprecated` ADRs leave the pinned set (the citable decision has
+  moved to the replacing ADR).
 - ADRs are **numbered sequentially** and never reused.
 - ADRs are **versioned with code** and live in the repo.
 
@@ -44,6 +55,7 @@ adr-055-experiment-core-contract-boundary
 adr-056-runtime-observed-values-and-credential-posture
 adr-057-runtime-secret-name-classifier-boundaries
 adr-058-datastore-node-engine-provenance-and-endpoints
+adr-059-adr-amendment-policy-and-pin-gate
 ```
 
 | ADR | Title | Status | Date |
@@ -107,3 +119,4 @@ adr-058-datastore-node-engine-provenance-and-endpoints
 | [056](adr-056-runtime-observed-values-and-credential-posture.md) | Runtime Observed Values and Credential Posture | accepted | 2026-06-05 |
 | [057](adr-057-runtime-secret-name-classifier-boundaries.md) | Runtime Scenario Value Realizability and Explicit Redaction | accepted | 2026-06-06 |
 | [058](adr-058-datastore-node-engine-provenance-and-endpoints.md) | Datastore Node Engine Provenance and Endpoints | accepted | 2026-06-07 |
+| [059](adr-059-adr-amendment-policy-and-pin-gate.md) | ADR Amendment Policy and Acceptance-Content Pin Gate | accepted | 2026-06-10 |

--- a/docs/decisions/adrs/adr-025-container-network-realization-surface.md
+++ b/docs/decisions/adrs/adr-025-container-network-realization-surface.md
@@ -202,3 +202,9 @@ creating a second network schema elsewhere.
 - A free-form backend payload would bypass closed-world schema validation and
   make redaction, stability classification, and cross-backend comparison
   brittle.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-05-25 | 4b959c3 | Corrected the control-plane API cross-reference from `aces_processor.control_plane_api` to `aces_runtime.control_plane_api`. |

--- a/docs/decisions/adrs/adr-029-database-logical-state-runtime-surface.md
+++ b/docs/decisions/adrs/adr-029-database-logical-state-runtime-surface.md
@@ -286,3 +286,9 @@ database schema elsewhere.
 - Overfitting to PostgreSQL would make the ACES surface poor at representing
   other SQL engines, embedded databases, document stores, or scanner-observed
   database surfaces.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-05-30 | d0b4332 | Corrected the runtime field reference `runtime.process` to `runtime.processes` during the DSL-139 family reconciliation. |

--- a/docs/decisions/adrs/adr-032-directory-domain-identity-runtime-surface.md
+++ b/docs/decisions/adrs/adr-032-directory-domain-identity-runtime-surface.md
@@ -251,3 +251,9 @@ directory exports.
   invite later incompatible surfaces.
 - Recording raw directory secrets would leak sensitive material into fixtures,
   generated artifacts, diagnostics, or logs.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-05-25 | 5e42bd8 | Added primary-standards and access-control literature grounding (LDAP/Kerberos/SCIM/SAML/OAuth/OIDC RFCs, NIST SP 800-63C/162/207, RBAC/ABAC) for identity authorities and authority boundaries. |

--- a/docs/decisions/adrs/adr-038-runtime-mail-service-logical-state.md
+++ b/docs/decisions/adrs/adr-038-runtime-mail-service-logical-state.md
@@ -169,3 +169,9 @@ Rejected alternatives:
 - [SDL Semantic Validation](../../explain/sdl/validation.md),
   [Runtime Architecture](../../explain/sdl/runtime-architecture.md), and
   [SDL Limitations](../../explain/sdl/limitations.md).
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-06 | 6958fed | Added Security and Validation Gates and Guardrails sections: shared enum-or-var parser, secret-classification boundaries, and service-local reference resolution. |

--- a/docs/decisions/adrs/adr-041-participant-implementation-manifest-and-provenance.md
+++ b/docs/decisions/adrs/adr-041-participant-implementation-manifest-and-provenance.md
@@ -162,3 +162,9 @@ results.
 - [Contract publication manifest](../../../contracts/schema-publication-manifest.json)
   and
   [Controlled vocabularies](../../../contracts/concept-authority/controlled-vocabularies-v1.json).
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-06 | 6958fed | Added Security and Validation Gates and Guardrails sections: controlled-vocabulary resolution and references/digests as the portable manifest/provenance surface. |

--- a/docs/decisions/adrs/adr-048-datastore-service-runtime-inventory.md
+++ b/docs/decisions/adrs/adr-048-datastore-service-runtime-inventory.md
@@ -177,3 +177,10 @@ replication, or persistence behavior.
 - [Scenario/Delivery Boundary for Runtime Node State](adr-033-scenario-delivery-boundary-for-runtime-node-state.md)
 - [Lineage and Prior Work](../../explain/sdl/lineage.md) and
   [Design Precedents](../../explain/sdl/precedents.md)
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-07 | e782722 | Added structured datastore mapping manifests. |
+| 2026-06-07 | adf63e5 | Added datastore cardinality fields. |

--- a/docs/decisions/adrs/adr-050-forwarding-agent-runtime-inventory.md
+++ b/docs/decisions/adrs/adr-050-forwarding-agent-runtime-inventory.md
@@ -158,3 +158,9 @@ resolves across both node-hosted and scenario-level forwarding-agent registries.
 - [Scenario/Delivery Boundary for Runtime Node State](adr-033-scenario-delivery-boundary-for-runtime-node-state.md)
 - [Lineage and Prior Work](../../explain/sdl/lineage.md) and
   [Design Precedents](../../explain/sdl/precedents.md)
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-05-31 | e815f27 | Added scenario-level forwarding agents (top-level `Scenario.forwarding_agents`) with cross-registry ref resolution and uniqueness. |

--- a/docs/decisions/adrs/adr-052-typed-runtime-relationship-subtypes.md
+++ b/docs/decisions/adrs/adr-052-typed-runtime-relationship-subtypes.md
@@ -151,3 +151,10 @@ silently contradict:
   NIST SP 800-44; Kubernetes Ingress / Gateway API.
 - [Lineage and Prior Work](../../explain/sdl/lineage.md) and
   [Design Precedents](../../explain/sdl/precedents.md)
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-05-31 | d727d84 | Tightened SCN-010 SDL validation closure: `authorization_ref` and `upstream_service_ref` resolution rules. |
+| 2026-05-31 | e815f27 | Extended typed relationship handling for scenario-level forwarding agents. |

--- a/docs/decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate.md
+++ b/docs/decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate.md
@@ -1,0 +1,157 @@
+# ADR-059: ADR Amendment Policy and Acceptance-Content Pin Gate
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-10
+
+## Context
+
+[ADR-000](adr-000-use-adrs.md) and `docs/decisions/adrs/README.md` state that
+ADRs are **immutable once accepted** and that the corpus is therefore citable:
+a reference to "ADR-048 as accepted" should mean a fixed, knowable piece of
+text. That claim was aspirational, not enforced. Git history shows accepted
+ADRs edited after acceptance — for example ADR-048 (`e782722` added structured
+mapping manifests, `adf63e5` added cardinality fields), ADR-052 (`d727d84`,
+`e815f27`), and the same pattern on ADR-025/029/032/038/041/050. Some of those
+edits were substantive design changes, not typos. Nothing in the verification
+graph noticed, so the citability property the README advertised was silently
+false.
+
+Two failure modes follow from an unenforced claim:
+
+- a reader cannot trust that "the accepted ADR" is the text they last read; and
+- a genuinely needed correction has no recorded, reviewable form — it either
+  masquerades as "still the original" or it is avoided, both of which corrode
+  the record.
+
+The fix is not to forbid all change (decisions legitimately evolve) but to make
+change **recorded and detectable**: pin each accepted ADR's content, and require
+that any substantive change be either a new superseding ADR or an explicit,
+in-band amendment record.
+
+## Decision
+
+### 1. What "accepted" pins
+
+An ADR's **canonical content** is its file with the `## Amendments` section
+removed, per-line trailing whitespace stripped, and exactly one file-final
+newline. Only the file-final newline run is normalized (so a final-newline
+toggle is not a change); leading and interior blank lines are significant, so
+adding or removing one is a real content change the pin detects. The corpus pins
+the `sha256` of the canonical content of every ADR whose status is exactly
+`accepted`. Because the `## Amendments` section is excluded, recording an
+amendment never perturbs the pin — keeping history honest cannot itself look
+like tampering.
+
+Pin scope follows status:
+
+- `accepted` ADRs are pinned and governed by this policy.
+- `proposed` ADRs are still being decided and are freely mutable; they are not
+  pinned.
+- `superseded by ADR-NNN` and `deprecated` ADRs leave the pinned set. The
+  citable decision has moved to the superseding/replacing ADR; the old text is
+  frozen by virtue of no longer being the live decision, and its manifest pin is
+  removed when its status changes.
+
+### 2. The pin manifest
+
+`docs/decisions/adrs/adr-index.yaml` is the machine-readable, **mutable** pin
+manifest (the README index table remains the human-facing index, validated
+separately by the existing repo-policy ADR-index check). Its shape:
+
+```yaml
+hash_algorithm: sha256            # the only supported algorithm today
+adrs:
+  - id: ADR-048                   # ADR-NNN, unique
+    path: docs/decisions/adrs/adr-048-...md   # repo-relative, non-escaping
+    pin: <sha256 of canonical content>
+    amendments:                   # optional; present for amended ADRs
+      - { date: 2026-06-07, ref: e782722, summary: "..." }
+```
+
+The algorithm lives in the manifest rather than baked into a rule id or
+filename, so a future migration to another digest is a manifest change, not a
+code change.
+
+### 3. Amending an accepted ADR
+
+A **substantive** change to an accepted ADR — anything that changes its meaning:
+the decision, its scope, normative references, invariants, or the artifacts it
+points at — is legitimate only when recorded one of two ways:
+
+1. **Supersession.** Add a new ADR that supersedes it, and set the old ADR's
+   status to `superseded by ADR-NNN` (the ADR-005→ADR-006 pattern). The old ADR
+   leaves the pinned set; the new ADR is pinned.
+2. **In-band amendment.** Keep the ADR `accepted`, append a row to its
+   `## Amendments` table, and update its pin in `adr-index.yaml` — **in the same
+   change**. A pin bump on its own is not enough: the change must also add the
+   amendment record.
+
+An **editorial-only** change — pure formatting, whitespace, or typo fixes that
+change no reference and no meaning — is still a change to canonical content, so
+it still updates the pin **and** records a `## Amendments` row (a one-line
+"editorial: …" summary is enough). The gate is filesystem-only and cannot tell
+an editorial fix from a substantive one, so it requires the same in-band record
+for both: every canonical-content change to an accepted ADR is recorded, with no
+silent-edit escape hatch. The friction of a one-line row is the price of the
+citability guarantee — an editorial amendment row is cheap; an unrecorded edit is
+the failure this ADR exists to prevent.
+
+The `## Amendments` section is a Markdown table at the end of the ADR:
+
+```markdown
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-07 | e782722 | Added structured datastore mapping manifests. |
+```
+
+Each table row corresponds 1:1 (by commit/PR ref) to a manifest `amendments[]`
+entry for that ADR.
+
+### 4. Enforcement
+
+`tools/check_adr_immutability.py`, wired into the `policy` nox session, enforces
+this filesystem-only and deterministically (it never calls Ground Control, so it
+cannot become flaky in CI):
+
+- the manifest is well-formed (`sha256`, unique ids, repo-relative non-escaping
+  paths validated by the shared `safe_repo_path`);
+- every `accepted` ADR is pinned and every manifest entry names an `accepted`
+  ADR (coverage both ways);
+- each pin equals its ADR's current canonical hash — the unrecorded-edit
+  detector;
+- manifest `amendments[]` refs match the `## Amendments` rows 1:1;
+- under `--base-rev`/`--staged` (CI runs `--base-rev`), an accepted ADR whose
+  canonical content changed versus the base must have gained a `## Amendments`
+  record in the same change — closing the "bare pin bump blesses an edit" gap.
+
+## Consequences
+
+**Positive**
+
+- The README's citability claim becomes true and is mechanically defended.
+- Legitimate evolution is preserved with a low-friction, reviewable path.
+- The manifest gives tooling a stable map from ADR to acceptance-content hash.
+
+**Negative / costs**
+
+- Editing an accepted ADR now requires a manifest pin update plus a
+  `## Amendments` row — even for an editorial fix. This is the intended friction;
+  it keeps the gate filesystem-only with no silent-edit escape hatch.
+- The editorial-vs-substantive line affects only how much you write in the
+  amendment summary, not whether you record one; the policy resolves doubt toward
+  recording.
+
+**Risks**
+
+- The pin is over normalized canonical bytes; a future change to the
+  normalization rule would re-pin the whole corpus. The rule is therefore kept
+  minimal (drop the `## Amendments` section; strip per-line trailing whitespace;
+  normalize only the file-final newline) and lives in one place shared by the
+  manifest generator and the checker.

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -1,0 +1,209 @@
+# Acceptance-content pin manifest for accepted ADRs (ADR-059).
+#
+# `pin` is the sha256 of each accepted ADR's canonical content (the file
+# with its `## Amendments` section removed, per-line trailing whitespace
+# trimmed). Enforced by tools/check_adr_immutability.py in the `policy` nox
+# session. A substantive change to an accepted ADR must add a `## Amendments`
+# row + update its pin here in the same change, or supersede it with a new ADR.
+hash_algorithm: sha256
+adrs:
+  - id: ADR-000
+    path: docs/decisions/adrs/adr-000-use-adrs.md
+    pin: 9fbb099fd8321b1351c0afd13f7502bc5cd4863c3853a087ba5fbf4940cc8634
+  - id: ADR-001
+    path: docs/decisions/adrs/adr-001-scenario-description-language.md
+    pin: 29d53078da3314320bca34148440e8ad80a0deb6fc0471177197d2ab90043389
+  - id: ADR-002
+    path: docs/decisions/adrs/adr-002-declarative-sdl-objectives.md
+    pin: 7550c868306aa4f6ff7a1522796b71ae8797aa0015d7faec37c8f7011e60c536
+  - id: ADR-003
+    path: docs/decisions/adrs/adr-003-workflows-targetable-subobjects-and-enum-variables.md
+    pin: 0039bea0de4e4d5d08ccf300a7fb7516a0ea01977f38f1e2e111409a13e108df
+  - id: ADR-004
+    path: docs/decisions/adrs/adr-004-sdl-runtime-layer.md
+    pin: 1fbd1578afe343fe869b0298aab24f1d5339db40188cc39a66e38f1dcd98370b
+  - id: ADR-006
+    path: docs/decisions/adrs/adr-006-workflow-control-language-redesign.md
+    pin: 14565096df37ebc65239db018da85a609701b7978523b44f20d06f189f085900
+  - id: ADR-007
+    path: docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md
+    pin: 1ca00bf9c4610117c7cb8c42fe9be828292dfff22828793b32e504bca4379d85
+  - id: ADR-008
+    path: docs/decisions/adrs/adr-008-processor-layer-and-execution-artifact-boundaries.md
+    pin: 55343496d8dc22a8b7348f1d1197cd9f446d40a0a9af5d9d7b40f0c7cc9a8966
+  - id: ADR-009
+    path: docs/decisions/adrs/adr-009-normative-artifact-authority-and-repository-structure.md
+    pin: f7a74751a70e8d5d96266e2c45d94b1aafda832afe7b418df819de1cb1983fcc
+  - id: ADR-010
+    path: docs/decisions/adrs/adr-010-repository-realignment-order-and-compatibility-policy.md
+    pin: 752d8577e900e9b6257ff0db362c275bf7b26e14162a892dcd9578cbd71717c3
+  - id: ADR-011
+    path: docs/decisions/adrs/adr-011-narrow-end-to-end-mvp-validation.md
+    pin: b18bc89bddce74a677321b2f5429243907491235266f71a3ba6f02829b32f7c0
+  - id: ADR-012
+    path: docs/decisions/adrs/adr-012-shared-concept-authority-and-aces-extension-discipline.md
+    pin: 3027ece9635715383318f0deb7ca8b9092631f95959a294034ebeadc5bc488a0
+  - id: ADR-013
+    path: docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md
+    pin: aaf414e1da0eb329432562b16ff9e132522e19e8a35933a1c99329b0be27cae8
+  - id: ADR-014
+    path: docs/decisions/adrs/adr-014-nox-as-canonical-verification-graph.md
+    pin: 940ce80b1f1d94e3efb4a9f56cb9147d09c9a9dc1453a4977c7a5e194238d708
+  - id: ADR-015
+    path: docs/decisions/adrs/adr-015-sdl-processor-layering-and-source-file-size-cap.md
+    pin: 1e6000c3405e84765a993d326a8d97822e7b28a6714463bcd4d1550951f20ec7
+  - id: ADR-016
+    path: docs/decisions/adrs/adr-016-semantic-layer-scope-and-coverage-model.md
+    pin: ff9a71be7f6d427b88ff26317da36e14b6cc5943418cd941df88dca29033449b
+  - id: ADR-017
+    path: docs/decisions/adrs/adr-017-conversation-surface-hardening.md
+    pin: 09d78645690d4ae3f416a72380317148662b3f252a96d31bbc28c969f2c7eb81
+  - id: ADR-018
+    path: docs/decisions/adrs/adr-018-classification-based-assurance-policy.md
+    pin: 168195279ea2e3dafb12d3d308f750af2804bc09700efa3dc258a31cb05e8d2f
+  - id: ADR-019
+    path: docs/decisions/adrs/adr-019-normative-authority-boundary-manifest.md
+    pin: 66b4ea3eb2482d6f8855462f4921c9cd7853ddb4c9adfaa21f311a07422f248b
+  - id: ADR-024
+    path: docs/decisions/adrs/adr-024-local-identity-inventory-surface.md
+    pin: 74f1a3df1a7c0f8dc6f44ff006abe88b20b9444fa93a736ac20fca1ca800e665
+  - id: ADR-025
+    path: docs/decisions/adrs/adr-025-container-network-realization-surface.md
+    pin: 5442b545bb5a038500dce5a66a0bccddbeea6449269481c8b4f960d9b6a9f488
+    amendments:
+      - date: 2026-05-25
+        ref: 4b959c3
+        summary: "Corrected the control-plane API cross-reference from `aces_processor.control_plane_api` to `aces_runtime.control_plane_api`."
+  - id: ADR-026
+    path: docs/decisions/adrs/adr-026-application-http-surface-inventory.md
+    pin: 8818f870d79498f3322fd5edb9d2269948d04079ef5fbc7238811911ab7f5373
+  - id: ADR-027
+    path: docs/decisions/adrs/adr-027-container-init-reaper-runtime-surface.md
+    pin: d568a5a77d55b995d23c057ed3ccc56d221509a6068374d3884b2608c926cdea
+  - id: ADR-028
+    path: docs/decisions/adrs/adr-028-container-seccomp-security-options-surface.md
+    pin: 8798070e5aaa08a1de27686e8fd346030f00c4f3cace56c83602c0f9a312ac39
+  - id: ADR-029
+    path: docs/decisions/adrs/adr-029-database-logical-state-runtime-surface.md
+    pin: b4fc7ca2d8996f0edf284385c7d731dbbe14794e7e6be2b66d0b2369c5c53440
+    amendments:
+      - date: 2026-05-30
+        ref: d0b4332
+        summary: "Corrected the runtime field reference `runtime.process` to `runtime.processes` during the DSL-139 family reconciliation."
+  - id: ADR-030
+    path: docs/decisions/adrs/adr-030-process-scoped-linux-capability-policy.md
+    pin: d0574426f9b249fa078f364988e309b14d73c03a9f00115ab04e6ddeab76ffa1
+  - id: ADR-031
+    path: docs/decisions/adrs/adr-031-ssh-server-configuration-surface.md
+    pin: c77a768a27cf1d457aaf143557588e259b550fb5037acd0ea1e4d21026ba7cee
+  - id: ADR-032
+    path: docs/decisions/adrs/adr-032-directory-domain-identity-runtime-surface.md
+    pin: 518395ad00cd7ef19d9c762c87702eb1677333a76e0d26e5f0d404e6fe20f216
+    amendments:
+      - date: 2026-05-25
+        ref: 5e42bd8
+        summary: "Added primary-standards and access-control literature grounding (LDAP/Kerberos/SCIM/SAML/OAuth/OIDC RFCs, NIST SP 800-63C/162/207, RBAC/ABAC) for identity authorities and authority boundaries."
+  - id: ADR-033
+    path: docs/decisions/adrs/adr-033-scenario-delivery-boundary-for-runtime-node-state.md
+    pin: da01715747264384779a9bb203f4081ca401edaf7a947ecc48d791a18c97b69b
+  - id: ADR-034
+    path: docs/decisions/adrs/adr-034-runtime-software-component-inventory.md
+    pin: eb62ece791c5c0b442d5c77d89867832c01f0f5bc108b577f8636089be7c647e
+  - id: ADR-035
+    path: docs/decisions/adrs/adr-035-service-manager-unit-state-runtime-surface.md
+    pin: a8eb4df39f8b88781fee62ce83a2d2abee3951ebbeed5dc0c544a2a929ffad06
+  - id: ADR-036
+    path: docs/decisions/adrs/adr-036-sdl-processor-runtime-module-boundaries.md
+    pin: 80274b6f6f7529fdce17d3451acb2201f6ecf07095dbc5f6b36aa81399ddcdd9
+  - id: ADR-037
+    path: docs/decisions/adrs/adr-037-runtime-file-service-and-filesystem-presence-semantics.md
+    pin: d58c39b1132fe59dedb53fa389fc9c9bee063c37fca4d30aecff056683550baa
+  - id: ADR-038
+    path: docs/decisions/adrs/adr-038-runtime-mail-service-logical-state.md
+    pin: e06becb845b360a89afa3921f01705ce08143c8af4df2091b83b7a915c70371d
+    amendments:
+      - date: 2026-06-06
+        ref: 6958fed
+        summary: "Added Security and Validation Gates and Guardrails sections: shared enum-or-var parser, secret-classification boundaries, and service-local reference resolution."
+  - id: ADR-039
+    path: docs/decisions/adrs/adr-039-dns-service-runtime-inventory.md
+    pin: b6cf6dce2611e64e565b80bb25acbbe5dad9d76f0922e9cbaf3bc39d19e8aa80
+  - id: ADR-040
+    path: docs/decisions/adrs/adr-040-security-monitoring-manager-runtime-inventory.md
+    pin: 57efb0ca019ca74bc0dfa4ff722491813c569c7039236be0af464d9e5730c3aa
+  - id: ADR-041
+    path: docs/decisions/adrs/adr-041-participant-implementation-manifest-and-provenance.md
+    pin: 62b9c2b348aaa2594086abae91432fc404e95f51255ab793aea32ce45aa1eaad
+    amendments:
+      - date: 2026-06-06
+        ref: 6958fed
+        summary: "Added Security and Validation Gates and Guardrails sections: controlled-vocabulary resolution and references/digests as the portable manifest/provenance surface."
+  - id: ADR-042
+    path: docs/decisions/adrs/adr-042-network-sensor-runtime-monitoring.md
+    pin: d2d244bdd3bbfe2d6eaecc2e69bc73a474f405ae7e1d4d8bbb5dd75dbed7826d
+  - id: ADR-043
+    path: docs/decisions/adrs/adr-043-runtime-service-listener-surface.md
+    pin: 10e261d7027b769097ae70fc139d8d2c452b48b48146ed67d6af171f970163c6
+  - id: ADR-044
+    path: docs/decisions/adrs/adr-044-network-detection-engine-runtime-inventory.md
+    pin: 9272830dd30284ab864c62eb7bd74a563403bbfdff59992173d154785d55d3f7
+  - id: ADR-045
+    path: docs/decisions/adrs/adr-045-security-monitoring-detection-definition-semantics.md
+    pin: aa199dde8b9d5baf3792e8ee4c1b1cca7b16af08041074d96d82fd8ef342179a
+  - id: ADR-046
+    path: docs/decisions/adrs/adr-046-app-authorization-runtime-inventory.md
+    pin: e98452dba70a26fadf21bd8f6cf0d2b5a24829a256a3af80325f114b4cf157a7
+  - id: ADR-047
+    path: docs/decisions/adrs/adr-047-scheduled-job-runtime-inventory.md
+    pin: f674658c76e3d4581f8ef64f189e558e6873959b6292081b343bd5c9ae8a6181
+  - id: ADR-048
+    path: docs/decisions/adrs/adr-048-datastore-service-runtime-inventory.md
+    pin: a53fbb437134c173879324b9a912dfc35f2a368c7ca2cfd0e049ef6632979d9c
+    amendments:
+      - date: 2026-06-07
+        ref: e782722
+        summary: "Added structured datastore mapping manifests."
+      - date: 2026-06-07
+        ref: adf63e5
+        summary: "Added datastore cardinality fields."
+  - id: ADR-049
+    path: docs/decisions/adrs/adr-049-platform-application-runtime-inventory.md
+    pin: efd2bda17b286ff8da753428439df26feabea21ea21aa7fc817916f329ce9bba
+  - id: ADR-050
+    path: docs/decisions/adrs/adr-050-forwarding-agent-runtime-inventory.md
+    pin: 8eaecd0c498353822c5fec91f83fa6af6b7a7bb32451025f97661673cc1b832c
+    amendments:
+      - date: 2026-05-31
+        ref: e815f27
+        summary: "Added scenario-level forwarding agents (top-level `Scenario.forwarding_agents`) with cross-registry ref resolution and uniqueness."
+  - id: ADR-051
+    path: docs/decisions/adrs/adr-051-orchestration-authority-runtime-inventory.md
+    pin: 080e29f079007f86d1be96f5bf94a29d44cf138778b0adf43ddefa16bafdd099
+  - id: ADR-052
+    path: docs/decisions/adrs/adr-052-typed-runtime-relationship-subtypes.md
+    pin: 304d33ad2b5e43ccc382d2001625e09039ae920ed924627f16ef02de5dca6227
+    amendments:
+      - date: 2026-05-31
+        ref: d727d84
+        summary: "Tightened SCN-010 SDL validation closure: `authorization_ref` and `upstream_service_ref` resolution rules."
+      - date: 2026-05-31
+        ref: e815f27
+        summary: "Extended typed relationship handling for scenario-level forwarding agents."
+  - id: ADR-053
+    path: docs/decisions/adrs/adr-053-sdl-module-composition-for-inventory-backed-scenarios.md
+    pin: e6eae89e31205274087e6c4e775744fba945091cddef1aa5dad3daad47921993
+  - id: ADR-055
+    path: docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
+    pin: 2e6666f2e066700df3dbf38d0592a2f24e062ad4f94d695113824f2ba73ff695
+  - id: ADR-056
+    path: docs/decisions/adrs/adr-056-runtime-observed-values-and-credential-posture.md
+    pin: 3aa602de53f7607cf531b4a9da3f58192eb87ad21ddd92846fd2ae2a7526a4c3
+  - id: ADR-057
+    path: docs/decisions/adrs/adr-057-runtime-secret-name-classifier-boundaries.md
+    pin: 44c638bf47df8545b8af8a3850476fabc46a4ea42b3a8003b4f9ea1e89f72f49
+  - id: ADR-058
+    path: docs/decisions/adrs/adr-058-datastore-node-engine-provenance-and-endpoints.md
+    pin: 1a3d389978318de260c1a8b603c62fc49ca340eab120ba5cbdeeb9f12d7cf726
+  - id: ADR-059
+    path: docs/decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate.md
+    pin: dd089a4cd415280fb87d278b70537d4a1144d2f28198314a22031fc88eaf5ce2

--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import shutil
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -14,6 +15,12 @@ if str(REPO_ROOT) not in sys.path:
 import pytest
 import tools.check_generated_schemas as check_generated_schemas
 import yaml
+from tools.check_adr_immutability import (
+    amendment_refs,
+    canonical_content,
+    content_hash,
+    evaluate_adr_immutability,
+)
 from tools.check_generated_schemas import _extra_published_schema_paths
 from tools.check_json_artifacts import collect_validation_targets, should_run_full_validation
 from tools.check_schema_publication import validate_schema_publication_manifest
@@ -1111,3 +1118,404 @@ def test_check_generated_schemas_main_rejects_stale_extra_schema_files(
     monkeypatch.setitem(sys.modules, "aces_contracts.contracts", fake_contracts)
 
     assert check_generated_schemas.main() == 1
+
+
+# --- ADR acceptance-content pin gate (ADR-059 / GOV-941) ----------------------
+
+AMENDMENTS_TABLE_HEADER = "## Amendments\n\n| Date | Commit/PR | Summary |\n|------|-----------|---------|\n"
+
+
+def _adr_dir(tmp_path: Path) -> Path:
+    adr_dir = tmp_path / "docs" / "decisions" / "adrs"
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    return adr_dir
+
+
+def _make_adr(
+    adr_dir: Path,
+    number: str,
+    *,
+    status: str = "accepted",
+    body: str = "\n## Context\n\nThe decision body.\n",
+    amendment_rows: list[tuple[str, str, str]] | None = None,
+) -> str:
+    text = _adr_text(number, status=status, body=body)
+    if amendment_rows:
+        rows = "".join(f"| {date} | {ref} | {summary} |\n" for date, ref, summary in amendment_rows)
+        text += "\n" + AMENDMENTS_TABLE_HEADER + rows
+    write_text(adr_dir / f"adr-{number}-example.md", text)
+    return text
+
+
+def _write_manifest(adr_dir: Path, entries: list[dict], *, algorithm: str = "sha256") -> None:
+    write_text(
+        adr_dir / "adr-index.yaml",
+        yaml.safe_dump({"hash_algorithm": algorithm, "adrs": entries}, sort_keys=False),
+    )
+
+
+def _entry(number: str, text: str, *, pin_text: str | None = None, amendments: list[dict] | None = None) -> dict:
+    # ``pin_text`` lets a caller pin over content that is NOT byte-identical to the
+    # on-disk ADR (``text``). Recorded-amendment tests rely on this to pin over the
+    # *unamended* body so the gate only stays green if ``canonical_content`` truly
+    # strips the ``## Amendments`` section — pinning over the amended text would be
+    # tautological (both sides hashed from the same amended bytes).
+    entry = {
+        "id": f"ADR-{number}",
+        "path": f"docs/decisions/adrs/adr-{number}-example.md",
+        "pin": content_hash(pin_text if pin_text is not None else text),
+    }
+    if amendments is not None:
+        entry["amendments"] = amendments
+    return entry
+
+
+def _adr_text(number: str, *, status: str = "accepted", body: str = "\n## Context\n\nThe decision body.\n") -> str:
+    """The unamended ADR text ``_make_adr`` writes for ``(number, status, body)``,
+    without touching disk. Used to compute a pin over body-only content so the
+    amendment-stripping invariant is falsifiable."""
+    return f"# ADR-{number}: Example {number}\n\n## Status\n\n{status}\n\n## Date\n\n2026-04-05\n{body}"
+
+
+def _rule_ids(failures: list[PolicyFailure]) -> list[str]:
+    return [failure.rule_id for failure in failures]
+
+
+def _init_git_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True, capture_output=True)
+
+
+def _git_commit_all(repo_root: Path, message: str) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=repo_root, check=True, capture_output=True, text=True)
+
+
+def _git_add_all(repo_root: Path) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True, capture_output=True, text=True)
+
+
+def test_adr_pin_gate_passes_on_pinned_accepted_corpus(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    accepted_one = _make_adr(adr_dir, "001")
+    accepted_two = _make_adr(adr_dir, "002")
+    _make_adr(adr_dir, "003", status="proposed")  # proposed ADRs are not pinned
+    _write_manifest(adr_dir, [_entry("001", accepted_one), _entry("002", accepted_two)])
+
+    assert evaluate_adr_immutability(tmp_path) == []
+
+
+def test_adr_pin_gate_flags_unrecorded_edit(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    # Edit the ADR body without updating the pin.
+    _make_adr(adr_dir, "001", body="\n## Context\n\nA substantively different body.\n")
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-pin-stale" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_accepts_recorded_amendment(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    text = _make_adr(adr_dir, "001", amendment_rows=[("2026-06-07", "abc1234", "added a field")])
+    # Pin over the *unamended* body. If canonical_content stops stripping the
+    # ## Amendments section, the on-disk (amended) hash diverges from this pin and
+    # the gate fires adr-pin-stale — so this assertion genuinely verifies the
+    # "amendment records never change the pin" invariant rather than tautologically
+    # hashing the same amended bytes on both sides.
+    _write_manifest(
+        adr_dir,
+        [
+            _entry(
+                "001",
+                text,
+                pin_text=_adr_text("001"),
+                amendments=[{"date": "2026-06-07", "ref": "abc1234", "summary": "added a field"}],
+            )
+        ],
+    )
+
+    # The pin is over canonical content (amendments excluded), so the recorded
+    # amendment does not perturb it, and the manifest refs match the table 1:1.
+    assert evaluate_adr_immutability(tmp_path) == []
+
+
+def test_adr_pin_gate_flags_missing_pin(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    pinned = _make_adr(adr_dir, "001")
+    _make_adr(adr_dir, "002")  # accepted but absent from the manifest
+    _write_manifest(adr_dir, [_entry("001", pinned)])
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-pin-missing" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_flags_orphan_entry(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    proposed = _make_adr(adr_dir, "001", status="proposed")
+    _write_manifest(adr_dir, [_entry("001", proposed)])  # pins a non-accepted ADR
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-pin-orphan" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_flags_amendment_record_mismatch(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    text = _make_adr(adr_dir, "001", amendment_rows=[("2026-06-07", "abc1234", "added a field")])
+    _write_manifest(adr_dir, [_entry("001", text, amendments=[])])  # table row not mirrored in manifest
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-amendment-record-mismatch" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_rejects_unsupported_algorithm(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    text = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", text)], algorithm="md5")
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert _rule_ids(failures) == ["adr-manifest-malformed"]
+
+
+def test_adr_pin_gate_rejects_duplicate_id(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    text = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", text), _entry("001", text)])
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-manifest-malformed" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_rejects_unsafe_path(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    _write_manifest(
+        adr_dir,
+        [{"id": "ADR-001", "path": "../outside-the-repo.md", "pin": "0" * 64}],
+    )
+
+    failures = evaluate_adr_immutability(tmp_path)
+    assert "adr-manifest-path-unsafe" in _rule_ids(failures)
+
+
+def test_adr_pin_gate_missing_manifest_fails_cleanly(tmp_path: Path) -> None:
+    _adr_dir(tmp_path)
+    failures = evaluate_adr_immutability(tmp_path)
+    assert _rule_ids(failures) == ["adr-manifest-malformed"]
+
+
+def test_adr_pin_gate_base_rev_flags_pin_bump_without_amendment(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    # Edit the body AND bump the pin, but record no amendment.
+    edited = _make_adr(adr_dir, "001", body="\n## Context\n\nA materially changed body.\n")
+    _write_manifest(adr_dir, [_entry("001", edited)])
+
+    failures = evaluate_adr_immutability(tmp_path, base_rev="HEAD")
+    assert _rule_ids(failures) == ["adr-amendment-unrecorded"]
+
+
+def test_adr_pin_gate_base_rev_accepts_recorded_amendment(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    changed_body = "\n## Context\n\nA materially changed body.\n"
+    edited = _make_adr(
+        adr_dir,
+        "001",
+        body=changed_body,
+        amendment_rows=[("2026-06-08", "def5678", "changed the body")],
+    )
+    # Pin over the unamended edited body so the recorded amendment is what makes
+    # the change legitimate; a canonical_content regression that stops stripping
+    # amendments would diverge this pin from the on-disk hash and fail the test.
+    _write_manifest(
+        adr_dir,
+        [
+            _entry(
+                "001",
+                edited,
+                pin_text=_adr_text("001", body=changed_body),
+                amendments=[{"date": "2026-06-08", "ref": "def5678", "summary": "changed the body"}],
+            )
+        ],
+    )
+
+    assert evaluate_adr_immutability(tmp_path, base_rev="HEAD") == []
+
+
+def test_adr_pin_gate_base_rev_allows_supersession(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    # Supersede ADR-001: status changes (so it leaves the accepted/pinned set)
+    # and a new superseding ADR-002 is added; drop ADR-001 from the manifest.
+    _make_adr(adr_dir, "001", status="superseded by ADR-002")
+    superseding = _make_adr(adr_dir, "002")
+    _write_manifest(adr_dir, [_entry("002", superseding)])
+
+    assert evaluate_adr_immutability(tmp_path, base_rev="HEAD") == []
+
+
+def test_adr_pin_gate_staged_flags_pin_bump_without_amendment(tmp_path: Path) -> None:
+    # The pre-commit invocation: ``staged=True`` compares the git *index*
+    # (``git show :<path>``) against HEAD, a distinct code path from ``base_rev``
+    # (which reads the working tree from disk). A staged pin bump without an
+    # amendment must be flagged just like the base_rev case.
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    edited = _make_adr(adr_dir, "001", body="\n## Context\n\nA materially changed body.\n")
+    _write_manifest(adr_dir, [_entry("001", edited)])
+    _git_add_all(tmp_path)
+
+    failures = evaluate_adr_immutability(tmp_path, staged=True)
+    assert _rule_ids(failures) == ["adr-amendment-unrecorded"]
+
+
+def test_adr_pin_gate_staged_accepts_recorded_amendment(tmp_path: Path) -> None:
+    # A staged edit that records its amendment (and bumps the pin) passes — proving
+    # the staged branch does not over-fire on legitimately recorded changes.
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    changed_body = "\n## Context\n\nA materially changed body.\n"
+    edited = _make_adr(
+        adr_dir,
+        "001",
+        body=changed_body,
+        amendment_rows=[("2026-06-08", "def5678", "changed the body")],
+    )
+    # Pin over the unamended edited body (see recorded-amendment tests above): the
+    # green result must depend on canonical_content actually stripping amendments.
+    _write_manifest(
+        adr_dir,
+        [
+            _entry(
+                "001",
+                edited,
+                pin_text=_adr_text("001", body=changed_body),
+                amendments=[{"date": "2026-06-08", "ref": "def5678", "summary": "changed the body"}],
+            )
+        ],
+    )
+    _git_add_all(tmp_path)
+
+    assert evaluate_adr_immutability(tmp_path, staged=True) == []
+
+
+def test_adr_pin_gate_staged_sources_head_text_from_index_not_disk(tmp_path: Path) -> None:
+    # Pins down that ``head_text`` in the staged branch comes from the git *index*
+    # (``git show :<path>``), not the working tree. We stage an unrecorded ADR edit
+    # (with a bumped pin) and then restore the working-tree file to the committed
+    # original. Now the index holds the edit while disk == HEAD, so:
+    #   * the pin-hash check (which reads disk) sees the original and stays green;
+    #   * the corpus checks all pass against the staged pin too, so evaluation
+    #     reaches the staged unrecorded-edit detector;
+    #   * only an index-sourced ``head_text`` can observe the edit and flag it.
+    # If the detector read disk instead, head_text would equal base_text and the
+    # edit would silently pass — exactly the false exit-0 this test forbids.
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    # Stage the edited ADR. The bumped pin must match the *index* (edited) content
+    # so the disk-based pin-hash check will be green once we restore disk below.
+    edited = _make_adr(adr_dir, "001", body="\n## Context\n\nA materially changed body.\n")
+    _git_add_all(tmp_path)  # index now holds the edited ADR
+
+    # Restore the working tree to the committed original while keeping the index
+    # edit. Pin stays over the original content so the disk-read pin-hash is green.
+    write_text(adr_dir / "adr-001-example.md", original)
+    _write_manifest(adr_dir, [_entry("001", original)])
+
+    failures = evaluate_adr_immutability(tmp_path, staged=True)
+    assert _rule_ids(failures) == ["adr-amendment-unrecorded"]
+
+
+def test_amendment_refs_parses_table_rows() -> None:
+    text = (
+        "# ADR-001: Example\n\n## Status\n\naccepted\n\n## Date\n\n2026-04-05\n\n"
+        + AMENDMENTS_TABLE_HEADER
+        + "| 2026-06-07 | abc1234 | first |\n| 2026-06-08 | def5678 | second |\n"
+    )
+    assert amendment_refs(text) == ["abc1234", "def5678"]
+
+
+def test_amendment_parsing_ignores_fenced_examples(tmp_path: Path) -> None:
+    # An ADR that documents the amendment format (like ADR-059) embeds a
+    # ``## Amendments`` example inside a fenced code block. That example must
+    # not be read as a real section, or the ADR's pin would truncate and a
+    # bogus amendment would be parsed from the example row.
+    adr_dir = _adr_dir(tmp_path)
+    text = (
+        "# ADR-001: Policy\n\n## Status\n\naccepted\n\n## Date\n\n2026-04-05\n\n"
+        "## Decision\n\nRecord amendments like:\n\n"
+        "```markdown\n## Amendments\n\n| Date | Commit/PR | Summary |\n"
+        "|------|-----------|---------|\n| 2026-06-07 | deadbee | example |\n```\n\n"
+        "## Consequences\n\nDone.\n"
+    )
+    write_text(adr_dir / "adr-001-example.md", text)
+    assert amendment_refs(text) == []
+    _write_manifest(adr_dir, [_entry("001", text)])  # _entry hashes full text; no amendments
+
+    assert evaluate_adr_immutability(tmp_path) == []
+
+
+def test_canonical_content_detects_boundary_blank_line_edits() -> None:
+    # ADR-059 declares only per-line trailing whitespace and the file-final
+    # newline as normalized. A leading or interior blank line is significant, so
+    # adding one must change the canonical hash; toggling the final newline must
+    # not. This keeps the pin from silently absorbing boundary blank-line edits.
+    base = "# ADR-001: Example\n\n## Context\n\nThe body.\n"
+    leading_blank = "\n" + base
+    interior_blank = "# ADR-001: Example\n\n\n## Context\n\nThe body.\n"
+    no_final_newline = base.rstrip("\n")
+    trailing_blank = base + "\n"
+
+    assert canonical_content(base) != canonical_content(leading_blank)
+    assert canonical_content(base) != canonical_content(interior_blank)
+    assert canonical_content(base) == canonical_content(no_final_newline)
+    assert canonical_content(base) == canonical_content(trailing_blank)
+
+
+def test_adr_pin_gate_base_rev_flags_boundary_blank_line_edit(tmp_path: Path) -> None:
+    adr_dir = _adr_dir(tmp_path)
+    original = _make_adr(adr_dir, "001")
+    _write_manifest(adr_dir, [_entry("001", original)])
+    _init_git_repo(tmp_path)
+    _git_commit_all(tmp_path, "base")
+
+    # Prepend a blank line (a boundary-only edit) and bump the pin, no amendment.
+    edited = "\n" + original
+    write_text(adr_dir / "adr-001-example.md", edited)
+    _write_manifest(adr_dir, [_entry("001", edited)])
+
+    failures = evaluate_adr_immutability(tmp_path, base_rev="HEAD")
+    assert _rule_ids(failures) == ["adr-amendment-unrecorded"]
+
+
+def test_real_repo_adr_index_is_green() -> None:
+    """The committed adr-index.yaml must pin every accepted ADR honestly so the
+    gate starts (and stays) green on the real corpus."""
+    failures = evaluate_adr_immutability(REPO_ROOT)
+    assert failures == [], "\n".join(failure.render() for failure in failures)

--- a/noxfile.py
+++ b/noxfile.py
@@ -484,6 +484,12 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         ),
     )
     repo_args, requirement_args, skip_requirement = _split_policy_session_args(list(args))
+    arg_list = list(args)
+    adr_pin_args: list[str] = []
+    if "--base-rev" in arg_list:
+        base_index = arg_list.index("--base-rev")
+        if base_index + 1 < len(arg_list):
+            adr_pin_args = ["--base-rev", arg_list[base_index + 1]]
     reporter.run(
         "policy / repo policy",
         lambda: _run_project_python(session, "tools/check_repo_policy.py", *repo_args),
@@ -519,6 +525,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
             "policy / example library catalog",
             "skipped on staged check; runs on push and verify",
         )
+        reporter.skip(
+            "policy / ADR acceptance-content pin",
+            "skipped on staged check; runs on push and verify",
+        )
     else:
         reporter.run(
             "policy / semantic coverage ADR",
@@ -539,6 +549,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         reporter.run(
             "policy / example library catalog",
             lambda: _run_project_python(session, "tools/check_example_library.py"),
+        )
+        reporter.run(
+            "policy / ADR acceptance-content pin",
+            lambda: _run_project_python(session, "tools/check_adr_immutability.py", *adr_pin_args),
         )
 
 

--- a/tools/check_adr_immutability.py
+++ b/tools/check_adr_immutability.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Acceptance-content pin gate for accepted ADRs (ADR-059).
+
+``docs/decisions/adrs/README.md`` claims the ADR corpus is citable — an
+accepted ADR's content does not silently change under you. ADR-059 makes that
+claim enforceable instead of aspirational: ``docs/decisions/adrs/adr-index.yaml``
+pins every *accepted* ADR to the ``sha256`` of its **canonical content** (the
+file with its ``## Amendments`` section removed), and a substantive change to an
+accepted ADR is only legitimate when it is recorded — as a new ``## Amendments``
+row plus an updated pin, or by superseding the ADR with a new one.
+
+What this gate enforces, filesystem-only and deterministically (it never calls
+Ground Control, so it cannot become flaky in CI):
+
+* the manifest is well-formed: a mapping with ``hash_algorithm: sha256`` and an
+  ``adrs`` list of ``{id, path, pin, amendments?}`` entries, unique ids, repo-
+  relative non-escaping paths (via the shared ``safe_repo_path``);
+* every ADR whose on-disk status is ``accepted`` has exactly one manifest entry
+  (``adr-pin-missing``), and every manifest entry names an ADR that is
+  ``accepted`` on disk (``adr-pin-orphan``) — only ``accepted`` ADRs are pinned;
+  ``proposed`` stay mutable and ``superseded``/``deprecated`` leave the pin set;
+* each pinned ADR's current canonical hash equals its pin (``adr-pin-stale``) —
+  the unrecorded-edit detector;
+* the manifest ``amendments[]`` refs match the ADR's ``## Amendments`` table rows
+  1:1 (``adr-amendment-record-mismatch``);
+* with ``--base-rev``/``--staged``: an accepted ADR whose canonical content
+  changed versus the base must also have gained a ``## Amendments`` record in the
+  same change (``adr-amendment-unrecorded``) — this is what stops a bare pin bump
+  from blessing an undocumented edit. (Status transitions to
+  superseded/deprecated and superseding ADRs naturally leave the accepted set, so
+  they are not flagged.)
+
+Failures use ``tools.policy.common.PolicyFailure``; the CLI honours ``--json`` and
+the shared ``tools/policy/exceptions.yaml`` waiver mechanism like the other
+``policy`` nox-stage entry points.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.policy.adr import parse_adr_file
+from tools.policy.common import (
+    PolicyFailure,
+    apply_exceptions,
+    failures_to_json,
+    load_exceptions,
+    load_yaml,
+    safe_repo_path,
+)
+
+ADR_DIR = "docs/decisions/adrs"
+MANIFEST_PATH = f"{ADR_DIR}/adr-index.yaml"
+SUPPORTED_HASH_ALGORITHM = "sha256"
+
+ADR_ID_RE = re.compile(r"^ADR-\d{3}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+AMENDMENTS_HEADING_RE = re.compile(r"##\s+Amendments\s*")
+SECTION_HEADING_RE = re.compile(r"##\s+")
+
+RULE_MALFORMED = "adr-manifest-malformed"
+RULE_PATH_UNSAFE = "adr-manifest-path-unsafe"
+RULE_PIN_STALE = "adr-pin-stale"
+RULE_PIN_MISSING = "adr-pin-missing"
+RULE_PIN_ORPHAN = "adr-pin-orphan"
+RULE_AMENDMENT_MISMATCH = "adr-amendment-record-mismatch"
+RULE_AMENDMENT_UNRECORDED = "adr-amendment-unrecorded"
+
+
+def _amendments_section_bounds(text: str) -> tuple[int, int] | None:
+    """Character bounds ``(start, end)`` of the ``## Amendments`` section — its
+    heading through the line before the next ``##`` heading (or end of file).
+    Headings inside fenced code blocks are ignored, so an ``## Amendments``
+    *example* in an ADR's prose (e.g. ADR-059) is not mistaken for a real
+    section. Returns None when the ADR has no Amendments section."""
+    lines = text.splitlines(keepends=True)
+    starts: list[int] = []
+    cursor = 0
+    for line in lines:
+        starts.append(cursor)
+        cursor += len(line)
+    total = cursor
+
+    in_fence = False
+    heading_line: int | None = None
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        body = line.rstrip("\n")
+        if heading_line is None:
+            if AMENDMENTS_HEADING_RE.fullmatch(body):
+                heading_line = index
+        elif SECTION_HEADING_RE.match(body):
+            return starts[heading_line], starts[index]
+    if heading_line is None:
+        return None
+    return starts[heading_line], total
+
+
+def _strip_amendments(text: str) -> str:
+    """Return ``text`` with its ``## Amendments`` section removed."""
+    bounds = _amendments_section_bounds(text)
+    if bounds is None:
+        return text
+    start, end = bounds
+    return text[:start] + text[end:]
+
+
+def canonical_content(text: str) -> str:
+    """The bytes the pin is taken over: the ADR minus its ``## Amendments``
+    section, with per-line trailing whitespace removed and exactly one trailing
+    newline. Recording an amendment therefore never perturbs the pin, and
+    per-line trailing-whitespace churn is not treated as a substantive edit.
+    Only the file-final newline run is normalized (a text file with or without a
+    final newline hashes the same); leading blank lines and interior blank lines
+    are significant, so adding or removing one is a detectable content change."""
+    body = _strip_amendments(text)
+    lines = [line.rstrip() for line in body.splitlines()]
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def content_hash(text: str) -> str:
+    return hashlib.sha256(canonical_content(text).encode("utf-8")).hexdigest()
+
+
+def amendment_refs(text: str) -> list[str]:
+    """The commit/PR ref column of the ``## Amendments`` markdown table
+    (``| Date | Commit/PR | Summary |``), in document order. Header and
+    separator rows are skipped."""
+    bounds = _amendments_section_bounds(text)
+    if bounds is None:
+        return []
+    start, end = bounds
+    section = text[start:end]
+    refs: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        if cells[0].lower() == "date":  # header row
+            continue
+        if set("".join(cells)) <= set("-: "):  # separator row
+            continue
+        refs.append(cells[1])
+    return refs
+
+
+def _coerce_manifest(raw: object, manifest_rel: str) -> tuple[list[dict] | None, list[PolicyFailure]]:
+    """Validate the manifest shape. Returns ``(entries, [])`` on success, or
+    ``(None, failures)`` when the manifest is malformed — shape errors are
+    reported before any hash comparison so a broken manifest fails cleanly."""
+
+    def fail(message: str) -> PolicyFailure:
+        return PolicyFailure(RULE_MALFORMED, message, manifest_rel)
+
+    if not isinstance(raw, dict):
+        return None, [fail("manifest root must be a mapping")]
+    algorithm = raw.get("hash_algorithm")
+    if algorithm != SUPPORTED_HASH_ALGORITHM:
+        return None, [fail(f"hash_algorithm must be '{SUPPORTED_HASH_ALGORITHM}'; got {algorithm!r}")]
+    entries = raw.get("adrs")
+    if not isinstance(entries, list):
+        return None, [fail("'adrs' must be a list")]
+
+    failures: list[PolicyFailure] = []
+    normalized: list[dict] = []
+    seen_ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            failures.append(fail(f"adrs[{index}] must be a mapping"))
+            continue
+        adr_id = entry.get("id")
+        path = entry.get("path")
+        pin = entry.get("pin")
+        if not isinstance(adr_id, str) or not ADR_ID_RE.match(adr_id):
+            failures.append(fail(f"adrs[{index}].id must match ADR-NNN; got {adr_id!r}"))
+            continue
+        if adr_id in seen_ids:
+            failures.append(fail(f"duplicate manifest entry for {adr_id}"))
+            continue
+        seen_ids.add(adr_id)
+        if not isinstance(path, str) or not path:
+            failures.append(fail(f"{adr_id}: path must be a non-empty string"))
+            continue
+        if not isinstance(pin, str) or not SHA256_RE.match(pin):
+            failures.append(fail(f"{adr_id}: pin must be a 64-character sha256 hex digest"))
+            continue
+        amendments = entry.get("amendments") or []
+        if not isinstance(amendments, list):
+            failures.append(fail(f"{adr_id}: amendments must be a list"))
+            continue
+        refs: list[str] = []
+        malformed_amendment = False
+        for aindex, amendment in enumerate(amendments):
+            if not isinstance(amendment, dict) or not isinstance(amendment.get("ref"), str):
+                failures.append(fail(f"{adr_id}: amendments[{aindex}] must be a mapping with a string 'ref'"))
+                malformed_amendment = True
+                break
+            refs.append(amendment["ref"])
+        if malformed_amendment:
+            continue
+        normalized.append({"id": adr_id, "path": path, "pin": pin, "amendment_refs": refs})
+
+    if failures:
+        return None, failures
+    return normalized, []
+
+
+def _rel(repo_root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _accepted_adrs(repo_root: Path) -> dict[str, Path]:
+    """Map ``ADR-NNN`` → file for every ADR whose on-disk status is accepted.
+    Unparseable ADR files are repo_policy's concern, not this gate's."""
+    accepted: dict[str, Path] = {}
+    adr_dir = repo_root / ADR_DIR
+    for adr_file in sorted(adr_dir.glob("adr-*.md")):
+        if adr_file.name == "README.md":
+            continue
+        try:
+            number, _title, status, _date = parse_adr_file(adr_file)
+        except ValueError:
+            continue
+        if status == "accepted":
+            accepted[f"ADR-{number}"] = adr_file
+    return accepted
+
+
+def _git_show(repo_root: Path, gitref: str) -> str | None:
+    """Content of a path at a git ref (``<rev>:<path>`` or ``:<path>`` for the
+    index). Returns None when the path does not exist at that ref."""
+    proc = subprocess.run(
+        ["git", "show", gitref],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _check_unrecorded_edits(
+    repo_root: Path,
+    accepted: dict[str, Path],
+    *,
+    base_rev: str | None,
+    staged: bool,
+) -> list[PolicyFailure]:
+    """A pin bump alone must not bless an edit: when an accepted ADR's canonical
+    content changed versus the base, the same change must also have added a
+    ``## Amendments`` record."""
+    failures: list[PolicyFailure] = []
+    for adr_id, disk_path in accepted.items():
+        rel = _rel(repo_root, disk_path)
+        base_ref = f"HEAD:{rel}" if staged else f"{base_rev}:{rel}"
+        base_text = _git_show(repo_root, base_ref)
+        if base_text is None:
+            continue  # not present at base (newly added) — nothing to compare
+        head_text = _git_show(repo_root, f":{rel}") if staged else disk_path.read_text(encoding="utf-8")
+        if head_text is None or content_hash(base_text) == content_hash(head_text):
+            continue
+        new_refs = set(amendment_refs(head_text)) - set(amendment_refs(base_text))
+        if new_refs:
+            continue
+        failures.append(
+            PolicyFailure(
+                RULE_AMENDMENT_UNRECORDED,
+                f"{adr_id}: accepted ADR content changed without a new ## Amendments record; "
+                "add an amendment (and update its pin) or supersede it with a new ADR",
+                rel,
+            )
+        )
+    return failures
+
+
+def evaluate_adr_immutability(
+    repo_root: Path,
+    *,
+    base_rev: str | None = None,
+    staged: bool = False,
+) -> list[PolicyFailure]:
+    manifest_rel = MANIFEST_PATH
+    manifest_file = repo_root / manifest_rel
+    if not manifest_file.is_file():
+        return [PolicyFailure(RULE_MALFORMED, "ADR pin manifest is missing", manifest_rel)]
+    try:
+        raw = load_yaml(manifest_file)
+    except Exception:  # noqa: BLE001 — surface a parse error as a clean failure, not a traceback
+        return [PolicyFailure(RULE_MALFORMED, "ADR pin manifest is not valid YAML", manifest_rel)]
+
+    entries, failures = _coerce_manifest(raw, manifest_rel)
+    if entries is None:
+        return failures
+
+    # Path safety before any file read.
+    resolved: dict[str, Path] = {}
+    for entry in entries:
+        safe = safe_repo_path(repo_root, entry["path"])
+        if safe is None:
+            failures.append(
+                PolicyFailure(RULE_PATH_UNSAFE, f"{entry['id']}: path escapes the repository", entry["path"])
+            )
+            continue
+        resolved[entry["id"]] = safe
+    if failures:
+        return failures
+
+    accepted = _accepted_adrs(repo_root)
+    manifest_ids = {entry["id"] for entry in entries}
+
+    # Coverage both ways.
+    for adr_id, disk_path in accepted.items():
+        if adr_id not in manifest_ids:
+            failures.append(
+                PolicyFailure(
+                    RULE_PIN_MISSING,
+                    f"{adr_id} is accepted but not pinned in the manifest",
+                    _rel(repo_root, disk_path),
+                )
+            )
+    for entry in entries:
+        if entry["id"] not in accepted:
+            failures.append(
+                PolicyFailure(
+                    RULE_PIN_ORPHAN,
+                    f"manifest pins {entry['id']} but it is missing or not 'accepted' on disk",
+                    entry["path"],
+                )
+            )
+
+    # Pin + amendment-record checks for entries that are accepted on disk.
+    for entry in entries:
+        adr_id = entry["id"]
+        disk_path = accepted.get(adr_id)
+        if disk_path is None:
+            continue  # already reported as orphan
+        if resolved[adr_id] != disk_path.resolve():
+            failures.append(
+                PolicyFailure(
+                    RULE_MALFORMED,
+                    f"{adr_id}: manifest path does not resolve to the ADR file on disk",
+                    entry["path"],
+                )
+            )
+            continue
+        text = disk_path.read_text(encoding="utf-8")
+        if content_hash(text) != entry["pin"]:
+            failures.append(
+                PolicyFailure(
+                    RULE_PIN_STALE,
+                    f"{adr_id} content differs from its pinned hash; record an amendment "
+                    "(and update the pin) or supersede it with a new ADR",
+                    entry["path"],
+                )
+            )
+        document_refs = amendment_refs(text)
+        if sorted(document_refs) != sorted(entry["amendment_refs"]):
+            failures.append(
+                PolicyFailure(
+                    RULE_AMENDMENT_MISMATCH,
+                    f"{adr_id}: manifest amendment refs {sorted(entry['amendment_refs'])} do not match "
+                    f"the ADR ## Amendments rows {sorted(document_refs)}",
+                    entry["path"],
+                )
+            )
+
+    if failures:
+        return failures
+
+    if base_rev or staged:
+        failures.extend(_check_unrecorded_edits(repo_root, accepted, base_rev=base_rev, staged=staged))
+    return failures
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Enforce ADR-059 acceptance-content pins for accepted ADRs.")
+    parser.add_argument("--staged", action="store_true", help="Compare staged content against HEAD.")
+    parser.add_argument("--base-rev", help="Compare against a specific git revision.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    # Accepted for CLI parity with the other policy entry points. The pin gate
+    # always evaluates the whole accepted-ADR corpus — a partial path list could
+    # not prove corpus-wide coverage — so an explicit path list is not consulted.
+    parser.add_argument("--paths", nargs="*", help=argparse.SUPPRESS)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_adr_immutability(REPO_ROOT, base_rev=args.base_rev, staged=args.staged)
+    failures = apply_exceptions(failures, load_exceptions(REPO_ROOT))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/policy/adr.py
+++ b/tools/policy/adr.py
@@ -1,0 +1,65 @@
+"""Shared parsing helpers for Architecture Decision Records.
+
+These were extracted from ``tools/policy/repo_policy.py`` so the README↔ADR
+index check there and the ADR acceptance-content pin gate
+(``tools/check_adr_immutability.py``, ADR-059) parse ADR headers, status, and
+date the same way instead of each growing its own parser. ``repo_policy.py``
+re-imports these under their historical private names.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# A canonical MADR ADR header, e.g. ``# ADR-048: Datastore Service Runtime
+# Inventory``. Group 1 is the zero-padded number, group 2 the title.
+ADR_HEADER_RE = re.compile(r"^# ADR-(\d{3}): (.+)$", re.MULTILINE)
+
+
+def extract_markdown_section(text: str, section: str) -> str:
+    """Return the first non-empty line of the ``## <section>`` block (or a
+    legacy ``**<section>:**`` inline marker). Raises ``ValueError`` when the
+    section is absent."""
+    marker = f"## {section}"
+    start = text.find(marker)
+    if start != -1:
+        body = text[start + len(marker) :]
+        body = body.lstrip()
+        next_header = body.find("\n## ")
+        if next_header != -1:
+            body = body[:next_header]
+        return body.strip().splitlines()[0].strip()
+
+    legacy_marker = re.search(rf"^\*\*{re.escape(section)}:\*\*\s*(.+)$", text, re.MULTILINE)
+    if legacy_marker:
+        return legacy_marker.group(1).strip()
+
+    raise ValueError(f"missing {section} section")
+
+
+def normalize_adr_status(status: str) -> str:
+    """Collapse whitespace and canonicalise the ADR status vocabulary.
+    Recognised values are ``accepted``/``proposed``/``deprecated`` and
+    ``superseded by ADR-NNN``; anything else is returned whitespace-normalised
+    but otherwise untouched."""
+    normalized = " ".join(status.split())
+    lowered = normalized.lower()
+    if lowered in {"accepted", "proposed", "deprecated"}:
+        return lowered
+    superseded = re.fullmatch(r"superseded by (adr-\d{3})", lowered)
+    if superseded:
+        return f"superseded by {superseded.group(1).upper()}"
+    return normalized
+
+
+def parse_adr_file(path: Path) -> tuple[str, str, str, str]:
+    """Parse an ADR file into ``(number, title, status, date)``. Raises
+    ``ValueError`` when the header or a required section is missing."""
+    text = path.read_text(encoding="utf-8")
+    header = ADR_HEADER_RE.search(text)
+    if not header:
+        raise ValueError(f"{path} is missing ADR header")
+    status = normalize_adr_status(extract_markdown_section(text, "Status"))
+    date = extract_markdown_section(text, "Date")
+    return header.group(1), header.group(2).strip(), status.strip(), date.strip()

--- a/tools/policy/common.py
+++ b/tools/policy/common.py
@@ -35,6 +35,23 @@ def repo_path(value: str | Path) -> str:
     return Path(value).as_posix().strip("/")
 
 
+def safe_repo_path(repo_root: Path, rel_path: str) -> Path | None:
+    """Resolve ``rel_path`` against ``repo_root`` and return the resolved
+    path only if it stays inside the repository. Returns None for absolute
+    paths, parent-traversal segments, or symlinks that resolve outside the
+    repo. This guards every place a policy reads a path that ultimately comes
+    from PR-controlled config or the changed-file list."""
+    candidate = Path(rel_path)
+    if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+        return None
+    try:
+        resolved = (repo_root / candidate).resolve()
+        resolved.relative_to(repo_root.resolve())
+    except (ValueError, OSError):
+        return None
+    return resolved
+
+
 def run_git(args: list[str], repo_root: Path = REPO_ROOT) -> str:
     proc = subprocess.run(
         ["git", *args],

--- a/tools/policy/repo_policy.py
+++ b/tools/policy/repo_policy.py
@@ -5,7 +5,14 @@ import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
+from .adr import (
+    normalize_adr_status as _normalize_adr_status,
+)
+from .adr import (
+    parse_adr_file as _parse_adr_file,
+)
 from .common import PolicyFailure, load_yaml, path_matches_prefix
+from .common import safe_repo_path as _safe_repo_path
 from .conftest_tool import run_conftest_policy
 
 StructuralPolicyRunner = Callable[[dict], list[PolicyFailure]]
@@ -159,23 +166,6 @@ def _str_list_ok(value: object, *, allow_empty: bool) -> bool:
     if not value and not allow_empty:
         return False
     return all(_is_str(item) for item in value)
-
-
-def _safe_repo_path(repo_root: Path, rel_path: str) -> Path | None:
-    """Resolve ``rel_path`` against ``repo_root`` and return the resolved
-    path only if it stays inside the repository. Returns None for absolute
-    paths, parent-traversal segments, or symlinks that resolve outside the
-    repo. This guards every place the policy reads a path that ultimately
-    comes from PR-controlled config or the changed-file list."""
-    candidate = Path(rel_path)
-    if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
-        return None
-    try:
-        resolved = (repo_root / candidate).resolve()
-        resolved.relative_to(repo_root.resolve())
-    except (ValueError, OSError):
-        return None
-    return resolved
 
 
 def _validate_oversized_config(
@@ -949,50 +939,14 @@ def _check_changelog_versioned(repo_root: Path) -> list[PolicyFailure]:
     return []
 
 
-ADR_HEADER_RE = re.compile(r"^# ADR-(\d{3}): (.+)$", re.MULTILINE)
+# ADR-file parsing (header regex, status/date extraction, status normalisation)
+# lives in ``tools/policy/adr.py`` and is imported above so this README↔index
+# check and the ADR pin gate (ADR-059) parse ADRs identically. ``README_ROW_RE``
+# stays here because it parses the README index table, not an ADR file.
 README_ROW_RE = re.compile(
     r"^\| \[(\d{3})\]\(([^)]+)\) \| (.+?) \| (.+?) \| (\d{4}-\d{2}-\d{2}) \|$",
     re.MULTILINE,
 )
-
-
-def _parse_adr_file(path: Path) -> tuple[str, str, str, str]:
-    text = path.read_text(encoding="utf-8")
-    header = ADR_HEADER_RE.search(text)
-    if not header:
-        raise ValueError(f"{path} is missing ADR header")
-    status = _normalize_adr_status(_extract_markdown_section(text, "Status"))
-    date = _extract_markdown_section(text, "Date")
-    return header.group(1), header.group(2).strip(), status.strip(), date.strip()
-
-
-def _extract_markdown_section(text: str, section: str) -> str:
-    marker = f"## {section}"
-    start = text.find(marker)
-    if start != -1:
-        body = text[start + len(marker) :]
-        body = body.lstrip()
-        next_header = body.find("\n## ")
-        if next_header != -1:
-            body = body[:next_header]
-        return body.strip().splitlines()[0].strip()
-
-    legacy_marker = re.search(rf"^\*\*{re.escape(section)}:\*\*\s*(.+)$", text, re.MULTILINE)
-    if legacy_marker:
-        return legacy_marker.group(1).strip()
-
-    raise ValueError(f"missing {section} section")
-
-
-def _normalize_adr_status(status: str) -> str:
-    normalized = " ".join(status.split())
-    lowered = normalized.lower()
-    if lowered in {"accepted", "proposed", "deprecated"}:
-        return lowered
-    superseded = re.fullmatch(r"superseded by (adr-\d{3})", lowered)
-    if superseded:
-        return f"superseded by {superseded.group(1).upper()}"
-    return normalized
 
 
 def _check_adr_index(repo_root: Path, policy: dict, changed: list[str]) -> list[PolicyFailure]:

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -74,6 +74,9 @@ phases:
       - EXP-703
       - EXP-704
       - EXP-705
+  - id: decision-record-governance
+    requirements:
+      - GOV-941
 
 ownership:
   gov-concept-authority:
@@ -176,6 +179,8 @@ ownership:
     - docs/explain/sdl
     - docs/index.md
     - CHANGELOG.md
+  decision-record-governance:
+    - docs/decisions/adrs
   experiment-core:
     - contracts/README.md
     - contracts/schema-publication-manifest.json


### PR DESCRIPTION
## Summary

docs/decisions/adrs/README.md claimed ADRs are "immutable once accepted", but git history shows accepted ADRs substantively edited post-acceptance (ADR-048, ADR-052, and ADR-025/029/032/038/041/050), so the corpus citability claim was unenforced and violated (review finding ADR-1). This adds ADR-059 (the amendment policy), a machine-readable pin manifest (adr-index.yaml) pinning every accepted ADR's canonical-content sha256, and tools/check_adr_immutability.py wired into the policy nox session that fails when an accepted ADR changes without a recorded ## Amendments entry or a superseding ADR. The 8 already-amended ADRs are reconciled with honest amendment records so the gate starts green, and the README is rewritten to state the actual policy.

## Requirement UIDs

- `GOV-941`

## Related Issues

Closes #481

## ADR Impact

- ADR-059
- ADR-025 (amended)
- ADR-029 (amended)
- ADR-032 (amended)
- ADR-038 (amended)
- ADR-041 (amended)
- ADR-048 (amended)
- ADR-050 (amended)
- ADR-052 (amended)

## Changes

- Add docs/decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate.md (status accepted): amendment policy, canonical-content/pin definition, accepted-only pin scope, manifest shape, and enforcement
- Add docs/decisions/adrs/adr-index.yaml pinning the canonical-content sha256 of every accepted ADR; the 8 reconciled ADRs carry amendments[] entries
- Add tools/check_adr_immutability.py: manifest shape + path-safety validation, pin==canonical-hash, accepted-coverage both ways, amendment-record 1:1, and a --base-rev/--staged unrecorded-edit check; wired as a new 'policy / ADR acceptance-content pin' stage in noxfile.py
- Extract shared ADR parsers into tools/policy/adr.py and move safe_repo_path into tools/policy/common.py so repo_policy.py and the new gate share one sanitizer/parser (behavior-preserving)
- Append honest ## Amendments tables to ADR-025/029/032/038/041/048/050/052 reconciling their real post-acceptance commits
- Rewrite the docs/decisions/adrs/README.md immutability principle to state the enforced policy and link ADR-059
- Add a decision-record-governance phase (GOV-941) owning docs/decisions/adrs to tools/policy/requirement_order.yaml

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

New checker tests live in implementations/python/tests/test_repo_policy_tools.py (the existing policy-tool test home): green corpus, pin-stale/unrecorded-edit, recorded amendment, missing pin, orphan entry, amendment 1:1 mismatch, malformed manifest, unsafe path, duplicate id, missing manifest, fenced-example parsing, canonical_content boundary normalization, staged index-vs-disk isolation, base-rev unrecorded/recorded/supersession, and a real-repo green check. CI auto-skips requirement governance for this UID-less branch; local verify ran with --skip-requirement (Ground Control HTTP is unreachable from this environment).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GOV-941 ← docs/decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate.md, GOV-941 ← docs/decisions/adrs/adr-index.yaml, GOV-941 ← tools/check_adr_immutability.py
- TESTS: GOV-941 ← implementations/python/tests/test_repo_policy_tools.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/481.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
