### PR TITLE
feat(runtime): add shared operational state snapshots

### DIFF
--- a/changelog.d/194.added.md
+++ b/changelog.d/194.added.md
@@ -1,0 +1,2 @@
+### Added
+- Added first-class RUN-307 shared operational state records/history to runtime snapshots with revision-aware validation.

--- a/changelog.d/194.added.md
+++ b/changelog.d/194.added.md
@@ -1,2 +1,3 @@
 ### Added
 - Added first-class RUN-307 shared operational state records/history to runtime snapshots with revision-aware validation.
+- Added semantic diagnostics for malformed shared-state records, access markers, and append-only history violations.

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -198,10 +198,10 @@
       "contract_id": "participant-shared-state-record-v1",
       "schema_path": "contracts/schemas/participant-runtime/participant-shared-state-record-v1.json",
       "stability": "draft",
-      "content_hash": "a3ad56415946417bfbd19cd637886d8442a3e2be510212471e1fcb139cf241d1",
+      "content_hash": "8de5075b682a2ef7f7bf9d18f9dcb51667f2efeb496f283d0bb54b9bb0ffd38b",
       "last_change": {
-        "summary": "Initial publication of the participant shared-state-record runtime contract: shared-state records in the backend-facing contract family (ADR-060, issue #76).",
-        "content_hash": "a3ad56415946417bfbd19cd637886d8442a3e2be510212471e1fcb139cf241d1"
+        "summary": "Require participant shared-state records and accesses to carry revision or digest markers for RUN-307 version discipline.",
+        "content_hash": "8de5075b682a2ef7f7bf9d18f9dcb51667f2efeb496f283d0bb54b9bb0ffd38b"
       }
     },
     {
@@ -236,10 +236,10 @@
       "contract_id": "runtime-snapshot-v1",
       "schema_path": "contracts/schemas/snapshots/runtime-snapshot-v1.json",
       "stability": "draft",
-      "content_hash": "348a25b49e30081797164f77cb344dbf27e85007fcf5d9e93c2e57e33795074a",
+      "content_hash": "530cb86899355de624465c1c37723f923a69e85ecb40ef3f01f2d8bc013019a3",
       "last_change": {
-        "summary": "Add SEM-218 realization_provenance ledger (RealizationProvenanceEntryModel) to the runtime snapshot envelope: per-concern author-declared/processor-derived/backend-realized provenance for realized realization concerns, enforcing invariant I5 (issue #491).",
-        "content_hash": "348a25b49e30081797164f77cb344dbf27e85007fcf5d9e93c2e57e33795074a"
+        "summary": "Add first-class shared_state_records and shared_state_history fields to the runtime snapshot envelope for RUN-307 shared operational state.",
+        "content_hash": "530cb86899355de624465c1c37723f923a69e85ecb40ef3f01f2d8bc013019a3"
       }
     },
     {

--- a/contracts/schemas/participant-runtime/participant-shared-state-record-v1.json
+++ b/contracts/schemas/participant-runtime/participant-shared-state-record-v1.json
@@ -67,6 +67,86 @@
     },
     "ParticipantSharedStateAccessModel": {
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "access_kind": {
+                "enum": [
+                  "read",
+                  "read_write"
+                ]
+              }
+            },
+            "required": [
+              "access_kind"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "read_revision": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "read_revision"
+                ]
+              },
+              {
+                "properties": {
+                  "read_digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "read_digest"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "access_kind": {
+                "enum": [
+                  "write",
+                  "read_write"
+                ]
+              }
+            },
+            "required": [
+              "access_kind"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "write_revision": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "write_revision"
+                ]
+              },
+              {
+                "properties": {
+                  "write_digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "write_digest"
+                ]
+              }
+            ]
+          }
+        }
+      ],
       "description": "RUN-307 read/write access record over one shared-state address.",
       "properties": {
         "access_kind": {
@@ -474,6 +554,28 @@
   "$id": "https://aces.dev/schemas/participant-shared-state-record-v1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "properties": {
+        "revision": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "revision"
+      ]
+    },
+    {
+      "properties": {
+        "digest": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "digest"
+      ]
+    }
+  ],
   "description": "RUN-307 versioned shared operational state-change report.",
   "properties": {
     "accesses": {

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -185,6 +185,71 @@
       "title": "EvaluationResultStateModel",
       "type": "object"
     },
+    "EventClassificationModel": {
+      "additionalProperties": false,
+      "description": "ACES-native normalized event classification tuple (ADR-054).",
+      "properties": {
+        "activity_id": {
+          "title": "Activity Id",
+          "type": "integer"
+        },
+        "activity_name": {
+          "minLength": 1,
+          "title": "Activity Name",
+          "type": "string"
+        },
+        "category_name": {
+          "minLength": 1,
+          "title": "Category Name",
+          "type": "string"
+        },
+        "category_uid": {
+          "title": "Category Uid",
+          "type": "integer"
+        },
+        "class_name": {
+          "minLength": 1,
+          "title": "Class Name",
+          "type": "string"
+        },
+        "class_uid": {
+          "title": "Class Uid",
+          "type": "integer"
+        },
+        "severity": {
+          "minLength": 1,
+          "title": "Severity",
+          "type": "string"
+        },
+        "severity_id": {
+          "title": "Severity Id",
+          "type": "integer"
+        },
+        "type_name": {
+          "minLength": 1,
+          "title": "Type Name",
+          "type": "string"
+        },
+        "type_uid": {
+          "title": "Type Uid",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "category_uid",
+        "category_name",
+        "class_uid",
+        "class_name",
+        "activity_id",
+        "activity_name",
+        "type_uid",
+        "type_name",
+        "severity_id",
+        "severity"
+      ],
+      "title": "EventClassificationModel",
+      "type": "object"
+    },
     "ExplicitnessClass": {
       "description": "SEM-218 author-intent class for a declaration.",
       "enum": [
@@ -1505,6 +1570,679 @@
       "title": "ParticipantRuntimeLifecyclePhase",
       "type": "string"
     },
+    "ParticipantSharedStateAccessModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "access_kind": {
+                "enum": [
+                  "read",
+                  "read_write"
+                ]
+              }
+            },
+            "required": [
+              "access_kind"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "read_revision": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "read_revision"
+                ]
+              },
+              {
+                "properties": {
+                  "read_digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "read_digest"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "access_kind": {
+                "enum": [
+                  "write",
+                  "read_write"
+                ]
+              }
+            },
+            "required": [
+              "access_kind"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {
+                  "write_revision": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "write_revision"
+                ]
+              },
+              {
+                "properties": {
+                  "write_digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "write_digest"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "description": "RUN-307 read/write access record over one shared-state address.",
+      "properties": {
+        "access_kind": {
+          "enum": [
+            "read",
+            "write",
+            "read_write"
+          ],
+          "title": "Access Kind",
+          "type": "string"
+        },
+        "access_purpose": {
+          "minLength": 1,
+          "title": "Access Purpose",
+          "type": "string"
+        },
+        "atomic_group_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Atomic Group Ref"
+        },
+        "evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "read_digest": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Read Digest"
+        },
+        "read_revision": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Read Revision"
+        },
+        "snapshot_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Snapshot Ref"
+        },
+        "state_address": {
+          "minLength": 1,
+          "title": "State Address",
+          "type": "string"
+        },
+        "write_digest": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Write Digest"
+        },
+        "write_revision": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Write Revision"
+        }
+      },
+      "required": [
+        "state_address",
+        "access_kind",
+        "access_purpose"
+      ],
+      "title": "ParticipantSharedStateAccessModel",
+      "type": "object"
+    },
+    "ParticipantSharedStateRecordModel": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "properties": {
+            "revision": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "revision"
+          ]
+        },
+        {
+          "properties": {
+            "digest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "digest"
+          ]
+        }
+      ],
+      "description": "RUN-307 versioned shared operational state-change report.",
+      "properties": {
+        "accesses": {
+          "items": {
+            "$ref": "#/$defs/ParticipantSharedStateAccessModel"
+          },
+          "title": "Accesses",
+          "type": "array"
+        },
+        "actor_ref": {
+          "minLength": 1,
+          "title": "Actor Ref",
+          "type": "string"
+        },
+        "authorization_scope": {
+          "minLength": 1,
+          "title": "Authorization Scope",
+          "type": "string"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "conflict_policy": {
+          "enum": [
+            "coordinate",
+            "serialize",
+            "reject",
+            "retry",
+            "withhold",
+            "merge",
+            "rollback",
+            "disclose_weak_guarantee",
+            "unsupported"
+          ],
+          "title": "Conflict Policy",
+          "type": "string"
+        },
+        "digest": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Digest"
+        },
+        "episode_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Episode Id"
+        },
+        "event_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EventClassificationModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "event_id": {
+          "minLength": 1,
+          "title": "Event Id",
+          "type": "string"
+        },
+        "event_type": {
+          "minLength": 1,
+          "title": "Event Type",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "extension_policy": {
+          "minLength": 1,
+          "title": "Extension Policy",
+          "type": "string"
+        },
+        "granular_markings": {
+          "additionalProperties": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Granular Markings",
+          "type": "object"
+        },
+        "ingested_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Ingested At",
+          "type": "string"
+        },
+        "logical_order_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logical Order Ref"
+        },
+        "marking_definition_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Marking Definition Refs",
+          "type": "array"
+        },
+        "markings": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Markings",
+          "type": "array"
+        },
+        "object_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Object Marking Refs",
+          "type": "array"
+        },
+        "occurred_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Occurred At",
+          "type": "string"
+        },
+        "ordering_basis": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "participant_address": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Participant Address"
+        },
+        "predecessor_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Predecessor Event Refs",
+          "type": "array"
+        },
+        "predecessor_revision_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Predecessor Revision Refs",
+          "type": "array"
+        },
+        "producer_ref": {
+          "minLength": 1,
+          "title": "Producer Ref",
+          "type": "string"
+        },
+        "provenance": {
+          "minLength": 1,
+          "title": "Provenance",
+          "type": "string"
+        },
+        "provenance_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Provenance Refs",
+          "type": "array"
+        },
+        "raw_data_integrity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawDataIntegrityModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "redaction_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Redaction Policy Ref"
+        },
+        "revision": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Revision"
+        },
+        "schema_name": {
+          "minLength": 1,
+          "title": "Schema Name",
+          "type": "string"
+        },
+        "schema_version": {
+          "minLength": 1,
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sequence_number": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence Number"
+        },
+        "source_pipeline": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourcePipelineModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_raw_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Raw Ref"
+        },
+        "source_record_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Record Ref"
+        },
+        "source_status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceStatusModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_system_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source System Ref"
+        },
+        "state_address": {
+          "minLength": 1,
+          "title": "State Address",
+          "type": "string"
+        },
+        "state_kind": {
+          "minLength": 1,
+          "title": "State Kind",
+          "type": "string"
+        },
+        "state_scope": {
+          "minLength": 1,
+          "title": "State Scope",
+          "type": "string"
+        },
+        "temporal_context": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temporal Context"
+        },
+        "value_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value Ref"
+        },
+        "visibility_projection_basis": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Visibility Projection Basis"
+        }
+      },
+      "required": [
+        "event_id",
+        "schema_name",
+        "schema_version",
+        "event_type",
+        "extension_policy",
+        "occurred_at",
+        "recorded_at",
+        "ingested_at",
+        "clock_authority",
+        "ordering_basis",
+        "actor_ref",
+        "producer_ref",
+        "authorization_scope",
+        "state_address",
+        "state_scope",
+        "state_kind",
+        "conflict_policy",
+        "provenance"
+      ],
+      "title": "ParticipantSharedStateRecordModel",
+      "type": "object"
+    },
     "ParticipantTemporalEventPoint": {
       "description": "Named participant event points used by temporal contracts.",
       "enum": [
@@ -1608,6 +2346,79 @@
       "title": "ParticipantTimeDomain",
       "type": "string"
     },
+    "RawDataIntegrityModel": {
+      "additionalProperties": false,
+      "description": "Hash, size, and truncation facts for raw data behind a runtime claim.",
+      "properties": {
+        "raw_data_hash": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash"
+        },
+        "raw_data_hash_algorithm": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash Algorithm"
+        },
+        "raw_data_is_truncated": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Is Truncated"
+        },
+        "raw_data_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Size"
+        },
+        "raw_data_untruncated_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Untruncated Size"
+        }
+      },
+      "title": "RawDataIntegrityModel",
+      "type": "object"
+    },
     "RealizationProvenanceEntryModel": {
       "additionalProperties": false,
       "description": "SEM-218 invariant I5: provenance for one realized realization concern.\n\nDistinguishes ``author-declared`` / ``processor-derived`` / ``backend-realized``\norigins for a realized concern recorded on the snapshot's result / history\nsurfaces. Carries field-path and kind references only (never the realized\nvalue, per the SEM-218 host-exposure gate). Kept distinct from ADR-054\nlifecycle ``phase_realization`` and API-407 participant feature support.",
@@ -1696,6 +2507,218 @@
         "resource_type"
       ],
       "title": "SnapshotEntryModel",
