### PR TITLE
test: trim tautological self-checks from participant spec-oracle suites

### DIFF
--- a/implementations/python/tests/test_participant_runtime_invariants.py
+++ b/implementations/python/tests/test_participant_runtime_invariants.py
@@ -1,10 +1,26 @@
-"""Executable oracle for participant-runtime trace predicates.
+"""Self-consistency oracle for the participant-runtime trace predicates.
+
+This file is NOT a test of a production participant-runtime subsystem. The
+predicates below (`ValidTrace`, `MonotoneSequence`, `RevisionDiscipline`,
+`OrderDiscipline`, `ConflictOK`, `TimeManagementOK`) have no callers under
+``src/`` or ``packages/`` — they are a closed, test-local executable encoding of
+the trace predicates published in the participant-runtime formal spec. The suite
+checks only that the encoding *discriminates*: each predicate accepts the
+legitimate variants of a spec-conforming trace and rejects a targeted violation
+while the other (non-targeted) predicates continue to hold.
 
 Spec mapping:
 - `ValidTrace`, `MonotoneSequence`, `RevisionDiscipline`, and
   `OrderDiscipline`: specs/formal/participant-runtime/README.md:1265
 - `ConflictOK` and `TimeManagementOK`:
   specs/formal/participant-runtime/README.md:2417
+
+The acceptance direction is exercised only as a positive control alongside the
+rejection tests (the ``*_accepts_supported_*_variants`` tests, plus the
+``assert <other predicate>(mutated)`` lines inside each rejection test). A green
+run here is NOT evidence that production code enforces these predicates; runtime
+enforcement of participant-runtime behaviour is covered behaviourally by
+``test_run_305_*``, ``test_run_306_*``, and ``test_run_311_*``.
 """
 
 from __future__ import annotations
@@ -790,24 +806,12 @@ def with_invalid_time_context_variant(trace: RuntimeTrace, variant: str) -> Runt
 
 @PROPERTY_SETTINGS
 @given(valid_traces())
-def test_valid_trace_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert valid_trace(trace)
-
-
-@PROPERTY_SETTINGS
-@given(valid_traces())
 def test_valid_trace_rejects_targeted_mutations(trace: RuntimeTrace) -> None:
     assert not valid_trace(with_sequence_regression(trace))
     assert not valid_trace(with_revision_violation(trace))
     assert not valid_trace(with_order_violation(trace))
     assert not valid_trace(with_conflicting_concurrent_writes(trace))
     assert not valid_trace(with_time_domain_violation(trace))
-
-
-@PROPERTY_SETTINGS
-@given(valid_traces())
-def test_monotone_sequence_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert monotone_sequence(trace)
 
 
 @PROPERTY_SETTINGS
@@ -820,12 +824,6 @@ def test_monotone_sequence_rejects_sequence_regression(trace: RuntimeTrace) -> N
     assert order_discipline(mutated)
     assert all(conflict_ok(record, mutated) for record in mutated.joint_actions)
     assert all(time_management_ok(context, mutated) for context in mutated.time_contexts)
-
-
-@PROPERTY_SETTINGS
-@given(valid_traces())
-def test_revision_discipline_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert revision_discipline(trace)
 
 
 @PROPERTY_SETTINGS
@@ -868,12 +866,6 @@ def test_revision_discipline_rejects_invalid_disclosure_specific_writes(
 
 
 @PROPERTY_SETTINGS
-@given(valid_traces())
-def test_order_discipline_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert order_discipline(trace)
-
-
-@PROPERTY_SETTINGS
 @given(valid_traces(), st.sampled_from(ORDER_CLAIM_VARIANTS))
 def test_order_discipline_accepts_supported_order_claim_strengths(
     trace: RuntimeTrace,
@@ -907,12 +899,6 @@ def test_order_discipline_rejects_claim_without_declared_basis(trace: RuntimeTra
     assert not order_discipline(mutated)
     assert all(conflict_ok(record, mutated) for record in mutated.joint_actions)
     assert all(time_management_ok(context, mutated) for context in mutated.time_contexts)
-
-
-@PROPERTY_SETTINGS
-@given(valid_traces())
-def test_conflict_ok_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert all(conflict_ok(record, trace) for record in trace.joint_actions)
 
 
 @PROPERTY_SETTINGS
@@ -966,12 +952,6 @@ def test_conflict_ok_rejects_joint_action_witnesses_that_are_not_exact_permutati
     assert order_discipline(mutated)
     assert all(not conflict_ok(record, mutated) for record in mutated.joint_actions)
     assert all(time_management_ok(context, mutated) for context in mutated.time_contexts)
-
-
-@PROPERTY_SETTINGS
-@given(valid_traces())
-def test_time_management_ok_accepts_generated_valid_traces(trace: RuntimeTrace) -> None:
-    assert all(time_management_ok(context, trace) for context in trace.time_contexts)
 
 
 @PROPERTY_SETTINGS

--- a/implementations/python/tests/test_participant_semantics_invariant_oracle.py
+++ b/implementations/python/tests/test_participant_semantics_invariant_oracle.py
@@ -1,8 +1,27 @@
-"""Executable invariant oracle for the participant-semantics abstract model.
+"""Self-consistency oracle for the participant-semantics formal model.
 
-The oracle intentionally stays test-local. It executes the published invariants
-from ``specs/formal/participant-semantics/README.md`` without introducing a
-runtime participant-semantics subsystem.
+This file is NOT a test of any production participant-semantics subsystem — no
+such runtime subsystem exists, and the invariant predicates below have no
+callers under ``src/`` or ``packages/``. It is a closed, test-local executable
+encoding of the invariants published in
+``specs/formal/participant-semantics/README.md`` (I1-I18), and it checks two
+things about that encoding:
+
+* **Spec sync** — the catalog of invariant IDs and their spec section headings
+  stay in lock-step with the spec document
+  (``test_oracle_and_spec_headings_map_both_directions``).
+* **Discrimination** — each invariant predicate actually separates a
+  spec-conforming progression from a targeted violation.
+  ``test_canonical_progression_satisfies_all_invariants`` is the positive
+  control and ``test_each_invariant_rejects_its_targeted_mutation`` is the
+  negative control. Because the fixtures and predicates are co-authored, the
+  acceptance-direction check is a positive control for the mutation test, not
+  evidence of production coverage.
+
+Runtime *enforcement* of participant semantics is covered behaviourally
+elsewhere (``test_sem_211_*`` … ``test_sem_218_*``, which drive the real
+parser/compiler/validator engines). A green run here does not mean participant
+semantics are implemented.
 """
 
 from __future__ import annotations
