### PR TITLE
test: add semantic invariant regression tests

### DIFF
--- a/changelog.d/488.fixed.md
+++ b/changelog.d/488.fixed.md
@@ -1,0 +1,1 @@
+Added named semantic regression tests for composition-readiness and objective-window invariants.

--- a/implementations/python/tests/test_semantics_assessment.py
+++ b/implementations/python/tests/test_semantics_assessment.py
@@ -8,11 +8,14 @@ fail-closed issue reporting.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
+from aces.core.sdl.parser import parse_sdl_file
 from aces.core.semantics.assessment import (
     ASSESSMENT_DEPENDENCY_ROLES,
     AssessmentDependencyRole,
+    AssessmentPipelineAnalysis,
     AssessmentResourceKind,
     analyze_assessment_pipeline,
     partition_assessment_dependencies,
@@ -40,6 +43,83 @@ def _goal(tlos: list[str]) -> SimpleNamespace:
 
 def _is_var(value: object) -> bool:
     return isinstance(value, str) and value.startswith("${") and value.endswith("}")
+
+
+def _write_assessment_scenario(path: Path, *, namespace: str = "") -> None:
+    prefix = f"{namespace}." if namespace else ""
+    path.write_text(
+        f"""
+name: {namespace or "assessment"}
+version: 1.0.0
+conditions:
+  {prefix}health:
+    command: /bin/true
+    interval: 15
+metrics:
+  {prefix}health-metric:
+    type: conditional
+    condition: {prefix}health
+    max-score: 7
+  {prefix}manual-metric:
+    type: manual
+    max-score: 5
+evaluations:
+  {prefix}readiness:
+    metrics: [{prefix}health-metric, {prefix}manual-metric]
+    min-score:
+      absolute: 10
+tlos:
+  {prefix}ready-tlo:
+    evaluation: {prefix}readiness
+goals:
+  {prefix}ready-goal:
+    tlos: [{prefix}ready-tlo]
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_importing_root(path: Path, imported_name: str, *, namespace: str) -> None:
+    path.write_text(
+        f"""
+name: root
+imports:
+  - path: {imported_name}
+    namespace: {namespace}
+    version: 1.0.0
+""",
+        encoding="utf-8",
+    )
+
+
+def _assessment_analysis_from_file(path: Path) -> AssessmentPipelineAnalysis:
+    scenario = parse_sdl_file(path)
+    return analyze_assessment_pipeline(
+        conditions_by_name=scenario.conditions,
+        metrics_by_name=scenario.metrics,
+        evaluations_by_name=scenario.evaluations,
+        tlos_by_name=scenario.tlos,
+        goals_by_name=scenario.goals,
+    )
+
+
+def _assessment_reference_signature(analysis: AssessmentPipelineAnalysis) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (
+            ref.raw,
+            ref.source_kind,
+            ref.source_name,
+            ref.target_kind,
+            ref.target_name,
+            ref.dependency_roles,
+            ref.namespace_path,
+        )
+        for ref in analysis.references
+    )
+
+
+def _strip_shared(name: str) -> str:
+    return name.removeprefix("shared.")
 
 
 class TestAssessmentPipelineSemantics:
@@ -203,6 +283,72 @@ class TestAssessmentPipelineSemantics:
             "tlo.evaluation-undeclared",
             "goal.tlo-undeclared",
         ]
+
+    def test_composition_ready_invariant_layout_variation_preserves_normalized_references_and_aggregation(
+        self, tmp_path: Path
+    ) -> None:
+        flat = tmp_path / "flat.yaml"
+        imported = tmp_path / "assessment-module.yaml"
+        root = tmp_path / "root.yaml"
+        _write_assessment_scenario(flat, namespace="shared")
+        _write_assessment_scenario(imported)
+        _write_importing_root(root, imported.name, namespace="shared")
+
+        flat_analysis = _assessment_analysis_from_file(flat)
+        imported_analysis = _assessment_analysis_from_file(root)
+
+        assert not flat_analysis.has_issues
+        assert not imported_analysis.has_issues
+        assert _assessment_reference_signature(imported_analysis) == _assessment_reference_signature(flat_analysis)
+        assert (
+            imported_analysis.evaluation_metric_totals
+            == flat_analysis.evaluation_metric_totals
+            == {"shared.readiness": 12}
+        )
+
+    def test_composition_ready_invariant_module_expansion_occurs_before_assessment_analysis(
+        self, tmp_path: Path
+    ) -> None:
+        imported = tmp_path / "assessment-module.yaml"
+        root = tmp_path / "root.yaml"
+        _write_assessment_scenario(imported)
+        _write_importing_root(root, imported.name, namespace="shared")
+
+        analysis = _assessment_analysis_from_file(root)
+
+        assert not analysis.has_issues
+        assert [ref.raw for ref in analysis.references] == [
+            "shared.health",
+            "shared.health-metric",
+            "shared.manual-metric",
+            "shared.readiness",
+            "shared.ready-tlo",
+        ]
+
+    def test_composition_ready_invariant_namespace_extends_identity_without_changing_kinds_roles_or_aggregation(
+        self, tmp_path: Path
+    ) -> None:
+        plain = tmp_path / "plain.yaml"
+        namespaced = tmp_path / "namespaced.yaml"
+        _write_assessment_scenario(plain)
+        _write_assessment_scenario(namespaced, namespace="shared")
+
+        plain_analysis = _assessment_analysis_from_file(plain)
+        namespaced_analysis = _assessment_analysis_from_file(namespaced)
+
+        assert [
+            (ref.source_kind, ref.target_kind, ref.dependency_roles, ref.namespace_path)
+            for ref in namespaced_analysis.references
+        ] == [
+            (ref.source_kind, ref.target_kind, ref.dependency_roles, ref.namespace_path)
+            for ref in plain_analysis.references
+        ]
+        assert [
+            (_strip_shared(ref.source_name), _strip_shared(ref.target_name)) for ref in namespaced_analysis.references
+        ] == [(ref.source_name, ref.target_name) for ref in plain_analysis.references]
+        assert list(namespaced_analysis.evaluation_metric_totals.values()) == list(
+            plain_analysis.evaluation_metric_totals.values()
+        )
 
 
 class TestAssessmentDependencyPartition:

--- a/implementations/python/tests/test_semantics_objectives.py
+++ b/implementations/python/tests/test_semantics_objectives.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from hypothesis import given
 from hypothesis import strategies as st
 
+from aces.core.sdl.parser import parse_sdl_file
 from aces.core.semantics.assessment import AssessmentResourceKind
 from aces.core.semantics.objective_semantics import (
     OBJECTIVE_ACTOR_DEPENDENCY_ROLES,
@@ -29,6 +31,103 @@ from aces.core.semantics.objectives import (
 
 def _workflow(*step_names: str) -> SimpleNamespace:
     return SimpleNamespace(steps={name: object() for name in step_names})
+
+
+def _window_analysis(
+    *,
+    story_refs: list[str] | None = None,
+    script_refs: list[str] | None = None,
+    event_refs: list[str] | None = None,
+    workflow_refs: list[str] | None = None,
+    step_refs: list[str] | None = None,
+    stories_by_name: dict[str, object] | None = None,
+    scripts_by_name: dict[str, object] | None = None,
+    events_by_name: dict[str, object] | None = None,
+    workflows_by_name: dict[str, object] | None = None,
+):
+    return analyze_objective_window(
+        story_refs=list(story_refs or []),
+        script_refs=list(script_refs or []),
+        event_refs=list(event_refs or []),
+        workflow_refs=list(workflow_refs or []),
+        step_refs=list(step_refs or []),
+        stories_by_name=stories_by_name or {},
+        scripts_by_name=scripts_by_name or {},
+        events_by_name=events_by_name or {},
+        workflows_by_name=workflows_by_name or {},
+    )
+
+
+def _window_issue_codes(analysis) -> set[str]:
+    return {issue.code for issue in analysis.issues}
+
+
+def _write_objective_window_scenario(path: Path, *, namespace: str = "") -> None:
+    prefix = f"{namespace}." if namespace else ""
+    path.write_text(
+        f"""
+name: {namespace or "window"}
+version: 1.0.0
+conditions:
+  {prefix}health:
+    command: /bin/true
+    interval: 15
+entities:
+  {prefix}blue:
+    role: blue
+stories:
+  {prefix}intro:
+    scripts: [{prefix}timeline]
+scripts:
+  {prefix}timeline:
+    start-time: 0
+    end-time: 60
+    speed: 1
+    events:
+      {prefix}kickoff: 0
+events:
+  {prefix}kickoff: {{}}
+objectives:
+  {prefix}observe:
+    entity: {prefix}blue
+    success:
+      conditions: [{prefix}health]
+    window:
+      stories: [{prefix}intro]
+      scripts: [{prefix}timeline]
+      events: [{prefix}kickoff]
+      workflows: [{prefix}flow]
+      steps: [{prefix}flow.start]
+workflows:
+  {prefix}flow:
+    start: start
+    steps:
+      start:
+        type: objective
+        objective: {prefix}observe
+        on-success: finish
+      finish:
+        type: end
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_importing_root(path: Path, imported_name: str, *, namespace: str) -> None:
+    path.write_text(
+        f"""
+name: root
+imports:
+  - path: {imported_name}
+    namespace: {namespace}
+    version: 1.0.0
+""",
+        encoding="utf-8",
+    )
+
+
+def _strip_shared(name: str) -> str:
+    return name.removeprefix("shared.")
 
 
 class TestObjectiveWindowSemantics:
@@ -91,6 +190,171 @@ class TestObjectiveWindowSemantics:
             "step-workflow-outside-window",
             "step-unbound",
         }
+
+    def test_window_invariant_story_refs_must_resolve(self) -> None:
+        analysis = _window_analysis(story_refs=["missing-story"])
+
+        assert _window_issue_codes(analysis) == {"story-unbound"}
+
+    def test_window_invariant_script_refs_must_resolve(self) -> None:
+        analysis = _window_analysis(script_refs=["missing-script"])
+
+        assert _window_issue_codes(analysis) == {"script-unbound"}
+
+    def test_window_invariant_event_refs_must_resolve(self) -> None:
+        analysis = _window_analysis(event_refs=["missing-event"])
+
+        assert _window_issue_codes(analysis) == {"event-unbound"}
+
+    def test_window_invariant_steps_must_use_workflow_step_syntax(self) -> None:
+        analysis = _window_analysis(
+            workflow_refs=["flow"],
+            step_refs=["bad-step-ref"],
+            workflows_by_name={"flow": _workflow("start")},
+        )
+
+        assert _window_issue_codes(analysis) == {"step-invalid-format"}
+
+    def test_window_invariant_steps_require_workflow_window(self) -> None:
+        analysis = _window_analysis(
+            step_refs=["flow.start"],
+            workflows_by_name={"flow": _workflow("start")},
+        )
+
+        assert "step-requires-workflow-window" in _window_issue_codes(analysis)
+
+    def test_window_invariant_workflow_refs_must_resolve(self) -> None:
+        analysis = _window_analysis(workflow_refs=["missing-flow"])
+
+        assert _window_issue_codes(analysis) == {"workflow-unbound"}
+
+    def test_window_invariant_step_workflow_must_resolve(self) -> None:
+        analysis = _window_analysis(
+            workflow_refs=["flow"],
+            step_refs=["missing-flow.start"],
+            workflows_by_name={"flow": _workflow("start")},
+        )
+
+        assert _window_issue_codes(analysis) == {"step-workflow-unbound"}
+
+    def test_window_invariant_step_name_must_resolve_within_workflow(self) -> None:
+        analysis = _window_analysis(
+            workflow_refs=["flow"],
+            step_refs=["flow.missing"],
+            workflows_by_name={"flow": _workflow("start")},
+        )
+
+        assert _window_issue_codes(analysis) == {"step-unbound"}
+
+    def test_window_invariant_step_workflow_must_be_inside_workflow_window(self) -> None:
+        analysis = _window_analysis(
+            workflow_refs=["flow"],
+            step_refs=["other.done"],
+            workflows_by_name={"flow": _workflow("start"), "other": _workflow("done")},
+        )
+
+        assert _window_issue_codes(analysis) == {"step-workflow-outside-window"}
+
+    def test_window_invariant_explicit_scripts_must_be_inside_story_window(self) -> None:
+        analysis = _window_analysis(
+            story_refs=["intro"],
+            script_refs=["side"],
+            stories_by_name={"intro": SimpleNamespace(scripts=["main"])},
+            scripts_by_name={"main": SimpleNamespace(events={}), "side": SimpleNamespace(events={})},
+        )
+
+        assert _window_issue_codes(analysis) == {"script-outside-window-stories"}
+
+    def test_window_invariant_events_must_be_inside_reachable_script_window(self) -> None:
+        analysis = _window_analysis(
+            script_refs=["timeline"],
+            event_refs=["cleanup"],
+            scripts_by_name={"timeline": SimpleNamespace(events={"kickoff": 10})},
+            events_by_name={"cleanup": SimpleNamespace()},
+        )
+
+        assert _window_issue_codes(analysis) == {"event-outside-window-scripts"}
+
+    def test_composition_ready_invariant_imported_window_analysis_uses_expanded_canonical_identities(
+        self, tmp_path: Path
+    ) -> None:
+        imported = tmp_path / "window-module.yaml"
+        root = tmp_path / "root.yaml"
+        _write_objective_window_scenario(imported)
+        _write_importing_root(root, imported.name, namespace="shared")
+        scenario = parse_sdl_file(root)
+
+        analysis = _analyze(
+            scenario.objectives,
+            entity_names=set(scenario.entities),
+            conditions_by_name=scenario.conditions,
+            stories_by_name=scenario.stories,
+            scripts_by_name=scenario.scripts,
+            events_by_name=scenario.events,
+            workflows_by_name=scenario.workflows,
+        )
+
+        assert not analysis.has_issues
+        assert {ref.canonical_name for ref in analysis.references_of_kind(ObjectiveReferenceKind.WINDOW)} == {
+            "shared.intro",
+            "shared.timeline",
+            "shared.kickoff",
+            "shared.flow",
+            "shared.flow.start",
+        }
+        window_step = [
+            ref
+            for ref in analysis.references_of_kind(ObjectiveReferenceKind.WINDOW)
+            if ref.window_reference_kind == ObjectiveWindowReferenceKind.WORKFLOW_STEP
+        ][0]
+        assert window_step.workflow_name == "shared.flow"
+        assert window_step.step_name == "start"
+
+    def test_composition_ready_invariant_namespace_extends_window_identity_without_changing_kind_roles_or_ownership(
+        self, tmp_path: Path
+    ) -> None:
+        plain = tmp_path / "plain.yaml"
+        namespaced = tmp_path / "namespaced.yaml"
+        _write_objective_window_scenario(plain)
+        _write_objective_window_scenario(namespaced, namespace="shared")
+        plain_scenario = parse_sdl_file(plain)
+        namespaced_scenario = parse_sdl_file(namespaced)
+
+        plain_window = plain_scenario.objectives["observe"].window
+        namespaced_window = namespaced_scenario.objectives["shared.observe"].window
+        plain_analysis = analyze_objective_window(
+            story_refs=plain_window.stories,
+            script_refs=plain_window.scripts,
+            event_refs=plain_window.events,
+            workflow_refs=plain_window.workflows,
+            step_refs=plain_window.steps,
+            stories_by_name=plain_scenario.stories,
+            scripts_by_name=plain_scenario.scripts,
+            events_by_name=plain_scenario.events,
+            workflows_by_name=plain_scenario.workflows,
+        )
+        namespaced_analysis = analyze_objective_window(
+            story_refs=namespaced_window.stories,
+            script_refs=namespaced_window.scripts,
+            event_refs=namespaced_window.events,
+            workflow_refs=namespaced_window.workflows,
+            step_refs=namespaced_window.steps,
+            stories_by_name=namespaced_scenario.stories,
+            scripts_by_name=namespaced_scenario.scripts,
+            events_by_name=namespaced_scenario.events,
+            workflows_by_name=namespaced_scenario.workflows,
+        )
+
+        assert [
+            (ref.reference_kind, ref.dependency_roles, ref.step_name, _strip_shared(ref.workflow_name or ""))
+            for ref in namespaced_analysis.references
+        ] == [
+            (ref.reference_kind, ref.dependency_roles, ref.step_name, ref.workflow_name or "")
+            for ref in plain_analysis.references
+        ]
+        assert [_strip_shared(ref.canonical_name) for ref in namespaced_analysis.references] == [
+            ref.canonical_name for ref in plain_analysis.references
+        ]
 
     @given(st.lists(st.sampled_from(["flow.start", "flow.branch"]), max_size=12))
     def test_workflow_step_normalization_is_stable(self, step_refs: list[str]):

--- a/specs/formal/assessment/pipeline-consistency.md
+++ b/specs/formal/assessment/pipeline-consistency.md
@@ -110,4 +110,7 @@ addresses.
   - `implementations/python/packages/aces_processor/semantics/planner.py`
 - differential and cross-stage tests:
   - `implementations/python/tests/test_semantics_assessment.py`
+    (`test_composition_ready_invariant_layout_variation_preserves_normalized_references_and_aggregation`,
+    `test_composition_ready_invariant_module_expansion_occurs_before_assessment_analysis`,
+    `test_composition_ready_invariant_namespace_extends_identity_without_changing_kinds_roles_or_aggregation`)
   - `implementations/python/tests/test_fm2_semantics.py`

--- a/specs/formal/composition-readiness.md
+++ b/specs/formal/composition-readiness.md
@@ -29,9 +29,17 @@ It does lock the semantic preconditions those features must respect.
 ## Current Implementation Hooks
 
 - objective/window references already carry a namespace-extensible path slot in
-  `implementations/python/packages/aces_processor/semantics/objectives.py`
+  `implementations/python/packages/aces_sdl/semantics/objectives.py`
 - planner identity handling is already defined in terms of canonical compiled
   addresses in `implementations/python/packages/aces_processor/semantics/planner.py`
+- named regression tests pin the layout/namespace invariants:
+  - assessment pipeline: `implementations/python/tests/test_semantics_assessment.py`
+    (`test_composition_ready_invariant_layout_variation_preserves_normalized_references_and_aggregation`,
+    `test_composition_ready_invariant_module_expansion_occurs_before_assessment_analysis`,
+    `test_composition_ready_invariant_namespace_extends_identity_without_changing_kinds_roles_or_aggregation`)
+  - objective windows: `implementations/python/tests/test_semantics_objectives.py`
+    (`test_composition_ready_invariant_imported_window_analysis_uses_expanded_canonical_identities`,
+    `test_composition_ready_invariant_namespace_extends_window_identity_without_changing_kind_roles_or_ownership`)
 
 These hooks are intended to let module/import work land later without
 redefining FM2 semantics.

--- a/specs/formal/objectives/window-consistency.md
+++ b/specs/formal/objectives/window-consistency.md
@@ -75,4 +75,17 @@ shape before compiler/planner semantics run. Each resolved reference carries:
   - `implementations/python/packages/aces_processor/models.py`
 - differential and property tests:
   - `implementations/python/tests/test_semantics_objectives.py`
+    (`test_window_invariant_story_refs_must_resolve`,
+    `test_window_invariant_script_refs_must_resolve`,
+    `test_window_invariant_event_refs_must_resolve`,
+    `test_window_invariant_steps_must_use_workflow_step_syntax`,
+    `test_window_invariant_steps_require_workflow_window`,
+    `test_window_invariant_workflow_refs_must_resolve`,
+    `test_window_invariant_step_workflow_must_resolve`,
+    `test_window_invariant_step_name_must_resolve_within_workflow`,
+    `test_window_invariant_step_workflow_must_be_inside_workflow_window`,
+    `test_window_invariant_explicit_scripts_must_be_inside_story_window`,
+    `test_window_invariant_events_must_be_inside_reachable_script_window`,
+    `test_composition_ready_invariant_imported_window_analysis_uses_expanded_canonical_identities`,
+    `test_composition_ready_invariant_namespace_extends_window_identity_without_changing_kind_roles_or_ownership`)
   - `implementations/python/tests/test_fm2_semantics.py`


### PR DESCRIPTION
## Summary

Adds named regression coverage for composition-readiness and objective-window invariants so reviewers can map each invariant in issue 488 to an explicit test and spec mapping entry.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #488

## ADR Impact

- ADR-016
- ADR-053

## Changes

- Add parser-loaded assessment composition-readiness tests for layout variation, import expansion before analysis, and namespace-stable kinds/roles/aggregation.
- Add targeted objective-window negative tests for each consistency/fail-closed invariant plus namespace-stable composition-readiness tests.
- Update the three formal spec mapping sections to cite exact test names and correct the objective-window helper path in composition-readiness.
- Add changelog fragment `changelog.d/488.fixed.md`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification passed: affected semantic suites (`48 passed`), `nox -s lint`, `pre-commit run --all-files`, and `tools/verify_all.py --requirement-uid SEM-205` (`2303 passed, 1 skipped, 7 deselected`). Pre-push Codex and test-quality review cycles both returned clean with zero findings.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: SEM-205 <- implementations/python/tests/test_semantics_assessment.py, SEM-205 <- implementations/python/tests/test_semantics_objectives.py, SEM-206 <- implementations/python/tests/test_semantics_assessment.py, SEM-202 <- implementations/python/tests/test_semantics_objectives.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/488.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.