+      "type": "object"
+    },
+    "SourcePipelineModel": {
+      "additionalProperties": false,
+      "description": "Source product, identity, and pipeline-time facts for a mapped record.",
+      "properties": {
+        "correlation_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Correlation Uid"
+        },
+        "log_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Name"
+        },
+        "log_provider": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Provider"
+        },
+        "log_source": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Source"
+        },
+        "logged_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logged Time"
+        },
+        "original_event_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Event Uid"
+        },
+        "original_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Time"
+        },
+        "processed_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Processed Time"
+        },
+        "product_ref": {
+          "minLength": 1,
+          "title": "Product Ref",
+          "type": "string"
+        },
+        "product_version": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Product Version"
+        },
+        "sequence": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence"
+        },
+        "transmit_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transmit Time"
+        }
+      },
+      "required": [
+        "product_ref"
+      ],
+      "title": "SourcePipelineModel",
+      "type": "object"
+    },
+    "SourceStatusModel": {
+      "additionalProperties": false,
+      "description": "Normalized source status claim for one participant runtime record.",
+      "properties": {
+        "source_status_label": {
+          "minLength": 1,
+          "title": "Source Status Label",
+          "type": "string"
+        },
+        "source_status_mapping": {
+          "minLength": 1,
+          "title": "Source Status Mapping",
+          "type": "string"
+        },
+        "status": {
+          "minLength": 1,
+          "title": "Status",
+          "type": "string"
+        },
+        "status_code": {
+          "minLength": 1,
+          "title": "Status Code",
+          "type": "string"
+        },
+        "status_detail": {
+          "minLength": 1,
+          "title": "Status Detail",
+          "type": "string"
+        },
+        "status_id": {
+          "title": "Status Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status_id",
+        "status",
+        "status_code",
+        "status_detail",
+        "source_status_label",
+        "source_status_mapping"
+      ],
+      "title": "SourceStatusModel",
       "type": "object"
     },
     "WorkflowExecutionStateModel": {
@@ -1983,6 +3006,23 @@
       "default": "runtime-snapshot/v1",
       "title": "Schema Version",
       "type": "string"
+    },
+    "shared_state_history": {
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/$defs/ParticipantSharedStateRecordModel"
+        },
+        "type": "array"
+      },
+      "title": "Shared State History",
+      "type": "object"
+    },
+    "shared_state_records": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ParticipantSharedStateRecordModel"
+      },
+      "title": "Shared State Records",
+      "type": "object"
     }
   },
   "title": "RuntimeSnapshotEnvelopeModel",

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -46,6 +46,7 @@ from aces_contracts.participant_episode import (
     ParticipantEpisodeTerminalReason,
     iter_participant_episode_snapshot_violations,
 )
+from aces_contracts.participant_shared_state import iter_participant_shared_state_snapshot_violations
 from aces_contracts.planning import RuntimeDomain
 from aces_contracts.runtime_state import RuntimeSnapshot, RuntimeSnapshotEnvelope, SnapshotEntry
 from aces_contracts.workflow import WorkflowExecutionState
@@ -433,6 +434,14 @@ def _snapshot_from_envelope(payload: dict[str, Any]) -> RuntimeSnapshot:
             participant_address: [event.model_dump(mode="json") for event in history]
             for participant_address, history in validated.participant_behavior_history.items()
         },
+        shared_state_records={
+            state_address: record.model_dump(mode="json")
+            for state_address, record in validated.shared_state_records.items()
+        },
+        shared_state_history={
+            state_address: [record.model_dump(mode="json") for record in records]
+            for state_address, records in validated.shared_state_history.items()
+        },
         metadata=dict(validated.metadata),
     )
 
@@ -708,6 +717,18 @@ def _participant_behavior_stream_diagnostics(contract_name: str, payload: Any) -
     return diagnostics
 
 
