### PR TITLE
changed: add episodes concept authority family

### DIFF
--- a/changelog.d/492.changed.md
+++ b/changelog.d/492.changed.md
@@ -1,0 +1,3 @@
+Added a native `episodes` concept family with participant-runtime lineage,
+semantic-profile coverage for participant episode contracts, and tests that
+anchor episode-keyed contracts to the shared concept authority.

--- a/contracts/concept-authority/concept-families-v1.json
+++ b/contracts/concept-authority/concept-families-v1.json
@@ -71,6 +71,22 @@
         "Run or study concepts must not be used to classify nodes, accounts, observables, tools, or events."
       ]
     },
+    "episodes": {
+      "title": "Episodes",
+      "description": "Participant runtime episode identity, lifecycle state, and history boundaries.",
+      "provenance": "native",
+      "extension_scope": "ACES participant runtime episode identity, lifecycle state, state/history contracts, reset/restart/terminate semantics, and participant-scoped behavior sequencing.",
+      "relation_rules": [
+        "May relate to tasks-runs-studies as the participant-level runtime segment that occurs within a task, run, or study without becoming that task, run, or study.",
+        "May relate to scenarios as the runtime execution instance of a participant admitted from scenario context, while scenario authoring remains governed by scenarios.",
+        "May relate to actions-and-events and observables through behavior or history records emitted inside an episode without classifying those records as the episode itself."
+      ],
+      "non_ambiguity_constraints": [
+        "Must not be used as a synonym for tasks, runs, studies, scenarios, workflow steps, operation receipts, or backend process restarts.",
+        "Must not classify participant actions, events, observables, tools, artifacts, or evidence records; those meanings must bind to their narrower families.",
+        "Episode identity and lifecycle state must remain separate from participant behavior sequence events and participant-local action outcomes."
+      ]
+    },
     "apparatus-declarations": {
       "title": "Apparatus Declarations",
       "description": "Processor, backend, and participant-implementation manifests.",

--- a/contracts/fixtures/concept-authority/concept-families-v1/valid/reference.json
+++ b/contracts/fixtures/concept-authority/concept-families-v1/valid/reference.json
@@ -71,6 +71,22 @@
         "Run or study concepts must not be used to classify nodes, accounts, observables, tools, or events."
       ]
     },