@@ -13,8 +32,6 @@ from pathlib import Path
 from typing import TypeVar
 
 import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
 
 SPEC_PATH = Path(__file__).resolve().parents[3] / "specs/formal/participant-semantics/README.md"
 
@@ -395,65 +412,6 @@ def canonical_progression() -> ParticipantProgression:
     )
 
 
-@st.composite
-def participant_progressions(draw) -> ParticipantProgression:
-    state = canonical_progression()
-    participant_count = draw(st.integers(min_value=2, max_value=4))
-    participants = tuple(
-        Participant(
-            participant_id=f"participant-{index}",
-            implementation_type=draw(st.sampled_from(IMPLEMENTATION_TYPES)),
-            semantic_profile="participant-semantics-v1",
-        )
-        for index in range(participant_count)
-    )
-    side_effects = frozenset(
-        draw(
-            st.lists(
-                st.sampled_from(["detection_effect", "visibility_effect", "evidence_effect"]),
-                min_size=1,
-                max_size=3,
-                unique=True,
-            )
-        )
-    )
-    actual_side_effects = frozenset(draw(st.lists(st.sampled_from(sorted(side_effects)), min_size=1)))
-    action = replace(
-        state.actions[0],
-        participant_id=participants[0].participant_id,
-        declared_side_effect_classes=side_effects,
-        actual_side_effect_classes=actual_side_effects,
-        interaction_classes=frozenset(
-            draw(st.lists(st.sampled_from(sorted(INTERACTION_CLASSES)), min_size=1, unique=True))
-        ),
-        time_domain=draw(st.sampled_from(["episode_step", "scenario_time", "simulation_time", "backend_time"])),
-        clock_authority=draw(st.sampled_from(["scenario-clock", "sim-clock", "backend-clock"])),
-    )
-    observation = replace(
-        state.observations[0],
-        participant_id=participants[0].participant_id,
-        latency_domain=action.time_domain,
-        visible_refs=frozenset(
-            draw(st.lists(st.sampled_from(["asset.public-host", "asset.public-service"]), min_size=1))
-        ),
-    )
-    fidelity_claim = replace(
-        state.fidelity_claim,
-        semantic_portability_claimed=draw(st.booleans()),
-        fidelity_equivalence_claimed=draw(st.booleans()),
-        portability_claim_implies_fidelity=False,
-    )
-    language_evaluation = replace(state.language_evaluation, concrete_syntax_declared=draw(st.booleans()))
-    return replace(
-        state,
-        participants=participants,
-        actions=(action,),
-        observations=(observation,),
-        fidelity_claim=fidelity_claim,
-        language_evaluation=language_evaluation,
-    )
-
-
 def _i1_role_neutral(state: ParticipantProgression) -> bool:
     profiles = {participant.semantic_profile for participant in state.participants}
     known_implementations = all(
@@ -800,10 +758,6 @@ INVARIANTS = (
 )
 
 
-def test_invariant_catalog_covers_i1_through_i18() -> None:
-    assert [invariant.invariant_id for invariant in INVARIANTS] == [f"I{index}" for index in range(1, 19)]
-
-
 def test_oracle_and_spec_headings_map_both_directions() -> None:
     spec_text = SPEC_PATH.read_text(encoding="utf-8")
     spec_headings = {
@@ -827,24 +781,12 @@ def test_each_invariant_rejects_its_targeted_mutation(invariant: Invariant) -> N
 
 
 def test_canonical_progression_satisfies_all_invariants() -> None:
+    # Positive control. The canonical progression must satisfy every predicate so
+    # that test_each_invariant_rejects_its_targeted_mutation proves a real
+    # True -> False flip rather than a vacuous False -> False. This is not
+    # evidence of production coverage; nothing under src/ or packages/ consumes
+    # these predicates.
     state = canonical_progression()
 
     for invariant in INVARIANTS:
         assert invariant.predicate(state), invariant.invariant_id
-
-
-@settings(max_examples=50, deadline=None)
-@given(state=participant_progressions())
-def test_generated_valid_progressions_satisfy_all_invariants(state: ParticipantProgression) -> None:
-    for invariant in INVARIANTS:
-        assert invariant.predicate(state), invariant.invariant_id
-
-
-@settings(max_examples=25, deadline=None)
-@given(base_state=participant_progressions())
-@pytest.mark.parametrize("invariant", INVARIANTS, ids=lambda invariant: invariant.invariant_id)
-def test_generated_targeted_mutations_are_rejected(
-    invariant: Invariant,
-    base_state: ParticipantProgression,
-) -> None:
-    assert not invariant.predicate(invariant.mutate(base_state)), invariant.invariant_id


### PR DESCRIPTION
Resolves #558.

## Context

A behavioural audit of the Python test suites (looking for the "assert against yourself / mock the thing under test" rot that affected a sibling project) found the suite is overwhelmingly sound — real parser/validator/runtime/conformance/CLI/MCP code runs across it. The one genuine soft spot was two executable spec-oracle files whose acceptance-direction tests were tautological.

Both `test_participant_semantics_invariant_oracle.py` and `test_participant_runtime_invariants.py` re-encode a formal spec's invariants as **test-local predicates with no production callers** (zero references under `src/`/`packages/`). Several tests asserted that a co-authored fixture / Hypothesis generator — built to satisfy those same predicates — satisfies them. Those pass by construction, can't catch a wrong implementation, and overstate participant-semantics/runtime coverage.

## Changes

- **semantics oracle**: removed the catalog self-check and both Hypothesis "generator output satisfies the predicates" tests; deleted the now-dead generator strategy and its imports.
- **runtime oracle**: removed the six bare `*_accepts_generated_valid_traces` tests.
- **kept** the load-bearing checks: the spec/catalog drift guard, the per-invariant mutation/rejection differential tests, the `*_accepts_supported_*_variants` over-rejection guards, and the canonical positive control (now commented to explain it gives the mutation test a real True→False flip).
- **relabelled** both module docstrings as spec self-consistency oracles (not tests of production code), pointing to the suites that cover runtime enforcement behaviourally (`test_sem_211_*`…`test_sem_218_*`, `test_run_305/306/311_*`).

Net: −78 lines (124 deletions, 46 insertions). No production code touched.

## Verification

- `ruff check` clean (no unused imports / dead code)
- affected suites pass: 35 tests
- full suite still collects: 2523 tests