### PR TITLE
docs: accept participant ADR dependency chain

### DIFF
--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -129,10 +129,10 @@ adr-060-participant-backend-facing-contract-surface
 | [017](adr-017-conversation-surface-hardening.md) | Conversation Surface Hardening | accepted | 2026-05-17 |
 | [018](adr-018-classification-based-assurance-policy.md) | Canonical Mapping for the Classification-Based Assurance Policy | accepted | 2026-05-17 |
 | [019](adr-019-normative-authority-boundary-manifest.md) | Canonical Manifest for the Normative Artifact Authority Boundary | accepted | 2026-05-17 |
-| [020](adr-020-declarative-participant-framing-boundaries.md) | Declarative Participant Framing Boundaries | proposed | 2026-05-18 |
-| [021](adr-021-falsification-first-claim-evidence-gate.md) | Falsification-First Claim Evidence Gate | proposed | 2026-05-18 |
-| [022](adr-022-participant-behavior-and-interaction-semantics.md) | Participant Behavior and Interaction Semantics | proposed | 2026-05-18 |
-| [023](adr-023-container-image-build-provenance-surface.md) | Container Image Build Provenance Surface | proposed | 2026-05-21 |
+| [020](adr-020-declarative-participant-framing-boundaries.md) | Declarative Participant Framing Boundaries | accepted | 2026-05-18 |
+| [021](adr-021-falsification-first-claim-evidence-gate.md) | Falsification-First Claim Evidence Gate | accepted | 2026-05-18 |
+| [022](adr-022-participant-behavior-and-interaction-semantics.md) | Participant Behavior and Interaction Semantics | accepted | 2026-05-18 |
+| [023](adr-023-container-image-build-provenance-surface.md) | Container Image Build Provenance Surface | accepted | 2026-05-21 |
 | [024](adr-024-local-identity-inventory-surface.md) | Local Identity Inventory Surface | accepted | 2026-05-21 |
 | [025](adr-025-container-network-realization-surface.md) | Container Network Realization Surface | accepted | 2026-05-21 |
 | [026](adr-026-application-http-surface-inventory.md) | Application HTTP Surface Inventory | accepted | 2026-05-22 |
@@ -163,7 +163,7 @@ adr-060-participant-backend-facing-contract-surface
 | [051](adr-051-orchestration-authority-runtime-inventory.md) | Orchestration Authority Runtime Inventory | accepted | 2026-05-30 |
 | [052](adr-052-typed-runtime-relationship-subtypes.md) | Typed Runtime Relationship Subtypes | accepted | 2026-05-30 |
 | [053](adr-053-sdl-module-composition-for-inventory-backed-scenarios.md) | SDL Module Composition for Inventory-Backed Scenarios | accepted | 2026-06-03 |
-| [054](adr-054-participant-runtime-observable-lifecycle.md) | Participant Runtime Observable Lifecycle | proposed | 2026-06-05 |
+| [054](adr-054-participant-runtime-observable-lifecycle.md) | Participant Runtime Observable Lifecycle | accepted | 2026-06-05 |
 | [055](adr-055-experiment-core-contract-boundary.md) | Experiment Core Contract Boundary | accepted | 2026-05-26 |
 | [056](adr-056-runtime-observed-values-and-credential-posture.md) | Runtime Observed Values and Credential Posture | accepted | 2026-06-05 |
 | [057](adr-057-runtime-secret-name-classifier-boundaries.md) | Runtime Scenario Value Realizability and Explicit Redaction | accepted | 2026-06-06 |

--- a/docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
+++ b/docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 

--- a/docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
+++ b/docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
@@ -171,3 +171,9 @@ field names; the `agents` section heading remains the publishing surface.
 - Introduce new control-plane authentication, authorization, logging, or
   persistence machinery.
 - Move schema authority away from the existing generated-contract pipeline.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-13 | #484 | Recorded acceptance of the implemented participant framing authoring surface. |

--- a/docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+++ b/docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 

--- a/docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+++ b/docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
@@ -100,3 +100,9 @@ The first claim protocols are tracked as GitHub issues:
 
 - ASR-530: Claim Falsification And Evidence Gate
 - Issue #162: Claim falsification and evidence gate
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-13 | #484 | Recorded acceptance of the falsification-first claim evidence gate and its ASR-530/#162 linkage. |

--- a/docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
+++ b/docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 
@@ -287,18 +287,18 @@ contracts, invariants, model/state-machine coverage, negative fixtures,
 backend-conformance fixtures, mapping-loss tests, leakage tests, and run/study
 provenance checks.
 
-## Cross-Issue Dependencies And Deferred Evidence
+## Cross-Issue Boundaries And Evidence Ownership
 
 The critical review for issue #71 identified several concerns that are broader
