### PR TITLE
test: validate worked examples against published JSON schema (CT-4)

### DIFF
--- a/changelog.d/501.added.md
+++ b/changelog.d/501.added.md
@@ -1,0 +1,1 @@
+The worked SDL examples under `examples/scenarios/` are now validated against the published `sdl-authoring-input-v1` JSON Schema in CI, proving the shipped example corpus conforms to the contract surface downstream consumers read (previously only Pydantic-parser acceptance was checked). Includes a non-vacuity corpus guard and a negative control so the suite cannot pass vacuously.

--- a/docs/decisions/issue-501-validation-corpus-schema-preflight.md
+++ b/docs/decisions/issue-501-validation-corpus-schema-preflight.md
@@ -1,0 +1,134 @@
+# Issue 501 Validation Corpus Schema Preflight
+
+Date: 2026-06-15
+
+Issue: #501.
+
+Requirement: ASR-504.
+
+This note records architecture preflight guardrails for validating shipped SDL
+examples against the published JSON Schema surface. It is guidance for the
+implementation and does not implement tests, change examples, edit schemas, or
+alter parser behavior.
+
+## Binding Sources
+
+- ADR-009 makes `contracts/schemas/` the normative machine-readable schema
+  authority. Python models and `schema_bundle()` are compatibility evidence.
+- ADR-061 and `contracts/schema-publication-manifest.json` govern published
+  schema inventory and evolution. This issue should not need a schema edit.
+- ADR-014 and `.ground-control.yaml` keep `nox -s verify` as the canonical
+  verification graph.
+- `docs/explain/sdl/testing.md` defines `examples/scenarios/*.sdl.yaml` as the
+  reusable positive example corpus.
+- `implementations/python/tests/paths.py` is the existing marker-based
+  repo-root and example-corpus path seam.
+- `load_scenario()` / `parse_sdl()` are the SDL parsing and semantic-validation
+  boundary for example files.
+
+## Architecture Decisions
+
+- Keep worked examples under repo-root `examples/scenarios/`. They are positive,
+  reusable SDL authoring examples, not invalid fixtures and not normative
+  contract fixtures.
+- Validate examples through the existing loading boundary first, then validate
+  the serialized model payload against the published schema file
+  `contracts/schemas/sdl/sdl-authoring-input-v1.json`.
+- Treat Pydantic acceptance and published-schema conformance as two separate
+  claims. The new evidence must prove both; it must not replace parser,
+  semantic-validator, or schema-publication tests.
+- Load the published schema artifact, not a freshly generated schema, when
+  proving example conformance. `schema_bundle()` remains the drift/compatibility
+  proof used by existing contract gates.
+- Keep the serialization choice explicit and centralized in test support:
+  `model_dump(mode="json", by_alias=True)` is the contract-shaped payload. Any
+  exclusions must be documented at that seam, not repeated at each assertion.
+- Add a non-vacuity guard around example enumeration. A stale corpus root must
+  fail loudly rather than collecting zero parametrized cases.
+- If instantiated-scenario examples are added later, cover them through the same
+  contract-id/serialization seam with `instantiated-scenario-v1`; do not
+  conflate authoring examples with concrete instantiated artifacts.
+
+## Required Incumbents
+
+- Corpus discovery: `implementations/python/tests/paths.py` and
+  `EXAMPLES_DIR`.
+- Scenario loading: `aces_sdl.scenarios.load_scenario`,
+  `aces_sdl.parser.parse_sdl`, `yaml.safe_load`, `SDLModel.extra="forbid"`,
+  `SemanticValidator`, and the existing SDL error types.
+- Schema authority and publication: `contracts/schemas/sdl/`,
+  `contracts/schema-publication-manifest.json`, ADR-009, ADR-061,
+  `tools/check_schema_publication.py`, `tools/check_generated_schemas.py`, and
+  `tools/check_json_artifacts.py`.
+- Schema validation idiom: `jsonschema.Draft202012Validator`, already used by
+  contract and SDL schema tests.
+- Contract-corpus resolution, when a schema path helper is needed:
+  `aces_contracts.corpus.corpus_family_root("schemas")` rather than new
+  `Path(__file__).parents[N]` heuristics.
+- Existing tests to extend or mirror: `test_scenarios.py`,
+  `test_instantiated_scenario_schema.py`, `test_runtime_contracts.py`, and
+  `test_mcp_server.py`.
+
+## Cross-Cutting Layers
+
+- YAML/config parsing: examples must pass through `yaml.safe_load`, key
+  normalization, shorthand expansion, top-level string-key checks, mapping-key
+  variable rejection, and Pydantic closed-world validation.
+- Semantic validation: unresolved references, ambiguity, dependency failures,
+  and runtime-family reference errors must continue to fail closed through
+  `SemanticValidator`. Advisories remain non-fatal but visible.
+- Published schema validation: the JSON Schema validator checks the serialized
+  authoring payload against the checked-in schema. It must not fetch remote
+  refs, generate schemas in place, or mutate the manifest.
+- Repo-path security: corpus and schema paths stay repo-relative or flow through
+  existing marker/corpus seams. Do not add absolute-path, `..`, symlink, or
+  environment-variable based discovery.
+- Secret handling and OS exposure: tests should run in process and pass file
+  paths only. Do not place scenario contents, tokens, operator secrets, or
+  payload JSON in subprocess argv or logs.
+- Error envelopes and leakage: keep existing `SDLParseError`,
+  `SDLValidationError`, `ScenarioValidationError`, and pytest assertion
+  surfaces. Failures should identify the example path and schema error, not dump
+  whole scenario payloads or environment state.
+- Auth, persistence, network, and control-plane layers: this work does not add
+  or change runtime auth, HTTP handlers, database state, audit logging, or live
+  network access.
+
+## Extension Boundary
+
+The extension seam is a small table of validation-corpus entries:
+example root, filename glob, model loader, contract id, schema path, and
+serialization options. Today that table has the authoring corpus
+`examples/scenarios/*.sdl.yaml` against `sdl-authoring-input-v1`. A future
+instantiated corpus should add a row for `instantiated-scenario-v1`; it should
+not require a new schema loader, new path convention, or new validator wrapper.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- validating zero examples because `EXAMPLES_DIR` points at the old
+  `implementations/python/examples` location;
+- using `schema_bundle()["sdl-authoring-input-v1"]` as the primary proof of
+  published-schema conformance;
+- adding duplicate schema files, schema registries, validation helpers, or
+  exception hierarchies;
+- placing invalid controls under `examples/scenarios/`;
+- proving only Pydantic acceptance and calling it published-contract
+  conformance;
+- serializing with field names instead of aliases, which misses YAML-facing
+  fields such as `on-success`, `max-attempts`, and `class`;
+- hiding all defaults/exclusions inline until the test no longer resembles the
+  published contract payload;
+- editing `implementations/python/src/aces/`, generated schema outputs, or
+  accepted ADR text for this issue.
+
+## Non-Goals
+
+- Changing SDL semantics, parser normalization, instantiation behavior, or MCP
+  example content.
+- Editing published schemas or the schema publication manifest.
+- Adding new corpus roots, package-data behavior, release workflow, control
+  plane endpoints, persistence, or authentication behavior.
+- Turning examples into conformance fixtures or making invalid examples part of
+  the reusable example corpus.

