### PR TITLE
test: add determinism witness for SDL parse/instantiate/compile pipeline

### DIFF
--- a/changelog.d/506.added.md
+++ b/changelog.d/506.added.md
@@ -1,0 +1,1 @@
+Add a determinism witness for the SDL parse/instantiate/compile pipeline: it compiles representative scenarios (including a module-import scenario) twice, and once more under a varied PYTHONHASHSEED in a subprocess, and asserts the compiled output is byte-identical. docs/explain/sdl/parser.md now cites it.

--- a/docs/decisions/issue-506-determinism-witness-preflight.md
+++ b/docs/decisions/issue-506-determinism-witness-preflight.md
@@ -1,0 +1,163 @@
+# Issue 506 Determinism Witness Preflight
+
+Date: 2026-06-15
+
+Issue: #506.
+
+Requirement: none. The issue title, body, and acceptance criteria are the
+contract.
+
+This note records architecture preflight guardrails for adding a narrow
+determinism witness for parse -> instantiate -> compile. It is guidance for the
+implementation and does not add the witness test, change parser/compiler
+behavior, or update the parser documentation citation.
+
+## Binding Sources
+
+- `docs/explain/sdl/parser.md` makes the documented claim: file-backed import
+  expansion is deterministic and in-memory parsing rejects imports.
+- ADR-053 fixes the module-composition model: imports are typed SDL
+  composition, resolved through lock/trust/digest/version checks, expanded
+  before semantic validation, and compiled as one canonical scenario.
+- ADR-016 fixes the lifecycle order: authoring, validation, instantiation,
+  compilation, planning, execution, observation. This issue witnesses only the
+  first four phases.
+- ADR-004 fixes the compiler boundary: `compile_runtime_model()` is a pure
+  normalization pass from an instantiated scenario into canonical runtime
+  resources.
+- `.ground-control.yaml`, `noxfile.py`, and `implementations/python/pyproject.toml`
+  define the verification graph. The witness must live under
+  `implementations/python/tests/` so CI and `nox -s verify` run it.
+
+## Architecture Decisions
+
+- Test the public pipeline, not internals: `parse_sdl_file(...)`,
+  `instantiate_scenario(...)`, and `compile_runtime_model(...)`.
+  `parse_sdl(...)`, `expand_sdl_modules(...)`, direct `Scenario(...)`
+  construction, and compiler helper calls are the wrong witness surface.
+- Build the representative scenario as temp files through `tmp_path`, including
+  at least one local module import, explicit namespace, module exports, variables
+  with defaults or provided parameters, multiple agents, multiple features, and
+  multiple relationships. This exercises import expansion, map-key preservation,
+  reference rewriting, variable substitution, and ordered collection surfaces.
+- Compare the compiled artifact with one canonical serializer local to the
+  witness. The serializer should convert dataclasses and Pydantic/contract
+  models to plain JSON-compatible data, then use
+  `json.dumps(..., sort_keys=True, separators=(",", ":"))`. Do not compare
+  `repr(...)`, object ids, dict iteration text, or pretty JSON.
+- Enumerate explicitly timestamp-typed compiled fields in the test. Today the
+  parse/instantiate/compile path does not generate timestamps; timestamp-shaped
+  values are authored data. If the witness fixture avoids timestamp-bearing
+  runtime inventory, the exclusion set should be empty and asserted as such.
+- The `PYTHONHASHSEED` variation must be a subprocess pass over the same
+  temp-file scenario graph. Use fixed argv, `sys.executable`, a controlled
+  `env`, and captured stdout containing only the canonical serialization or a
+  digest of it. Do not use `shell=True` or embed secrets in argv.
+- After the test exists, `docs/explain/sdl/parser.md` should cite the test by
+  stable test name or file path. Do not pre-cite a non-existent test.
+
+## Required Incumbents
+
+- Parser and composition: `aces_sdl.parser.parse_sdl_file`,
+  `_load_normalized_data`, `ImportDecl`, `ModuleDescriptor`,
+  `aces_sdl.composition.expand_sdl_modules`, and
+  `aces_sdl.module_registry.resolve_import`.
+- Validation and instantiation: `SDLModel(extra="forbid")`,
+  `SemanticValidator`, `instantiate_scenario`, `InstantiatedScenario`, and
+  `SDLInstantiationError` / `SDLParseError` / `SDLValidationError`.
+- Compilation: `aces_processor.compiler.compile_runtime_model`,
+  `RuntimeModel`, existing compiler dataclasses, and `resource_payload(...)`
+  where backend-facing resource shape is relevant.
+- Existing test patterns: `test_sdl_module_registry.py` for temp-file module
+  imports and lock/trust behavior, `test_runtime_models.py` for compile
+  assertions, `test_instantiated_scenario_schema.py` for concrete instantiated
+  payload constraints, and `test_corpus_packaging.py` for fixed-argv subprocess
+  style.
+- Verification workflow: `nox -s tests` for the default CI pytest sweep and
+  `nox -s verify` for the full repository gate.
+
+## Cross-Cutting Layers
+
+- YAML/config parsing: the witness must enter through `parse_sdl_file(...)`,
+  which uses `yaml.safe_load`, top-level mapping checks, key normalization,
+  shorthand expansion, variable-key rejection, import expansion, and
+  `extra="forbid"` Pydantic construction.
+- Module supply-chain validation: local imports still pass through
+  `ImportDecl`, module descriptor validation, version checks, digest pins when
+  authored, optional lockfile checks, allowed-parameter checks, namespace
+  collision rejection, reserved `__private` namespace rejection, and import-cycle
+  detection. The test should not bypass those layers with direct payload merges.
+- Semantic validation: the root expanded scenario must pass the existing
+  `SemanticValidator`; missing, ambiguous, or unexported references must remain
+  hard errors rather than being normalized away by the witness.
+- Instantiated-shape validation: variable substitution must go through
+  `instantiate_scenario(...)`, including variable type checks, undeclared
+  parameter rejection, unresolved-placeholder rejection, `InstantiatedScenario`
+  revalidation, and post-substitution semantic validation.
+- Compiler contracts: compilation must use the existing `RuntimeModel` and
+  dataclass resources. The witness must not introduce a second compiled schema,
+  duplicate DTO, or alternate address generator.
+- Secret-handling surface: fixture data should avoid real credentials. If an
+  environment/runtime secret-shaped value is needed, use existing redaction
+  classifications and assert only the classification, not raw secret material.
+- Environment and OS exposure: the subprocess should set only
+  `PYTHONHASHSEED` and any minimal import-path/cwd variables needed to import
+  the project under pytest. Pass scenario paths as argv values, never shell
+  fragments, and never place tokens, private keys, or operator secrets in argv
+  or stdout.
+- Error envelopes: failures should be ordinary pytest assertion failures or the
+  existing SDL exception types. Do not add a new exception hierarchy, logging
+  channel, CLI wrapper, or diagnostic envelope for the witness.
+- Auth, persistence, and network layers: this issue should touch none of them.
+  No control-plane auth, HTTP API, database, runtime manager, backend registry,
+  OCI network fetch, or audit-log behavior is in scope.
+
+## Extension Boundary
+
+The extensibility seam is the canonical serializer plus a small fixture builder
+parameterized by scenario root path, parameters, and hash seed. Future
+determinism witnesses can reuse that seam for other pipeline phases or broader
+ASR-514 coverage without editing production parser, composition, instantiation,
+or compiler code.
+
+If future compiled models add genuinely generated timestamp fields, add those
+field paths to the explicit exclusion list with a comment naming the producer.
+Do not introduce broad key-name scrubbing such as dropping every field whose
+name contains `time`.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- comparing `repr(model)`, object identity, insertion-order pretty JSON, or
+  unsorted dict text;
+- mutating production code only to make the witness deterministic unless the
+  test exposes a real nondeterminism bug that the implementation deliberately
+  fixes;
+- constructing `Scenario` or `RuntimeModel` objects directly instead of passing
+  through parse, import resolution, instantiation, and compilation;
+- adding a duplicate schema, duplicate validator, duplicate exception hierarchy,
+  or duplicate module-import workflow for test convenience;
+- using sets in fixture construction where the witness is supposed to exercise
+  authored order and stable compiler order;
+- masking nondeterminism by sorting away ordered collection values that are
+  semantically ordered, such as authored list fields, workflow steps, or
+  compiled tuples;
+- making the subprocess test depend on the developer's ambient environment,
+  home directory, network, installed package, or shell;
+- running an OCI registry or generating signing keys for this narrow witness
+  when a local file import is enough to exercise composition order;
+- updating `docs/explain/sdl/parser.md` with a citation before the executable
+  test lands.
+
+## Non-Goals
+
+- Proving all ASR-514 determinism and stability properties.
+- Redesigning module composition, lockfile semantics, trust policy, parser
+  normalization, variable substitution, compiler ordering, or runtime planning.
+- Adding a public canonical-serialization API or published compiled-runtime
+  JSON schema.
+- Changing contract schemas, generated schema bundles, formal specs, or the
+  compatibility-only `implementations/python/src/aces/` wrappers.
+- Adding control-plane, backend, persistence, auth, logging, or network
+  behavior.