-than participant semantics. This ADR records them as dependencies or deferrals
-instead of claiming that SEM-208 through SEM-215 solve them alone.
+than participant semantics. This ADR records the ownership boundary for those
+concerns instead of claiming that SEM-208 through SEM-215 solve them alone.
 
 | Concern | Owning issue(s) | ADR-022 obligation |
 | ------- | --------------- | ------------------ |
 | Scenario/run/study provenance and comparability | #87, #89, #105, #106 | Require participant-semantics artifacts to name the provenance fields they consume or emit; do not define the whole study model here |
 | Observability and evidence-capture adequacy | #88, #127, #128, #170, #273 | Require observation/evidence contracts to disclose capture basis, loss, latency, redaction, and observer effects |
-| Benchmark hidden truth, gold standards, canaries, holdouts, and adjudication assets | #125, #328, #333, #166 | Treat these as information-boundary objects in participant views; defer asset lifecycle, corpus governance, and assurance protocols |
-| Trajectories, demonstrations, replay, and participant datasets | #124 and its spawned trajectory issues | Require participant histories and outcomes to be compatible with replay/evidence needs; defer corpus/dataset semantics |
+| Benchmark hidden truth, gold standards, canaries, holdouts, and adjudication assets | #125, #328, #333, #166 | Treat these as information-boundary objects in participant views; leave asset lifecycle, corpus governance, and assurance protocols with their owning issues |
+| Trajectories, demonstrations, replay, and participant datasets | #124 and its spawned trajectory issues | Require participant histories and outcomes to be compatible with replay/evidence needs; leave corpus/dataset semantics with their owning issues |
 | Fidelity, backend realization, and sim/emulation transfer disclosure | #100, #165, #177, #239, #335 | Require action/observation contracts to state realization profiles and weakened guarantees |
 | Machine-checkable semantic validation and evidence gates | #162, #168 | Require participant-specific invariants and negative fixtures; broader validation evidence remains under the falsification gates |
 | DSL language adequacy and author/reviewer evaluation | #346 | Treat expressiveness, ambiguity, usability, maintainability, and domain-expert reviewability as evidence claims outside #71 |

