### PR TITLE
changed: tighten ADR corpus hygiene

### DIFF
--- a/changelog.d/482.changed.md
+++ b/changelog.d/482.changed.md
@@ -1,0 +1,1 @@
+ADR corpus policy now validates the canonical ADR template's required sections.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -12,7 +12,11 @@ Each ADR includes:
 - **Status**: `proposed`, `accepted`, `deprecated`, or `superseded by ADR-XXX`
 - **Context**: The problem or situation driving the decision
 - **Decision**: What we chose and why
+- **Alternatives Considered**: Credible rejected options and why they were not
+  chosen
 - **Consequences**: Trade-offs (positive, negative, risks)
+
+Use [`TEMPLATE.md`](TEMPLATE.md) when drafting a new ADR.
 
 ## Principles
 
@@ -29,7 +33,9 @@ Each ADR includes:
 - `proposed` ADRs are still being decided and may change freely;
   `superseded`/`deprecated` ADRs leave the pinned set (the citable decision has
   moved to the replacing ADR).
-- ADRs are **numbered sequentially** and never reused.
+- ADRs are **numbered sequentially** in landing order and never reused. The ADR
+  date records when the decision was made; it may differ from the landing order
+  when a decision is backfilled or merged later.
 - ADRs are **versioned with code** and live in the repo.
 
 ## Index
@@ -37,6 +43,48 @@ Each ADR includes:
 ```{toctree}
 :hidden:
 
+TEMPLATE
+adr-000-use-adrs
+adr-001-scenario-description-language
+adr-002-declarative-sdl-objectives
+adr-003-workflows-targetable-subobjects-and-enum-variables
+adr-004-sdl-runtime-layer
+adr-005-control-flow-primitives
+adr-006-workflow-control-language-redesign
+adr-007-lightweight-formal-methods-policy
+adr-008-processor-layer-and-execution-artifact-boundaries
+adr-009-normative-artifact-authority-and-repository-structure
+adr-010-repository-realignment-order-and-compatibility-policy
+adr-011-narrow-end-to-end-mvp-validation
+adr-012-shared-concept-authority-and-aces-extension-discipline
+adr-013-participant-episode-lifecycle-boundaries
+adr-014-nox-as-canonical-verification-graph
+adr-015-sdl-processor-layering-and-source-file-size-cap
+adr-016-semantic-layer-scope-and-coverage-model
+adr-017-conversation-surface-hardening
+adr-018-classification-based-assurance-policy
+adr-019-normative-authority-boundary-manifest
+adr-020-declarative-participant-framing-boundaries
+adr-021-falsification-first-claim-evidence-gate
+adr-022-participant-behavior-and-interaction-semantics
+adr-023-container-image-build-provenance-surface
+adr-024-local-identity-inventory-surface
+adr-025-container-network-realization-surface
+adr-026-application-http-surface-inventory
+adr-027-container-init-reaper-runtime-surface
+adr-028-container-seccomp-security-options-surface
+adr-029-database-logical-state-runtime-surface
+adr-030-process-scoped-linux-capability-policy
+adr-031-ssh-server-configuration-surface
+adr-032-directory-domain-identity-runtime-surface
+adr-033-scenario-delivery-boundary-for-runtime-node-state
+adr-034-runtime-software-component-inventory
+adr-035-service-manager-unit-state-runtime-surface
+adr-036-sdl-processor-runtime-module-boundaries
+adr-037-runtime-file-service-and-filesystem-presence-semantics
+adr-038-runtime-mail-service-logical-state
+adr-039-dns-service-runtime-inventory
+adr-040-security-monitoring-manager-runtime-inventory
 adr-041-participant-implementation-manifest-and-provenance
 adr-042-network-sensor-runtime-monitoring
 adr-043-runtime-service-listener-surface
@@ -56,6 +104,7 @@ adr-056-runtime-observed-values-and-credential-posture
 adr-057-runtime-secret-name-classifier-boundaries
 adr-058-datastore-node-engine-provenance-and-endpoints
 adr-059-adr-amendment-policy-and-pin-gate
+adr-060-participant-backend-facing-contract-surface
 ```
 
 | ADR | Title | Status | Date |

--- a/docs/decisions/adrs/TEMPLATE.md
+++ b/docs/decisions/adrs/TEMPLATE.md
@@ -1,0 +1,29 @@
+# ADR-NNN: Title
+
+## Status
+
+proposed
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+Describe the problem, constraints, and forces that make an architectural
+decision necessary.
+
+## Decision
+
+State the chosen option and the reasons it is the best fit for the current
+system.
+
+## Alternatives Considered
+
+List the credible options that were rejected, including the main reason each
+was not chosen.
+
+## Consequences
+
+Record the positive outcomes, negative costs, and risks introduced by the
+decision.