+def _shared_state_snapshot_diagnostics(snapshot: RuntimeSnapshot) -> list[Diagnostic]:
+    return [
+        _diagnostic(_SEMANTIC_INVALID_DIAGNOSTIC_CODE, address, message)
+        for address, message in iter_participant_shared_state_snapshot_violations(
+            snapshot.shared_state_records,
+            snapshot.shared_state_history,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            metadata=snapshot.metadata,
+        )
+    ]
+
+
 def _runtime_snapshot_semantic_diagnostics(payload: Any) -> list[Diagnostic]:
     snapshot = _snapshot_from_envelope(payload)
     return [
@@ -715,6 +736,7 @@ def _runtime_snapshot_semantic_diagnostics(payload: Any) -> list[Diagnostic]:
         *evaluation_result_contract_diagnostics(snapshot),
         *_participant_episode_snapshot_diagnostics(snapshot),
         *_participant_behavior_snapshot_diagnostics(snapshot),
+        *_shared_state_snapshot_diagnostics(snapshot),
     ]
 
 
@@ -1251,6 +1273,15 @@ def _live_target_cases(
         "participant_episode_history": {
             participant_address: list(events)
             for participant_address, events in control_plane.snapshot.participant_episode_history.items()
+        },
+        "participant_behavior_history": {
+            participant_address: list(events)
+            for participant_address, events in control_plane.snapshot.participant_behavior_history.items()
+        },
+        "shared_state_records": dict(control_plane.snapshot.shared_state_records),
+        "shared_state_history": {
+            state_address: list(records)
+            for state_address, records in control_plane.snapshot.shared_state_history.items()
         },
         "metadata": dict(control_plane.snapshot.metadata),
     }