--- a/implementations/python/tests/test_example_schema_conformance.py
+++ b/implementations/python/tests/test_example_schema_conformance.py
@@ -1,0 +1,153 @@
+"""Issue #501 (review CT-4) — worked examples conform to the *published* JSON Schema.
+
+``test_scenarios.py`` proves every ``examples/scenarios/*.sdl.yaml`` loads through the
+Pydantic parser, but Pydantic acceptance is not published-schema conformance, and the
+worked examples are the proof artifacts third parties read. This suite serializes each
+example with the canonical, contract-shaped publication serialization
+(``model_dump(mode="json", by_alias=True)`` — the same flags ``aces_processor/compiler.py``
+uses) and validates the result against the *checked-in* published schema
+``contracts/schemas/sdl/sdl-authoring-input-v1.json`` with ``Draft202012Validator``.
+
+Validating the shipped schema artifact rather than ``schema_bundle()`` is deliberate: per
+ADR-009 the published ``contracts/schemas/`` JSON is the normative authority, while
+``schema_bundle()`` remains the drift/compatibility proof used by other gates.
+
+A non-vacuity guard and a deliberate negative control keep the suite from passing
+vacuously — a stale corpus path that collects zero cases, or a validator that accepts
+everything, both fail loudly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import cache
+from pathlib import Path
+
+import pytest
+from aces_contracts.corpus import corpus_family_root
+from aces_sdl.scenario import Scenario
+from aces_sdl.scenarios import load_scenario
+from jsonschema import Draft202012Validator
+from paths import EXAMPLES_DIR
+
+# ``by_alias=True`` is load-bearing: the published schema is generated from the model with
+# ``model_json_schema()`` (aliases on), so a field-name dump fails on YAML-facing aliases
+# such as ``class``, ``on-success``, and ``max-attempts``. ``mode="json"`` yields JSON-native
+# scalars (enum values, not enum members). These are the same flags the runtime compiler
+# uses for its contract-shaped serialization.
+_PUBLICATION_DUMP_KWARGS = {"mode": "json", "by_alias": True}
+
+
+@dataclass(frozen=True)
+class CorpusEntry:
+    """One validation-corpus leg: a glob of example files checked against one published schema.
+
+    The extension seam (issue #501 preflight): a future instantiated-example corpus adds a
+    row to ``VALIDATION_CORPUS`` — root, glob, loader, contract id, schema file, and
+    serialization kwargs — rather than a new loader, path convention, or validator wrapper.
+    """
+
+    contract_id: str
+    root: Path
+    glob: str
+    loader: Callable[[Path], Scenario]
+    schema_path: Path
+    dump_kwargs: dict = field(default_factory=lambda: dict(_PUBLICATION_DUMP_KWARGS))
+
+    def examples(self) -> list[Path]:
+        return sorted(self.root.glob(self.glob))
+
+    def validator(self) -> Draft202012Validator:
+        return _validator_for(self.schema_path)
+
+
+@cache
+def _validator_for(schema_path: Path) -> Draft202012Validator:
+    """Load the *checked-in* published schema artifact and build its validator once."""
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return Draft202012Validator(schema)
+
+
+_SDL_SCHEMA_DIR = corpus_family_root("schemas") / "sdl"
+
+# Today the table has exactly one leg: the authoring example corpus against the published
+# authoring-input contract. No instantiated-scenario *example* artifacts exist under
+# ``examples/`` — the instantiated schema's fixtures under ``contracts/fixtures/sdl/`` are
+# covered by ``test_instantiated_scenario_schema.py`` — so a future instantiated corpus adds
+# a row here for ``instantiated-scenario-v1``.
+VALIDATION_CORPUS = [
+    CorpusEntry(
+        contract_id="sdl-authoring-input-v1",
+        root=EXAMPLES_DIR,
+        glob="*.sdl.yaml",
+        loader=load_scenario,
+        schema_path=_SDL_SCHEMA_DIR / "sdl-authoring-input-v1.json",
+    ),
+]
+
+
+def _example_cases() -> list[tuple[CorpusEntry, Path]]:
+    return [(entry, path) for entry in VALIDATION_CORPUS for path in entry.examples()]
+
+
+def _case_id(value: object) -> str:
+    if isinstance(value, Path):
+        return value.name
+    if isinstance(value, CorpusEntry):
+        return value.contract_id
+    return str(value)
+
+
+@pytest.mark.parametrize(("entry", "path"), _example_cases(), ids=_case_id)
+def test_example_conforms_to_published_schema(entry: CorpusEntry, path: Path) -> None:
+    """Every shipped example provably conforms to the published contract surface in CI.
+
+    The serialization mirrors the runtime compiler's publication serialization, so the JSON
+    validated here is the shape a downstream consumer reads — not an internal Pydantic-only
+    projection.
+    """
+    scenario = entry.loader(path)
+    payload = scenario.model_dump(**entry.dump_kwargs)
+
+    errors = sorted(entry.validator().iter_errors(payload), key=lambda error: error.json_path)
+
+    assert not errors, f"{path.name} violates {entry.contract_id}:\n" + "\n".join(
+        f"  {error.json_path}: {error.message}" for error in errors
+    )
+
+
+@pytest.mark.parametrize("entry", VALIDATION_CORPUS, ids=_case_id)
+def test_corpus_leg_is_nonempty(entry: CorpusEntry) -> None:
+    """Non-vacuity guard: a stale/relocated corpus root must fail loudly, not collect zero cases."""
+    assert entry.examples(), f"No examples for {entry.contract_id} under {entry.root} (glob {entry.glob!r})"
+
+
+# --- Negative control: the validator must be engaged (the suite cannot pass vacuously) ---
+
+_AUTHORING_ENTRY = VALIDATION_CORPUS[0]
+
+_MINIMAL_VALID_PAYLOAD = {"name": "negative-control-baseline"}
+
+# Each payload violates exactly one published-schema rule: ``required: ["name"]``,
+# ``name`` typed ``string``, and top-level ``additionalProperties: false``. Kept inline,
+# never as a file under ``examples/scenarios/``, so an invalid control never leaks into the
+# reusable positive example corpus.
+_INVALID_PAYLOADS = {
+    "missing-required-name": {"description": "no name field"},
+    "wrong-type-name": {"name": 123},
+    "additional-top-level-property": {"name": "neg-control", "not_a_real_section": True},
+}
+
+
+def test_negative_control_baseline_is_accepted() -> None:
+    """A minimal valid document validates, so the rejections below indicate the injected defect,
+    not a validator that rejects everything."""
+    _AUTHORING_ENTRY.validator().validate(_MINIMAL_VALID_PAYLOAD)
+
+
+@pytest.mark.parametrize("payload", _INVALID_PAYLOADS.values(), ids=list(_INVALID_PAYLOADS))
+def test_negative_control_invalid_payload_is_rejected(payload: dict) -> None:
+    """A known-invalid payload must fail published-schema validation, proving the validator is engaged."""
+    assert not _AUTHORING_ENTRY.validator().is_valid(payload)


### PR DESCRIPTION
## Summary

Harden the validation corpus so the worked SDL examples are proven against the *published* JSON Schema in CI, not just the Pydantic parser. A new pytest module loads each examples/scenarios/*.sdl.yaml through load_scenario, serializes it with the contract-shaped publication serialization model_dump(mode="json", by_alias=True) (the same flags aces_processor/compiler.py uses), and validates the result against the checked-in contracts/schemas/sdl/sdl-authoring-input-v1.json with Draft202012Validator. All four shipped examples conform with zero validator errors. A non-vacuity corpus guard and a negative control keep the suite from passing vacuously. This closes the example/negative-path leg of ASR-504, whose rationale named exactly this gap (the example scenario test path was stale after the repo reorg). The prerequisite #7/ASR-504 corpus-path fix already landed (tests/paths.EXAMPLES_DIR now resolves examples/scenarios via a .ground-control.yaml marker walk-up), so no step-0 path fix was needed.

## Requirement UIDs

- `ASR-504`

## Related Issues

Closes #501

## ADR Impact

- ADR-009

## Changes

- Add implementations/python/tests/test_example_schema_conformance.py: parametrized validation of every examples/scenarios/*.sdl.yaml against the published sdl-authoring-input-v1 schema via Draft202012Validator
- Serialize each example with the canonical publication serialization model_dump(mode=json, by_alias=True); by_alias is load-bearing so YAML-facing aliases (class, on-success, max-attempts) match the schema
- Resolve the published schema via aces_contracts.corpus.corpus_family_root('schemas') and the examples via tests/paths.EXAMPLES_DIR (no parents[N] heuristics)
- Add a non-vacuity corpus guard and a negative control (missing name, wrong-typed name, extra top-level property) so the suite cannot pass vacuously
- Model the corpus as an extensible validation-corpus table so a future instantiated-scenario example corpus adds a row, not a new loader (per the Step 2.5 preflight note)
- Add docs/decisions/issue-501-validation-corpus-schema-preflight.md (architecture preflight design note) and changelog.d/501.added.md

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

All four examples (hospital-ransomware-surgery-day, port-authority-surge-response, satcom-release-poisoning, techvault) validate with zero schema errors. The negative control proves engagement: a field-name dump (by_alias=False) produces 8+ schema errors, the three invalid payloads are each rejected, and a minimal valid {name} document is accepted. Full `nox -s verify` graph is green (pytest 503s, including the new module). No instantiated-scenario example artifacts exist under examples/, so scope item 2 is a documented no-op; the corpus table leaves the seam open for a future instantiated-scenario-v1 row.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: ASR-504 ← implementations/python/tests/test_example_schema_conformance.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/501.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