--- a/docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
+++ b/docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
@@ -287,3 +287,9 @@ and redaction patterns.
 - If later APIs need draft or partial experiment records, they must introduce an
   explicit draft lifecycle surface rather than weakening these archival
   contracts.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-12 | #482 | Recorded that the ADR's decision date is 2026-05-26 and it landed with experiment-core PR #422 on 2026-06-05. |

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -195,6 +195,10 @@ adrs:
   - id: ADR-055
     path: docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
     pin: 2e6666f2e066700df3dbf38d0592a2f24e062ad4f94d695113824f2ba73ff695
+    amendments:
+      - date: 2026-06-12
+        ref: "#482"
+        summary: "Recorded that the ADR's decision date is 2026-05-26 and it landed with experiment-core PR #422 on 2026-06-05."
   - id: ADR-056
     path: docs/decisions/adrs/adr-056-runtime-observed-values-and-credential-posture.md
     pin: 3aa602de53f7607cf531b4a9da3f58192eb87ad21ddd92846fd2ae2a7526a4c3

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,26 @@ decisions/adrs/adr-037-runtime-file-service-and-filesystem-presence-semantics
 decisions/adrs/adr-038-runtime-mail-service-logical-state
 decisions/adrs/adr-039-dns-service-runtime-inventory
 decisions/adrs/adr-040-security-monitoring-manager-runtime-inventory
+decisions/adrs/adr-041-participant-implementation-manifest-and-provenance
+decisions/adrs/adr-042-network-sensor-runtime-monitoring
+decisions/adrs/adr-043-runtime-service-listener-surface
+decisions/adrs/adr-044-network-detection-engine-runtime-inventory
+decisions/adrs/adr-045-security-monitoring-detection-definition-semantics
+decisions/adrs/adr-046-app-authorization-runtime-inventory
+decisions/adrs/adr-047-scheduled-job-runtime-inventory
+decisions/adrs/adr-048-datastore-service-runtime-inventory
+decisions/adrs/adr-049-platform-application-runtime-inventory
+decisions/adrs/adr-050-forwarding-agent-runtime-inventory
+decisions/adrs/adr-051-orchestration-authority-runtime-inventory
+decisions/adrs/adr-052-typed-runtime-relationship-subtypes
+decisions/adrs/adr-053-sdl-module-composition-for-inventory-backed-scenarios
+decisions/adrs/adr-054-participant-runtime-observable-lifecycle
 decisions/adrs/adr-055-experiment-core-contract-boundary