--- a/implementations/python/packages/aces_contracts/_participant_behavior_types.py
+++ b/implementations/python/packages/aces_contracts/_participant_behavior_types.py
@@ -100,6 +100,8 @@ _RESERVED_RUNTIME_STATE_KEYS = frozenset(
         "participant_episode_results",
         "participant_episode_history",
         "participant_behavior_history",
+        "shared_state_records",
+        "shared_state_history",
     }
 )
 _REQUIRED_BEHAVIOR_EVENT_FIELDS = (

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -1091,6 +1091,52 @@ class ParticipantSharedStateAccessModel(ContractModel):
     atomic_group_ref: NonEmptyString | None = None
     evidence_refs: list[NonEmptyString] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def _validate_revision_markers(self) -> ParticipantSharedStateAccessModel:
+        if self.access_kind in {"read", "read_write"} and self.read_revision is None and self.read_digest is None:
+            raise ValueError("shared state read access requires read_revision or read_digest")
+        if self.access_kind in {"write", "read_write"} and self.write_revision is None and self.write_digest is None:
+            raise ValueError("shared state write access requires write_revision or write_digest")
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.setdefault("allOf", []).extend(
+            [
+                {
+                    "if": {
+                        "properties": {"access_kind": {"enum": ["read", "read_write"]}},
+                        "required": ["access_kind"],
+                    },
+                    "then": {
+                        "anyOf": [
+                            {"required": ["read_revision"], "properties": {"read_revision": {"type": "string"}}},
+                            {"required": ["read_digest"], "properties": {"read_digest": {"type": "string"}}},
+                        ]
+                    },
+                },
+                {
+                    "if": {
+                        "properties": {"access_kind": {"enum": ["write", "read_write"]}},
+                        "required": ["access_kind"],
+                    },
+                    "then": {
+                        "anyOf": [
+                            {"required": ["write_revision"], "properties": {"write_revision": {"type": "string"}}},
+                            {"required": ["write_digest"], "properties": {"write_digest": {"type": "string"}}},
+                        ]
+                    },
+                },
+            ]
+        )
+        return json_schema
+
 
 class ParticipantSharedStateRecordModel(ParticipantRuntimeBaseEnvelopeModel):
     """RUN-307 versioned shared operational state-change report."""
@@ -1106,6 +1152,28 @@ class ParticipantSharedStateRecordModel(ParticipantRuntimeBaseEnvelopeModel):
     provenance: NonEmptyString
     value_ref: NonEmptyString | None = None
     accesses: list[ParticipantSharedStateAccessModel] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_revision_marker(self) -> ParticipantSharedStateRecordModel:
+        if self.revision is None and self.digest is None:
+            raise ValueError("participant shared state record requires revision or digest")
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.setdefault("anyOf", []).extend(
+            [
+                {"required": ["revision"], "properties": {"revision": {"type": "string"}}},
+                {"required": ["digest"], "properties": {"digest": {"type": "string"}}},
+            ]
+        )
+        return json_schema
 
 
 class ParticipantOutcomeReportSourceModel(ContractModel):
@@ -1440,6 +1508,8 @@ class RuntimeSnapshotEnvelopeModel(ContractModel):
     participant_episode_results: dict[str, ParticipantEpisodeStateModel] = Field(default_factory=dict)
     participant_episode_history: dict[str, list[ParticipantEpisodeHistoryEventModel]] = Field(default_factory=dict)
     participant_behavior_history: dict[str, list[ParticipantBehaviorHistoryEventModel]] = Field(default_factory=dict)
+    shared_state_records: dict[str, ParticipantSharedStateRecordModel] = Field(default_factory=dict)
+    shared_state_history: dict[str, list[ParticipantSharedStateRecordModel]] = Field(default_factory=dict)
     realization_provenance: list[RealizationProvenanceEntryModel] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/implementations/python/packages/aces_contracts/participant_shared_state.py
+++ b/implementations/python/packages/aces_contracts/participant_shared_state.py
@@ -1,0 +1,222 @@
+"""Shared operational state runtime validators for RUN-307."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+
+from ._participant_behavior_types import _RESERVED_RUNTIME_STATE_KEYS
+
+_SHARED_STATE_RECORDS_KEY = "runtime.snapshot.shared-state-records"
+_SHARED_STATE_HISTORY_KEY = "runtime.snapshot.shared-state-history"
+_METADATA_KEY = "runtime.snapshot.metadata"
+_BEHAVIOR_HISTORY_KEY = "runtime.snapshot.participant-behavior-history"
+_VALID_ACCESS_KINDS = frozenset({"read", "write", "read_write"})
+_REQUIRED_RECORD_FIELDS = (
+    "state_address",
+    "state_scope",
+    "state_kind",
+    "ordering_basis",
+    "conflict_policy",
+    "provenance",
+)
+
+
+def iter_participant_shared_state_snapshot_violations(
+    shared_state_records: object,
+    shared_state_history: object,
+    *,
+    participant_behavior_history: object = None,
+    metadata: object = None,
+) -> Iterator[tuple[str, str]]:
+    """Yield RUN-307 shared-state snapshot violations."""
+
+    yield from _iter_reserved_metadata_key_violations(metadata)
+    known_addresses: set[str] = set()
+    yield from _iter_shared_state_records(shared_state_records, known_addresses)
+    yield from _iter_shared_state_history(shared_state_history, known_addresses)
+    yield from _iter_behavior_shared_state_ref_violations(participant_behavior_history, known_addresses)
+
+
+def iter_participant_shared_state_history_transition_violations(
+    previous_shared_state_history: object,
+    next_shared_state_history: object,
+) -> Iterator[tuple[str, str]]:
+    """Yield append-only violations for shared-state history transitions."""
+
+    if not isinstance(previous_shared_state_history, Mapping) or not isinstance(next_shared_state_history, Mapping):
+        return
+    for state_address, previous_records in previous_shared_state_history.items():
+        if not isinstance(state_address, str) or not state_address or not isinstance(previous_records, list):
+            continue
+        next_records = next_shared_state_history.get(state_address)
+        locator = f"{_SHARED_STATE_HISTORY_KEY}.{state_address}"
+        if not isinstance(next_records, list):
+            yield (locator, f"shared_state_history must be append-only; state {state_address!r} history was removed")
+            continue
+        if len(next_records) < len(previous_records):
+            yield (
+                locator,
+                (
+                    f"shared_state_history must be append-only; state {state_address!r} history shrank "
+                    f"from {len(previous_records)} to {len(next_records)} records"
+                ),
+            )
+            continue
+        for index, previous_record in enumerate(previous_records):
+            if next_records[index] != previous_record:
+                yield (
+                    f"{locator}[{index}]",
+                    f"shared_state_history must be append-only; existing record at index {index} changed",
+                )
+
+
+def _iter_reserved_metadata_key_violations(metadata: object) -> Iterator[tuple[str, str]]:
+    if metadata is None:
+        return
+    if not isinstance(metadata, Mapping):
+        yield (_METADATA_KEY, "RuntimeSnapshot.metadata must be a mapping")
+        return
+    for key in sorted(_RESERVED_RUNTIME_STATE_KEYS.intersection(str(item) for item in metadata)):
+        yield (
+            f"{_METADATA_KEY}.{key}",
+            (
+                f"RuntimeSnapshot.metadata must not contain {key!r}; "
+                "participant runtime state/history must use first-class snapshot fields"
+            ),
+        )
+
+
+def _iter_shared_state_records(records: object, known_addresses: set[str]) -> Iterator[tuple[str, str]]:
+    if not isinstance(records, Mapping):
+        yield (_SHARED_STATE_RECORDS_KEY, "shared_state_records must be a mapping")
+        return
+    for outer_key, record in records.items():
+        locator = f"{_SHARED_STATE_RECORDS_KEY}.{outer_key}"
+        if not isinstance(outer_key, str) or not outer_key:
+            yield (_SHARED_STATE_RECORDS_KEY, "shared_state_records keys must be non-empty strings")
+            continue
+        if not isinstance(record, Mapping):
+            yield (locator, "shared state record must be a mapping")
+            continue
+        yield from _iter_shared_state_record_violations(locator, outer_key, record)
+        known_addresses.add(outer_key)
+        state_address = record.get("state_address")
+        if isinstance(state_address, str) and state_address:
+            known_addresses.add(state_address)
+
+
+def _iter_shared_state_history(history: object, known_addresses: set[str]) -> Iterator[tuple[str, str]]:
+    if not isinstance(history, Mapping):
+        yield (_SHARED_STATE_HISTORY_KEY, "shared_state_history must be a mapping")
+        return
+    for outer_key, records in history.items():
+        locator = f"{_SHARED_STATE_HISTORY_KEY}.{outer_key}"
+        if not isinstance(outer_key, str) or not outer_key:
+            yield (_SHARED_STATE_HISTORY_KEY, "shared_state_history keys must be non-empty strings")
+            continue
+        if not isinstance(records, list):
+            yield (locator, "shared_state_history entries must be lists")
+            continue
+        known_addresses.add(outer_key)
+        for index, record in enumerate(records):
+            record_locator = f"{locator}[{index}]"
+            if not isinstance(record, Mapping):
+                yield (record_locator, "shared state history record must be a mapping")
+                continue
+            yield from _iter_shared_state_record_violations(record_locator, outer_key, record)
+            state_address = record.get("state_address")
+            if isinstance(state_address, str) and state_address:
+                known_addresses.add(state_address)
+
+
+def _iter_shared_state_record_violations(
+    locator: str,
+    expected_address: str,
+    record: Mapping[object, object],
+) -> Iterator[tuple[str, str]]:
+    missing = [field for field in _REQUIRED_RECORD_FIELDS if not _non_empty_string(record.get(field))]
+    if missing:
+        yield (locator, "shared state record is missing required fields: " + ", ".join(missing))
+        return
+
+    state_address = record["state_address"]
+    if state_address != expected_address:
+        yield (
+            locator,
+            f"shared state record outer key {expected_address!r} does not match state_address {state_address!r}",
+        )
+
+    if not (_non_empty_string(record.get("revision")) or _non_empty_string(record.get("digest"))):
+        yield (locator, "shared state record requires revision or digest")
+
+    accesses = record.get("accesses", [])
+    if not isinstance(accesses, list):
+        yield (locator, "shared state record accesses must be a list")
+        return
+    for index, access in enumerate(accesses):
+        access_locator = f"{locator}.accesses[{index}]"
+        if not isinstance(access, Mapping):
+            yield (access_locator, "shared state access must be a mapping")
+            continue
+        yield from _iter_shared_state_access_violations(access_locator, state_address, access)
+
+
+def _iter_shared_state_access_violations(
+    locator: str,
+    record_address: object,
+    access: Mapping[object, object],
+) -> Iterator[tuple[str, str]]:
+    state_address = access.get("state_address")
+    if not _non_empty_string(state_address):
+        yield (locator, "shared state access state_address must be a non-empty string")
+    elif state_address != record_address:
+        yield (locator, f"shared state access state_address {state_address!r} does not match record state_address")
+
+    access_kind = access.get("access_kind")
+    if access_kind not in _VALID_ACCESS_KINDS:
+        yield (locator, f"shared state access_kind {access_kind!r} is not supported")
+        return
+    if access_kind in {"read", "read_write"} and not (
+        _non_empty_string(access.get("read_revision")) or _non_empty_string(access.get("read_digest"))
+    ):
+        yield (locator, "shared state read access requires read_revision or read_digest")
+    if access_kind in {"write", "read_write"} and not (
+        _non_empty_string(access.get("write_revision")) or _non_empty_string(access.get("write_digest"))
+    ):
+        yield (locator, "shared state write access requires write_revision or write_digest")
+
+
+def _iter_behavior_shared_state_ref_violations(
+    participant_behavior_history: object,
+    known_addresses: set[str],
+) -> Iterator[tuple[str, str]]:
+    if participant_behavior_history is None or not isinstance(participant_behavior_history, Mapping):
+        return
+    for participant_address, history in participant_behavior_history.items():
+        if not isinstance(participant_address, str) or not isinstance(history, list):
+            continue
+        for index, event in enumerate(history):
+            if not isinstance(event, Mapping):
+                continue
+            refs = event.get("shared_state_refs", [])
+            if not isinstance(refs, list):
+                continue
+            for ref in refs:
+                if isinstance(ref, str) and ref and ref not in known_addresses:
+                    yield (
+                        f"{_BEHAVIOR_HISTORY_KEY}.{participant_address}[{index}].shared_state_refs",
+                        (
+                            f"participant behavior shared_state_refs entry {ref!r} does not resolve to "
+                            "shared_state_records or shared_state_history"
+                        ),
+                    )
+
+
+def _non_empty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+__all__ = (
+    "iter_participant_shared_state_history_transition_violations",
+    "iter_participant_shared_state_snapshot_violations",
+)

--- a/implementations/python/packages/aces_contracts/participant_shared_state.py
+++ b/implementations/python/packages/aces_contracts/participant_shared_state.py
@@ -6,6 +6,8 @@ from collections.abc import Iterator, Mapping
 
 from ._participant_behavior_types import _RESERVED_RUNTIME_STATE_KEYS
 
+Violation = tuple[str, str]
+
 _SHARED_STATE_RECORDS_KEY = "runtime.snapshot.shared-state-records"
 _SHARED_STATE_HISTORY_KEY = "runtime.snapshot.shared-state-history"
 _METADATA_KEY = "runtime.snapshot.metadata"
@@ -30,11 +32,13 @@ def iter_participant_shared_state_snapshot_violations(
 ) -> Iterator[tuple[str, str]]:
     """Yield RUN-307 shared-state snapshot violations."""
 
-    yield from _iter_reserved_metadata_key_violations(metadata)
     known_addresses: set[str] = set()
-    yield from _iter_shared_state_records(shared_state_records, known_addresses)
-    yield from _iter_shared_state_history(shared_state_history, known_addresses)
-    yield from _iter_behavior_shared_state_ref_violations(participant_behavior_history, known_addresses)
+    violations: list[Violation] = []
+    violations.extend(_reserved_metadata_key_violations(metadata))
+    violations.extend(_shared_state_records_violations(shared_state_records, known_addresses))
+    violations.extend(_shared_state_history_violations(shared_state_history, known_addresses))
+    violations.extend(_behavior_shared_state_ref_violations(participant_behavior_history, known_addresses))
+    return iter(violations)
 
 
 def iter_participant_shared_state_history_transition_violations(
@@ -43,173 +47,302 @@ def iter_participant_shared_state_history_transition_violations(
 ) -> Iterator[tuple[str, str]]:
     """Yield append-only violations for shared-state history transitions."""
 
-    if not isinstance(previous_shared_state_history, Mapping) or not isinstance(next_shared_state_history, Mapping):
-        return
-    for state_address, previous_records in previous_shared_state_history.items():
-        if not isinstance(state_address, str) or not state_address or not isinstance(previous_records, list):
-            continue
+    violations: list[Violation] = []
+    if isinstance(previous_shared_state_history, Mapping) and isinstance(next_shared_state_history, Mapping):
+        for state_address, previous_records in previous_shared_state_history.items():
+            violations.extend(
+                _history_transition_state_violations(state_address, previous_records, next_shared_state_history)
+            )
+    return iter(violations)
+
+
+def _history_transition_state_violations(
+    state_address: object,
+    previous_records: object,
+    next_shared_state_history: Mapping[object, object],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if isinstance(state_address, str) and state_address and isinstance(previous_records, list):
         next_records = next_shared_state_history.get(state_address)
         locator = f"{_SHARED_STATE_HISTORY_KEY}.{state_address}"
         if not isinstance(next_records, list):
-            yield (locator, f"shared_state_history must be append-only; state {state_address!r} history was removed")
-            continue
-        if len(next_records) < len(previous_records):
-            yield (
-                locator,
-                (
-                    f"shared_state_history must be append-only; state {state_address!r} history shrank "
-                    f"from {len(previous_records)} to {len(next_records)} records"
-                ),
+            violations.append(
+                (locator, f"shared_state_history must be append-only; state {state_address!r} history was removed")
             )
-            continue
-        for index, previous_record in enumerate(previous_records):
-            if next_records[index] != previous_record:
-                yield (
+        elif len(next_records) < len(previous_records):
+            violations.append(
+                (
+                    locator,
+                    (
+                        f"shared_state_history must be append-only; state {state_address!r} history shrank "
+                        f"from {len(previous_records)} to {len(next_records)} records"
+                    ),
+                )
+            )
+        else:
+            violations.extend(_history_record_rewrite_violations(locator, previous_records, next_records))
+    return violations
+
+
+def _history_record_rewrite_violations(
+    locator: str,
+    previous_records: list[object],
+    next_records: list[object],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for index, previous_record in enumerate(previous_records):
+        if next_records[index] != previous_record:
+            violations.append(
+                (
                     f"{locator}[{index}]",
                     f"shared_state_history must be append-only; existing record at index {index} changed",
                 )
+            )
+    return violations
 
 
-def _iter_reserved_metadata_key_violations(metadata: object) -> Iterator[tuple[str, str]]:
+def _reserved_metadata_key_violations(metadata: object) -> list[Violation]:
+    violations: list[Violation] = []
     if metadata is None:
-        return
-    if not isinstance(metadata, Mapping):
-        yield (_METADATA_KEY, "RuntimeSnapshot.metadata must be a mapping")
-        return
-    for key in sorted(_RESERVED_RUNTIME_STATE_KEYS.intersection(str(item) for item in metadata)):
-        yield (
-            f"{_METADATA_KEY}.{key}",
-            (
-                f"RuntimeSnapshot.metadata must not contain {key!r}; "
-                "participant runtime state/history must use first-class snapshot fields"
-            ),
-        )
+        pass
+    elif not isinstance(metadata, Mapping):
+        violations.append((_METADATA_KEY, "RuntimeSnapshot.metadata must be a mapping"))
+    else:
+        for key in sorted(_RESERVED_RUNTIME_STATE_KEYS.intersection(str(item) for item in metadata)):
+            violations.append(
+                (
+                    f"{_METADATA_KEY}.{key}",
+                    (
+                        f"RuntimeSnapshot.metadata must not contain {key!r}; "
+                        "participant runtime state/history must use first-class snapshot fields"
+                    ),
+                )
+            )
+    return violations
 
 
-def _iter_shared_state_records(records: object, known_addresses: set[str]) -> Iterator[tuple[str, str]]:
+def _shared_state_records_violations(records: object, known_addresses: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
     if not isinstance(records, Mapping):
-        yield (_SHARED_STATE_RECORDS_KEY, "shared_state_records must be a mapping")
-        return
-    for outer_key, record in records.items():
-        locator = f"{_SHARED_STATE_RECORDS_KEY}.{outer_key}"
-        if not isinstance(outer_key, str) or not outer_key:
-            yield (_SHARED_STATE_RECORDS_KEY, "shared_state_records keys must be non-empty strings")
-            continue
-        if not isinstance(record, Mapping):
-            yield (locator, "shared state record must be a mapping")
-            continue
-        yield from _iter_shared_state_record_violations(locator, outer_key, record)
-        known_addresses.add(outer_key)
-        state_address = record.get("state_address")
-        if isinstance(state_address, str) and state_address:
-            known_addresses.add(state_address)
+        violations.append((_SHARED_STATE_RECORDS_KEY, "shared_state_records must be a mapping"))
+    else:
+        for outer_key, record in records.items():
+            violations.extend(_shared_state_record_entry_violations(outer_key, record, known_addresses))
+    return violations
 
 
-def _iter_shared_state_history(history: object, known_addresses: set[str]) -> Iterator[tuple[str, str]]:
+def _shared_state_record_entry_violations(
+    outer_key: object,
+    record: object,
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    locator = f"{_SHARED_STATE_RECORDS_KEY}.{outer_key}"
+    if not isinstance(outer_key, str) or not outer_key:
+        violations.append((_SHARED_STATE_RECORDS_KEY, "shared_state_records keys must be non-empty strings"))
+    elif not isinstance(record, Mapping):
+        violations.append((locator, "shared state record must be a mapping"))
+    else:
+        violations.extend(_shared_state_record_violations(locator, outer_key, record))
+        _add_known_state_addresses(known_addresses, outer_key, record)
+    return violations
+
+
+def _shared_state_history_violations(history: object, known_addresses: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
     if not isinstance(history, Mapping):
-        yield (_SHARED_STATE_HISTORY_KEY, "shared_state_history must be a mapping")
-        return
-    for outer_key, records in history.items():
-        locator = f"{_SHARED_STATE_HISTORY_KEY}.{outer_key}"
-        if not isinstance(outer_key, str) or not outer_key:
-            yield (_SHARED_STATE_HISTORY_KEY, "shared_state_history keys must be non-empty strings")
-            continue
-        if not isinstance(records, list):
-            yield (locator, "shared_state_history entries must be lists")
-            continue
+        violations.append((_SHARED_STATE_HISTORY_KEY, "shared_state_history must be a mapping"))
+    else:
+        for outer_key, records in history.items():
+            violations.extend(_shared_state_history_entry_violations(outer_key, records, known_addresses))
+    return violations
+
+
+def _shared_state_history_entry_violations(
+    outer_key: object,
+    records: object,
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    locator = f"{_SHARED_STATE_HISTORY_KEY}.{outer_key}"
+    if not isinstance(outer_key, str) or not outer_key:
+        violations.append((_SHARED_STATE_HISTORY_KEY, "shared_state_history keys must be non-empty strings"))
+    elif not isinstance(records, list):
+        violations.append((locator, "shared_state_history entries must be lists"))
+    else:
         known_addresses.add(outer_key)
-        for index, record in enumerate(records):
-            record_locator = f"{locator}[{index}]"
-            if not isinstance(record, Mapping):
-                yield (record_locator, "shared state history record must be a mapping")
-                continue
-            yield from _iter_shared_state_record_violations(record_locator, outer_key, record)
-            state_address = record.get("state_address")
-            if isinstance(state_address, str) and state_address:
-                known_addresses.add(state_address)
+        violations.extend(_shared_state_history_records_violations(locator, outer_key, records, known_addresses))
+    return violations
 
 
-def _iter_shared_state_record_violations(
+def _shared_state_history_records_violations(
+    locator: str,
+    outer_key: str,
+    records: list[object],
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for index, record in enumerate(records):
+        record_locator = f"{locator}[{index}]"
+        if not isinstance(record, Mapping):
+            violations.append((record_locator, "shared state history record must be a mapping"))
+        else:
+            violations.extend(_shared_state_record_violations(record_locator, outer_key, record))
+            _add_known_state_addresses(known_addresses, outer_key, record)
+    return violations
+
+
+def _shared_state_record_violations(
     locator: str,
     expected_address: str,
     record: Mapping[object, object],
-) -> Iterator[tuple[str, str]]:
+) -> list[Violation]:
+    violations: list[Violation] = []
     missing = [field for field in _REQUIRED_RECORD_FIELDS if not _non_empty_string(record.get(field))]
     if missing:
-        yield (locator, "shared state record is missing required fields: " + ", ".join(missing))
-        return
+        violations.append((locator, "shared state record is missing required fields: " + ", ".join(missing)))
+    else:
+        state_address = record["state_address"]
+        if state_address != expected_address:
+            violations.append(
+                (
+                    locator,
+                    f"shared state record outer key {expected_address!r} does not match state_address {state_address!r}",
+                )
+            )
 
-    state_address = record["state_address"]
-    if state_address != expected_address:
-        yield (
-            locator,
-            f"shared state record outer key {expected_address!r} does not match state_address {state_address!r}",
-        )
+        if not (_non_empty_string(record.get("revision")) or _non_empty_string(record.get("digest"))):
+            violations.append((locator, "shared state record requires revision or digest"))
 
-    if not (_non_empty_string(record.get("revision")) or _non_empty_string(record.get("digest"))):
-        yield (locator, "shared state record requires revision or digest")
+        accesses = record.get("accesses", [])
+        if not isinstance(accesses, list):
+            violations.append((locator, "shared state record accesses must be a list"))
+        else:
+            violations.extend(_shared_state_accesses_violations(locator, state_address, accesses))
+    return violations
 
-    accesses = record.get("accesses", [])
-    if not isinstance(accesses, list):
-        yield (locator, "shared state record accesses must be a list")
-        return
+
+def _shared_state_accesses_violations(
+    locator: str,
+    state_address: object,
+    accesses: list[object],
+) -> list[Violation]:
+    violations: list[Violation] = []
     for index, access in enumerate(accesses):
         access_locator = f"{locator}.accesses[{index}]"
         if not isinstance(access, Mapping):
-            yield (access_locator, "shared state access must be a mapping")
-            continue
-        yield from _iter_shared_state_access_violations(access_locator, state_address, access)
+            violations.append((access_locator, "shared state access must be a mapping"))
+        else:
+            violations.extend(_shared_state_access_violations(access_locator, state_address, access))
+    return violations
 
 
-def _iter_shared_state_access_violations(
+def _shared_state_access_violations(
     locator: str,
     record_address: object,
     access: Mapping[object, object],
-) -> Iterator[tuple[str, str]]:
+) -> list[Violation]:
+    violations: list[Violation] = []
     state_address = access.get("state_address")
     if not _non_empty_string(state_address):
-        yield (locator, "shared state access state_address must be a non-empty string")
+        violations.append((locator, "shared state access state_address must be a non-empty string"))
     elif state_address != record_address:
-        yield (locator, f"shared state access state_address {state_address!r} does not match record state_address")
+        violations.append(
+            (locator, f"shared state access state_address {state_address!r} does not match record state_address")
+        )
 
     access_kind = access.get("access_kind")
     if access_kind not in _VALID_ACCESS_KINDS:
-        yield (locator, f"shared state access_kind {access_kind!r} is not supported")
-        return
+        violations.append((locator, f"shared state access_kind {access_kind!r} is not supported"))
+    else:
+        violations.extend(_shared_state_access_version_violations(locator, access_kind, access))
+    return violations
+
+
+def _shared_state_access_version_violations(
+    locator: str,
+    access_kind: object,
+    access: Mapping[object, object],
+) -> list[Violation]:
+    violations: list[Violation] = []
     if access_kind in {"read", "read_write"} and not (
         _non_empty_string(access.get("read_revision")) or _non_empty_string(access.get("read_digest"))
     ):
-        yield (locator, "shared state read access requires read_revision or read_digest")
+        violations.append((locator, "shared state read access requires read_revision or read_digest"))
     if access_kind in {"write", "read_write"} and not (
         _non_empty_string(access.get("write_revision")) or _non_empty_string(access.get("write_digest"))
     ):
-        yield (locator, "shared state write access requires write_revision or write_digest")
+        violations.append((locator, "shared state write access requires write_revision or write_digest"))
+    return violations
 
 
-def _iter_behavior_shared_state_ref_violations(
+def _behavior_shared_state_ref_violations(
     participant_behavior_history: object,
     known_addresses: set[str],
-) -> Iterator[tuple[str, str]]:
-    if participant_behavior_history is None or not isinstance(participant_behavior_history, Mapping):
-        return
-    for participant_address, history in participant_behavior_history.items():
-        if not isinstance(participant_address, str) or not isinstance(history, list):
-            continue
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if isinstance(participant_behavior_history, Mapping):
+        for participant_address, history in participant_behavior_history.items():
+            violations.extend(_participant_behavior_ref_violations(participant_address, history, known_addresses))
+    return violations
+
+
+def _participant_behavior_ref_violations(
+    participant_address: object,
+    history: object,
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if isinstance(participant_address, str) and isinstance(history, list):
         for index, event in enumerate(history):
-            if not isinstance(event, Mapping):
-                continue
-            refs = event.get("shared_state_refs", [])
-            if not isinstance(refs, list):
-                continue
-            for ref in refs:
-                if isinstance(ref, str) and ref and ref not in known_addresses:
-                    yield (
-                        f"{_BEHAVIOR_HISTORY_KEY}.{participant_address}[{index}].shared_state_refs",
-                        (
-                            f"participant behavior shared_state_refs entry {ref!r} does not resolve to "
-                            "shared_state_records or shared_state_history"
-                        ),
-                    )
+            violations.extend(_behavior_event_ref_violations(participant_address, index, event, known_addresses))
+    return violations
+
+
+def _behavior_event_ref_violations(
+    participant_address: str,
+    index: int,
+    event: object,
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if isinstance(event, Mapping):
+        refs = event.get("shared_state_refs", [])
+        if isinstance(refs, list):
+            violations.extend(_unresolved_behavior_ref_violations(participant_address, index, refs, known_addresses))
+    return violations
+
+
+def _unresolved_behavior_ref_violations(
+    participant_address: str,
+    index: int,
+    refs: list[object],
+    known_addresses: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for ref in refs:
+        if isinstance(ref, str) and ref and ref not in known_addresses:
+            violations.append(
+                (
+                    f"{_BEHAVIOR_HISTORY_KEY}.{participant_address}[{index}].shared_state_refs",
+                    (
+                        f"participant behavior shared_state_refs entry {ref!r} does not resolve to "
+                        "shared_state_records or shared_state_history"
+                    ),
+                )
+            )
+    return violations
+
+
+def _add_known_state_addresses(
+    known_addresses: set[str],
+    outer_key: str,
+    record: Mapping[object, object],
+) -> None:
+    known_addresses.add(outer_key)
+    state_address = record.get("state_address")
+    if isinstance(state_address, str) and state_address:
+        known_addresses.add(state_address)
 
 
 def _non_empty_string(value: object) -> bool:

--- a/implementations/python/packages/aces_contracts/participant_shared_state.py
+++ b/implementations/python/packages/aces_contracts/participant_shared_state.py
@@ -103,11 +103,9 @@ def _history_record_rewrite_violations(
 
 def _reserved_metadata_key_violations(metadata: object) -> list[Violation]:
     violations: list[Violation] = []
-    if metadata is None:
-        pass
-    elif not isinstance(metadata, Mapping):
+    if metadata is not None and not isinstance(metadata, Mapping):
         violations.append((_METADATA_KEY, "RuntimeSnapshot.metadata must be a mapping"))
-    else:
+    elif isinstance(metadata, Mapping):
         for key in sorted(_RESERVED_RUNTIME_STATE_KEYS.intersection(str(item) for item in metadata)):
             violations.append(
                 (
@@ -207,7 +205,10 @@ def _shared_state_record_violations(
             violations.append(
                 (
                     locator,
-                    f"shared state record outer key {expected_address!r} does not match state_address {state_address!r}",
+                    (
+                        f"shared state record outer key {expected_address!r} "
+                        f"does not match state_address {state_address!r}"
+                    ),
                 )
             )
 

--- a/implementations/python/packages/aces_contracts/runtime_state.py
+++ b/implementations/python/packages/aces_contracts/runtime_state.py
@@ -71,6 +71,8 @@ class RuntimeSnapshot:
     participant_episode_results: dict[str, dict[str, Any]] = field(default_factory=dict)
     participant_episode_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     participant_behavior_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    shared_state_records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    shared_state_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     # SEM-218 invariant I5: per-concern provenance for realized realization
     # concerns recorded across this snapshot's result / history surfaces.
     realization_provenance: tuple[RealizationProvenanceEntry, ...] = ()
@@ -117,6 +119,16 @@ class RuntimeSnapshot:
                 "participant_behavior_history",
                 self.participant_behavior_history,
             ),
+            shared_state_records=_mapping_update(
+                updates,
+                "shared_state_records",
+                self.shared_state_records,
+            ),
+            shared_state_history=_history_update(
+                updates,
+                "shared_state_history",
+                self.shared_state_history,
+            ),
             realization_provenance=_provenance_update(
                 updates,
                 "realization_provenance",
@@ -134,6 +146,8 @@ _SNAPSHOT_UPDATE_KEYS = {
     "participant_episode_results",
     "participant_episode_history",
     "participant_behavior_history",
+    "shared_state_records",
+    "shared_state_history",
     "realization_provenance",
     "metadata",
 }

--- a/implementations/python/packages/aces_runtime/control_plane_api_models.py
+++ b/implementations/python/packages/aces_runtime/control_plane_api_models.py
@@ -154,6 +154,8 @@ def _snapshot_model(envelope: RuntimeSnapshotEnvelope) -> RuntimeSnapshotEnvelop
             "participant_episode_results": dict(snapshot.participant_episode_results),
             "participant_episode_history": dict(snapshot.participant_episode_history),
             "participant_behavior_history": dict(snapshot.participant_behavior_history),
+            "shared_state_records": dict(snapshot.shared_state_records),
+            "shared_state_history": dict(snapshot.shared_state_history),
             "metadata": dict(snapshot.metadata),
         }
     )

--- a/implementations/python/packages/aces_runtime/control_plane_store.py
+++ b/implementations/python/packages/aces_runtime/control_plane_store.py
@@ -95,6 +95,10 @@ def _snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
             participant_address: list(events)
             for participant_address, events in snapshot.participant_behavior_history.items()
         },
+        "shared_state_records": dict(snapshot.shared_state_records),
+        "shared_state_history": {
+            state_address: list(records) for state_address, records in snapshot.shared_state_history.items()
+        },
         "realization_provenance": [
             {
                 "address": entry.address,
@@ -141,6 +145,10 @@ def _snapshot_from_payload(payload: dict[str, Any]) -> RuntimeSnapshot:
         participant_behavior_history={
             participant_address: list(events)
             for participant_address, events in payload.get("participant_behavior_history", {}).items()
+        },
+        shared_state_records=dict(payload.get("shared_state_records", {})),
+        shared_state_history={
+            state_address: list(records) for state_address, records in payload.get("shared_state_history", {}).items()
         },
         realization_provenance=tuple(
             RealizationProvenanceEntry(

--- a/implementations/python/packages/aces_runtime/participant_result_contracts.py
+++ b/implementations/python/packages/aces_runtime/participant_result_contracts.py
@@ -8,6 +8,10 @@ from aces_contracts.participant_behavior import (
     iter_participant_runtime_history_transition_violations,
 )
 from aces_contracts.participant_episode import iter_participant_episode_snapshot_violations
+from aces_contracts.participant_shared_state import (
+    iter_participant_shared_state_history_transition_violations,
+    iter_participant_shared_state_snapshot_violations,
+)
 from aces_contracts.runtime_state import RuntimeSnapshot
 
 from .diagnostics import _failure_diagnostic
@@ -55,6 +59,12 @@ def participant_runtime_state_contract_diagnostics(
             participant_episode_history=snapshot.participant_episode_history,
             metadata=snapshot.metadata,
         ),
+        *iter_participant_shared_state_snapshot_violations(
+            snapshot.shared_state_records,
+            snapshot.shared_state_history,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            metadata=snapshot.metadata,
+        ),
     ]
     return [
         _failure_diagnostic("runtime.backend-contract-invalid", address, message) for address, message in violations
@@ -74,5 +84,11 @@ def participant_runtime_history_transition_diagnostics(
             next_snapshot.participant_episode_history,
             previous_snapshot.participant_behavior_history,
             next_snapshot.participant_behavior_history,
+        )
+    ] + [
+        _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+        for address, message in iter_participant_shared_state_history_transition_violations(
+            previous_snapshot.shared_state_history,
+            next_snapshot.shared_state_history,
         )
     ]

--- a/implementations/python/tests/test_run_307_shared_operational_state.py
+++ b/implementations/python/tests/test_run_307_shared_operational_state.py
@@ -8,6 +8,10 @@ from pathlib import Path
 import pytest
 from aces_conformance.conformance import _semantic_diagnostics
 from aces_contracts.contracts import ParticipantSharedStateRecordModel, schema_bundle
+from aces_contracts.participant_shared_state import (
+    iter_participant_shared_state_history_transition_violations,
+    iter_participant_shared_state_snapshot_violations,
+)
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
 from aces_runtime.backend_calls import _call_backend_apply
 from jsonschema import Draft202012Validator
@@ -44,6 +48,14 @@ def _fixture_record(**overrides: object) -> dict[str, object]:
     payload = json.loads(fixture_path.read_text(encoding="utf-8"))
     payload.update(overrides)
     return payload
+
+
+def _record_for(state_address: str, **overrides: object) -> dict[str, object]:
+    record = _fixture_record(state_address=state_address)
+    for access in record["accesses"]:
+        access["state_address"] = state_address
+    record.update(overrides)
+    return record
 
 
 def _state_update_event(**overrides: object) -> dict[str, object]:
@@ -149,6 +161,110 @@ def test_runtime_snapshot_semantics_reject_unresolved_shared_state_ref() -> None
     )
 
     assert any("shared_state_refs" in item.message and STATE_ADDRESS in item.message for item in diagnostics)
+
+
+def test_shared_state_semantics_reject_invalid_container_shapes() -> None:
+    assert list(iter_participant_shared_state_snapshot_violations({}, {})) == []
+
+    violations = list(iter_participant_shared_state_snapshot_violations([], [], metadata=[]))
+    messages = [message for _, message in violations]
+
+    assert "RuntimeSnapshot.metadata must be a mapping" in messages
+    assert "shared_state_records must be a mapping" in messages
+    assert "shared_state_history must be a mapping" in messages
+
+
+def test_shared_state_semantics_reject_invalid_record_shapes_and_accesses() -> None:
+    records: dict[object, object] = {
+        "": _record_for(STATE_ADDRESS),
+        "not.mapping": "invalid",
+        "missing.scope": _record_for("missing.scope", state_scope=None),
+        "outer.key": _record_for("inner.key"),
+        "no.version": _record_for("no.version", revision=None, digest=None),
+        "bad.accesses": _record_for("bad.accesses", accesses="invalid"),
+        "access.not.mapping": _record_for("access.not.mapping", accesses=["invalid"]),
+        "access.no.address": _record_for(
+            "access.no.address",
+            accesses=[{"access_kind": "read", "read_revision": "rev1"}],
+        ),
+        "access.mismatch": _record_for(
+            "access.mismatch",
+            accesses=[{"state_address": "other.address", "access_kind": "read", "read_revision": "rev1"}],
+        ),
+        "access.bad.kind": _record_for(
+            "access.bad.kind",
+            accesses=[{"state_address": "access.bad.kind", "access_kind": "observe"}],
+        ),
+        "access.no.read": _record_for(
+            "access.no.read",
+            accesses=[{"state_address": "access.no.read", "access_kind": "read"}],
+        ),
+        "access.no.write": _record_for(
+            "access.no.write",
+            accesses=[{"state_address": "access.no.write", "access_kind": "write"}],
+        ),
+    }
+
+    messages = [
+        message
+        for _, message in iter_participant_shared_state_snapshot_violations(
+            records,
+            {},
+        )
+    ]
+
+    expected_messages = [
+        "shared_state_records keys must be non-empty strings",
+        "shared state record must be a mapping",
+        "shared state record is missing required fields: state_scope",
+        "shared state record outer key 'outer.key' does not match state_address 'inner.key'",
+        "shared state record requires revision or digest",
+        "shared state record accesses must be a list",
+        "shared state access must be a mapping",
+        "shared state access state_address must be a non-empty string",
+        "shared state access state_address 'other.address' does not match record state_address",
+        "shared state access_kind 'observe' is not supported",
+        "shared state read access requires read_revision or read_digest",
+        "shared state write access requires write_revision or write_digest",
+    ]
+    for expected in expected_messages:
+        assert expected in messages
+
+
+def test_shared_state_semantics_reject_invalid_history_shapes() -> None:
+    history: dict[object, object] = {
+        "": [_record_for(STATE_ADDRESS)],
+        "not.list": "invalid",
+        "bad.record": ["invalid"],
+    }
+
+    messages = [
+        message
+        for _, message in iter_participant_shared_state_snapshot_violations(
+            {},
+            history,
+        )
+    ]
+
+    assert "shared_state_history keys must be non-empty strings" in messages
+    assert "shared_state_history entries must be lists" in messages
+    assert "shared state history record must be a mapping" in messages
+
+
+def test_shared_state_history_transition_rejects_removed_or_shrunk_history() -> None:
+    original = _fixture_record()
+    second = _fixture_record(revision="rev9")
+
+    removed = list(iter_participant_shared_state_history_transition_violations({STATE_ADDRESS: [original]}, {}))
+    shrunk = list(
+        iter_participant_shared_state_history_transition_violations(
+            {STATE_ADDRESS: [original, second]},
+            {STATE_ADDRESS: [original]},
+        )
+    )
+
+    assert any("history was removed" in message for _, message in removed)
+    assert any("history shrank from 2 to 1 records" in message for _, message in shrunk)
 
 
 def test_backend_apply_rejects_shared_state_in_metadata() -> None:

--- a/implementations/python/tests/test_run_307_shared_operational_state.py
+++ b/implementations/python/tests/test_run_307_shared_operational_state.py
@@ -1,0 +1,208 @@
+"""RUN-307 shared operational state model tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aces_conformance.conformance import _semantic_diagnostics
+from aces_contracts.contracts import ParticipantSharedStateRecordModel, schema_bundle
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_runtime.backend_calls import _call_backend_apply
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+from starlette.testclient import TestClient
+
+from aces.backends.stubs import create_stub_target
+from aces.core.runtime.control_plane import RuntimeControlPlane
+from aces.core.runtime.control_plane_api import create_control_plane_app
+from aces.core.runtime.control_plane_security import (
+    ControlPlaneIdentity,
+    ControlPlaneRole,
+    ControlPlaneSecurityConfig,
+)
+
+PARTICIPANT = "participants.red.llm"
+EPISODE = "ep-red-004"
+ACTION_INSTANCE = "scan-0001"
+STATE_ADDRESS = "hosts.web01.service.http"
+T0 = "2026-05-26T10:50:00Z"
+
+
+def _fixture_record(**overrides: object) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[3]
+    fixture_path = (
+        repo_root
+        / "contracts"
+        / "fixtures"
+        / "participant-runtime"
+        / "participant-shared-state-record-v1"
+        / "valid"
+        / "serialized-service-state-commit.json"
+    )
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    payload.update(overrides)
+    return payload
+
+
+def _state_update_event(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "event_type": "state_transition_recorded",
+        "timestamp": T0,
+        "participant_address": PARTICIPANT,
+        "episode_id": EPISODE,
+        "action_instance_id": ACTION_INSTANCE,
+        "state_transition_kind": "shared_state_updated",
+        "post_state_digest": "sha256:known",
+        "lifecycle_phase": "state_update_commit",
+        "phase_realization": "runtime_mediated",
+        "shared_state_refs": [STATE_ADDRESS],
+        "details": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _snapshot_payload(
+    *,
+    shared_state_records: dict[str, dict[str, object]] | None = None,
+    shared_state_history: dict[str, list[dict[str, object]]] | None = None,
+    participant_behavior_history: dict[str, list[dict[str, object]]] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "runtime-snapshot/v1",
+        "entries": {},
+        "orchestration_results": {},
+        "orchestration_history": {},
+        "evaluation_results": {},
+        "evaluation_history": {},
+        "participant_episode_results": {},
+        "participant_episode_history": {},
+        "participant_behavior_history": participant_behavior_history or {},
+        "shared_state_records": shared_state_records or {},
+        "shared_state_history": shared_state_history or {},
+        "metadata": metadata or {},
+    }
+
+
+def _security(target_name: str) -> ControlPlaneSecurityConfig:
+    return ControlPlaneSecurityConfig(
+        max_request_bytes=1_000_000,
+        trust_proxy_identity_headers=True,
+        trusted_identities={
+            "backend-service": ControlPlaneIdentity(
+                identity="backend-service",
+                roles=frozenset({ControlPlaneRole.BACKEND}),
+                target_name=target_name,
+            ),
+        },
+    )
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "x-aces-client-verified": "true",
+        "x-aces-client-identity": "backend-service",
+    }
+
+
+def test_runtime_snapshot_exposes_shared_state_records_and_history() -> None:
+    record = _fixture_record()
+    snapshot = RuntimeSnapshot(
+        shared_state_records={STATE_ADDRESS: record},
+        shared_state_history={STATE_ADDRESS: [record]},
+    )
+    target = create_stub_target()
+    control_plane = RuntimeControlPlane(target, initial_snapshot=snapshot)
+    app = create_control_plane_app(control_plane, security=_security(target.name))
+
+    with TestClient(app) as client:
+        response = client.get("/snapshot", headers=_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["shared_state_records"][STATE_ADDRESS]["revision"] == "rev8"
+    assert body["shared_state_history"][STATE_ADDRESS][0]["state_address"] == STATE_ADDRESS
+
+    validator = Draft202012Validator(schema_bundle()["runtime-snapshot-v1"])
+    assert list(validator.iter_errors(body)) == []
+
+
+def test_shared_state_record_requires_revision_or_digest() -> None:
+    invalid = _fixture_record(revision=None, digest=None)
+
+    with pytest.raises(ValidationError, match="revision or digest"):
+        ParticipantSharedStateRecordModel.model_validate(invalid)
+
+    validator = Draft202012Validator(schema_bundle()["participant-shared-state-record-v1"])
+    assert list(validator.iter_errors(invalid))
+
+
+def test_runtime_snapshot_semantics_reject_unresolved_shared_state_ref() -> None:
+    diagnostics = _semantic_diagnostics(
+        "runtime-snapshot-v1",
+        _snapshot_payload(
+            participant_behavior_history={PARTICIPANT: [_state_update_event()]},
+        ),
+    )
+
+    assert any("shared_state_refs" in item.message and STATE_ADDRESS in item.message for item in diagnostics)
+
+
+def test_backend_apply_rejects_shared_state_in_metadata() -> None:
+    base_snapshot = RuntimeSnapshot()
+    record = _fixture_record()
+
+    def _backend_apply(_request: object, snapshot: RuntimeSnapshot) -> ApplyResult:
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                metadata={"shared_state_records": {STATE_ADDRESS: record}},
+            ),
+            changed_addresses=[STATE_ADDRESS],
+        )
+
+    result = _call_backend_apply(
+        _backend_apply,
+        object(),
+        base_snapshot,
+        address="runtime.control-plane.shared-state",
+        snapshot=base_snapshot,
+    )
+
+    assert result.success is False
+    assert any("shared_state_records" in diagnostic.message for diagnostic in result.diagnostics)
+
+
+def test_backend_apply_rejects_shared_state_history_rewrite() -> None:
+    original = _fixture_record()
+    rewritten = _fixture_record(revision="rev9")
+    base_snapshot = RuntimeSnapshot(
+        shared_state_records={STATE_ADDRESS: original},
+        shared_state_history={STATE_ADDRESS: [original]},
+    )
+
+    def _backend_apply(_request: object, snapshot: RuntimeSnapshot) -> ApplyResult:
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                shared_state_records={STATE_ADDRESS: rewritten},
+                shared_state_history={STATE_ADDRESS: [rewritten]},
+            ),
+            changed_addresses=[STATE_ADDRESS],
+        )
+
+    result = _call_backend_apply(
+        _backend_apply,
+        object(),
+        base_snapshot,
+        address="runtime.control-plane.shared-state",
+        snapshot=base_snapshot,
+    )
+
+    assert result.success is False
+    assert any("shared_state_history must be append-only" in item.message for item in result.diagnostics)


