### PR TITLE
changed: add FM classification assurance gate

### DIFF
--- a/changelog.d/483.changed.md
+++ b/changelog.d/483.changed.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Added an auditable FM classification ledger and policy gate for new ADR
+  classification fields.

--- a/docs/decisions/adrs/TEMPLATE.md
+++ b/docs/decisions/adrs/TEMPLATE.md
@@ -8,6 +8,12 @@ proposed
 
 YYYY-MM-DD
 
+## Classification
+
+Classification: FM<n>
+Required artifacts: <artifact kinds delivered or waived>
+Waivers: <none, or artifact kind plus rationale>
+
 ## Context
 
 Describe the problem, constraints, and forces that make an architectural

--- a/docs/explain/reference/fm-classification-ledger.yaml
+++ b/docs/explain/reference/fm-classification-ledger.yaml
@@ -1,0 +1,437 @@
+ledger: per-change-fm-classification
+policy_ref: specs/formal/assurance-policy.yaml
+entries:
+  - adr: ADR-023
+    surface: Container image build provenance surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_scenarios.py
+    waived_artifacts: []
+  - adr: ADR-024
+    surface: Local identity inventory surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-024-local-identity-inventory-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_models.py
+    waived_artifacts: []
+  - adr: ADR-025
+    surface: Container network realization surface
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-025-container-network-realization-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_sdl_validator.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-026
+    surface: Application HTTP surface inventory
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-026-application-http-surface-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+    waived_artifacts: []
+  - adr: ADR-027
+    surface: Container init and reaper runtime surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-027-container-init-reaper-runtime-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+    waived_artifacts: []
+  - adr: ADR-028
+    surface: Container seccomp and security options surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-028-container-seccomp-security-options-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+    waived_artifacts: []
+  - adr: ADR-029
+    surface: Database logical-state runtime surface
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-029-database-logical-state-runtime-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_datastore.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-030
+    surface: Process-scoped Linux capability policy
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-030-process-scoped-linux-capability-policy.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+    waived_artifacts: []
+  - adr: ADR-031
+    surface: SSH server configuration surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-031-ssh-server-configuration-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_ssh_server.py
+    waived_artifacts: []
+  - adr: ADR-032
+    surface: Directory and domain identity runtime surface
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-032-directory-domain-identity-runtime-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-033
+    surface: Scenario delivery boundary for runtime node state
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-033-scenario-delivery-boundary-for-runtime-node-state.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-034
+    surface: Runtime software component inventory
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-034-runtime-software-component-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_models.py
+    waived_artifacts: []
+  - adr: ADR-035
+    surface: Service-manager unit state runtime surface
+    fm_level: FM3
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-035-service-manager-unit-state-runtime-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_service_units.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+      - kind: abstract_state_machine_model
+        rationale: Historical backfill records current evidence; no abstract state-machine artifact was recorded for this accepted ADR.
+  - adr: ADR-036
+    surface: SDL, processor, and runtime module boundaries
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-036-sdl-processor-runtime-module-boundaries.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_contract_boundaries.py
+      - kind: typed_ir_or_contract_coverage
+        path: tools/policy/adr_policy.yaml
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-037
+    surface: Runtime file-service and filesystem presence semantics
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-037-runtime-file-service-and-filesystem-presence-semantics.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-038
+    surface: Runtime mail-service logical state
+    fm_level: FM3
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-038-runtime-mail-service-logical-state.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_mail_service.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+      - kind: abstract_state_machine_model
+        rationale: Historical backfill records current evidence; no abstract state-machine artifact was recorded for this accepted ADR.
+  - adr: ADR-039
+    surface: DNS service runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-039-dns-service-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_validator.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-040
+    surface: Security-monitoring manager runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-040-security-monitoring-manager-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_security_monitoring.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-041
+    surface: Participant implementation manifest and provenance surface
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-041-participant-implementation-manifest-and-provenance.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_participant_implementation_manifest.py
+    waived_artifacts: []
+  - adr: ADR-042
+    surface: Network sensor runtime monitoring posture
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-042-network-sensor-runtime-monitoring.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_network_sensor.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-043
+    surface: Generic runtime service listener surface
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-043-runtime-service-listener-surface.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_service_listeners.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-044
+    surface: Network detection engine runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-044-network-detection-engine-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_network_detection.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-045
+    surface: Security-monitoring detection definition semantics
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-045-security-monitoring-detection-definition-semantics.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_security_monitoring.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-046
+    surface: Application-internal authorization runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-046-app-authorization-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_app_authorization.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-047
+    surface: Scheduled-job runtime inventory
+    fm_level: FM3
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-047-scheduled-job-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_scheduled_job.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+      - kind: abstract_state_machine_model
+        rationale: Historical backfill records current evidence; no abstract state-machine artifact was recorded for this accepted ADR.
+  - adr: ADR-048
+    surface: Datastore service runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-048-datastore-service-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_datastore.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-049
+    surface: Platform application runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-049-platform-application-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_platform_application.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-050
+    surface: Forwarding agent runtime inventory
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-050-forwarding-agent-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_forwarding_agent.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-051
+    surface: Orchestration authority runtime inventory
+    fm_level: FM3
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-051-orchestration-authority-runtime-inventory.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_orchestration.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+      - kind: abstract_state_machine_model
+        rationale: Historical backfill records current evidence; no abstract state-machine artifact was recorded for this accepted ADR.
+  - adr: ADR-052
+    surface: Typed runtime relationship subtypes
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-052-typed-runtime-relationship-subtypes.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_family_invariants.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-053
+    surface: SDL module composition for inventory-backed scenarios
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-053-sdl-module-composition-for-inventory-backed-scenarios.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_sdl_module_registry.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-054
+    surface: Participant runtime observable lifecycle
+    fm_level: FM3
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_control_plane.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+      - kind: abstract_state_machine_model
+        rationale: Historical backfill records current evidence; no abstract state-machine artifact was recorded for this accepted ADR.
+  - adr: ADR-055
+    surface: Experiment core contract boundary
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_contracts.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.
+  - adr: ADR-056
+    surface: Runtime observed values and credential posture
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-056-runtime-observed-values-and-credential-posture.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_observed_values.py
+    waived_artifacts: []
+  - adr: ADR-057
+    surface: Runtime scenario value realizability and explicit redaction
+    fm_level: FM1
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-057-runtime-secret-name-classifier-boundaries.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_observed_values.py
+    waived_artifacts: []
+  - adr: ADR-058
+    surface: Datastore node engine provenance and endpoints
+    fm_level: FM2
+    delivered_artifacts:
+      - kind: invariant_list
+        path: docs/decisions/adrs/adr-058-datastore-node-engine-provenance-and-endpoints.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_runtime_datastore.py
+      - kind: typed_ir_or_contract_coverage
+        path: implementations/python/tests/test_runtime_contracts.py
+    waived_artifacts:
+      - kind: property_based_or_differential_tests
+        rationale: Historical backfill records current evidence; no dedicated property-based or differential artifact was recorded for this accepted ADR.