+    "episodes": {
+      "title": "Episodes",
+      "description": "Participant runtime episode identity, lifecycle state, and history boundaries.",
+      "provenance": "native",
+      "extension_scope": "ACES participant runtime episode identity, lifecycle state, state/history contracts, reset/restart/terminate semantics, and participant-scoped behavior sequencing.",
+      "relation_rules": [
+        "May relate to tasks-runs-studies as the participant-level runtime segment that occurs within a task, run, or study without becoming that task, run, or study.",
+        "May relate to scenarios as the runtime execution instance of a participant admitted from scenario context, while scenario authoring remains governed by scenarios.",
+        "May relate to actions-and-events and observables through behavior or history records emitted inside an episode without classifying those records as the episode itself."
+      ],
+      "non_ambiguity_constraints": [
+        "Must not be used as a synonym for tasks, runs, studies, scenarios, workflow steps, operation receipts, or backend process restarts.",
+        "Must not classify participant actions, events, observables, tools, artifacts, or evidence records; those meanings must bind to their narrower families.",
+        "Episode identity and lifecycle state must remain separate from participant behavior sequence events and participant-local action outcomes."
+      ]
+    },
     "apparatus-declarations": {
       "title": "Apparatus Declarations",
       "description": "Processor, backend, and participant-implementation manifests.",

--- a/contracts/fixtures/semantic-profile/semantic-profile-v1/valid/reference-stack-v1.json
+++ b/contracts/fixtures/semantic-profile/semantic-profile-v1/valid/reference-stack-v1.json
@@ -42,6 +42,8 @@
       "processor-manifest-v2",
       "backend-manifest-v2",
       "runtime-snapshot-v1",
+      "participant-episode-state-envelope-v1",
+      "participant-episode-history-event-stream-v1",
       "workflow-result-envelope-v1",
       "workflow-history-event-stream-v1",
       "evaluation-result-envelope-v1",
@@ -53,6 +55,7 @@
       "actions-and-events",
       "apparatus-declarations",
       "assets",
+      "episodes",
       "identities",
       "observables",
       "provenance-and-evidence",
@@ -121,6 +124,8 @@
       "operation-receipt-v1",
       "operation-status-v1",
       "runtime-snapshot-v1",
+      "participant-episode-state-envelope-v1",
+      "participant-episode-history-event-stream-v1",
       "workflow-result-envelope-v1",
       "workflow-history-event-stream-v1",
       "evaluation-result-envelope-v1",
@@ -129,6 +134,7 @@
     "required_concept_families": [
       "actions-and-events",
       "assets",
+      "episodes",
       "identities",
       "observables",
       "tools-and-artifacts"

--- a/contracts/profiles/semantic/reference-stack-v1.json
+++ b/contracts/profiles/semantic/reference-stack-v1.json
@@ -42,6 +42,8 @@
       "processor-manifest-v2",
       "backend-manifest-v2",
       "runtime-snapshot-v1",
+      "participant-episode-state-envelope-v1",
+      "participant-episode-history-event-stream-v1",
       "workflow-result-envelope-v1",
       "workflow-history-event-stream-v1",
       "evaluation-result-envelope-v1",
@@ -53,6 +55,7 @@
       "actions-and-events",
       "apparatus-declarations",
       "assets",
+      "episodes",
       "identities",
       "observables",
       "provenance-and-evidence",
@@ -121,6 +124,8 @@
       "operation-receipt-v1",
       "operation-status-v1",
       "runtime-snapshot-v1",
+      "participant-episode-state-envelope-v1",
+      "participant-episode-history-event-stream-v1",
       "workflow-result-envelope-v1",
       "workflow-history-event-stream-v1",
       "evaluation-result-envelope-v1",
@@ -129,6 +134,7 @@
     "required_concept_families": [
       "actions-and-events",
       "assets",
+      "episodes",
       "identities",
       "observables",
       "tools-and-artifacts"

--- a/implementations/python/tests/test_concept_authority.py
+++ b/implementations/python/tests/test_concept_authority.py
@@ -20,9 +20,14 @@ from pydantic import ValidationError
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CATALOG_PATH = REPO_ROOT / "contracts" / "concept-authority" / "concept-families-v1.json"
+CONTROLLED_VOCABULARY_PATH = REPO_ROOT / "contracts" / "concept-authority" / "controlled-vocabularies-v1.json"
 FIXTURES_ROOT = REPO_ROOT / "contracts" / "fixtures"
 VALID_DIR = FIXTURES_ROOT / "concept-authority" / "concept-families-v1" / "valid"
 INVALID_DIR = FIXTURES_ROOT / "concept-authority" / "concept-families-v1" / "invalid"
+EPISODE_CONTRACT_TERM_IDS = {
+    "participant-episode-history-event-stream-v1",
+    "participant-episode-state-envelope-v1",
+}
 
 
 def _native_family_payload() -> dict[str, object]:
@@ -264,6 +269,37 @@ def test_authoritative_catalog_native_families_have_no_authority_metadata():
             assert family.non_ambiguity_constraints, (
                 f"Native family '{family_id}' should declare non-ambiguity constraints"
             )
+
+
+def test_authoritative_catalog_declares_episode_family():
+    payload = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    model = ConceptFamilyCatalogModel.model_validate(payload)
+
+    episode_family = model.families["episodes"]
+    assert episode_family.provenance == ConceptProvenanceCategory.NATIVE
+    assert episode_family.authority is None
+    assert episode_family.authority_reference is None
+    assert "participant runtime episode identity" in episode_family.extension_scope
+
+    relation_rules = " ".join(episode_family.relation_rules).lower()
+    for related_concept in ("task", "run", "scenario"):
+        assert related_concept in relation_rules
+
+    non_ambiguity_constraints = " ".join(episode_family.non_ambiguity_constraints).lower()
+    for forbidden_synonym in ("task", "run", "observable", "action"):
+        assert forbidden_synonym in non_ambiguity_constraints
+
+
+def test_episode_contract_terms_have_catalog_family_anchor():
+    catalog_payload = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    vocabulary_payload = json.loads(CONTROLLED_VOCABULARY_PATH.read_text(encoding="utf-8"))
+    catalog = ConceptFamilyCatalogModel.model_validate(catalog_payload)
+
+    participant_contract_terms = set(
+        vocabulary_payload["vocabularies"]["participant-implementation-contracts"]["terms"]
+    )
+    assert participant_contract_terms >= EPISODE_CONTRACT_TERM_IDS
+    assert "episodes" in catalog.families
 
 
 def test_valid_fixture_passes_validation():

--- a/implementations/python/tests/test_semantic_profiles.py
+++ b/implementations/python/tests/test_semantic_profiles.py
@@ -17,6 +17,10 @@ PROFILE_PATH = REPO_ROOT / "contracts" / "profiles" / "semantic" / "reference-st
 FIXTURES_ROOT = REPO_ROOT / "contracts" / "fixtures" / "semantic-profile" / "semantic-profile-v1"
 VALID_DIR = FIXTURES_ROOT / "valid"
 INVALID_DIR = FIXTURES_ROOT / "invalid"
+EPISODE_CONTRACTS = {
+    "participant-episode-history-event-stream-v1",
+    "participant-episode-state-envelope-v1",
+}
 
 
 def _binding_set(bindings: object) -> set[tuple[str, str]]:
@@ -92,3 +96,14 @@ def test_stub_backend_satisfies_execution_profile():
 
     assert required_contracts <= manifest.supported_contract_versions
     assert required_bindings <= _binding_set(manifest.concept_bindings)
+
+
+def test_reference_profile_declares_episode_family_for_runtime_exchange_and_execution():
+    profile = load_semantic_profile("reference-stack-v1")
+
+    assert "episodes" not in profile.authoring.required_concept_families
+    assert "episodes" not in profile.processing.required_concept_families
+
+    for phase in (profile.exchange, profile.execution):
+        assert set(phase.required_contracts) >= EPISODE_CONTRACTS
+        assert "episodes" in phase.required_concept_families

--- a/specs/concept-authority/concept-authority.md
+++ b/specs/concept-authority/concept-authority.md
@@ -76,10 +76,18 @@ ecosystem-specific concerns.
 |--------|-------|
 | `scenarios` | SDL scenarios, compositions, modules, and authoring constructs. |
 | `tasks-runs-studies` | Execution lifecycle, run records, and study organization. |
+| `episodes` | Participant runtime episode identity, lifecycle state, and history boundaries. |
 | `apparatus-declarations` | Processor, backend, and participant-implementation manifests. |
 | `realization-and-disclosure` | Instantiation, planning, compilation, and realization artifacts. |
 | `provenance-and-evidence` | Run provenance records, evidence expectations, and audit artifacts. |
 | `time-and-apparatus` | Clocks, timing constraints, and apparatus-level concerns. |
+
+The `episodes` family is native because participant episode semantics are an
+ACES runtime boundary, not a UCO cyber object and not a task/run/study alias.
+It covers participant-scoped episode identity, lifecycle state, reset/restart
+boundaries, and append-only episode history. Episode-bound behavior events,
+observables, actions, tools, artifacts, and evidence still bind to their
+narrower concept families when those records are the artifact's subject.
 
 ## Extension Discipline
 

--- a/specs/concept-authority/reference-models.md
+++ b/specs/concept-authority/reference-models.md
@@ -55,6 +55,24 @@ slice:
 - scenario events as action or event structures
 - scenario content as tool or artifact structures
 
+## Participant Episode Lineage
+
+Participant episodes are cataloged as the native `episodes` concept family
+rather than as an SDL reference model entry. The external lineage is the
+reinforcement-learning environment episode notion used by Gymnasium and
+OpenAI Gym: a bounded interaction sequence that starts after initialization or
+reset and ends at a terminal, timeout, or truncation boundary. ACES narrows
+that lineage to participant-runtime contracts by requiring stable
+`participant_address`, per-episode `episode_id`, explicit lifecycle state, and
+append-only state/history surfaces.
+
+The internal authority is
+[ADR-013](../../docs/decisions/adrs/adr-013-participant-episode-lifecycle-boundaries.md),
+which makes participant episode state its own processor/runtime contract
+surface and keeps it separate from workflow state, evaluation state,
+operation receipts, backend process restarts, tasks, runs, scenarios, and
+participant-local actions or observations.
+
 ## Machine-Readable Artifacts
 
 The JSON Schema for the catalog format is published at:

--- a/specs/concept-authority/semantic-profiles.md
+++ b/specs/concept-authority/semantic-profiles.md
@@ -59,6 +59,18 @@ The reference stack profile is intentionally concrete. It is the first
 repo-owned semantic profile, not a promise that the ecosystem will forever use
 only one profile.
 
+The reference stack requires the native `episodes` concept family in the
+`exchange` and `execution` phases because those phases exchange and execute the
+participant episode state and episode history contracts. Authoring and
+processing do not require the family today: ADR-013 explicitly avoids adding
+SDL authoring syntax for episode semantics, and the reference processor does
+not publish participant episode state/history contracts as a processing
+capability. The profile therefore records episode coverage through
+`required_contracts` and `required_concept_families`, not through a
+`required_bindings` entry on `capabilities.supported_participant_contracts`;
+that manifest scope also contains implementation, behavior, and provenance
+contracts and is not an episode-only binding surface.
+
 ## Machine-Readable Artifacts
 
 The JSON Schema for semantic profiles is published at:


### PR DESCRIPTION
## Summary

Adds a native episodes concept family and wires the reference semantic profile so participant episode state/history contracts require shared episode meaning.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #492

## ADR Impact

- ADR-012
- ADR-013

## Changes

- Added the native `episodes` concept family to the authoritative catalog and valid fixture with extension scope, relation rules, and non-ambiguity constraints.
- Updated the reference semantic profile and fixture so exchange and execution require participant episode state/history contracts and the `episodes` family.
- Documented the family in concept-authority prose, recorded RL/Gymnasium/OpenAI Gym plus ADR-013 lineage, and clarified that mixed participant-contract manifest scopes are not episode-only bindings.
- Added tests that validate the episode family, episode contract anchor, and semantic-profile phase coverage.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Targeted red/green pytest for concept authority and semantic profiles; `pre-commit run --all-files`; explicit repo policy, requirement governance, `tools/verify_all.py`, and configured nox verify completion command with `ACES_REQUIREMENT_UID=GOV-918`; pre-push Codex and test-quality review cycles clean.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #492 <- contracts/concept-authority/concept-families-v1.json, #492 <- contracts/profiles/semantic/reference-stack-v1.json, #492 <- specs/concept-authority/reference-models.md, #492 <- specs/concept-authority/semantic-profiles.md
- TESTS: #492 <- implementations/python/tests/test_concept_authority.py, #492 <- implementations/python/tests/test_semantic_profiles.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/492.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