### PR DESCRIPTION
## Summary

Adds first-class RUN-307 shared operational state records and history to runtime snapshots with revision-aware validation.

## Requirement UIDs

- `RUN-307`

## Related Issues

Closes #194

## ADR Impact

- ADR-054
- ADR-060

## Changes

- Add `shared_state_records` and `shared_state_history` to runtime snapshots, envelopes, control-plane API serialization, persistence, and live conformance payloads.
- Validate shared-state record identity/version markers, access read/write markers, behavior `shared_state_refs`, and append-only history transitions.
- Regenerate runtime snapshot and participant shared-state schemas, update the schema-publication manifest, and add RUN-307 regression coverage.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification: targeted RUN-307 pytest, RUN-305/RUN-306 regression pytest, runtime contracts/conformance pytest, schema generation/publication checks, repo-policy checks, `tools/verify_all.py`, `pre-commit run --all-files`, Codex review cycle, and test-quality review cycle.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Runtime snapshot shared-state fields in `runtime_state.py`, `contracts.py`, control-plane API/store, participant-result diagnostics, and conformance payload handling., Schema artifacts in `contracts/schemas/snapshots/runtime-snapshot-v1.json` and `contracts/schemas/participant-runtime/participant-shared-state-record-v1.json`., Manifest/changelog updates in `contracts/schema-publication-manifest.json` and `changelog.d/194.added.md`.
- TESTS: `implementations/python/tests/test_run_307_shared_operational_state.py` covers snapshot exposure, schema validation, semantic reference checks, metadata smuggling rejection, and append-only history rejection., `tools/verify_all.py`, `pre-commit run --all-files`, Codex review cycle, and test-quality review cycle completed cleanly.

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/194.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.