--- a/docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
+++ b/docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
@@ -352,3 +352,9 @@ concerns as unverified claims.
 - [IEEE HLA 1516 family](https://standards.ieee.org/ieee/1516/3744/)
 - [Do Software Languages Engineers Evaluate their Languages?](https://arxiv.org/abs/1109.6794)
 - [SISO Cyber DEM](https://cdn.ymaws.com/www.sisostandards.org/resource/resmgr/standards_products/siso-std-025-2023_cyberdem.pdf)
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-13 | #484 | Recorded acceptance-time ownership-boundary wording for cross-issue evidence concerns. |

--- a/docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
+++ b/docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 
@@ -134,9 +134,10 @@ sections or overloading `runtime`.
 
 ## Non-Goals
 
-- Implementing issue #364.
-- Updating `examples/scenarios/techvault.sdl.yaml`.
-- Building or inspecting images.
+- Building or inspecting images; issue #364 shipped the declarative
+  `Source.build` authoring surface only.
+- Adding further TechVault scenario parity beyond the source build-provenance
+  examples already used to validate issue #364.
 - Defining a backend build executor, Docker Compose authoring format, registry
   distribution service, or OCI module packaging policy.
 - Adding archival run-provenance contracts beyond the SDL expressivity needed

--- a/docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
+++ b/docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
@@ -170,3 +170,9 @@ sections or overloading `runtime`.
   values enter diagnostics.
 - Overfitting to Dockerfile syntax could make future OCI/SBOM/provenance
   inputs look like incompatible second-class artifacts.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-13 | #484 | Recorded acceptance-time non-goal wording after the issue #364 Source.build surface shipped. |

--- a/docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
+++ b/docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 
@@ -648,8 +648,9 @@ plane.
 
 ## Non-Goals
 
-- Implementing participant runtime contracts, schemas, APIs, backends, or
-  storage.
+- Completing every participant runtime contract, schema, API, backend, or
+  storage surface beyond the subsets already published by the RUN-305 and
+  backend-facing contract work.
 - Adding new SDL participant syntax.
 - Replacing ADR-013 participant episode lifecycle semantics.
 - Replacing ADR-022 participant behavior and interaction semantics.

--- a/docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
+++ b/docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
@@ -663,3 +663,9 @@ plane.
 - Defining a full archival study-management system beyond the runtime fields
   needed to preserve participant history, shared-state evidence, and benchmark
   reproducibility claims.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-06-13 | #484 | Recorded acceptance-time non-goal wording for already-published RUN-305 and backend-facing contract subsets. |

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -64,6 +64,18 @@ adrs:
   - id: ADR-019
     path: docs/decisions/adrs/adr-019-normative-authority-boundary-manifest.md
     pin: 66b4ea3eb2482d6f8855462f4921c9cd7853ddb4c9adfaa21f311a07422f248b
+  - id: ADR-020
+    path: docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
+    pin: 4a5d146fc0ffd6da97af94e9f2d257a893de0ab7f63c709339d27f33178609d0
+  - id: ADR-021
+    path: docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
+    pin: 3e6053efd262abdbc37c8804bb066466b4c968dc647bfc605c16b563f6639642
+  - id: ADR-022
+    path: docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
+    pin: 87557c92a82c413c0e9042a239735ad78b24e73516c58be2249e97159c5dea38
+  - id: ADR-023
+    path: docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
+    pin: 55aea7a6726bc8942f9df35f83f9d50c3a2e4ffaff091ea47c581f8ef5525133
   - id: ADR-024
     path: docs/decisions/adrs/adr-024-local-identity-inventory-surface.md
     pin: 74f1a3df1a7c0f8dc6f44ff006abe88b20b9444fa93a736ac20fca1ca800e665
@@ -192,6 +204,9 @@ adrs:
   - id: ADR-053
     path: docs/decisions/adrs/adr-053-sdl-module-composition-for-inventory-backed-scenarios.md
     pin: e6eae89e31205274087e6c4e775744fba945091cddef1aa5dad3daad47921993
+  - id: ADR-054
+    path: docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
+    pin: a20312d7eb9a82a2611cb16bbe9590f1e43389d4ed1ea4341ae773edb8529086
   - id: ADR-055
     path: docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
     pin: 2e6666f2e066700df3dbf38d0592a2f24e062ad4f94d695113824f2ba73ff695

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -67,15 +67,31 @@ adrs:
   - id: ADR-020
     path: docs/decisions/adrs/adr-020-declarative-participant-framing-boundaries.md
     pin: 4a5d146fc0ffd6da97af94e9f2d257a893de0ab7f63c709339d27f33178609d0
+    amendments:
+      - date: 2026-06-13
+        ref: "#484"
+        summary: "Recorded acceptance of the implemented participant framing authoring surface."
   - id: ADR-021
     path: docs/decisions/adrs/adr-021-falsification-first-claim-evidence-gate.md
     pin: 3e6053efd262abdbc37c8804bb066466b4c968dc647bfc605c16b563f6639642
+    amendments:
+      - date: 2026-06-13
+        ref: "#484"
+        summary: "Recorded acceptance of the falsification-first claim evidence gate and its ASR-530/#162 linkage."
   - id: ADR-022
     path: docs/decisions/adrs/adr-022-participant-behavior-and-interaction-semantics.md
     pin: 87557c92a82c413c0e9042a239735ad78b24e73516c58be2249e97159c5dea38
+    amendments:
+      - date: 2026-06-13
+        ref: "#484"
+        summary: "Recorded acceptance-time ownership-boundary wording for cross-issue evidence concerns."
   - id: ADR-023
     path: docs/decisions/adrs/adr-023-container-image-build-provenance-surface.md
     pin: 55aea7a6726bc8942f9df35f83f9d50c3a2e4ffaff091ea47c581f8ef5525133
+    amendments:
+      - date: 2026-06-13
+        ref: "#484"
+        summary: "Recorded acceptance-time non-goal wording after the issue #364 Source.build surface shipped."
   - id: ADR-024
     path: docs/decisions/adrs/adr-024-local-identity-inventory-surface.md
     pin: 74f1a3df1a7c0f8dc6f44ff006abe88b20b9444fa93a736ac20fca1ca800e665
@@ -207,6 +223,10 @@ adrs:
   - id: ADR-054
     path: docs/decisions/adrs/adr-054-participant-runtime-observable-lifecycle.md
     pin: a20312d7eb9a82a2611cb16bbe9590f1e43389d4ed1ea4341ae773edb8529086
+    amendments:
+      - date: 2026-06-13
+        ref: "#484"
+        summary: "Recorded acceptance-time non-goal wording for already-published RUN-305 and backend-facing contract subsets."
   - id: ADR-055
     path: docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md
     pin: 2e6666f2e066700df3dbf38d0592a2f24e062ad4f94d695113824f2ba73ff695


### PR DESCRIPTION
## Summary

Accept the proposed ADRs that are already relied on by participant-framing, falsification-first evidence, participant-semantics, image-provenance, and participant-runtime documentation/spec surfaces, and pin the newly accepted records under the ADR-059 acceptance-content gate.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #484

## ADR Impact

- ADR-020
- ADR-021
- ADR-022
- ADR-023
- ADR-054
- ADR-059

## Changes

- Transition ADR-020, ADR-021, ADR-022, ADR-023, and ADR-054 from proposed to accepted.
- Revise stale pre-acceptance wording in ADR-022, ADR-023, and ADR-054 so accepted text matches the current implementation/spec state without overstating incomplete child surfaces.
- Update the ADR README index statuses and add acceptance-content pins for the five newly accepted ADRs in docs/decisions/adrs/adr-index.yaml.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Pre-commit passed with ACES_REQUIREMENT_UID=GOV-941. Direct policy checks passed: check_repo_policy.py --base-rev origin/dev and check_requirement_governance.py --base-rev origin/dev. tools/verify_all.py passed, including 2285 tests passed, 1 skipped, 7 deselected. Exact configured completion command `uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify` passed with the same test counts. Codex pre-push review cycle 1 returned clean with zero findings. Test-quality review skipped because the diff has no test files.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