--- a/docs/explain/reference/shared-semantic-integrity.md
+++ b/docs/explain/reference/shared-semantic-integrity.md
@@ -12,6 +12,13 @@ ADR-016 governs; every `SEM-2xx` implementation PR moves its construct family's
 row toward `active` there. The structural gate `tools/check_semantic_coverage.py`
 validates that table on every `nox` policy run.
 
+Per-change FM classifications for semantic and runtime-surface ADRs are
+recorded in the sibling
+[`fm-classification-ledger.yaml`](fm-classification-ledger.yaml) file. The
+assurance-policy gate validates that ledger against
+`specs/formal/assurance-policy.yaml`, including the ADR-023 through ADR-058
+runtime-surface backfill.
+
 `SEM-200` is broader than concept authority alone. It covers whether scenario
 constructs keep the same meaning across authoring, validation, instantiation,
 compilation, planning, execution, live observation, and post-run experiment

--- a/implementations/python/tests/test_assurance_policy.py
+++ b/implementations/python/tests/test_assurance_policy.py
@@ -10,12 +10,15 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.check_assurance_policy import (  # noqa: E402
+    ADR_CLASSIFICATION_REQUIRED_FROM,
     ADR_POLICY_RELATIVE_PATH,
     ADR_REF,
     ADR_REFS,
+    ADR_TEMPLATE_RELATIVE_PATH,
     ASSURANCE_POLICY_RELATIVE_PATH,
     CANONICAL_LEVEL_IDS,
     CODING_STANDARDS_RELATIVE_PATH,
+    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
     FORMAL_OVERVIEW_RELATIVE_PATH,
     REQUIRED_CHANGE_CATEGORIES,
     REQUIREMENT_REF,
@@ -99,6 +102,44 @@ _GOOD_FORMAL_OVERVIEW = """# Formal Specifications
 | FM3 | Stateful / Control Semantics | FM2 + abstract state-machine model |
 """
 
+_GOOD_ADR_TEMPLATE = """# ADR-NNN: Title
+
+## Status
+
+proposed
+
+## Date
+
+YYYY-MM-DD
+
+## Classification
+
+Classification: FM<n>
+Required artifacts: <artifact kinds delivered or waived>
+Waivers: <none, or artifact kind plus rationale>
+
+## Context
+
+Describe the problem.
+
+## Decision
+
+State the decision.
+
+## Alternatives Considered
+
+List rejected options.
+
+## Consequences
+
+Record outcomes.
+"""
+
+_GOOD_EMPTY_LEDGER = """ledger: per-change-fm-classification
+policy_ref: specs/formal/assurance-policy.yaml
+entries: []
+"""
+
 
 def _seed_repo(
     tmp_path: Path,
@@ -107,8 +148,10 @@ def _seed_repo(
     adr_body: str | None = _GOOD_ADR,
     coding_standards_body: str | None = _GOOD_CODING_STANDARDS,
     formal_overview_body: str | None = _GOOD_FORMAL_OVERVIEW,
+    adr_template_body: str | None = _GOOD_ADR_TEMPLATE,
+    ledger_body: str | None = _GOOD_EMPTY_LEDGER,
 ) -> Path:
-    """Seed a temp repo skeleton with the policy YAML and the three referencing docs."""
+    """Seed a temp repo skeleton with the policy YAML and referencing docs."""
     policy_path = tmp_path / ASSURANCE_POLICY_RELATIVE_PATH
     policy_path.parent.mkdir(parents=True, exist_ok=True)
     policy_path.write_text(policy_body, encoding="utf-8")
@@ -128,6 +171,16 @@ def _seed_repo(
         fo_path.parent.mkdir(parents=True, exist_ok=True)
         fo_path.write_text(formal_overview_body, encoding="utf-8")
 
+    if adr_template_body is not None:
+        template_path = tmp_path / ADR_TEMPLATE_RELATIVE_PATH
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        template_path.write_text(adr_template_body, encoding="utf-8")
+
+    if ledger_body is not None:
+        ledger_path = tmp_path / FM_CLASSIFICATION_LEDGER_RELATIVE_PATH
+        ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        ledger_path.write_text(ledger_body, encoding="utf-8")
+
     return tmp_path
 
 
@@ -135,6 +188,84 @@ def _flagged(failures, marker: str) -> bool:
     """Return True if some failure matches ``marker`` by rule id or substring of its render."""
     needle = marker.lower()
     return any(f.rule_id == marker or needle in f.render().lower() for f in failures)
+
+
+def _write(path: Path, text: str = "placeholder\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _new_adr_body(
+    *,
+    classification: str | None = "FM1",
+    artifacts: str | None = "unit_tests",
+    waivers: str | None = "none",
+) -> str:
+    fields: list[str] = []
+    if classification is not None:
+        fields.append(f"Classification: {classification}")
+    if artifacts is not None:
+        fields.append(f"Required artifacts: {artifacts}")
+    if waivers is not None:
+        fields.append(f"Waivers: {waivers}")
+    classification_section = "\n".join(fields)
+    return f"""# ADR-{ADR_CLASSIFICATION_REQUIRED_FROM:03d}: New Semantic Surface
+
+## Status
+
+proposed
+
+## Date
+
+2026-06-12
+
+## Classification
+
+{classification_section}
+
+## Context
+
+This proposed ADR adds a semantic runtime surface.
+
+## Decision
+
+Record a semantic decision.
+
+## Alternatives Considered
+
+None.
+
+## Consequences
+
+The new decision is auditable.
+"""
+
+
+def _ledger_entry(
+    adr: str = "ADR-023",
+    *,
+    fm_level: str = "FM1",
+    include_unit_test: bool = True,
+) -> str:
+    delivered = [
+        f"      - kind: invariant_list\n        path: docs/decisions/adrs/adr-{adr[-3:]}-surface.md",
+    ]
+    if include_unit_test:
+        delivered.append(
+            "      - kind: unit_tests\n        path: implementations/python/tests/test_assurance_policy_surface.py"
+        )
+    return f"""  - adr: {adr}
+    surface: Example runtime surface
+    fm_level: {fm_level}
+    delivered_artifacts:
+{chr(10).join(delivered)}
+    waived_artifacts: []
+"""
+
+
+def _seed_runtime_surface(repo: Path, adr: str = "ADR-023") -> None:
+    _write(repo / f"docs/decisions/adrs/adr-{adr[-3:]}-surface.md", f"# {adr}: Surface\n")
+    _write(repo / "implementations/python/tests/test_assurance_policy_surface.py")
 
 
 # ----------------------------------------------------------------------------- #
@@ -793,6 +924,105 @@ def test_fm4_with_artifacts_not_superset_of_fm3_is_flagged(tmp_path: Path) -> No
     failures = evaluate_assurance_policy(_seed_repo(tmp_path, policy_body=body))
     assert _flagged(failures, "assurance-policy-proportionality")
     assert _flagged(failures, "FM4")
+
+
+# ----------------------------------------------------------------------------- #
+# ADR classification and per-change FM ledger.                                  #
+# ----------------------------------------------------------------------------- #
+
+
+def test_new_adr_without_classification_is_flagged(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    _write(
+        repo / f"docs/decisions/adrs/adr-{ADR_CLASSIFICATION_REQUIRED_FROM:03d}-new-semantic-surface.md",
+        _new_adr_body(classification=None),
+    )
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "adr-classification-missing")
+
+
+def test_new_adr_with_unknown_fm_level_is_flagged(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    _write(
+        repo / f"docs/decisions/adrs/adr-{ADR_CLASSIFICATION_REQUIRED_FROM:03d}-new-semantic-surface.md",
+        _new_adr_body(classification="FM9"),
+    )
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "adr-classification-level")
+    assert _flagged(failures, "FM9")
+
+
+def test_new_adr_missing_required_artifacts_line_is_flagged(tmp_path: Path) -> None:
+    repo = _seed_repo(tmp_path)
+    _write(
+        repo / f"docs/decisions/adrs/adr-{ADR_CLASSIFICATION_REQUIRED_FROM:03d}-new-semantic-surface.md",
+        _new_adr_body(artifacts=None),
+    )
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "adr-classification-artifacts")
+
+
+def test_adr_template_missing_classification_field_is_flagged(tmp_path: Path) -> None:
+    template = _GOOD_ADR_TEMPLATE.replace("Classification: FM<n>\n", "", 1)
+
+    failures = evaluate_assurance_policy(_seed_repo(tmp_path, adr_template_body=template))
+
+    assert _flagged(failures, "adr-template-classification")
+
+
+def test_ledger_missing_existing_runtime_surface_entry_is_flagged(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        ledger_body=(
+            f"ledger: per-change-fm-classification\npolicy_ref: {ASSURANCE_POLICY_RELATIVE_PATH}\nentries:\n"
+            f"{_ledger_entry('ADR-023')}"
+        ),
+    )
+    _seed_runtime_surface(repo, "ADR-023")
+    _seed_runtime_surface(repo, "ADR-024")
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "fm-classification-ledger-coverage")
+    assert _flagged(failures, "ADR-024")
+
+
+def test_ledger_fm_level_must_resolve_to_policy_yaml(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        ledger_body=(
+            f"ledger: per-change-fm-classification\npolicy_ref: {ASSURANCE_POLICY_RELATIVE_PATH}\nentries:\n"
+            f"{_ledger_entry(fm_level='FM9')}"
+        ),
+    )
+    _seed_runtime_surface(repo)
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "fm-classification-ledger-level")
+    assert _flagged(failures, "FM9")
+
+
+def test_ledger_required_artifacts_must_be_delivered_or_waived(tmp_path: Path) -> None:
+    repo = _seed_repo(
+        tmp_path,
+        ledger_body=(
+            f"ledger: per-change-fm-classification\npolicy_ref: {ASSURANCE_POLICY_RELATIVE_PATH}\nentries:\n"
+            f"{_ledger_entry(include_unit_test=False)}"
+        ),
+    )
+    _seed_runtime_surface(repo)
+
+    failures = evaluate_assurance_policy(repo)
+
+    assert _flagged(failures, "fm-classification-ledger-artifacts")
+    assert _flagged(failures, "unit_tests")
 
 
 # ----------------------------------------------------------------------------- #