+decisions/adrs/adr-056-runtime-observed-values-and-credential-posture
+decisions/adrs/adr-057-runtime-secret-name-classifier-boundaries
+decisions/adrs/adr-058-datastore-node-engine-provenance-and-endpoints
+decisions/adrs/adr-059-adr-amendment-policy-and-pin-gate
+decisions/adrs/adr-060-participant-backend-facing-contract-surface
 decisions/sem-213-temporal-participant-preflight
 ```
 

--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -83,6 +83,22 @@ def setup_policy_repo(tmp_path: Path) -> Path:
         "| --- | --- | --- | --- |\n"
         "| [001](adr-001-example.md) | Example ADR | Accepted | 2026-04-05 |\n",
     )
+    write_text(
+        adr_dir / "TEMPLATE.md",
+        "# ADR-NNN: Title\n\n"
+        "## Status\n\n"
+        "proposed\n\n"
+        "## Date\n\n"
+        "YYYY-MM-DD\n\n"
+        "## Context\n\n"
+        "What problem or situation is driving this decision?\n\n"
+        "## Decision\n\n"
+        "What did we choose, and why?\n\n"
+        "## Alternatives Considered\n\n"
+        "Which credible options were rejected, and why?\n\n"
+        "## Consequences\n\n"
+        "What are the positive, negative, and risk trade-offs?\n",
+    )
     for package in (
         "aces_sdl",
         "aces_processor",
@@ -234,6 +250,32 @@ def test_adr_index_accepts_legacy_inline_status_and_date_fields(tmp_path: Path) 
     )
 
     assert failures == []
+
+
+def test_adr_template_requires_alternatives_considered(tmp_path: Path) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    write_text(
+        repo_root / "docs" / "decisions" / "adrs" / "TEMPLATE.md",
+        "# ADR-NNN: Title\n\n"
+        "## Status\n\n"
+        "proposed\n\n"
+        "## Date\n\n"
+        "YYYY-MM-DD\n\n"
+        "## Context\n\n"
+        "Context.\n\n"
+        "## Decision\n\n"
+        "Decision.\n\n"
+        "## Consequences\n\n"
+        "Consequences.\n",
+    )
+
+    failures = evaluate_repo_policy(
+        repo_root,
+        ["docs/decisions/adrs/TEMPLATE.md"],
+        structural_runner=structural_runner_stub,
+    )
+
+    assert [failure.rule_id for failure in failures] == ["adr-template-section-missing"]
 
 
 # ── ADR-015: SDL→processor layering rule ────────────────────────────────

--- a/tools/policy/repo_policy.py
+++ b/tools/policy/repo_policy.py
@@ -104,6 +104,7 @@ def evaluate_repo_policy(
     failures.extend(_check_module_boundaries(repo_root, policy, changed, check_set=check_set))
 
     if check_set == "full":
+        failures.extend(_check_adr_template(repo_root, changed))
         failures.extend(_check_adr_index(repo_root, policy, changed))
 
     if "CHANGELOG.md" in changed:
@@ -947,6 +948,44 @@ README_ROW_RE = re.compile(
     r"^\| \[(\d{3})\]\(([^)]+)\) \| (.+?) \| (.+?) \| (\d{4}-\d{2}-\d{2}) \|$",
     re.MULTILINE,
 )
+ADR_TEMPLATE_PATH = "docs/decisions/adrs/TEMPLATE.md"
+ADR_TEMPLATE_REQUIRED_SECTIONS = (
+    "Status",
+    "Date",
+    "Context",
+    "Decision",
+    "Alternatives Considered",
+    "Consequences",
+)
+ADR_TEMPLATE_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _check_adr_template(repo_root: Path, changed: list[str]) -> list[PolicyFailure]:
+    if not any(path.startswith("docs/decisions/adrs/") or path == "tools/policy/repo_policy.py" for path in changed):
+        return []
+
+    template = repo_root / ADR_TEMPLATE_PATH
+    if not template.exists():
+        return [
+            PolicyFailure(
+                "adr-template-missing",
+                "ADR template is missing",
+                ADR_TEMPLATE_PATH,
+            )
+        ]
+
+    text = template.read_text(encoding="utf-8")
+    headings = {match.group(1).strip() for match in ADR_TEMPLATE_HEADING_RE.finditer(text)}
+    missing = [section for section in ADR_TEMPLATE_REQUIRED_SECTIONS if section not in headings]
+    if missing:
+        return [
+            PolicyFailure(
+                "adr-template-section-missing",
+                f"ADR template is missing required section(s): {', '.join(missing)}",
+                ADR_TEMPLATE_PATH,
+            )
+        ]
+    return []
 
 
 def _check_adr_index(repo_root: Path, policy: dict, changed: list[str]) -> list[PolicyFailure]:

--- a/tools/policy/requirement_order.yaml
+++ b/tools/policy/requirement_order.yaml
@@ -181,6 +181,8 @@ ownership:
     - CHANGELOG.md
   decision-record-governance:
     - docs/decisions/adrs
+    - docs/index.md
+    - implementations/python/tests
   experiment-core:
     - contracts/README.md
     - contracts/schema-publication-manifest.json


### PR DESCRIPTION
## Summary

Tightens ADR corpus hygiene by completing the ADR toctrees, adding a canonical ADR template with Alternatives Considered, recording ADR-055 landing provenance through an amendment, and enforcing the template shape through repo policy.

## Requirement UIDs

- `GOV-941`

## Related Issues

Closes #482

## ADR Impact

- ADR-055 (amended)
- ADR-059

## Changes

- Complete ADR corpus toctrees in the ADR README and docs index, including ADRs 041-060 and the canonical template.
- Add a canonical ADR template with required sections, including Alternatives Considered, and document the numbering versus decision-date convention.
- Record ADR-055 provenance using ADR-059 amendment metadata without rewriting immutable ADR history.
- Add repo-policy enforcement and pytest coverage for the ADR template required-section gate.
- Map the touched docs index and policy-test surfaces under decision-record governance ownership.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Validated with `uv run --frozen python -m pytest tests/test_repo_policy_tools.py`, `ACES_REQUIREMENT_UID=GOV-941 GC_BASE_URL=http://100.98.28.66:8000 pre-commit run --all-files`, `ACES_REQUIREMENT_UID=GOV-941 GC_BASE_URL=http://100.98.28.66:8000 implementations/python/.venv/bin/python tools/verify_all.py`, and `implementations/python/.venv/bin/python tools/check_adr_immutability.py --staged`. Pre-push Codex review was clean; test-quality review was clean via fallback decision record after the wrapper engine failed before findings.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GOV-941 <- tools/policy/repo_policy.py, GOV-941 <- docs/decisions/adrs/TEMPLATE.md, GOV-941 <- docs/decisions/adrs/README.md, GOV-941 <- docs/decisions/adrs/adr-index.yaml
- TESTS: GOV-941 <- implementations/python/tests/test_repo_policy_tools.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/482.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.