--- a/docs/explain/sdl/parser.md
+++ b/docs/explain/sdl/parser.md
@@ -106,7 +106,11 @@ scenario = parse_sdl(yaml_string, skip_semantic_validation=True)
 
 Use `parse_sdl_file(...)` for SDL that uses top-level `imports:`. Import
 expansion is file-backed and deterministic, so in-memory `parse_sdl(...)`
-rejects module/import composition by design.
+rejects module/import composition by design. This determinism is witnessed by
+`implementations/python/tests/test_pipeline_determinism.py`, which runs the
+`parse → instantiate → compile` pipeline twice over representative scenarios
+(including a module-import scenario) and under varied `PYTHONHASHSEED`, and
+asserts the compiled output is byte-identical.
 
 Top-level composition supports:
 

--- a/implementations/python/tests/test_pipeline_determinism.py
+++ b/implementations/python/tests/test_pipeline_determinism.py
@@ -1,0 +1,253 @@
+"""Determinism witness for the SDL ``parse -> instantiate -> compile`` pipeline.
+
+Records the executable witness that review finding IMP-4 (issue #506) found
+missing: ``docs/explain/sdl/parser.md`` claims "Import expansion is file-backed
+and deterministic", and the pipeline design (lockfile-backed imports, no ambient
+state) is plausibly deterministic, but no test ran the pipeline twice and
+asserted identical output. This is also the narrow witness for the broader
+ASR-514 determinism-verification surface.
+
+Three checks:
+
+1. ``test_pipeline_is_byte_identical_across_two_passes`` -- run the public
+   pipeline twice in one process over the shipped complex example scenarios
+   (multiple agents / features / relationships + variable substitution +
+   ordered collections) and assert the canonical serializations are
+   byte-identical.
+2. ``test_module_import_pipeline_is_byte_identical_across_two_passes`` -- same
+   two-pass assertion for a local module-import scenario (explicit namespace,
+   module ``exports``, multiple imported nodes) so import-expansion order is
+   exercised.
+3. ``test_pipeline_is_hash_seed_independent`` -- compile the same scenario in
+   two fixed-argv ``sys.executable`` subprocesses under different
+   ``PYTHONHASHSEED`` values and assert the canonical serializations are
+   byte-identical. A single process pins one hash seed, so cross-process
+   variation is the only way to catch hash-order dependence (set/dict iteration
+   order leaking into the output).
+
+Canonical serializer notes:
+
+* Keys are intentionally **not** sorted. Determinism means the pipeline must
+  reproduce identical ordering on its own; sorting keys would canonicalize away
+  the hash-seed-dependent ordering that check (3) exists to detect. The pipeline
+  is verified hash-stable, so the strict assertion is not flaky. (This is a
+  deliberate refinement over the Step 2.5 preflight's ``sort_keys=True``
+  serializer suggestion, justified by the hash-order acceptance criterion.)
+* The generated-timestamp exclusion set is **empty by design**: the
+  ``parse -> instantiate -> compile`` path injects no wall-clock / uuid / random
+  values, so the compiled ``RuntimeModel`` carries no per-run fields (verified:
+  no ``datetime.now`` / ``time.time`` / ``uuid4`` / ``random`` / ``secrets`` in
+  ``aces_sdl`` or ``aces_processor``). Author-provided time-typed values
+  (``start_time``, OCR durations, script ``time``) are deterministic functions
+  of the input and need no exclusion. The strip mechanism is retained and
+  check (1) is the tripwire: a future generated timestamp would differ between
+  two same-process passes and fail loudly, prompting its field name to be added
+  to ``_GENERATED_TIMESTAMP_FIELDS``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from paths import EXAMPLES_DIR
+
+from aces.core.runtime.compiler import compile_runtime_model
+from aces.core.sdl import instantiate_scenario, parse_sdl_file
+
+# This whole witness is integration-style: it reads shipped scenarios from the
+# real repo on disk and spawns subprocesses, so it is excluded from the default
+# fast unit sweep and runs in the `integration` session (which `nox -s verify`
+# and CI both execute). A module-level mark keeps every current and future test
+# in this file inside that boundary -- per the repo's pytest marker taxonomy.
+pytestmark = pytest.mark.integration
+
+# Shipped scenarios that exercise ordered-collection surfaces (multiple agents,
+# features, and relationships) and -- for the first two -- variable
+# substitution. These are the representative inputs the witness compiles.
+COMPLEX_EXAMPLES = [
+    EXAMPLES_DIR / "hospital-ransomware-surgery-day.sdl.yaml",
+    EXAMPLES_DIR / "satcom-release-poisoning.sdl.yaml",
+    EXAMPLES_DIR / "port-authority-surge-response.sdl.yaml",
+]
+
+# Compiled RuntimeModel field names carrying per-run wall-clock / generated
+# values to exclude from the determinism comparison. Empty by design -- see the
+# module docstring. Adding a name here is the documented escape hatch if the
+# compiler ever emits a genuinely generated timestamp.
+_GENERATED_TIMESTAMP_FIELDS: frozenset[str] = frozenset()
+
+
+def _strip_excluded(value: object) -> object:
+    """Recursively drop excluded (generated-timestamp) keys from a payload."""
+    if isinstance(value, dict):
+        return {k: _strip_excluded(v) for k, v in value.items() if k not in _GENERATED_TIMESTAMP_FIELDS}
+    if isinstance(value, list):
+        return [_strip_excluded(item) for item in value]
+    return value
+
+
+def _canonical_json(model: object) -> str:
+    """Serialize a compiled ``RuntimeModel`` deterministically for byte compare.
+
+    ``sort_keys`` is intentionally ``False`` (see the module docstring).
+    ``default=str`` renders any enum or non-JSON-native leaf deterministically.
+    """
+    payload = _strip_excluded(dataclasses.asdict(model))
+    return json.dumps(payload, ensure_ascii=False, sort_keys=False, separators=(",", ":"), default=str)
+
+
+def _compile_canonical(path: Path, *, substitute_variables: bool) -> str:
+    """Run the full public pipeline for ``path`` and return canonical JSON."""
+    scenario = parse_sdl_file(path)
+    parameters: dict[str, object] = {}
+    if substitute_variables:
+        # Exercise variable substitution through the parameters path (rather
+        # than relying on implicit defaults) by passing each declared default
+        # back in as a provided value.
+        parameters = {name: var.default for name, var in scenario.variables.items() if var.default is not None}
+    instantiated = instantiate_scenario(scenario, parameters=parameters)
+    return _canonical_json(compile_runtime_model(instantiated))
+
+
+@pytest.mark.parametrize("scenario_path", COMPLEX_EXAMPLES, ids=lambda path: path.stem)
+def test_pipeline_is_byte_identical_across_two_passes(scenario_path: Path) -> None:
+    first = _compile_canonical(scenario_path, substitute_variables=True)
+    # Non-vacuous guard: a serializer that collapsed to empty/constant output
+    # would make byte-identity trivially true. Require real compiled content.
+    assert len(first) > 1000
+    assert '"node_deployments"' in first
+    second = _compile_canonical(scenario_path, substitute_variables=True)
+    assert first == second
+
+
+def test_canonical_serializer_distinguishes_distinct_scenarios() -> None:
+    # Proves the comparison is meaningful (sensitive to input), so the two-pass
+    # equality assertions above are not tautological.
+    first = _compile_canonical(COMPLEX_EXAMPLES[0], substitute_variables=True)
+    second = _compile_canonical(COMPLEX_EXAMPLES[1], substitute_variables=True)
+    assert first != second
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+    return path
+
+
+def _module_import_root(tmp_path: Path) -> Path:
+    """Write a local module + an importing root, returning the root path.
+
+    The module exports multiple nodes and infrastructure with switch links so
+    import expansion and ordered-collection rewriting are exercised. A ``path:``
+    import needs no lockfile/trust material (it is the backward-compatible
+    direct-path source).
+    """
+    _write(
+        tmp_path / "shared.yaml",
+        """
+        name: shared
+        version: 1.2.3
+        module:
+          id: acme/shared
+          version: 1.2.3
+          exports:
+            nodes: [web, db, edge]
+            infrastructure: [web, db, edge]
+        nodes:
+          web: {type: vm, os: linux, resources: {ram: 1 gib, cpu: 1}}
+          db: {type: vm, os: linux, resources: {ram: 2 gib, cpu: 2}}
+          edge: {type: switch}
+        infrastructure:
+          web: {count: 1, links: [edge]}
+          db: {count: 1, links: [edge]}
+          edge: 1
+        """,
+    )
+    return _write(
+        tmp_path / "root.yaml",
+        """
+        name: root
+        imports:
+          - path: shared.yaml
+            namespace: shared
+        """,
+    )
+
+
+def test_module_import_pipeline_is_byte_identical_across_two_passes(tmp_path: Path) -> None:
+    root = _module_import_root(tmp_path)
+    first = _compile_canonical(root, substitute_variables=False)
+    # Confirm the namespaced import actually expanded into the compiled model.
+    assert "shared.web" in first
+    second = _compile_canonical(root, substitute_variables=False)
+    assert first == second
+
+
+# Fixed-argv subprocess driver: read a scenario path (argv[1]), run the public
+# pipeline, and print the sha256 of the canonical serialization. The exclusion
+# set is passed as a JSON argv (argv[2]) so the driver mirrors `_canonical_json`
+# exactly with a single source of truth. No shell, no secrets in argv/stdout.
+_SUBPROCESS_DRIVER = textwrap.dedent(
+    """
+    import dataclasses
+    import hashlib
+    import json
+    import sys
+    from pathlib import Path
+
+    from aces.core.runtime.compiler import compile_runtime_model
+    from aces.core.sdl import instantiate_scenario, parse_sdl_file
+
+    exclude = set(json.loads(sys.argv[2]))
+
+    def strip(value):
+        if isinstance(value, dict):
+            return {k: strip(v) for k, v in value.items() if k not in exclude}
+        if isinstance(value, list):
+            return [strip(item) for item in value]
+        return value
+
+    scenario = parse_sdl_file(Path(sys.argv[1]))
+    parameters = {n: v.default for n, v in scenario.variables.items() if v.default is not None}
+    model = compile_runtime_model(instantiate_scenario(scenario, parameters=parameters))
+    canonical = json.dumps(
+        strip(dataclasses.asdict(model)),
+        ensure_ascii=False,
+        sort_keys=False,
+        separators=(",", ":"),
+        default=str,
+    )
+    sys.stdout.write(hashlib.sha256(canonical.encode("utf-8")).hexdigest())
+    """
+)
+
+
+def _subprocess_digest(scenario_path: Path, hash_seed: str) -> str:
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = hash_seed
+    exclude_arg = json.dumps(sorted(_GENERATED_TIMESTAMP_FIELDS))
+    result = subprocess.run(
+        [sys.executable, "-c", _SUBPROCESS_DRIVER, str(scenario_path), exclude_arg],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, f"determinism driver failed (seed={hash_seed}): {result.stderr}"
+    digest = result.stdout.strip()
+    assert len(digest) == 64, f"unexpected driver output (seed={hash_seed}): {result.stdout!r} / {result.stderr!r}"
+    return digest
+
+
+@pytest.mark.parametrize("scenario_path", COMPLEX_EXAMPLES, ids=lambda path: path.stem)
+def test_pipeline_is_hash_seed_independent(scenario_path: Path) -> None:
+    digest_seed_0 = _subprocess_digest(scenario_path, "0")
+    digest_seed_1 = _subprocess_digest(scenario_path, "1")
+    assert digest_seed_0 == digest_seed_1


### PR DESCRIPTION
## Summary

Witnesses review finding IMP-4: docs/explain/sdl/parser.md claimed SDL import expansion is file-backed and deterministic with no executable witness running the pipeline twice. Adds a determinism witness that runs the public parse -> instantiate -> compile pipeline twice over representative shipped scenarios (multiple agents/features/relationships + variable substitution) and a local module-import scenario, asserting byte-identical canonical JSON, plus a cross-process PYTHONHASHSEED pass (fixed-argv subprocess) to catch hash-order dependence. Requirement-free run; this is the narrow witness for ASR-514's determinism-verification surface (ASR-514 stays the broader requirement and is not transitioned). parser.md's determinism claim now cites the test. ADR-053 (module composition), ADR-016 (lifecycle order), and ADR-004 (compiler boundary) are the binding architecture per the Step 2.5 preflight; no ADR changes.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #506

## ADR Impact

- ADR-053
- ADR-016
- ADR-004

## Changes

- Add implementations/python/tests/test_pipeline_determinism.py: two-pass byte-identity over shipped scenarios + a local module-import scenario, plus a cross-process PYTHONHASHSEED pass; integration-marked so it runs in CI's integration sweep.
- Cite the witness from docs/explain/sdl/parser.md's determinism claim.
- Record the Step 2.5 architecture preflight note under docs/decisions/issue-506-determinism-witness-preflight.md.
- Add changelog.d/506.added.md.

## Test Plan

Witness is integration-marked: excluded from the default unit sweep, run by `nox -s integration` (which `nox -s verify` and CI both execute). Verified locally: `nox -s verify -- --skip-requirement` green; 8 witness tests pass in the integration sweep.

## Ground Control Checks

- [x] policy gate passes (`nox -s verify -- --skip-requirement`)
- [x] codex pre-push review clean (Step 6.5)
- [x] test-quality pre-push review finding fixed (Step 6.6)

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: ASR-514 ← implementations/python/tests/test_pipeline_determinism.py

## Checklist

- [x] Changelog fragment added at `changelog.d/506.added.md`
- [x] parser.md determinism claim cites the witness