--- a/tools/check_assurance_policy.py
+++ b/tools/check_assurance_policy.py
@@ -23,6 +23,7 @@ matching the other policy gates (``check_repo_policy.py``,
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -49,10 +50,18 @@ ASSURANCE_POLICY_RELATIVE_PATH = "specs/formal/assurance-policy.yaml"
 ADR_POLICY_RELATIVE_PATH = "docs/decisions/adrs/adr-007-lightweight-formal-methods-policy.md"
 CODING_STANDARDS_RELATIVE_PATH = "docs/explain/reference/coding-standards.md"
 FORMAL_OVERVIEW_RELATIVE_PATH = "docs/specs/formal.md"
+ADR_TEMPLATE_RELATIVE_PATH = "docs/decisions/adrs/TEMPLATE.md"
+ADR_DIRECTORY_RELATIVE_PATH = "docs/decisions/adrs"
+FM_CLASSIFICATION_LEDGER_RELATIVE_PATH = "docs/explain/reference/fm-classification-ledger.yaml"
 
 # The baseline canonical level ids. The YAML MAY add more levels (e.g. FM4),
 # but these four are the floor and must always be present.
 CANONICAL_LEVEL_IDS: tuple[str, ...] = ("FM0", "FM1", "FM2", "FM3")
+
+# ADR-060 existed before this gate. ADR-061 and later ADRs must carry the
+# explicit per-change FM classification record.
+ADR_CLASSIFICATION_REQUIRED_FROM = 61
+FM_LEDGER_RUNTIME_ADR_RANGE = range(23, 59)
 
 # The four words in the ASR-505 statement -- the validator pins each to a
 # specific level so reordering does not silently keep passing.
@@ -111,6 +120,11 @@ _LEVEL_SEQUENCE_FIELDS: tuple[str, ...] = (
     "prohibited_artifacts",
 )
 _FM0_PROHIBITED_ARTIFACTS: frozenset[str] = frozenset({"TLA+", "Alloy"})
+_ADR_FILE_RE = re.compile(r"^adr-(\d{3})-.+\.md$")
+_ADR_CLASSIFICATION_RE = re.compile(r"^Classification:\s*(FM\d+)\s*$", re.MULTILINE)
+_ADR_REQUIRED_ARTIFACTS_RE = re.compile(r"^Required artifacts:\s*(.+?)\s*$", re.MULTILINE)
+_ADR_WAIVERS_RE = re.compile(r"^Waivers:\s*(.+?)\s*$", re.MULTILINE)
+_LEDGER_VALUE = "per-change-fm-classification"
 
 # Human-readable phrasings for each YAML artifact slug. The drift guard
 # requires the union of required artifacts (across all levels in the YAML) to
@@ -499,6 +513,431 @@ def _required_artifact_union(levels: list[Any]) -> set[str]:
     return union
 
 
+def _level_ids(levels: list[Any]) -> set[str]:
+    """Return valid FM level ids from the canonical YAML."""
+    return {level["id"] for level in levels if isinstance(level, dict) and isinstance(level.get("id"), str)}
+
+
+def _required_artifacts_by_level(levels: list[Any]) -> dict[str, set[str]]:
+    """Return YAML-required artifact kinds per FM level."""
+    by_level: dict[str, set[str]] = {}
+    for level in levels:
+        if isinstance(level, dict) and isinstance(level.get("id"), str):
+            by_level[level["id"]] = set(_level_sequence(level, "required_artifacts"))
+    return by_level
+
+
+def _is_filled_field(value: str | None) -> bool:
+    """Return true when a template field has been replaced with a real value."""
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    if not normalized:
+        return False
+    if normalized in {"tbd", "todo", "none yet", "n/a"}:
+        return False
+    return "<" not in value and "..." not in value
+
+
+def _adr_number(path: Path) -> int | None:
+    match = _ADR_FILE_RE.match(path.name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _adr_id_from_number(number: int) -> str:
+    return f"ADR-{number:03d}"
+
+
+def _find_adr_path(repo_root: Path, adr_id: str) -> Path | None:
+    suffix = adr_id.removeprefix("ADR-")
+    if not suffix.isdigit():
+        return None
+    adr_dir = repo_root / ADR_DIRECTORY_RELATIVE_PATH
+    matches = sorted(adr_dir.glob(f"adr-{suffix}-*.md"))
+    return matches[0] if matches else None
+
+
+def _resolve_repo_path(repo_root: Path, relative_path: str) -> Path | None:
+    root = repo_root.resolve()
+    candidate = (root / relative_path).resolve()
+    if candidate == root or root in candidate.parents:
+        return candidate
+    return None
+
+
+def _check_adr_template_classification(repo_root: Path) -> list[PolicyFailure]:
+    template_path = repo_root / ADR_TEMPLATE_RELATIVE_PATH
+    if not template_path.is_file():
+        return [_fail("adr-template-classification", "ADR template is missing", ADR_TEMPLATE_RELATIVE_PATH)]
+    text = template_path.read_text(encoding="utf-8")
+    required_snippets = (
+        "## Classification",
+        "Classification: FM<n>",
+        "Required artifacts:",
+        "Waivers:",
+    )
+    missing = [snippet for snippet in required_snippets if snippet not in text]
+    if missing:
+        return [
+            _fail(
+                "adr-template-classification",
+                "ADR template is missing FM classification field(s): " + ", ".join(missing),
+                ADR_TEMPLATE_RELATIVE_PATH,
+            )
+        ]
+    return []
+
+
+def _check_new_adr_classifications(repo_root: Path, level_ids: set[str]) -> list[PolicyFailure]:
+    adr_dir = repo_root / ADR_DIRECTORY_RELATIVE_PATH
+    if not adr_dir.is_dir():
+        return []
+    failures: list[PolicyFailure] = []
+    for adr_path in sorted(adr_dir.glob("adr-*.md")):
+        number = _adr_number(adr_path)
+        if number is None or number < ADR_CLASSIFICATION_REQUIRED_FROM:
+            continue
+        rel_path = adr_path.relative_to(repo_root).as_posix()
+        text = adr_path.read_text(encoding="utf-8")
+        classification_matches = _ADR_CLASSIFICATION_RE.findall(text)
+        if len(classification_matches) != 1:
+            failures.append(
+                _fail(
+                    "adr-classification-missing",
+                    f"{_adr_id_from_number(number)} must contain exactly one 'Classification: FM<n>' field",
+                    rel_path,
+                )
+            )
+            continue
+        level_id = classification_matches[0]
+        if level_id not in level_ids:
+            failures.append(
+                _fail(
+                    "adr-classification-level",
+                    f"{_adr_id_from_number(number)} classification level {level_id} "
+                    f"is not defined in {ASSURANCE_POLICY_RELATIVE_PATH}",
+                    rel_path,
+                )
+            )
+        artifacts_match = _ADR_REQUIRED_ARTIFACTS_RE.search(text)
+        if not _is_filled_field(artifacts_match.group(1) if artifacts_match else None):
+            failures.append(
+                _fail(
+                    "adr-classification-artifacts",
+                    f"{_adr_id_from_number(number)} must name required artifacts delivered or waived",
+                    rel_path,
+                )
+            )
+        waivers_match = _ADR_WAIVERS_RE.search(text)
+        if not _is_filled_field(waivers_match.group(1) if waivers_match else None):
+            failures.append(
+                _fail(
+                    "adr-classification-waivers",
+                    f"{_adr_id_from_number(number)} must name waivers or explicitly say none",
+                    rel_path,
+                )
+            )
+    return failures
+
+
+def _runtime_adr_ids_present(repo_root: Path) -> set[str]:
+    adr_dir = repo_root / ADR_DIRECTORY_RELATIVE_PATH
+    if not adr_dir.is_dir():
+        return set()
+    present: set[str] = set()
+    for path in adr_dir.glob("adr-*.md"):
+        number = _adr_number(path)
+        if number in FM_LEDGER_RUNTIME_ADR_RANGE:
+            present.add(_adr_id_from_number(number))
+    return present
+
+
+def _check_ledger_artifact(
+    repo_root: Path,
+    entry_id: str,
+    artifact: Any,
+    valid_artifact_kinds: set[str],
+    index: int,
+) -> tuple[str | None, list[PolicyFailure]]:
+    path = FM_CLASSIFICATION_LEDGER_RELATIVE_PATH
+    if not isinstance(artifact, dict):
+        return None, [
+            _fail(
+                "fm-classification-ledger-artifact",
+                f"{entry_id} delivered_artifacts[{index}] must be a mapping",
+                path,
+            )
+        ]
+    kind = artifact.get("kind")
+    artifact_path = artifact.get("path")
+    failures: list[PolicyFailure] = []
+    if not isinstance(kind, str) or kind not in valid_artifact_kinds:
+        failures.append(
+            _fail(
+                "fm-classification-ledger-artifact",
+                f"{entry_id} delivered_artifacts[{index}].kind must be one of "
+                f"{sorted(valid_artifact_kinds)}; got {kind!r}",
+                path,
+            )
+        )
+    if not isinstance(artifact_path, str) or not artifact_path.strip():
+        failures.append(
+            _fail(
+                "fm-classification-ledger-artifact",
+                f"{entry_id} delivered_artifacts[{index}].path must be a non-empty repo-relative path",
+                path,
+            )
+        )
+    else:
+        resolved = _resolve_repo_path(repo_root, artifact_path)
+        if resolved is None:
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-artifact",
+                    f"{entry_id} delivered artifact path escapes the repo root: {artifact_path}",
+                    path,
+                )
+            )
+        elif not resolved.exists():
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-artifact",
+                    f"{entry_id} delivered artifact path does not exist: {artifact_path}",
+                    path,
+                )
+            )
+    return kind if isinstance(kind, str) else None, failures
+
+
+def _check_ledger_waiver(
+    entry_id: str,
+    waiver: Any,
+    valid_artifact_kinds: set[str],
+    index: int,
+) -> tuple[str | None, list[PolicyFailure]]:
+    path = FM_CLASSIFICATION_LEDGER_RELATIVE_PATH
+    if not isinstance(waiver, dict):
+        return None, [
+            _fail(
+                "fm-classification-ledger-waiver",
+                f"{entry_id} waived_artifacts[{index}] must be a mapping",
+                path,
+            )
+        ]
+    kind = waiver.get("kind")
+    rationale = waiver.get("rationale")
+    failures: list[PolicyFailure] = []
+    if not isinstance(kind, str) or kind not in valid_artifact_kinds:
+        failures.append(
+            _fail(
+                "fm-classification-ledger-waiver",
+                f"{entry_id} waived_artifacts[{index}].kind must be one of "
+                f"{sorted(valid_artifact_kinds)}; got {kind!r}",
+                path,
+            )
+        )
+    if not isinstance(rationale, str) or not rationale.strip():
+        failures.append(
+            _fail(
+                "fm-classification-ledger-waiver",
+                f"{entry_id} waived_artifacts[{index}].rationale must be non-empty",
+                path,
+            )
+        )
+    return kind if isinstance(kind, str) else None, failures
+
+
+def _check_fm_classification_ledger(repo_root: Path, levels: list[Any]) -> list[PolicyFailure]:
+    ledger_path = repo_root / FM_CLASSIFICATION_LEDGER_RELATIVE_PATH
+    if not ledger_path.is_file():
+        return [
+            _fail(
+                "fm-classification-ledger-missing",
+                f"FM classification ledger not found: {FM_CLASSIFICATION_LEDGER_RELATIVE_PATH}",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        ]
+    try:
+        raw = yaml.safe_load(ledger_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [
+            _fail(
+                "fm-classification-ledger-parse",
+                f"failed to parse {FM_CLASSIFICATION_LEDGER_RELATIVE_PATH}: {exc}",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        ]
+    if not isinstance(raw, dict):
+        return [
+            _fail(
+                "fm-classification-ledger-shape",
+                f"{FM_CLASSIFICATION_LEDGER_RELATIVE_PATH} must be a YAML mapping at the top level",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        ]
+
+    failures: list[PolicyFailure] = []
+    if raw.get("ledger") != _LEDGER_VALUE:
+        failures.append(
+            _fail(
+                "fm-classification-ledger-field",
+                f"ledger field must be {_LEDGER_VALUE!r}",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        )
+    if raw.get("policy_ref") != ASSURANCE_POLICY_RELATIVE_PATH:
+        failures.append(
+            _fail(
+                "fm-classification-ledger-policy-ref",
+                f"policy_ref must be {ASSURANCE_POLICY_RELATIVE_PATH}",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        )
+
+    entries = raw.get("entries")
+    if not isinstance(entries, list):
+        return failures + [
+            _fail(
+                "fm-classification-ledger-field",
+                "entries must be a YAML list",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        ]
+
+    level_ids = _level_ids(levels)
+    required_by_level = _required_artifacts_by_level(levels)
+    valid_artifact_kinds = _required_artifact_union(levels)
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-entry",
+                    f"entries[{index}] must be a mapping",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+            continue
+        adr = entry.get("adr")
+        entry_id = adr if isinstance(adr, str) else f"entries[{index}]"
+        if not isinstance(adr, str) or not re.fullmatch(r"ADR-\d{3}", adr):
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-entry",
+                    f"entries[{index}].adr must be an ADR-NNN id",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+        elif adr in seen:
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-duplicate",
+                    f"ledger contains duplicate entry for {adr}",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+        else:
+            seen.add(adr)
+            if _find_adr_path(repo_root, adr) is None:
+                failures.append(
+                    _fail(
+                        "fm-classification-ledger-entry",
+                        f"{adr} does not resolve to an ADR file under {ADR_DIRECTORY_RELATIVE_PATH}",
+                        FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                    )
+                )
+        surface = entry.get("surface")
+        if not isinstance(surface, str) or not surface.strip():
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-entry",
+                    f"{entry_id}.surface must be non-empty",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+        fm_level = entry.get("fm_level")
+        if not isinstance(fm_level, str) or fm_level not in level_ids:
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-level",
+                    f"{entry_id}.fm_level {fm_level!r} is not defined in {ASSURANCE_POLICY_RELATIVE_PATH}",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+            required = set()
+        else:
+            required = required_by_level.get(fm_level, set())
+
+        delivered = entry.get("delivered_artifacts")
+        if not isinstance(delivered, list):
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-artifact",
+                    f"{entry_id}.delivered_artifacts must be a YAML list",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+            delivered = []
+        delivered_kinds: set[str] = set()
+        for artifact_index, artifact in enumerate(delivered):
+            kind, artifact_failures = _check_ledger_artifact(
+                repo_root,
+                entry_id,
+                artifact,
+                valid_artifact_kinds,
+                artifact_index,
+            )
+            if kind is not None:
+                delivered_kinds.add(kind)
+            failures.extend(artifact_failures)
+
+        waived = entry.get("waived_artifacts", [])
+        if not isinstance(waived, list):
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-waiver",
+                    f"{entry_id}.waived_artifacts must be a YAML list when present",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+            waived = []
+        waived_kinds: set[str] = set()
+        for waiver_index, waiver in enumerate(waived):
+            kind, waiver_failures = _check_ledger_waiver(
+                entry_id,
+                waiver,
+                valid_artifact_kinds,
+                waiver_index,
+            )
+            if kind is not None:
+                waived_kinds.add(kind)
+            failures.extend(waiver_failures)
+
+        missing_required = sorted(required - delivered_kinds - waived_kinds)
+        if missing_required:
+            failures.append(
+                _fail(
+                    "fm-classification-ledger-artifacts",
+                    f"{entry_id} ({fm_level}) must deliver or waive required artifact kind(s): {missing_required}",
+                    FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+                )
+            )
+
+    missing = sorted(_runtime_adr_ids_present(repo_root) - seen)
+    if missing:
+        failures.append(
+            _fail(
+                "fm-classification-ledger-coverage",
+                f"ledger must cover existing runtime-surface ADRs {FM_LEDGER_RUNTIME_ADR_RANGE.start:03d}-"
+                f"{FM_LEDGER_RUNTIME_ADR_RANGE.stop - 1:03d}; missing: {missing}",
+                FM_CLASSIFICATION_LEDGER_RELATIVE_PATH,
+            )
+        )
+    return failures
+
+
 def _check_artifact_keyword_drift(
     repo_root: Path,
     doc_rel: str,
@@ -716,6 +1155,10 @@ def evaluate_assurance_policy(repo_root: Path) -> list[PolicyFailure]:
             required_artifacts,
         )
     )
+
+    failures.extend(_check_adr_template_classification(repo_root))
+    failures.extend(_check_new_adr_classifications(repo_root, _level_ids(levels)))
+    failures.extend(_check_fm_classification_ledger(repo_root, levels))
 
     return failures
 


### PR DESCRIPTION
## Summary

Adds the FM classification record and gate for ADR assurance policy enforcement.

## Requirement UIDs

- `ASR-505`

## Related Issues

Closes #483

## ADR Impact

- docs/decisions/adrs/adr-002-declarative-sdl-objectives.md

## Changes

- Extended `tools/check_assurance_policy.py` to require the ADR template classification block, validate ADR-061+ classification records, and check a backfilled FM classification ledger for ADR-023 through ADR-058 against `specs/formal/assurance-policy.yaml`.
- Added `docs/explain/reference/fm-classification-ledger.yaml` and linked it from the shared semantic integrity reference docs.
- Updated the ADR template with classification, required artifact, and waiver fields.
- Added focused assurance-policy tests for new ADR classification failures, template coverage, ledger coverage, FM-level resolution, and required artifact enforcement.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Passed: `ACES_REQUIREMENT_UID=ASR-505 implementations/python/.venv/bin/python -m pytest implementations/python/tests/test_assurance_policy.py -q`; `ACES_REQUIREMENT_UID=ASR-505 implementations/python/.venv/bin/python tools/check_assurance_policy.py`; `ACES_REQUIREMENT_UID=ASR-505 implementations/python/.venv/bin/python tools/check_repo_policy.py`; `ACES_REQUIREMENT_UID=ASR-505 implementations/python/.venv/bin/python tools/check_requirement_governance.py` (local Ground Control HTTP endpoint timed out; checker exited 0 with skip); `ACES_REQUIREMENT_UID=ASR-505 implementations/python/.venv/bin/python tools/verify_all.py`; `ACES_REQUIREMENT_UID=ASR-505 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`; `ACES_REQUIREMENT_UID=ASR-505 pre-commit run --all-files`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: tools/check_assurance_policy.py, docs/decisions/adrs/TEMPLATE.md, docs/explain/reference/fm-classification-ledger.yaml, docs/explain/reference/shared-semantic-integrity.md
- TESTS: implementations/python/tests/test_assurance_policy.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/483.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
