### PR TITLE
fix: preserve inventory target secrets

### DIFF
--- a/.claude/skills/aces-asset-inventory-capture/SKILL.md
+++ b/.claude/skills/aces-asset-inventory-capture/SKILL.md
@@ -20,8 +20,12 @@ For Docker/Compose/container-image captures, start by copying
 `scripts/capture-container-evidence-template.sh` and
 `scripts/normalize-syft-cyclonedx.jq` into the target bundle as runnable capture
 resources, then tailor the copied script for asset-specific source paths,
-filesystem manifests, and redaction names. Keep every evidence-affecting
-normalization in the script or a referenced jq file.
+filesystem manifests, and any explicit operator/out-of-scenario withholding
+rules. Set `CAPTURE_BOUNDARY=scenario-target` only after confirming the script
+is pointed at participant-discoverable target state, and set
+`OPERATOR_SECRET_NAME_REGEX` only for material classified outside that boundary.
+Keep every evidence-affecting normalization in the script or a referenced jq
+file.
 
 ## Inputs
 
@@ -47,10 +51,10 @@ Produce a bundle that validates with the current APTL reference ledger tooling:
 - `capture-evidence.sh` or equivalent committed capture commands, derived from
   the template for Docker/Compose assets when applicable;
 - `mapping-ledger.yaml` using the current reference ledger schema;
-- `evidence/` with raw or redacted evidence files;
+- `evidence/` with source evidence files;
 - `evidence/capture-limits.txt` with one first-class limit for every skipped
   required step, declined useful-optional step, contamination boundary, or
-  redaction that changes what was captured;
+  operator/out-of-scenario withholding that changes what was captured;
 - `evidence/captured-at-utc.txt`;
 - `evidence/evidence-sha256sums.txt` covering committed evidence files.
 
@@ -117,13 +121,26 @@ No `needs_gap_triage` row may remain at review time.
    intact and separate filesystem provenance is captured or the omission is
    recorded in `capture-limits.txt`.
 
-5. Hash and redact before committing.
+5. Preserve scenario-target secrets and withhold only operator material.
 
-   Follow ADR-029 redaction discipline. Do not place credentials, bearer
-   tokens, private keys, generated service secrets, cookies, session ids, or
-   operator-only values in evidence, logs, argv, tracebacks, issue comments, or
-   `mapping-ledger.yaml`. Participant-visible fixture secrets may be retained
-   only through the repo-approved secret-fixture classification.
+   Follow ADR-057 as the inventory boundary. Scenario-target secrets are
+   capture facts and must not be redacted from source inventory bundles when a
+   participant or in-range agent could discover them. This includes passwords,
+   hashes, private keys, tokens, generated range secrets, service config
+   secrets, and security product state required to realize or inspect the
+   target. The Wazuh/OpenSearch Security `internal_users.yml` bcrypt hashes
+   from APTL #341 are the canonical example: preserve them unredacted in the
+   source evidence bundle because they are target configuration facts.
+
+   Operator/out-of-scenario secrets remain outside the inventory boundary.
+   Host SSH keys, cloud or CI tokens, maintainer credentials, local
+   control-plane secrets, workstation secrets, and accidental adjacent
+   environment material must not be captured as scenario facts. Exclude them
+   or record a first-class `capture-limits.txt` entry describing the withheld
+   scope. ADR-029 still governs operator-secret handling in logs, argv,
+   tracebacks, issue comments, and other non-evidence surfaces.
+   Sanitized/public exports are separate derived views; do not replace source
+   evidence with `<REDACTED>` placeholders as the default safety mechanism.
 
 6. Build the ledger fact-by-fact.
 
@@ -200,7 +217,8 @@ Before returning:
 - every evidence file is referenced from `mapping-ledger.yaml`;
 - `capture-limits.txt` records skipped methodology steps as first-class
   limits;
-- no raw secrets or operator-only values are committed;
+- scenario-target secrets are preserved as source capture facts, while
+  operator/out-of-scenario material is excluded or recorded as a capture limit;
 - `aptl aces-inventory validate <asset-dir>` passes;
 - `aptl aces-inventory gaps <asset-dir>` has no unresolved
   `needs_gap_triage`;

--- a/.claude/skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh
+++ b/.claude/skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh
@@ -10,7 +10,8 @@ CONTAINER="${CONTAINER:-}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/docker-compose.yml}"
 COMPOSE_SERVICE="${COMPOSE_SERVICE:-}"
 COMPOSE_PROFILES="${COMPOSE_PROFILES:-}"
-SECRET_NAME_REGEX="${SECRET_NAME_REGEX:-(token|secret|password|credential|cookie|session|private_key|api_key|jwt|flag_key)}"
+CAPTURE_BOUNDARY="${CAPTURE_BOUNDARY:-}"
+OPERATOR_SECRET_NAME_REGEX="${OPERATOR_SECRET_NAME_REGEX:-}"
 
 TRIVY_IMAGE="${TRIVY_IMAGE:-aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e}"
 SYFT_IMAGE="${SYFT_IMAGE:-anchore/syft@sha256:86fde6445b483d902fe011dd9f68c4987dd94e07da1e9edc004e3c2422650de6}"
@@ -26,12 +27,25 @@ require() {
   }
 }
 
+require_capture_boundary() {
+  if [[ "$CAPTURE_BOUNDARY" != "scenario-target" ]]; then
+    printf '%s\n' \
+      "Set CAPTURE_BOUNDARY=scenario-target after confirming this capture is scoped to participant-discoverable target state." \
+      "Use OPERATOR_SECRET_NAME_REGEX only for operator/out-of-scenario material that must be withheld." >&2
+    exit 2
+  fi
+}
+
 record_limit() {
   printf -- '- %s\n' "$*" >> "$OUT/capture-limits.txt"
 }
 
 redact_text_stream() {
-  awk -v secret_re="$SECRET_NAME_REGEX" '
+  if [[ -z "$OPERATOR_SECRET_NAME_REGEX" ]]; then
+    cat
+    return
+  fi
+  awk -v secret_re="$OPERATOR_SECRET_NAME_REGEX" '
     {
       for (i = 1; i <= NF; i++) {
         token = $i
@@ -57,7 +71,7 @@ redact_text_stream() {
 
 redact_env_jq='
   def redact_env($secret_re):
-    if contains("=") then
+    if (($secret_re | length) > 0) and contains("=") then
       capture("^(?<name>[^=]+)=(?<value>.*)$") as $m
       | if ($m.name | test($secret_re; "i")) then
           "\($m.name)=<REDACTED-\($m.name | gsub("_"; "-"))>"
@@ -69,28 +83,40 @@ redact_env_jq='
     end;
 
   def redact_sensitive_keys($secret_re):
-    walk(
-      if type == "object" then
-        with_entries(
-          if (.key | test($secret_re; "i")) then
-            .value = "<REDACTED>"
-          else
-            .
-          end
-        )
-      else
-        .
-      end
-    );
+    if ($secret_re | length) == 0 then
+      .
+    else
+      walk(
+        if type == "object" then
+          with_entries(
+            if (.key | test($secret_re; "i")) then
+              .value = "<REDACTED>"
+            else
+              .
+            end
+          )
+        else
+          .
+        end
+      )
+    end;
 '
 
 require docker
 require jq
 require sha256sum
+require_capture_boundary
 
 mkdir -p "$OUT"
 : > "$OUT/capture-limits.txt"
 date -u +"%Y-%m-%dT%H:%M:%SZ" > "$OUT/captured-at-utc.txt"
+
+# With CAPTURE_BOUNDARY=scenario-target, this template preserves scenario-target values by default.
+# Configure OPERATOR_SECRET_NAME_REGEX only after classifying a value as
+# operator/out-of-scenario material rather than target evidence.
+if [[ -n "$OPERATOR_SECRET_NAME_REGEX" ]]; then
+  record_limit "Operator/out-of-scenario values matching OPERATOR_SECRET_NAME_REGEX were withheld by the capture template; ledger must describe the boundary and evidence impact"
+fi
 
 docker version --format json | jq . > "$OUT/docker-version.json"
 if compose_version="$(docker compose version --format json 2>/dev/null)"; then
@@ -106,7 +132,7 @@ if [[ -n "$COMPOSE_SERVICE" && -f "$COMPOSE_FILE" ]]; then
     docker compose -f "$COMPOSE_FILE" config --format json
   fi | jq \
     --arg service "$COMPOSE_SERVICE" \
-    --arg secret_re "$SECRET_NAME_REGEX" '
+    --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" '
       if ((.services // {}) | has($service) | not) then
         error("compose service not found: " + $service)
       else
@@ -115,7 +141,7 @@ if [[ -n "$COMPOSE_SERVICE" && -f "$COMPOSE_FILE" ]]; then
       | .environment = (
           (.environment // {})
           | with_entries(
-              if (.key | test($secret_re; "i")) then
+              if (($secret_re | length) > 0 and (.key | test($secret_re; "i"))) then
                 .value = ("<REDACTED-" + (.key | gsub("_"; "-")) + ">")
               else
                 .
@@ -129,7 +155,7 @@ fi
 
 if [[ -n "$CONTAINER" ]]; then
   docker inspect "$CONTAINER" \
-    | jq --arg secret_re "$SECRET_NAME_REGEX" \
+    | jq --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" \
         "$redact_env_jq
         .[].Config.Env |= ((. // []) | map(redact_env(\$secret_re)))
         | redact_sensitive_keys(\$secret_re)" \
@@ -162,7 +188,7 @@ else
 fi
 
 docker image inspect "$IMAGE" \
-  | jq --arg secret_re "$SECRET_NAME_REGEX" "$redact_env_jq redact_sensitive_keys(\$secret_re)" \
+  | jq --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" "$redact_env_jq redact_sensitive_keys(\$secret_re)" \
   > "$OUT/docker-inspect.image.json"
 docker history --no-trunc "$IMAGE" | redact_text_stream > "$OUT/docker-history.image.txt"
 

--- a/.codex-skills/aces-asset-inventory-capture/SKILL.md
+++ b/.codex-skills/aces-asset-inventory-capture/SKILL.md
@@ -20,8 +20,12 @@ For Docker/Compose/container-image captures, start by copying
 `scripts/capture-container-evidence-template.sh` and
 `scripts/normalize-syft-cyclonedx.jq` into the target bundle as runnable capture
 resources, then tailor the copied script for asset-specific source paths,
-filesystem manifests, and redaction names. Keep every evidence-affecting
-normalization in the script or a referenced jq file.
+filesystem manifests, and any explicit operator/out-of-scenario withholding
+rules. Set `CAPTURE_BOUNDARY=scenario-target` only after confirming the script
+is pointed at participant-discoverable target state, and set
+`OPERATOR_SECRET_NAME_REGEX` only for material classified outside that boundary.
+Keep every evidence-affecting normalization in the script or a referenced jq
+file.
 
 ## Inputs
 
@@ -47,10 +51,10 @@ Produce a bundle that validates with the current APTL reference ledger tooling:
 - `capture-evidence.sh` or equivalent committed capture commands, derived from
   the template for Docker/Compose assets when applicable;
 - `mapping-ledger.yaml` using the current reference ledger schema;
-- `evidence/` with raw or redacted evidence files;
+- `evidence/` with source evidence files;
 - `evidence/capture-limits.txt` with one first-class limit for every skipped
   required step, declined useful-optional step, contamination boundary, or
-  redaction that changes what was captured;
+  operator/out-of-scenario withholding that changes what was captured;
 - `evidence/captured-at-utc.txt`;
 - `evidence/evidence-sha256sums.txt` covering committed evidence files.
 
@@ -117,13 +121,26 @@ No `needs_gap_triage` row may remain at review time.
    intact and separate filesystem provenance is captured or the omission is
    recorded in `capture-limits.txt`.
 
-5. Hash and redact before committing.
+5. Preserve scenario-target secrets and withhold only operator material.
 
-   Follow ADR-029 redaction discipline. Do not place credentials, bearer
-   tokens, private keys, generated service secrets, cookies, session ids, or
-   operator-only values in evidence, logs, argv, tracebacks, issue comments, or
-   `mapping-ledger.yaml`. Participant-visible fixture secrets may be retained
-   only through the repo-approved secret-fixture classification.
+   Follow ADR-057 as the inventory boundary. Scenario-target secrets are
+   capture facts and must not be redacted from source inventory bundles when a
+   participant or in-range agent could discover them. This includes passwords,
+   hashes, private keys, tokens, generated range secrets, service config
+   secrets, and security product state required to realize or inspect the
+   target. The Wazuh/OpenSearch Security `internal_users.yml` bcrypt hashes
+   from APTL #341 are the canonical example: preserve them unredacted in the
+   source evidence bundle because they are target configuration facts.
+
+   Operator/out-of-scenario secrets remain outside the inventory boundary.
+   Host SSH keys, cloud or CI tokens, maintainer credentials, local
+   control-plane secrets, workstation secrets, and accidental adjacent
+   environment material must not be captured as scenario facts. Exclude them
+   or record a first-class `capture-limits.txt` entry describing the withheld
+   scope. ADR-029 still governs operator-secret handling in logs, argv,
+   tracebacks, issue comments, and other non-evidence surfaces.
+   Sanitized/public exports are separate derived views; do not replace source
+   evidence with `<REDACTED>` placeholders as the default safety mechanism.
 
 6. Build the ledger fact-by-fact.
 
@@ -200,7 +217,8 @@ Before returning:
 - every evidence file is referenced from `mapping-ledger.yaml`;
 - `capture-limits.txt` records skipped methodology steps as first-class
   limits;
-- no raw secrets or operator-only values are committed;
+- scenario-target secrets are preserved as source capture facts, while
+  operator/out-of-scenario material is excluded or recorded as a capture limit;
 - `aptl aces-inventory validate <asset-dir>` passes;
 - `aptl aces-inventory gaps <asset-dir>` has no unresolved
   `needs_gap_triage`;

--- a/.codex-skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh
+++ b/.codex-skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh
@@ -10,7 +10,8 @@ CONTAINER="${CONTAINER:-}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT/docker-compose.yml}"
 COMPOSE_SERVICE="${COMPOSE_SERVICE:-}"
 COMPOSE_PROFILES="${COMPOSE_PROFILES:-}"
-SECRET_NAME_REGEX="${SECRET_NAME_REGEX:-(token|secret|password|credential|cookie|session|private_key|api_key|jwt|flag_key)}"
+CAPTURE_BOUNDARY="${CAPTURE_BOUNDARY:-}"
+OPERATOR_SECRET_NAME_REGEX="${OPERATOR_SECRET_NAME_REGEX:-}"
 
 TRIVY_IMAGE="${TRIVY_IMAGE:-aquasec/trivy@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e}"
 SYFT_IMAGE="${SYFT_IMAGE:-anchore/syft@sha256:86fde6445b483d902fe011dd9f68c4987dd94e07da1e9edc004e3c2422650de6}"
@@ -26,12 +27,25 @@ require() {
   }
 }
 
+require_capture_boundary() {
+  if [[ "$CAPTURE_BOUNDARY" != "scenario-target" ]]; then
+    printf '%s\n' \
+      "Set CAPTURE_BOUNDARY=scenario-target after confirming this capture is scoped to participant-discoverable target state." \
+      "Use OPERATOR_SECRET_NAME_REGEX only for operator/out-of-scenario material that must be withheld." >&2
+    exit 2
+  fi
+}
+
 record_limit() {
   printf -- '- %s\n' "$*" >> "$OUT/capture-limits.txt"
 }
 
 redact_text_stream() {
-  awk -v secret_re="$SECRET_NAME_REGEX" '
+  if [[ -z "$OPERATOR_SECRET_NAME_REGEX" ]]; then
+    cat
+    return
+  fi
+  awk -v secret_re="$OPERATOR_SECRET_NAME_REGEX" '
     {
       for (i = 1; i <= NF; i++) {
         token = $i
@@ -57,7 +71,7 @@ redact_text_stream() {
 
 redact_env_jq='
   def redact_env($secret_re):
-    if contains("=") then
+    if (($secret_re | length) > 0) and contains("=") then
       capture("^(?<name>[^=]+)=(?<value>.*)$") as $m
       | if ($m.name | test($secret_re; "i")) then
           "\($m.name)=<REDACTED-\($m.name | gsub("_"; "-"))>"
@@ -69,28 +83,40 @@ redact_env_jq='
     end;
 
   def redact_sensitive_keys($secret_re):
-    walk(
-      if type == "object" then
-        with_entries(
-          if (.key | test($secret_re; "i")) then
-            .value = "<REDACTED>"
-          else
-            .
-          end
-        )
-      else
-        .
-      end
-    );
+    if ($secret_re | length) == 0 then
+      .
+    else
+      walk(
+        if type == "object" then
+          with_entries(
+            if (.key | test($secret_re; "i")) then
+              .value = "<REDACTED>"
+            else
+              .
+            end
+          )
+        else
+          .
+        end
+      )
+    end;
 '
 
 require docker
 require jq
 require sha256sum
+require_capture_boundary
 
 mkdir -p "$OUT"
 : > "$OUT/capture-limits.txt"
 date -u +"%Y-%m-%dT%H:%M:%SZ" > "$OUT/captured-at-utc.txt"
+
+# With CAPTURE_BOUNDARY=scenario-target, this template preserves scenario-target values by default.
+# Configure OPERATOR_SECRET_NAME_REGEX only after classifying a value as
+# operator/out-of-scenario material rather than target evidence.
+if [[ -n "$OPERATOR_SECRET_NAME_REGEX" ]]; then
+  record_limit "Operator/out-of-scenario values matching OPERATOR_SECRET_NAME_REGEX were withheld by the capture template; ledger must describe the boundary and evidence impact"
+fi
 
 docker version --format json | jq . > "$OUT/docker-version.json"
 if compose_version="$(docker compose version --format json 2>/dev/null)"; then
@@ -106,7 +132,7 @@ if [[ -n "$COMPOSE_SERVICE" && -f "$COMPOSE_FILE" ]]; then
     docker compose -f "$COMPOSE_FILE" config --format json
   fi | jq \
     --arg service "$COMPOSE_SERVICE" \
-    --arg secret_re "$SECRET_NAME_REGEX" '
+    --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" '
       if ((.services // {}) | has($service) | not) then
         error("compose service not found: " + $service)
       else
@@ -115,7 +141,7 @@ if [[ -n "$COMPOSE_SERVICE" && -f "$COMPOSE_FILE" ]]; then
       | .environment = (
           (.environment // {})
           | with_entries(
-              if (.key | test($secret_re; "i")) then
+              if (($secret_re | length) > 0 and (.key | test($secret_re; "i"))) then
                 .value = ("<REDACTED-" + (.key | gsub("_"; "-")) + ">")
               else
                 .
@@ -129,7 +155,7 @@ fi
 
 if [[ -n "$CONTAINER" ]]; then
   docker inspect "$CONTAINER" \
-    | jq --arg secret_re "$SECRET_NAME_REGEX" \
+    | jq --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" \
         "$redact_env_jq
         .[].Config.Env |= ((. // []) | map(redact_env(\$secret_re)))
         | redact_sensitive_keys(\$secret_re)" \
@@ -162,7 +188,7 @@ else
 fi
 
 docker image inspect "$IMAGE" \
-  | jq --arg secret_re "$SECRET_NAME_REGEX" "$redact_env_jq redact_sensitive_keys(\$secret_re)" \
+  | jq --arg secret_re "$OPERATOR_SECRET_NAME_REGEX" "$redact_env_jq redact_sensitive_keys(\$secret_re)" \
   > "$OUT/docker-inspect.image.json"
 docker history --no-trunc "$IMAGE" | redact_text_stream > "$OUT/docker-history.image.txt"
 

--- a/changelog.d/516.fixed.md
+++ b/changelog.d/516.fixed.md
@@ -1,0 +1,1 @@
+Corrected the ACES asset-inventory capture guidance so participant-discoverable scenario-target secrets are preserved in source evidence bundles, while operator/out-of-scenario secrets remain withheld or recorded as capture limits.

--- a/docs/aces/inventory/ad-preflight.md
+++ b/docs/aces/inventory/ad-preflight.md
@@ -19,8 +19,12 @@ the issue phase marker, but the tool did not create a repo-local note file.
 - Reuse `docs/aces/inventory/asset-inventory-methodology.md`,
   `src/aptl/core/aces_inventory.py`, `src/aptl/cli/aces_inventory.py`, the
   existing webapp and db inventory bundles, and `docs/aces/parity-inventory.yaml`.
-- Redact AD administrator credentials, generated flags, Kerberos/Samba secret
-  material, Wazuh client keys, and private key contents from committed evidence.
+- Historical note: issue #516 supersedes the original blanket-redaction rule
+  for source inventory bundles. Preserve AD administrator credentials,
+  generated flags, Kerberos/Samba secret material, Wazuh client keys, and
+  private key contents when they are participant-discoverable scenario-target
+  facts; withhold only operator/out-of-scenario material and record that
+  boundary in `capture-limits.txt`.
 - Keep legacy `aptl.core.sdl` and `scenarios/*.yaml` functional until the
   downstream APTL ADR-035 cutover PR. This issue does not change backend
   runtime behavior or flip default scenario selection.

--- a/docs/aces/inventory/asset-inventory-methodology.md
+++ b/docs/aces/inventory/asset-inventory-methodology.md
@@ -46,8 +46,8 @@ The practical reproducibility standard is therefore:
 - every captured fact has either an ACES specification mapping or an ACES
   issue for the expressivity gap;
 - the capture can be rerun with non-commercial tooling on a local lab;
-- limits, time-sensitive scanner output, mutable tags, redactions, and
-  skipped steps are recorded plainly.
+- limits, time-sensitive scanner output, mutable tags, operator/out-of-scenario
+  withholding, and skipped steps are recorded plainly.
 
 This follows the computational reproducibility framing in Peng (2011),
 Goodman, Fanelli, and Ioannidis (2016), and Boettiger (2015): preserve
@@ -122,11 +122,24 @@ instead of pretending a local build recipe exists.
 
    Preserve container inspect, network inspect, volume inspect, process
    list, listeners, mounts, OS release, users/groups, working directory,
-   command/entrypoint, exposed ports, restart policy, resource limits, and
-   bind mounts. Redact secret values before evidence enters git unless the
-   scenario explicitly requires a participant-visible secret fixture to be
-   specified; in that case, store it through the repo's approved secret-fixture
-   mechanism rather than leaking live local secrets.
+   command/entrypoint, exposed ports, restart policy, resource limits, bind
+   mounts, and scenario-target secrets. Participant-discoverable target
+   credentials, password hashes, private keys, bearer tokens, generated service
+   secrets, config secrets, and other credential-shaped values are capture
+   facts and must not be redacted from source inventory bundles. For example,
+   Wazuh/OpenSearch Security `internal_users.yml` bcrypt hashes are target
+   configuration facts; replacing them with `<REDACTED-...>` corrupts the
+   inventory and prevents later ACES/APTL mapping from seeing the realized
+   system.
+
+   Operator/out-of-scenario secrets remain outside the capture boundary:
+   host SSH keys, cloud or CI tokens, maintainer credentials, local
+   control-plane secrets, workstation secrets, unrelated prior-run
+   transcripts, and accidental adjacent-environment material are not scenario
+   facts. Exclude them, or record the withheld scope and reason as a
+   first-class `capture-limits.txt` entry. Sanitized publication/export
+   bundles are separate derived views; they must not replace the authoritative
+   source inventory bundle.
 
 6. Capture package and dependency inventory.
 
@@ -283,8 +296,8 @@ The pass proved that the method can capture an upstream-image asset with:
   surfaces, and runtime process/listener baseline;
 - OS package inventory and Go module manifests visible in the image;
 - CycloneDX SBOM and Trivy vulnerability output;
-- evidence checksums and pytest validation for redaction, digest identity,
-  SBOM structure, and severity-count consistency.
+- evidence checksums and pytest validation for capture-boundary handling,
+  digest identity, SBOM structure, and severity-count consistency.
 
 This proof pass is not yet a full maximal-discovery pass because it mostly
 uses host-side Docker evidence plus a container runtime baseline. The next

--- a/docs/aces/inventory/index.md
+++ b/docs/aces/inventory/index.md
@@ -33,6 +33,7 @@ methodology owner.
 asset-inventory-methodology
 methodology-assurance-report
 scn010-expressivity-gap-analysis
+issue-516-redaction-boundary-preflight
 webapp-preflight
 kali-preflight
 ad-preflight

--- a/docs/aces/inventory/issue-516-redaction-boundary-preflight.md
+++ b/docs/aces/inventory/issue-516-redaction-boundary-preflight.md
@@ -1,0 +1,96 @@
+# Issue 516 Inventory Redaction Boundary Preflight
+
+This note is architecture guidance for the issue 516 documentation and
+workflow cleanup. It is not an implementation plan and does not replace the
+canonical methodology, skill, or runtime ADRs.
+
+## Architecture Decisions
+
+- ADR-057 is the controlling secret-boundary decision for scenario inventory.
+  A scenario-target value that a participant or in-range agent can discover is
+  scenario content, even when it is a password, token, private key, bcrypt
+  hash, generated service secret, config secret, or other credential-shaped
+  value.
+- Source inventory bundles are authoritative capture artifacts, not sanitized
+  publication views. Sanitized exports may redact scenario secrets later, but
+  that is a separate projection concern and must not change the source bundle.
+- Operator and out-of-scenario secrets remain outside the inventory boundary:
+  host SSH keys, cloud or CI tokens, maintainer credentials, local control-plane
+  secrets, unrelated prior-run transcripts, and other values that are not facts
+  of the described target system must not be captured as scenario facts.
+- APTL #341 would have preserved the Wazuh indexer OpenSearch Security
+  `internal_users.yml` bcrypt hashes in the source evidence bundle because they
+  are target configuration facts inside the participant range.
+
+## Cross-Cutting Concerns To Reuse
+
+- Inventory authority: `docs/aces/inventory/asset-inventory-methodology.md`
+  remains the canonical capture workflow and inclusion rule.
+- Agent workflow: `.codex-skills/aces-asset-inventory-capture/SKILL.md` must
+  continue to operationalize the methodology without defining a second ledger
+  schema or secret taxonomy.
+- Template workflow:
+  `.codex-skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh`
+  is the reusable Docker/Compose capture entry point. It must not keep
+  name-based blanket redaction as the default for scenario-target evidence.
+- Runtime SDL validation: `runtime_values.enforce_observed_value_redaction()`
+  is the canonical helper for explicit `redacted` and `operator_secret`
+  omission. `name_indicates_secret()` is advisory only and must not be copied
+  into capture-time source evidence policy.
+- Ledger accountability: `mapping-ledger.yaml`, `capture-limits.txt`, evidence
+  checksums, and the downstream `aptl aces-inventory validate/gaps/schema`
+  commands remain the evidence accountability surface.
+
+## Security And Validation Layers
+
+- **Secret-handling surface:** scenario-target secrets pass through unredacted
+  when they are participant-discoverable facts. Operator/out-of-scenario
+  secrets are excluded or explicitly recorded as capture limits; they are not
+  represented as scenario facts.
+- **Schema and model validators:** no SDL schema or validator change is
+  required for this issue. Existing explicit-redaction validators already
+  reject raw values only when the author marks a field `redacted` or
+  `operator_secret`.
+- **Config and environment shapes:** do not introduce a second env parser,
+  secret classifier, or config schema. Capture scripts should parameterize the
+  scenario-vs-operator boundary instead of relying on credential-shaped names.
+- **OS/process exposure:** capture commands should avoid putting operator
+  secrets in argv, logs, tracebacks, or issue comments. Scenario-target secrets
+  that are read from target files or target runtime state may appear in source
+  evidence, but tooling should still avoid leaking unrelated host/operator
+  material through command construction.
+- **Error envelopes and observability:** CLI/test/helper failures should report
+  narrow diagnostics and avoid dumping host-side command payloads that could
+  contain operator secrets.
+
+## Extensibility Seam
+
+The reusable seam is an explicit capture-boundary parameter: target scenario
+content versus operator/out-of-scenario material. Future sanitized publication,
+teaching, or external-release workflows should consume the source bundle and
+emit a redacted projection instead of changing capture semantics or adding a
+second source-artifact schema.
+
+## Gotchas And Anti-Patterns
+
+- Do not replace blanket redaction with blanket publication of all host-side
+  material. The boundary is participant-discoverable target state.
+- Do not require `secret_fixture` for generated scenario credentials, hashes,
+  keys, or tokens that are needed to realize or inspect the range. ADR-057 made
+  `secret_fixture` an author classification, not a bypass for name-based
+  omission.
+- Do not update generated schemas under `contracts/schemas/` directly.
+- Do not edit accepted ADRs to clean up stale historical language unless the
+  change follows ADR-059 with an amendment record and pin update, or a new ADR
+  supersedes the old one.
+- Do not create a new inventory validator, secret taxonomy, exception
+  hierarchy, or logging/redaction utility for this issue.
+
+## Non-Goals
+
+- No change to SDL runtime model semantics.
+- No new source evidence schema.
+- No implementation of a sanitized export/publication pipeline.
+- No change to downstream APTL runtime behavior.
+- No broad rewrite of historical preflight notes beyond correcting or marking
+  stale guidance that could be reused as current capture policy.

--- a/docs/aces/inventory/kali-preflight.md
+++ b/docs/aces/inventory/kali-preflight.md
@@ -73,11 +73,13 @@ asset-inventorying methodology.
 - **Inventory ledger:** every captured fact needs an existing
   `AcesSurface` mapping, caveat, or linked ACES issue in
   `mapping-ledger.yaml`. No `needs_gap_triage` rows should remain at review.
-- **Secret classification:** ADR-029 is canonical. Operator secrets, private
-  SSH keys, bearer tokens, cookies, generated service config, and arbitrary
-  prior run transcripts must not be committed unredacted. Intentional target
-  fixture credentials may be encoded only when they are participant-visible
-  scenario facts with an explicit `secret_fixture`-style classification.
+- **Secret classification:** ADR-057 is canonical for scenario-target values,
+  with ADR-029 still governing operator/control-plane handling. Preserve
+  participant-discoverable target credentials, keys, tokens, generated service
+  config, and hashes as source evidence. Withhold only operator secrets,
+  private host SSH keys, control-plane bearer tokens, cookies, and arbitrary
+  prior-run transcripts that are not facts of the Kali target; record the
+  boundary in `capture-limits.txt`.
 - **Kali capture data:** ADR-033 capture surfaces can contain full argv, hidden
   PTY input, raw pcap bytes, and prior experiment data. A non-empty
   `kali_captures` volume is evidence to account for, but it is not safe to
@@ -88,9 +90,10 @@ asset-inventorying methodology.
   `find_placeholder_env_values`. Do not add ACES-specific environment parsing
   for Kali. Compose `VICTIM_IP` and SSH `APTL_*` session env vars are
   different surfaces and must not be collapsed.
-- **OS/process exposure:** inventory capture commands must not place private
-  keys, passwords, hashes, tokens, or replayable IDs in argv, logs, or
-  exception text. Store command provenance, not secret-bearing command lines.
+- **OS/process exposure:** inventory capture commands must not place
+  operator/out-of-scenario private keys, passwords, hashes, tokens, or
+  replayable IDs in argv, logs, or exception text. Store command provenance,
+  not operator-secret command lines.
 - **Runtime isolation:** preserve ADR-033 non-contamination. No Wazuh agent,
   rsyslog forwarding, or red-to-SIEM pipe belongs in Kali evidence or future
   fixes unless a later ADR explicitly overrides ADR-033.

--- a/docs/aces/inventory/webapp-preflight.md
+++ b/docs/aces/inventory/webapp-preflight.md
@@ -48,15 +48,16 @@ methodology.
 - ACES SDL authority: sibling `../aces-sdl` parser/model documentation and
   the closed ACES #354 runtime-surface gap. Do not parse
   `techvault.sdl.yaml` with `aptl.core.sdl`.
-- Secret and evidence safety: ADR-029, `aptl.utils.redaction`, the existing
-  test pattern that blocks raw secret assignments, and redacted evidence files.
+- Secret and evidence safety: ADR-057, ADR-029, `aptl.utils.redaction`, the
+  existing test pattern for explicit redaction classifications, and source
+  evidence files that preserve participant-discoverable target facts.
 
 ## Security And Validation Gates
 
-- Evidence committed to git must redact operator/control-plane secrets. The
-  webapp's intentional participant-visible fixture secrets are allowed only
-  when they are scenario facts already present in checked-in source or Compose
-  configuration.
+- Evidence committed to git must preserve participant-discoverable
+  scenario-target facts, including target credentials and config secrets. Only
+  operator/control-plane or other out-of-scenario secrets are withheld, with
+  the boundary recorded in `capture-limits.txt`.
 - Runtime evidence must cite the command/source that produced each claim:
   Docker inspect/history/network/volume/top, in-container runtime baseline,
   package manifests, filesystem hashes, and scanner output when available.

--- a/implementations/python/tests/test_agent_inventory_skill.py
+++ b/implementations/python/tests/test_agent_inventory_skill.py
@@ -11,6 +11,10 @@ SKILL_PATHS = (
     CLAUDE_SKILL_DIR / "SKILL.md",
     CODEX_SKILL_DIR / "SKILL.md",
 )
+TEMPLATE_PATHS = (
+    CLAUDE_SKILL_DIR / "scripts" / "capture-container-evidence-template.sh",
+    CODEX_SKILL_DIR / "scripts" / "capture-container-evidence-template.sh",
+)
 GAP_SKILL_PATHS = (
     GAP_CLAUDE_SKILL_DIR / "SKILL.md",
     GAP_CODEX_SKILL_DIR / "SKILL.md",
@@ -119,6 +123,49 @@ def test_asset_inventory_skill_blocks_known_agent_failure_modes() -> None:
     ]
 
     assert not missing
+
+
+def test_asset_inventory_skill_preserves_scenario_target_secrets() -> None:
+    skills = [path.read_text(encoding="utf-8") for path in SKILL_PATHS]
+    required_terms = (
+        "scenario-target secrets",
+        "capture facts",
+        "must not be redacted",
+        "operator/out-of-scenario",
+        "internal_users.yml",
+        "bcrypt hashes",
+    )
+    stale_terms = (
+        "Hash and redact before committing",
+        "Participant-visible fixture secrets may be retained only",
+        "Do not place credentials, bearer tokens, private keys, generated service secrets",
+    )
+
+    missing = [
+        (path, term)
+        for path, skill in zip(SKILL_PATHS, skills, strict=True)
+        for term in required_terms
+        if term not in skill
+    ]
+    stale = [
+        (path, term) for path, skill in zip(SKILL_PATHS, skills, strict=True) for term in stale_terms if term in skill
+    ]
+
+    assert not missing
+    assert not stale
+
+
+def test_asset_inventory_container_template_preserves_target_values_by_default() -> None:
+    claude_template = TEMPLATE_PATHS[0].read_text(encoding="utf-8")
+    codex_template = TEMPLATE_PATHS[1].read_text(encoding="utf-8")
+
+    assert claude_template == codex_template
+    assert 'CAPTURE_BOUNDARY="${CAPTURE_BOUNDARY:-}"' in claude_template
+    assert "CAPTURE_BOUNDARY=scenario-target" in claude_template
+    assert 'OPERATOR_SECRET_NAME_REGEX="${OPERATOR_SECRET_NAME_REGEX:-}"' in claude_template
+    assert 'SECRET_NAME_REGEX="${SECRET_NAME_REGEX:-' not in claude_template
+    assert "preserves scenario-target values by default" in claude_template
+    assert "operator/out-of-scenario" in claude_template
 
 
 def test_gap_remediation_skill_is_cross_agent_and_discoverable_by_codex() -> None:


### PR DESCRIPTION
## Summary

Corrects the ACES inventory capture boundary so participant-discoverable scenario-target secrets stay in source evidence bundles, while operator/out-of-scenario material requires explicit withholding.

## Requirement UIDs

- `ASR-516`

## Related Issues

Closes #516

## ADR Impact

- ADR-021
- ADR-057
- ADR-029

## Changes

- Updated the ACES asset-inventory methodology, cross-agent capture skill, and reusable container template to preserve scenario-target secrets by default after an explicit `CAPTURE_BOUNDARY=scenario-target` acknowledgement.
- Added `OPERATOR_SECRET_NAME_REGEX` as the opt-in withholding mechanism for operator/out-of-scenario values and records that boundary in `capture-limits.txt`.
- Audited historical inventory preflight guidance, added the issue 516 boundary note, and added focused tests that keep the Claude/Codex skills and templates aligned.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused test: `implementations/python/.venv/bin/python -m pytest implementations/python/tests/test_agent_inventory_skill.py`. Shell syntax: `bash -n` on both capture templates. Policy/precommit: `ACES_REQUIREMENT_UID=ASR-516 pre-commit run --all-files`. Completion gate: `ACES_REQUIREMENT_UID=ASR-516 implementations/python/.venv/bin/python tools/verify_all.py` (passed; requirement-governance step reported the existing Ground Control HTTP timeout skip and exited 0). AI review: Codex review finding fixed and re-verified; user declined over-cap cycle. Test-quality review clean.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-516 <- docs/aces/inventory/asset-inventory-methodology.md, ASR-516 <- .codex-skills/aces-asset-inventory-capture/SKILL.md, ASR-516 <- .codex-skills/aces-asset-inventory-capture/scripts/capture-container-evidence-template.sh
- TESTS: ASR-516 <- implementations/python/tests/test_agent_inventory_skill.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/516.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed