### PR TITLE
feat: add participant concurrency runtime contracts

### DIFF
--- a/changelog.d/195.added.md
+++ b/changelog.d/195.added.md
@@ -1,1 +1,1 @@
-Added RUN-308 participant-runtime contract surfaces for joint action records, time-management contexts, and runtime snapshot concurrency validation.
+Added RUN-308 participant-runtime contract surfaces for joint action records, time-management contexts, runtime snapshot concurrency validation, and coverage for the concurrency guardrails.

--- a/changelog.d/195.added.md
+++ b/changelog.d/195.added.md
@@ -1,0 +1,1 @@
+Added RUN-308 participant-runtime contract surfaces for joint action records, time-management contexts, and runtime snapshot concurrency validation.

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-duplicate-feature.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-duplicate-feature.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-missing-disclosure.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-missing-disclosure.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-unguarded-feature-term.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-unguarded-feature-term.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-unsupported-declared-feature.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/invalid/feature-support-unsupported-declared-feature.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/feature-support-bounded.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/feature-support-bounded.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
@@ -22,6 +22,8 @@
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1"
   ],
   "compatibility": {

--- a/contracts/fixtures/participant-runtime/participant-joint-action-record-v1/invalid/implicit-last-writer-wins.json
+++ b/contracts/fixtures/participant-runtime/participant-joint-action-record-v1/invalid/implicit-last-writer-wins.json
@@ -1,0 +1,42 @@
+{
+  "access_sets": [
+    {
+      "member_event_ref": "scan-red-0001",
+      "shared_state_write_refs": [
+        "hosts.web01.service.http"
+      ]
+    },
+    {
+      "member_event_ref": "scan-blue-0001",
+      "shared_state_write_refs": [
+        "hosts.web01.service.http"
+      ]
+    }
+  ],
+  "actor_ref": "runtime.coordinator",
+  "atomicity_scope": "single_object",
+  "authorization_scope": "operators",
+  "clock_authority": "clock.logical.runtime",
+  "conflict_class": "none",
+  "conflict_policy": "last_write_wins",
+  "event_id": "joint-red-blue-0001",
+  "event_type": "joint_action_recorded",
+  "exact_concurrency_claim": true,
+  "extension_policy": "forbid_unknown_fields",
+  "ingested_at": "2026-06-20T08:00:00Z",
+  "isolation_guarantee": "none",
+  "joint_action_set_id": "joint-red-blue-0001",
+  "logical_order_ref": "order.joint-red-blue-0001",
+  "member_event_refs": [
+    "scan-red-0001",
+    "scan-blue-0001"
+  ],
+  "occurred_at": "2026-06-20T08:00:00Z",
+  "ordering_basis": "wall_clock_only",
+  "producer_ref": "backend.stub",
+  "realized_order": [],
+  "recorded_at": "2026-06-20T08:00:00Z",
+  "schema_name": "participant-joint-action-record",
+  "schema_version": "participant-joint-action-record/v1",
+  "unsupported_disclosure": false
+}

--- a/contracts/fixtures/participant-runtime/participant-joint-action-record-v1/valid/serialized-red-blue-shared-state.json
+++ b/contracts/fixtures/participant-runtime/participant-joint-action-record-v1/valid/serialized-red-blue-shared-state.json
@@ -1,0 +1,46 @@
+{
+  "access_sets": [
+    {
+      "member_event_ref": "scan-red-0001",
+      "shared_state_write_refs": [
+        "hosts.web01.service.http"
+      ]
+    },
+    {
+      "member_event_ref": "scan-blue-0001",
+      "shared_state_read_refs": [
+        "hosts.web01.service.http"
+      ]
+    }
+  ],
+  "actor_ref": "runtime.coordinator",
+  "atomicity_scope": "single_object",
+  "authorization_scope": "operators",
+  "clock_authority": "clock.logical.runtime",
+  "conflict_class": "read_write",
+  "conflict_policy": "serialize",
+  "event_id": "joint-red-blue-0001",
+  "event_type": "joint_action_recorded",
+  "exact_concurrency_claim": false,
+  "extension_policy": "forbid_unknown_fields",
+  "ingested_at": "2026-06-20T08:00:00Z",
+  "isolation_guarantee": "serializable",
+  "joint_action_set_id": "joint-red-blue-0001",
+  "logical_order_ref": "order.joint-red-blue-0001",
+  "member_event_refs": [
+    "scan-red-0001",
+    "scan-blue-0001"
+  ],
+  "occurred_at": "2026-06-20T08:00:00Z",
+  "ordering_basis": "serialized_backend_order",
+  "producer_ref": "backend.stub",
+  "realized_order": [
+    "scan-red-0001",
+    "scan-blue-0001"
+  ],
+  "recorded_at": "2026-06-20T08:00:00Z",
+  "schema_name": "participant-joint-action-record",
+  "schema_version": "participant-joint-action-record/v1",
+  "time_management_context_ref": "tm-red-blue-0001",
+  "unsupported_disclosure": false
+}

--- a/contracts/fixtures/participant-runtime/participant-time-management-context-v1/invalid/timestamp-only-exact.json
+++ b/contracts/fixtures/participant-runtime/participant-time-management-context-v1/invalid/timestamp-only-exact.json
@@ -1,0 +1,23 @@
+{
+  "actor_ref": "runtime.coordinator",
+  "authorization_scope": "operators",
+  "backend_serialized": false,
+  "basis": "wall_clock_only",
+  "claim_strength": "precise",
+  "clock_authority": "clock.wall",
+  "clock_ref": "clock.wall",
+  "context_id": "tm-red-blue-0001",
+  "event_id": "tm-red-blue-0001",
+  "event_type": "time_management_context_recorded",
+  "extension_policy": "forbid_unknown_fields",
+  "ingested_at": "2026-06-20T08:00:00Z",
+  "logical_order_ref": "order.wall-clock",
+  "mode": "display",
+  "occurred_at": "2026-06-20T08:00:00Z",
+  "ordering_basis": "wall_clock_only",
+  "producer_ref": "backend.stub",
+  "recorded_at": "2026-06-20T08:00:00Z",
+  "schema_name": "participant-time-management-context",
+  "schema_version": "participant-time-management-context/v1",
+  "unsupported_disclosure": false
+}

--- a/contracts/fixtures/participant-runtime/participant-time-management-context-v1/valid/backend-serialized-logical-clock.json
+++ b/contracts/fixtures/participant-runtime/participant-time-management-context-v1/valid/backend-serialized-logical-clock.json
@@ -1,0 +1,23 @@
+{
+  "actor_ref": "runtime.coordinator",
+  "authorization_scope": "operators",
+  "backend_serialized": true,
+  "basis": "serialized_backend_order",
+  "claim_strength": "bounded",
+  "clock_authority": "clock.logical.runtime",
+  "clock_ref": "clock.logical.runtime",
+  "context_id": "tm-red-blue-0001",
+  "event_id": "tm-red-blue-0001",
+  "event_type": "time_management_context_recorded",
+  "extension_policy": "forbid_unknown_fields",
+  "ingested_at": "2026-06-20T08:00:00Z",
+  "logical_order_ref": "order.joint-red-blue-0001",
+  "mode": "backend_serialized",
+  "occurred_at": "2026-06-20T08:00:00Z",
+  "ordering_basis": "serialized_backend_order",
+  "producer_ref": "backend.stub",
+  "recorded_at": "2026-06-20T08:00:00Z",
+  "schema_name": "participant-time-management-context",
+  "schema_version": "participant-time-management-context/v1",
+  "unsupported_disclosure": false
+}

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -12,20 +12,20 @@
       "contract_id": "backend-manifest-v2",
       "schema_path": "contracts/schemas/backend-manifest/backend-manifest-v2.json",
       "stability": "draft",
-      "content_hash": "da156411d9877ad75045569b47e3b98597b6dec23a827d176c1fc64d9532cc90",
+      "content_hash": "7698fe1c5350d56917663b9642c563a8ea0cb633fd42f15b8e585dd75017a92b",
       "last_change": {
-        "summary": "Extended the backend manifest with the participant backend-facing runtime capability surface (API-407 manifest extension; ADR-060, issue #76).",
-        "content_hash": "da156411d9877ad75045569b47e3b98597b6dec23a827d176c1fc64d9532cc90"
+        "summary": "Added the RUN-308 participant joint-action and time-management contract identifiers to backend-supported contract declarations.",
+        "content_hash": "7698fe1c5350d56917663b9642c563a8ea0cb633fd42f15b8e585dd75017a92b"
       }
     },
     {
       "contract_id": "backend-profile-v1",
       "schema_path": "contracts/schemas/profiles/backend-profile-v1.json",
       "stability": "draft",
-      "content_hash": "1c9ffe10f1c2c420610d1353dc1406bb0e0d63001c4f6a32e1aca061b164af1d",
+      "content_hash": "52476744039a9ef398de1c7b0ecac5eceb47e6b7ebde93c3d69dab9f0928d06a",
       "last_change": {
-        "summary": "Added the participant backend-facing contract identifiers (lifecycle-event, observation-envelope, shared-state-record, outcome-report) to the backend profile contract vocabulary (ADR-060, issue #76).",
-        "content_hash": "1c9ffe10f1c2c420610d1353dc1406bb0e0d63001c4f6a32e1aca061b164af1d"
+        "summary": "Added the RUN-308 participant joint-action and time-management contract identifiers to the backend profile contract vocabulary.",
+        "content_hash": "52476744039a9ef398de1c7b0ecac5eceb47e6b7ebde93c3d69dab9f0928d06a"
       }
     },
     {
@@ -165,6 +165,16 @@
       "content_hash": "a4c050fb2a53129148f7d2960a7cb06d36c4682483064734e505acda4677d7ec"
     },
     {
+      "contract_id": "participant-joint-action-record-v1",
+      "schema_path": "contracts/schemas/participant-runtime/participant-joint-action-record-v1.json",
+      "stability": "draft",
+      "content_hash": "bfd0f43f8b19f3658d71ca81520c481aa447f0486eee669edfc4521d0cdbd1a8",
+      "last_change": {
+        "summary": "Initial publication of the RUN-308 participant joint-action runtime contract: membership, access-set, conflict, isolation, and realized-order evidence.",
+        "content_hash": "bfd0f43f8b19f3658d71ca81520c481aa447f0486eee669edfc4521d0cdbd1a8"
+      }
+    },
+    {
       "contract_id": "participant-lifecycle-event-v1",
       "schema_path": "contracts/schemas/participant-runtime/participant-lifecycle-event-v1.json",
       "stability": "draft",
@@ -215,6 +225,16 @@
       }
     },
     {
+      "contract_id": "participant-time-management-context-v1",
+      "schema_path": "contracts/schemas/participant-runtime/participant-time-management-context-v1.json",
+      "stability": "draft",
+      "content_hash": "e4711ff9a4674697fb8aed40af863ea0327ad31824ef0a8f07d182ccfa9f28a1",
+      "last_change": {
+        "summary": "Initial publication of the RUN-308 participant time-management context contract: clock, ordering, lookahead, pacing, rollback, and backend-serialization basis.",
+        "content_hash": "e4711ff9a4674697fb8aed40af863ea0327ad31824ef0a8f07d182ccfa9f28a1"
+      }
+    },
+    {
       "contract_id": "processor-manifest-v2",
       "schema_path": "contracts/schemas/processor-manifest/processor-manifest-v2.json",
       "stability": "draft",
@@ -236,10 +256,10 @@
       "contract_id": "runtime-snapshot-v1",
       "schema_path": "contracts/schemas/snapshots/runtime-snapshot-v1.json",
       "stability": "draft",
-      "content_hash": "530cb86899355de624465c1c37723f923a69e85ecb40ef3f01f2d8bc013019a3",
+      "content_hash": "cb6a599ef5137bcc5954ffd4f451167562186112c7595ec20b50eb94b97e1550",
       "last_change": {
-        "summary": "Add first-class shared_state_records and shared_state_history fields to the runtime snapshot envelope for RUN-307 shared operational state.",
-        "content_hash": "530cb86899355de624465c1c37723f923a69e85ecb40ef3f01f2d8bc013019a3"
+        "summary": "Added first-class joint_action_records and time_management_contexts fields to the runtime snapshot envelope for RUN-308 concurrent participant execution.",
+        "content_hash": "cb6a599ef5137bcc5954ffd4f451167562186112c7595ec20b50eb94b97e1550"
       }
     },
     {

--- a/contracts/schemas/backend-manifest/backend-manifest-v2.json
+++ b/contracts/schemas/backend-manifest/backend-manifest-v2.json
@@ -763,6 +763,8 @@
           "participant-lifecycle-event-v1",
           "participant-observation-envelope-v1",
           "participant-shared-state-record-v1",
+          "participant-joint-action-record-v1",
+          "participant-time-management-context-v1",
           "participant-outcome-report-v1"
         ],
         "minLength": 1,

--- a/contracts/schemas/participant-runtime/participant-joint-action-record-v1.json
+++ b/contracts/schemas/participant-runtime/participant-joint-action-record-v1.json
@@ -1,0 +1,928 @@
+{
+  "$defs": {
+    "EventClassificationModel": {
+      "additionalProperties": false,
+      "description": "ACES-native normalized event classification tuple (ADR-054).",
+      "properties": {
+        "activity_id": {
+          "title": "Activity Id",
+          "type": "integer"
+        },
+        "activity_name": {
+          "minLength": 1,
+          "title": "Activity Name",
+          "type": "string"
+        },
+        "category_name": {
+          "minLength": 1,
+          "title": "Category Name",
+          "type": "string"
+        },
+        "category_uid": {
+          "title": "Category Uid",
+          "type": "integer"
+        },
+        "class_name": {
+          "minLength": 1,
+          "title": "Class Name",
+          "type": "string"
+        },
+        "class_uid": {
+          "title": "Class Uid",
+          "type": "integer"
+        },
+        "severity": {
+          "minLength": 1,
+          "title": "Severity",
+          "type": "string"
+        },
+        "severity_id": {
+          "title": "Severity Id",
+          "type": "integer"
+        },
+        "type_name": {
+          "minLength": 1,
+          "title": "Type Name",
+          "type": "string"
+        },
+        "type_uid": {
+          "title": "Type Uid",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "category_uid",
+        "category_name",
+        "class_uid",
+        "class_name",
+        "activity_id",
+        "activity_name",
+        "type_uid",
+        "type_name",
+        "severity_id",
+        "severity"
+      ],
+      "title": "EventClassificationModel",
+      "type": "object"
+    },
+    "ParticipantJointActionAccessSetModel": {
+      "additionalProperties": false,
+      "description": "Read/write footprint for one member event in a joint action record.",
+      "properties": {
+        "evidence_stream_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Stream Refs",
+          "type": "array"
+        },
+        "exclusive_resource_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Exclusive Resource Refs",
+          "type": "array"
+        },
+        "member_event_ref": {
+          "minLength": 1,
+          "title": "Member Event Ref",
+          "type": "string"
+        },
+        "shared_state_read_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Shared State Read Refs",
+          "type": "array"
+        },
+        "shared_state_write_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Shared State Write Refs",
+          "type": "array"
+        },
+        "visibility_effect_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Visibility Effect Refs",
+          "type": "array"
+        }
+      },
+      "required": [
+        "member_event_ref"
+      ],
+      "title": "ParticipantJointActionAccessSetModel",
+      "type": "object"
+    },
+    "RawDataIntegrityModel": {
+      "additionalProperties": false,
+      "description": "Hash, size, and truncation facts for raw data behind a runtime claim.",
+      "properties": {
+        "raw_data_hash": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash"
+        },
+        "raw_data_hash_algorithm": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash Algorithm"
+        },
+        "raw_data_is_truncated": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Is Truncated"
+        },
+        "raw_data_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Size"
+        },
+        "raw_data_untruncated_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Untruncated Size"
+        }
+      },
+      "title": "RawDataIntegrityModel",
+      "type": "object"
+    },
+    "SourcePipelineModel": {
+      "additionalProperties": false,
+      "description": "Source product, identity, and pipeline-time facts for a mapped record.",
+      "properties": {
+        "correlation_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Correlation Uid"
+        },
+        "log_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Name"
+        },
+        "log_provider": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Provider"
+        },
+        "log_source": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Source"
+        },
+        "logged_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logged Time"
+        },
+        "original_event_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Event Uid"
+        },
+        "original_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Time"
+        },
+        "processed_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Processed Time"
+        },
+        "product_ref": {
+          "minLength": 1,
+          "title": "Product Ref",
+          "type": "string"
+        },
+        "product_version": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Product Version"
+        },
+        "sequence": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence"
+        },
+        "transmit_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transmit Time"
+        }
+      },
+      "required": [
+        "product_ref"
+      ],
+      "title": "SourcePipelineModel",
+      "type": "object"
+    },
+    "SourceStatusModel": {
+      "additionalProperties": false,
+      "description": "Normalized source status claim for one participant runtime record.",
+      "properties": {
+        "source_status_label": {
+          "minLength": 1,
+          "title": "Source Status Label",
+          "type": "string"
+        },
+        "source_status_mapping": {
+          "minLength": 1,
+          "title": "Source Status Mapping",
+          "type": "string"
+        },
+        "status": {
+          "minLength": 1,
+          "title": "Status",
+          "type": "string"
+        },
+        "status_code": {
+          "minLength": 1,
+          "title": "Status Code",
+          "type": "string"
+        },
+        "status_detail": {
+          "minLength": 1,
+          "title": "Status Detail",
+          "type": "string"
+        },
+        "status_id": {
+          "title": "Status Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status_id",
+        "status",
+        "status_code",
+        "status_detail",
+        "source_status_label",
+        "source_status_mapping"
+      ],
+      "title": "SourceStatusModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://aces.dev/schemas/participant-joint-action-record-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "RUN-308 joint action / concurrency record over behavior events.",
+  "properties": {
+    "access_sets": {
+      "items": {
+        "$ref": "#/$defs/ParticipantJointActionAccessSetModel"
+      },
+      "minItems": 1,
+      "title": "Access Sets",
+      "type": "array"
+    },
+    "actor_ref": {
+      "minLength": 1,
+      "title": "Actor Ref",
+      "type": "string"
+    },
+    "atomicity_scope": {
+      "enum": [
+        "single_object",
+        "multi_object",
+        "coordination_interval",
+        "unsupported"
+      ],
+      "title": "Atomicity Scope",
+      "type": "string"
+    },
+    "authorization_scope": {
+      "minLength": 1,
+      "title": "Authorization Scope",
+      "type": "string"
+    },
+    "clock_authority": {
+      "minLength": 1,
+      "title": "Clock Authority",
+      "type": "string"
+    },
+    "confidence": {
+      "anyOf": [
+        {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Confidence"
+    },
+    "conflict_class": {
+      "enum": [
+        "none",
+        "read_write",
+        "write_write",
+        "unsupported"
+      ],
+      "title": "Conflict Class",
+      "type": "string"
+    },
+    "conflict_policy": {
+      "enum": [
+        "none",
+        "coordinate",
+        "serialize",
+        "reject",
+        "retry",
+        "withhold",
+        "merge",
+        "rollback",
+        "disclose_weak_guarantee",
+        "unsupported"
+      ],
+      "title": "Conflict Policy",
+      "type": "string"
+    },
+    "episode_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Episode Id"
+    },
+    "event_classification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EventClassificationModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "event_id": {
+      "minLength": 1,
+      "title": "Event Id",
+      "type": "string"
+    },
+    "event_type": {
+      "minLength": 1,
+      "title": "Event Type",
+      "type": "string"
+    },
+    "evidence_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Evidence Refs",
+      "type": "array"
+    },
+    "exact_concurrency_claim": {
+      "default": false,
+      "title": "Exact Concurrency Claim",
+      "type": "boolean"
+    },
+    "extension_policy": {
+      "minLength": 1,
+      "title": "Extension Policy",
+      "type": "string"
+    },
+    "fairness_policy_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Fairness Policy Ref"
+    },
+    "granular_markings": {
+      "additionalProperties": {
+        "items": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "propertyNames": {
+        "minLength": 1
+      },
+      "title": "Granular Markings",
+      "type": "object"
+    },
+    "ingested_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Ingested At",
+      "type": "string"
+    },
+    "isolation_guarantee": {
+      "enum": [
+        "none",
+        "serializable",
+        "snapshot",
+        "causal",
+        "unsupported"
+      ],
+      "title": "Isolation Guarantee",
+      "type": "string"
+    },
+    "joint_action_set_id": {
+      "minLength": 1,
+      "title": "Joint Action Set Id",
+      "type": "string"
+    },
+    "logical_order_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Logical Order Ref"
+    },
+    "marking_definition_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Marking Definition Refs",
+      "type": "array"
+    },
+    "markings": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Markings",
+      "type": "array"
+    },
+    "member_event_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Member Event Refs",
+      "type": "array"
+    },
+    "object_marking_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Object Marking Refs",
+      "type": "array"
+    },
+    "occurred_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Occurred At",
+      "type": "string"
+    },
+    "ordering_basis": {
+      "enum": [
+        "total_order",
+        "partial_order",
+        "simultaneous",
+        "serialized_backend_order",
+        "simulation_tick",
+        "control_plane_order",
+        "logical_clock",
+        "vector_clock",
+        "wall_clock_only",
+        "unknown",
+        "unsupported"
+      ],
+      "title": "Ordering Basis",
+      "type": "string"
+    },
+    "participant_address": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Participant Address"
+    },
+    "participant_observation_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Participant Observation Refs",
+      "type": "array"
+    },
+    "predecessor_event_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Predecessor Event Refs",
+      "type": "array"
+    },
+    "producer_ref": {
+      "minLength": 1,
+      "title": "Producer Ref",
+      "type": "string"
+    },
+    "provenance_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Provenance Refs",
+      "type": "array"
+    },
+    "raw_data_integrity": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RawDataIntegrityModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "realized_order": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Realized Order",
+      "type": "array"
+    },
+    "recorded_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "redaction_policy_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Redaction Policy Ref"
+    },
+    "retry_limit": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Retry Limit"
+    },
+    "rollback_event_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Rollback Event Refs",
+      "type": "array"
+    },
+    "schema_name": {
+      "minLength": 1,
+      "title": "Schema Name",
+      "type": "string"
+    },
+    "schema_version": {
+      "minLength": 1,
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sequence_number": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Sequence Number"
+    },
+    "simultaneity_group_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Simultaneity Group Ref"
+    },
+    "source_pipeline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SourcePipelineModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "source_raw_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Raw Ref"
+    },
+    "source_record_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Record Ref"
+    },
+    "source_status": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SourceStatusModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "source_system_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source System Ref"
+    },
+    "temporal_context": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Temporal Context"
+    },
+    "time_management_context_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Time Management Context Ref"
+    },
+    "timeout_policy_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timeout Policy Ref"
+    },
+    "unsupported_disclosure": {
+      "default": false,
+      "title": "Unsupported Disclosure",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "event_id",
+    "schema_name",
+    "schema_version",
+    "event_type",
+    "extension_policy",
+    "occurred_at",
+    "recorded_at",
+    "ingested_at",
+    "clock_authority",
+    "ordering_basis",
+    "actor_ref",
+    "producer_ref",
+    "authorization_scope",
+    "joint_action_set_id",
+    "member_event_refs",
+    "access_sets",
+    "conflict_class",
+    "conflict_policy",
+    "isolation_guarantee",
+    "atomicity_scope"
+  ],
+  "title": "ParticipantJointActionRecordModel",
+  "type": "object"
+}

--- a/contracts/schemas/participant-runtime/participant-time-management-context-v1.json
+++ b/contracts/schemas/participant-runtime/participant-time-management-context-v1.json
@@ -1,0 +1,804 @@
+{
+  "$defs": {
+    "EventClassificationModel": {
+      "additionalProperties": false,
+      "description": "ACES-native normalized event classification tuple (ADR-054).",
+      "properties": {
+        "activity_id": {
+          "title": "Activity Id",
+          "type": "integer"
+        },
+        "activity_name": {
+          "minLength": 1,
+          "title": "Activity Name",
+          "type": "string"
+        },
+        "category_name": {
+          "minLength": 1,
+          "title": "Category Name",
+          "type": "string"
+        },
+        "category_uid": {
+          "title": "Category Uid",
+          "type": "integer"
+        },
+        "class_name": {
+          "minLength": 1,
+          "title": "Class Name",
+          "type": "string"
+        },
+        "class_uid": {
+          "title": "Class Uid",
+          "type": "integer"
+        },
+        "severity": {
+          "minLength": 1,
+          "title": "Severity",
+          "type": "string"
+        },
+        "severity_id": {
+          "title": "Severity Id",
+          "type": "integer"
+        },
+        "type_name": {
+          "minLength": 1,
+          "title": "Type Name",
+          "type": "string"
+        },
+        "type_uid": {
+          "title": "Type Uid",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "category_uid",
+        "category_name",
+        "class_uid",
+        "class_name",
+        "activity_id",
+        "activity_name",
+        "type_uid",
+        "type_name",
+        "severity_id",
+        "severity"
+      ],
+      "title": "EventClassificationModel",
+      "type": "object"
+    },
+    "RawDataIntegrityModel": {
+      "additionalProperties": false,
+      "description": "Hash, size, and truncation facts for raw data behind a runtime claim.",
+      "properties": {
+        "raw_data_hash": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash"
+        },
+        "raw_data_hash_algorithm": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Hash Algorithm"
+        },
+        "raw_data_is_truncated": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Is Truncated"
+        },
+        "raw_data_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Size"
+        },
+        "raw_data_untruncated_size": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Raw Data Untruncated Size"
+        }
+      },
+      "title": "RawDataIntegrityModel",
+      "type": "object"
+    },
+    "SourcePipelineModel": {
+      "additionalProperties": false,
+      "description": "Source product, identity, and pipeline-time facts for a mapped record.",
+      "properties": {
+        "correlation_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Correlation Uid"
+        },
+        "log_name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Name"
+        },
+        "log_provider": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Provider"
+        },
+        "log_source": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Log Source"
+        },
+        "logged_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logged Time"
+        },
+        "original_event_uid": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Event Uid"
+        },
+        "original_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Original Time"
+        },
+        "processed_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Processed Time"
+        },
+        "product_ref": {
+          "minLength": 1,
+          "title": "Product Ref",
+          "type": "string"
+        },
+        "product_version": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Product Version"
+        },
+        "sequence": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence"
+        },
+        "transmit_time": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transmit Time"
+        }
+      },
+      "required": [
+        "product_ref"
+      ],
+      "title": "SourcePipelineModel",
+      "type": "object"
+    },
+    "SourceStatusModel": {
+      "additionalProperties": false,
+      "description": "Normalized source status claim for one participant runtime record.",
+      "properties": {
+        "source_status_label": {
+          "minLength": 1,
+          "title": "Source Status Label",
+          "type": "string"
+        },
+        "source_status_mapping": {
+          "minLength": 1,
+          "title": "Source Status Mapping",
+          "type": "string"
+        },
+        "status": {
+          "minLength": 1,
+          "title": "Status",
+          "type": "string"
+        },
+        "status_code": {
+          "minLength": 1,
+          "title": "Status Code",
+          "type": "string"
+        },
+        "status_detail": {
+          "minLength": 1,
+          "title": "Status Detail",
+          "type": "string"
+        },
+        "status_id": {
+          "title": "Status Id",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status_id",
+        "status",
+        "status_code",
+        "status_detail",
+        "source_status_label",
+        "source_status_mapping"
+      ],
+      "title": "SourceStatusModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://aces.dev/schemas/participant-time-management-context-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "RUN-308 time-management basis for concurrent or distributed runtime claims.",
+  "properties": {
+    "actor_ref": {
+      "minLength": 1,
+      "title": "Actor Ref",
+      "type": "string"
+    },
+    "advance_by": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Advance By"
+    },
+    "authorization_scope": {
+      "minLength": 1,
+      "title": "Authorization Scope",
+      "type": "string"
+    },
+    "backend_serialized": {
+      "default": false,
+      "title": "Backend Serialized",
+      "type": "boolean"
+    },
+    "basis": {
+      "enum": [
+        "total_order",
+        "partial_order",
+        "simultaneous",
+        "serialized_backend_order",
+        "simulation_tick",
+        "control_plane_order",
+        "logical_clock",
+        "vector_clock",
+        "wall_clock_only",
+        "unknown",
+        "unsupported"
+      ],
+      "title": "Basis",
+      "type": "string"
+    },
+    "claim_strength": {
+      "enum": [
+        "display",
+        "bounded",
+        "exact",
+        "unsupported"
+      ],
+      "title": "Claim Strength",
+      "type": "string"
+    },
+    "clock_authority": {
+      "minLength": 1,
+      "title": "Clock Authority",
+      "type": "string"
+    },
+    "clock_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Clock Ref"
+    },
+    "confidence": {
+      "anyOf": [
+        {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Confidence"
+    },
+    "context_id": {
+      "minLength": 1,
+      "title": "Context Id",
+      "type": "string"
+    },
+    "episode_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Episode Id"
+    },
+    "event_classification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EventClassificationModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "event_id": {
+      "minLength": 1,
+      "title": "Event Id",
+      "type": "string"
+    },
+    "event_type": {
+      "minLength": 1,
+      "title": "Event Type",
+      "type": "string"
+    },
+    "evidence_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Evidence Refs",
+      "type": "array"
+    },
+    "extension_policy": {
+      "minLength": 1,
+      "title": "Extension Policy",
+      "type": "string"
+    },
+    "granular_markings": {
+      "additionalProperties": {
+        "items": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "propertyNames": {
+        "minLength": 1
+      },
+      "title": "Granular Markings",
+      "type": "object"
+    },
+    "ingested_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Ingested At",
+      "type": "string"
+    },
+    "logical_order_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Logical Order Ref"
+    },
+    "lookahead": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Lookahead"
+    },
+    "marking_definition_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Marking Definition Refs",
+      "type": "array"
+    },
+    "markings": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Markings",
+      "type": "array"
+    },
+    "mode": {
+      "enum": [
+        "display",
+        "pacing",
+        "lookahead",
+        "rollback",
+        "devs",
+        "fmi",
+        "backend_serialized",
+        "unsupported"
+      ],
+      "title": "Mode",
+      "type": "string"
+    },
+    "object_marking_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Object Marking Refs",
+      "type": "array"
+    },
+    "occurred_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Occurred At",
+      "type": "string"
+    },
+    "ordering_basis": {
+      "enum": [
+        "total_order",
+        "partial_order",
+        "simultaneous",
+        "serialized_backend_order",
+        "simulation_tick",
+        "control_plane_order",
+        "logical_clock",
+        "vector_clock",
+        "wall_clock_only",
+        "unknown",
+        "unsupported"
+      ],
+      "title": "Ordering Basis",
+      "type": "string"
+    },
+    "participant_address": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Participant Address"
+    },
+    "predecessor_event_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Predecessor Event Refs",
+      "type": "array"
+    },
+    "producer_ref": {
+      "minLength": 1,
+      "title": "Producer Ref",
+      "type": "string"
+    },
+    "provenance_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Provenance Refs",
+      "type": "array"
+    },
+    "raw_data_integrity": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RawDataIntegrityModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "recorded_at": {
+      "format": "date-time",
+      "minLength": 1,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+      "title": "Recorded At",
+      "type": "string"
+    },
+    "redaction_policy_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Redaction Policy Ref"
+    },
+    "rollback_event_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Rollback Event Refs",
+      "type": "array"
+    },
+    "schema_name": {
+      "minLength": 1,
+      "title": "Schema Name",
+      "type": "string"
+    },
+    "schema_version": {
+      "minLength": 1,
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "sequence_number": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Sequence Number"
+    },
+    "source_pipeline": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SourcePipelineModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "source_raw_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Raw Ref"
+    },
+    "source_record_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Record Ref"
+    },
+    "source_status": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SourceStatusModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "source_system_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source System Ref"
+    },
+    "temporal_context": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Temporal Context"
+    },
+    "unsupported_disclosure": {
+      "default": false,
+      "title": "Unsupported Disclosure",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "event_id",
+    "schema_name",
+    "schema_version",
+    "event_type",
+    "extension_policy",
+    "occurred_at",
+    "recorded_at",
+    "ingested_at",
+    "clock_authority",
+    "ordering_basis",
+    "actor_ref",
+    "producer_ref",
+    "authorization_scope",
+    "context_id",
+    "mode",
+    "claim_strength",
+    "basis"
+  ],
+  "title": "ParticipantTimeManagementContextModel",
+  "type": "object"
+}

--- a/contracts/schemas/profiles/backend-profile-v1.json
+++ b/contracts/schemas/profiles/backend-profile-v1.json
@@ -29,6 +29,8 @@
           "participant-lifecycle-event-v1",
           "participant-observation-envelope-v1",
           "participant-shared-state-record-v1",
+          "participant-joint-action-record-v1",
+          "participant-time-management-context-v1",
           "participant-outcome-report-v1"
         ],
         "type": "string"

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -1259,6 +1259,580 @@
       "title": "ParticipantInteractionClass",
       "type": "string"
     },
+    "ParticipantJointActionAccessSetModel": {
+      "additionalProperties": false,
+      "description": "Read/write footprint for one member event in a joint action record.",
+      "properties": {
+        "evidence_stream_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Stream Refs",
+          "type": "array"
+        },
+        "exclusive_resource_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Exclusive Resource Refs",
+          "type": "array"
+        },
+        "member_event_ref": {
+          "minLength": 1,
+          "title": "Member Event Ref",
+          "type": "string"
+        },
+        "shared_state_read_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Shared State Read Refs",
+          "type": "array"
+        },
+        "shared_state_write_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Shared State Write Refs",
+          "type": "array"
+        },
+        "visibility_effect_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Visibility Effect Refs",
+          "type": "array"
+        }
+      },
+      "required": [
+        "member_event_ref"
+      ],
+      "title": "ParticipantJointActionAccessSetModel",
+      "type": "object"
+    },
+    "ParticipantJointActionRecordModel": {
+      "additionalProperties": false,
+      "description": "RUN-308 joint action / concurrency record over behavior events.",
+      "properties": {
+        "access_sets": {
+          "items": {
+            "$ref": "#/$defs/ParticipantJointActionAccessSetModel"
+          },
+          "minItems": 1,
+          "title": "Access Sets",
+          "type": "array"
+        },
+        "actor_ref": {
+          "minLength": 1,
+          "title": "Actor Ref",
+          "type": "string"
+        },
+        "atomicity_scope": {
+          "enum": [
+            "single_object",
+            "multi_object",
+            "coordination_interval",
+            "unsupported"
+          ],
+          "title": "Atomicity Scope",
+          "type": "string"
+        },
+        "authorization_scope": {
+          "minLength": 1,
+          "title": "Authorization Scope",
+          "type": "string"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "conflict_class": {
+          "enum": [
+            "none",
+            "read_write",
+            "write_write",
+            "unsupported"
+          ],
+          "title": "Conflict Class",
+          "type": "string"
+        },
+        "conflict_policy": {
+          "enum": [
+            "none",
+            "coordinate",
+            "serialize",
+            "reject",
+            "retry",
+            "withhold",
+            "merge",
+            "rollback",
+            "disclose_weak_guarantee",
+            "unsupported"
+          ],
+          "title": "Conflict Policy",
+          "type": "string"
+        },
+        "episode_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Episode Id"
+        },
+        "event_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EventClassificationModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "event_id": {
+          "minLength": 1,
+          "title": "Event Id",
+          "type": "string"
+        },
+        "event_type": {
+          "minLength": 1,
+          "title": "Event Type",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "exact_concurrency_claim": {
+          "default": false,
+          "title": "Exact Concurrency Claim",
+          "type": "boolean"
+        },
+        "extension_policy": {
+          "minLength": 1,
+          "title": "Extension Policy",
+          "type": "string"
+        },
+        "fairness_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fairness Policy Ref"
+        },
+        "granular_markings": {
+          "additionalProperties": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Granular Markings",
+          "type": "object"
+        },
+        "ingested_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Ingested At",
+          "type": "string"
+        },
+        "isolation_guarantee": {
+          "enum": [
+            "none",
+            "serializable",
+            "snapshot",
+            "causal",
+            "unsupported"
+          ],
+          "title": "Isolation Guarantee",
+          "type": "string"
+        },
+        "joint_action_set_id": {
+          "minLength": 1,
+          "title": "Joint Action Set Id",
+          "type": "string"
+        },
+        "logical_order_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logical Order Ref"
+        },
+        "marking_definition_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Marking Definition Refs",
+          "type": "array"
+        },
+        "markings": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Markings",
+          "type": "array"
+        },
+        "member_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Member Event Refs",
+          "type": "array"
+        },
+        "object_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Object Marking Refs",
+          "type": "array"
+        },
+        "occurred_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Occurred At",
+          "type": "string"
+        },
+        "ordering_basis": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "participant_address": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Participant Address"
+        },
+        "participant_observation_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Participant Observation Refs",
+          "type": "array"
+        },
+        "predecessor_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Predecessor Event Refs",
+          "type": "array"
+        },
+        "producer_ref": {
+          "minLength": 1,
+          "title": "Producer Ref",
+          "type": "string"
+        },
+        "provenance_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Provenance Refs",
+          "type": "array"
+        },
+        "raw_data_integrity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawDataIntegrityModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "realized_order": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Realized Order",
+          "type": "array"
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "redaction_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Redaction Policy Ref"
+        },
+        "retry_limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retry Limit"
+        },
+        "rollback_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Rollback Event Refs",
+          "type": "array"
+        },
+        "schema_name": {
+          "minLength": 1,
+          "title": "Schema Name",
+          "type": "string"
+        },
+        "schema_version": {
+          "minLength": 1,
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sequence_number": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence Number"
+        },
+        "simultaneity_group_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Simultaneity Group Ref"
+        },
+        "source_pipeline": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourcePipelineModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_raw_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Raw Ref"
+        },
+        "source_record_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Record Ref"
+        },
+        "source_status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceStatusModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_system_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source System Ref"
+        },
+        "temporal_context": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temporal Context"
+        },
+        "time_management_context_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Time Management Context Ref"
+        },
+        "timeout_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Timeout Policy Ref"
+        },
+        "unsupported_disclosure": {
+          "default": false,
+          "title": "Unsupported Disclosure",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "event_id",
+        "schema_name",
+        "schema_version",
+        "event_type",
+        "extension_policy",
+        "occurred_at",
+        "recorded_at",
+        "ingested_at",
+        "clock_authority",
+        "ordering_basis",
+        "actor_ref",
+        "producer_ref",
+        "authorization_scope",
+        "joint_action_set_id",
+        "member_event_refs",
+        "access_sets",
+        "conflict_class",
+        "conflict_policy",
+        "isolation_guarantee",
+        "atomicity_scope"
+      ],
+      "title": "ParticipantJointActionRecordModel",
+      "type": "object"
+    },
     "ParticipantLifecycleOperationState": {
       "description": "RUN-306 operation states for execution-attempt records.",
       "enum": [
@@ -2346,6 +2920,456 @@
       "title": "ParticipantTimeDomain",
       "type": "string"
     },
+    "ParticipantTimeManagementContextModel": {
+      "additionalProperties": false,
+      "description": "RUN-308 time-management basis for concurrent or distributed runtime claims.",
+      "properties": {
+        "actor_ref": {
+          "minLength": 1,
+          "title": "Actor Ref",
+          "type": "string"
+        },
+        "advance_by": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Advance By"
+        },
+        "authorization_scope": {
+          "minLength": 1,
+          "title": "Authorization Scope",
+          "type": "string"
+        },
+        "backend_serialized": {
+          "default": false,
+          "title": "Backend Serialized",
+          "type": "boolean"
+        },
+        "basis": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Basis",
+          "type": "string"
+        },
+        "claim_strength": {
+          "enum": [
+            "display",
+            "bounded",
+            "exact",
+            "unsupported"
+          ],
+          "title": "Claim Strength",
+          "type": "string"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "clock_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clock Ref"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "context_id": {
+          "minLength": 1,
+          "title": "Context Id",
+          "type": "string"
+        },
+        "episode_id": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Episode Id"
+        },
+        "event_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EventClassificationModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "event_id": {
+          "minLength": 1,
+          "title": "Event Id",
+          "type": "string"
+        },
+        "event_type": {
+          "minLength": 1,
+          "title": "Event Type",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "extension_policy": {
+          "minLength": 1,
+          "title": "Extension Policy",
+          "type": "string"
+        },
+        "granular_markings": {
+          "additionalProperties": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Granular Markings",
+          "type": "object"
+        },
+        "ingested_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Ingested At",
+          "type": "string"
+        },
+        "logical_order_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logical Order Ref"
+        },
+        "lookahead": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lookahead"
+        },
+        "marking_definition_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Marking Definition Refs",
+          "type": "array"
+        },
+        "markings": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Markings",
+          "type": "array"
+        },
+        "mode": {
+          "enum": [
+            "display",
+            "pacing",
+            "lookahead",
+            "rollback",
+            "devs",
+            "fmi",
+            "backend_serialized",
+            "unsupported"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "object_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Object Marking Refs",
+          "type": "array"
+        },
+        "occurred_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Occurred At",
+          "type": "string"
+        },
+        "ordering_basis": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "participant_address": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Participant Address"
+        },
+        "predecessor_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Predecessor Event Refs",
+          "type": "array"
+        },
+        "producer_ref": {
+          "minLength": 1,
+          "title": "Producer Ref",
+          "type": "string"
+        },
+        "provenance_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Provenance Refs",
+          "type": "array"
+        },
+        "raw_data_integrity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawDataIntegrityModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "redaction_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Redaction Policy Ref"
+        },
+        "rollback_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Rollback Event Refs",
+          "type": "array"
+        },
+        "schema_name": {
+          "minLength": 1,
+          "title": "Schema Name",
+          "type": "string"
+        },
+        "schema_version": {
+          "minLength": 1,
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sequence_number": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence Number"
+        },
+        "source_pipeline": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourcePipelineModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_raw_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Raw Ref"
+        },
+        "source_record_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Record Ref"
+        },
+        "source_status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceStatusModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_system_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source System Ref"
+        },
+        "temporal_context": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temporal Context"
+        },
+        "unsupported_disclosure": {
+          "default": false,
+          "title": "Unsupported Disclosure",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "event_id",
+        "schema_name",
+        "schema_version",
+        "event_type",
+        "extension_policy",
+        "occurred_at",
+        "recorded_at",
+        "ingested_at",
+        "clock_authority",
+        "ordering_basis",
+        "actor_ref",
+        "producer_ref",
+        "authorization_scope",
+        "context_id",
+        "mode",
+        "claim_strength",
+        "basis"
+      ],
+      "title": "ParticipantTimeManagementContextModel",
+      "type": "object"
+    },
     "RawDataIntegrityModel": {
       "additionalProperties": false,
       "description": "Hash, size, and truncation facts for raw data behind a runtime claim.",
@@ -2945,6 +3969,13 @@
       "title": "Evaluation Results",
       "type": "object"
     },
+    "joint_action_records": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ParticipantJointActionRecordModel"
+      },
+      "title": "Joint Action Records",
+      "type": "object"
+    },
     "metadata": {
       "additionalProperties": true,
       "title": "Metadata",
@@ -3022,6 +4053,13 @@
         "$ref": "#/$defs/ParticipantSharedStateRecordModel"
       },
       "title": "Shared State Records",
+      "type": "object"
+    },
+    "time_management_contexts": {
+      "additionalProperties": {
+        "$ref": "#/$defs/ParticipantTimeManagementContextModel"
+      },
+      "title": "Time Management Contexts",
       "type": "object"
     }
   },

--- a/implementations/python/packages/aces_backend_protocols/capabilities.py
+++ b/implementations/python/packages/aces_backend_protocols/capabilities.py
@@ -30,6 +30,15 @@ _PARTICIPANT_BEHAVIOR_CONTRACTS = frozenset(
         "runtime-snapshot-v1",
     }
 )
+_PARTICIPANT_INTERACTION_CONTRACTS = frozenset(
+    {
+        "participant-behavior-history-event-stream-v1",
+        "participant-shared-state-record-v1",
+        "participant-joint-action-record-v1",
+        "participant-time-management-context-v1",
+        "runtime-snapshot-v1",
+    }
+)
 
 PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS = {
     PARTICIPANT_RUNTIME_ROLE_SCOPE: {
@@ -51,10 +60,10 @@ PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS = {
         "temporal_contracts": _PARTICIPANT_BEHAVIOR_CONTRACTS,
     },
     PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE: {
-        "contention": _PARTICIPANT_BEHAVIOR_CONTRACTS,
-        "coordination": _PARTICIPANT_BEHAVIOR_CONTRACTS,
-        "interference": _PARTICIPANT_BEHAVIOR_CONTRACTS,
-        "shared_state_change": _PARTICIPANT_BEHAVIOR_CONTRACTS,
+        "contention": _PARTICIPANT_INTERACTION_CONTRACTS,
+        "coordination": _PARTICIPANT_INTERACTION_CONTRACTS,
+        "interference": _PARTICIPANT_INTERACTION_CONTRACTS,
+        "shared_state_change": _PARTICIPANT_INTERACTION_CONTRACTS,
     },
 }
 """Minimum published contract surfaces needed to make API-405 claims checkable.

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -81,6 +81,8 @@ def create_stub_manifest(
         supported_contract_versions.discard("participant-lifecycle-event-v1")
         supported_contract_versions.discard("participant-observation-envelope-v1")
         supported_contract_versions.discard("participant-shared-state-record-v1")
+        supported_contract_versions.discard("participant-joint-action-record-v1")
+        supported_contract_versions.discard("participant-time-management-context-v1")
         supported_contract_versions.discard("participant-outcome-report-v1")
     concept_bindings = (
         ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -40,6 +40,7 @@ from aces_contracts.contracts import (
 from aces_contracts.corpus import FIXTURES, corpus_family_root
 from aces_contracts.diagnostics import Diagnostic, Severity
 from aces_contracts.evaluation import EvaluationExecutionState
+from aces_contracts.participant_concurrency import iter_participant_concurrency_snapshot_violations
 from aces_contracts.participant_episode import (
     ParticipantEpisodeExecutionState,
     ParticipantEpisodeHistoryEvent,
@@ -441,6 +442,13 @@ def _snapshot_from_envelope(payload: dict[str, Any]) -> RuntimeSnapshot:
             state_address: [record.model_dump(mode="json") for record in records]
             for state_address, records in validated.shared_state_history.items()
         },
+        joint_action_records={
+            record_id: record.model_dump(mode="json") for record_id, record in validated.joint_action_records.items()
+        },
+        time_management_contexts={
+            context_id: context.model_dump(mode="json")
+            for context_id, context in validated.time_management_contexts.items()
+        },
         metadata=dict(validated.metadata),
     )
 
@@ -728,6 +736,19 @@ def _shared_state_snapshot_diagnostics(snapshot: RuntimeSnapshot) -> list[Diagno
     ]
 
 
+def _participant_concurrency_snapshot_diagnostics(snapshot: RuntimeSnapshot) -> list[Diagnostic]:
+    return [
+        _diagnostic(_SEMANTIC_INVALID_DIAGNOSTIC_CODE, address, message)
+        for address, message in iter_participant_concurrency_snapshot_violations(
+            snapshot.joint_action_records,
+            snapshot.time_management_contexts,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            shared_state_records=snapshot.shared_state_records,
+            shared_state_history=snapshot.shared_state_history,
+        )
+    ]
+
+
 def _runtime_snapshot_semantic_diagnostics(payload: Any) -> list[Diagnostic]:
     snapshot = _snapshot_from_envelope(payload)
     return [
@@ -736,6 +757,7 @@ def _runtime_snapshot_semantic_diagnostics(payload: Any) -> list[Diagnostic]:
         *_participant_episode_snapshot_diagnostics(snapshot),
         *_participant_behavior_snapshot_diagnostics(snapshot),
         *_shared_state_snapshot_diagnostics(snapshot),
+        *_participant_concurrency_snapshot_diagnostics(snapshot),
     ]
 
 
@@ -1282,6 +1304,8 @@ def _live_target_cases(
             state_address: list(records)
             for state_address, records in control_plane.snapshot.shared_state_history.items()
         },
+        "joint_action_records": dict(control_plane.snapshot.joint_action_records),
+        "time_management_contexts": dict(control_plane.snapshot.time_management_contexts),
         "metadata": dict(control_plane.snapshot.metadata),
     }
     snapshot_diags = [

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -1234,6 +1234,63 @@ def _joint_action_actual_conflict(access_sets: list[ParticipantJointActionAccess
     return "read_write" if read_write_conflict else "none"
 
 
+def _joint_action_member_ref_set(member_event_refs: list[str]) -> set[str]:
+    member_refs = list(member_event_refs)
+    member_ref_set = set(member_refs)
+    if len(member_refs) != len(member_ref_set):
+        raise ValueError("joint action member_event_refs must be unique")
+    return member_ref_set
+
+
+def _validate_joint_action_members(record: Any, member_ref_set: set[str]) -> None:
+    access_event_refs = [access.member_event_ref for access in record.access_sets]
+    if not _exact_string_permutation(access_event_refs, member_ref_set):
+        raise ValueError("joint action access_sets must cover member_event_refs exactly once")
+    if record.realized_order and not _exact_string_permutation(record.realized_order, member_ref_set):
+        raise ValueError("joint action realized_order must be an exact permutation of member_event_refs")
+
+
+def _validate_joint_action_disclosure(record: Any) -> None:
+    if record.unsupported_disclosure and record.exact_concurrency_claim:
+        raise ValueError("unsupported concurrency disclosure cannot carry an exact concurrency claim")
+    if record.exact_concurrency_claim and record.time_management_context_ref is None:
+        raise ValueError("exact concurrency claims require time_management_context_ref")
+
+
+def _joint_action_unsupported_policy_applies(record: Any) -> bool:
+    if record.conflict_policy != "unsupported":
+        return False
+    if not record.unsupported_disclosure or record.exact_concurrency_claim:
+        raise ValueError("unsupported conflict_policy requires unsupported_disclosure and no exact claim")
+    return True
+
+
+def _validate_joint_action_conflict(record: Any, actual_conflict: str) -> None:
+    if not record.unsupported_disclosure and record.conflict_class != actual_conflict:
+        raise ValueError("joint action conflict_class must match declared access-set conflicts")
+    if record.conflict_class == "none" and actual_conflict != "none":
+        raise ValueError("joint action conflict_class cannot be none when access sets conflict")
+    _validate_joint_action_conflict_policy(record, actual_conflict)
+    _validate_joint_action_atomicity(record, actual_conflict)
+
+
+def _validate_joint_action_conflict_policy(record: Any, actual_conflict: str) -> None:
+    if record.isolation_guarantee == "serializable" and not record.realized_order:
+        raise ValueError("serializable joint action isolation requires realized_order")
+    if record.conflict_policy == "serialize" and not record.realized_order:
+        raise ValueError("serialize conflict_policy requires realized_order")
+    if record.conflict_policy == "retry" and (record.retry_limit is None or not record.rollback_event_refs):
+        raise ValueError("retry conflict_policy requires retry_limit and rollback_event_refs")
+    if record.conflict_policy == "none" and actual_conflict != "none":
+        raise ValueError("none conflict_policy is only valid when access sets do not conflict")
+
+
+def _validate_joint_action_atomicity(record: Any, actual_conflict: str) -> None:
+    has_recovery_evidence = bool(record.realized_order or record.rollback_event_refs)
+    if record.atomicity_scope == "multi_object" and actual_conflict != "none" and not has_recovery_evidence:
+        raise ValueError("multi_object conflicting joint actions require realized_order or rollback_event_refs")
+
+
 class ParticipantJointActionRecordModel(ParticipantRuntimeBaseEnvelopeModel):
     """RUN-308 joint action / concurrency record over behavior events."""
 
@@ -1257,48 +1314,44 @@ class ParticipantJointActionRecordModel(ParticipantRuntimeBaseEnvelopeModel):
 
     @model_validator(mode="after")
     def _validate_joint_action_record(self) -> ParticipantJointActionRecordModel:
-        member_refs = list(self.member_event_refs)
-        member_ref_set = set(member_refs)
-        if len(member_refs) != len(member_ref_set):
-            raise ValueError("joint action member_event_refs must be unique")
-
-        access_event_refs = [access.member_event_ref for access in self.access_sets]
-        if not _exact_string_permutation(access_event_refs, member_ref_set):
-            raise ValueError("joint action access_sets must cover member_event_refs exactly once")
-
-        if self.realized_order and not _exact_string_permutation(self.realized_order, member_ref_set):
-            raise ValueError("joint action realized_order must be an exact permutation of member_event_refs")
-
-        if self.unsupported_disclosure and self.exact_concurrency_claim:
-            raise ValueError("unsupported concurrency disclosure cannot carry an exact concurrency claim")
-        if self.exact_concurrency_claim and self.time_management_context_ref is None:
-            raise ValueError("exact concurrency claims require time_management_context_ref")
-
-        if self.conflict_policy == "unsupported":
-            if not self.unsupported_disclosure or self.exact_concurrency_claim:
-                raise ValueError("unsupported conflict_policy requires unsupported_disclosure and no exact claim")
+        member_ref_set = _joint_action_member_ref_set(self.member_event_refs)
+        _validate_joint_action_members(self, member_ref_set)
+        _validate_joint_action_disclosure(self)
+        if _joint_action_unsupported_policy_applies(self):
             return self
 
         actual_conflict = _joint_action_actual_conflict(self.access_sets)
-        if not self.unsupported_disclosure and self.conflict_class != actual_conflict:
-            raise ValueError("joint action conflict_class must match declared access-set conflicts")
-        if self.conflict_class == "none" and actual_conflict != "none":
-            raise ValueError("joint action conflict_class cannot be none when access sets conflict")
-        if self.isolation_guarantee == "serializable" and not self.realized_order:
-            raise ValueError("serializable joint action isolation requires realized_order")
-        if self.conflict_policy == "serialize" and not self.realized_order:
-            raise ValueError("serialize conflict_policy requires realized_order")
-        if self.conflict_policy == "retry" and (self.retry_limit is None or not self.rollback_event_refs):
-            raise ValueError("retry conflict_policy requires retry_limit and rollback_event_refs")
-        if self.conflict_policy == "none" and actual_conflict != "none":
-            raise ValueError("none conflict_policy is only valid when access sets do not conflict")
-        if (
-            self.atomicity_scope == "multi_object"
-            and actual_conflict != "none"
-            and not (self.realized_order or self.rollback_event_refs)
-        ):
-            raise ValueError("multi_object conflicting joint actions require realized_order or rollback_event_refs")
+        _validate_joint_action_conflict(self, actual_conflict)
         return self
+
+
+def _validate_time_management_claim(context: Any) -> None:
+    if context.unsupported_disclosure and context.claim_strength == "exact":
+        raise ValueError("unsupported time-management disclosure cannot carry an exact claim")
+    if context.basis == "wall_clock_only" and context.claim_strength != "display":
+        raise ValueError("wall_clock_only time basis supports display claims only")
+    if context.claim_strength in {"bounded", "exact"} and context.clock_ref is None:
+        raise ValueError("bounded or exact time-management claims require clock_ref")
+
+
+def _validate_time_management_mode(context: Any) -> None:
+    if context.mode == "backend_serialized":
+        _validate_backend_serialized_time_management(context)
+    if context.mode == "lookahead" and context.lookahead is None:
+        raise ValueError("lookahead mode requires lookahead")
+    if context.mode == "pacing" and context.advance_by is None:
+        raise ValueError("pacing mode requires advance_by")
+    if context.mode == "rollback" and not context.rollback_event_refs:
+        raise ValueError("rollback mode requires rollback_event_refs")
+    if context.mode in {"devs", "fmi"} and (context.clock_ref is None or context.basis == "wall_clock_only"):
+        raise ValueError("devs and fmi modes require a non-wall-clock basis and clock_ref")
+    if context.mode == "unsupported" and not context.unsupported_disclosure:
+        raise ValueError("unsupported time-management mode requires unsupported_disclosure")
+
+
+def _validate_backend_serialized_time_management(context: Any) -> None:
+    if not context.backend_serialized or context.basis != "serialized_backend_order" or context.clock_ref is None:
+        raise ValueError("backend_serialized mode requires serialized_backend_order basis and clock_ref")
 
 
 class ParticipantTimeManagementContextModel(ParticipantRuntimeBaseEnvelopeModel):
@@ -1317,26 +1370,8 @@ class ParticipantTimeManagementContextModel(ParticipantRuntimeBaseEnvelopeModel)
 
     @model_validator(mode="after")
     def _validate_time_management_context(self) -> ParticipantTimeManagementContextModel:
-        if self.unsupported_disclosure and self.claim_strength == "exact":
-            raise ValueError("unsupported time-management disclosure cannot carry an exact claim")
-        if self.basis == "wall_clock_only" and self.claim_strength != "display":
-            raise ValueError("wall_clock_only time basis supports display claims only")
-        if self.claim_strength in {"bounded", "exact"} and self.clock_ref is None:
-            raise ValueError("bounded or exact time-management claims require clock_ref")
-        if self.mode == "backend_serialized" and (
-            not self.backend_serialized or self.basis != "serialized_backend_order" or self.clock_ref is None
-        ):
-            raise ValueError("backend_serialized mode requires serialized_backend_order basis and clock_ref")
-        if self.mode == "lookahead" and self.lookahead is None:
-            raise ValueError("lookahead mode requires lookahead")
-        if self.mode == "pacing" and self.advance_by is None:
-            raise ValueError("pacing mode requires advance_by")
-        if self.mode == "rollback" and not self.rollback_event_refs:
-            raise ValueError("rollback mode requires rollback_event_refs")
-        if self.mode in {"devs", "fmi"} and (self.clock_ref is None or self.basis == "wall_clock_only"):
-            raise ValueError("devs and fmi modes require a non-wall-clock basis and clock_ref")
-        if self.mode == "unsupported" and not self.unsupported_disclosure:
-            raise ValueError("unsupported time-management mode requires unsupported_disclosure")
+        _validate_time_management_claim(self)
+        _validate_time_management_mode(self)
         return self
 
 

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -914,6 +914,32 @@ ParticipantRuntimeConflictPolicy = Literal[
     "disclose_weak_guarantee",
     "unsupported",
 ]
+ParticipantRuntimeConflictClass = Literal["none", "read_write", "write_write", "unsupported"]
+ParticipantRuntimeJointActionConflictPolicy = Literal[
+    "none",
+    "coordinate",
+    "serialize",
+    "reject",
+    "retry",
+    "withhold",
+    "merge",
+    "rollback",
+    "disclose_weak_guarantee",
+    "unsupported",
+]
+ParticipantRuntimeIsolationGuarantee = Literal["none", "serializable", "snapshot", "causal", "unsupported"]
+ParticipantRuntimeAtomicityScope = Literal["single_object", "multi_object", "coordination_interval", "unsupported"]
+ParticipantRuntimeTimeManagementMode = Literal[
+    "display",
+    "pacing",
+    "lookahead",
+    "rollback",
+    "devs",
+    "fmi",
+    "backend_serialized",
+    "unsupported",
+]
+ParticipantRuntimeTimeClaimStrength = Literal["display", "bounded", "exact", "unsupported"]
 
 
 class EventClassificationModel(ContractModel):
@@ -1174,6 +1200,144 @@ class ParticipantSharedStateRecordModel(ParticipantRuntimeBaseEnvelopeModel):
             ]
         )
         return json_schema
+
+
+class ParticipantJointActionAccessSetModel(ContractModel):
+    """Read/write footprint for one member event in a joint action record."""
+
+    member_event_ref: NonEmptyString
+    shared_state_read_refs: list[NonEmptyString] = Field(default_factory=list)
+    shared_state_write_refs: list[NonEmptyString] = Field(default_factory=list)
+    exclusive_resource_refs: list[NonEmptyString] = Field(default_factory=list)
+    visibility_effect_refs: list[NonEmptyString] = Field(default_factory=list)
+    evidence_stream_refs: list[NonEmptyString] = Field(default_factory=list)
+
+
+def _exact_string_permutation(values: list[str], expected: set[str]) -> bool:
+    return len(values) == len(expected) and set(values) == expected
+
+
+def _joint_action_actual_conflict(access_sets: list[ParticipantJointActionAccessSetModel]) -> str:
+    read_write_conflict = False
+    for left_index, left in enumerate(access_sets):
+        left_reads = set(left.shared_state_read_refs)
+        left_writes = set(left.shared_state_write_refs) | {f"resource:{ref}" for ref in left.exclusive_resource_refs}
+        for right in access_sets[left_index + 1 :]:
+            right_reads = set(right.shared_state_read_refs)
+            right_writes = set(right.shared_state_write_refs) | {
+                f"resource:{ref}" for ref in right.exclusive_resource_refs
+            }
+            if left_writes & right_writes:
+                return "write_write"
+            if (left_writes & right_reads) or (left_reads & right_writes):
+                read_write_conflict = True
+    return "read_write" if read_write_conflict else "none"
+
+
+class ParticipantJointActionRecordModel(ParticipantRuntimeBaseEnvelopeModel):
+    """RUN-308 joint action / concurrency record over behavior events."""
+
+    joint_action_set_id: NonEmptyString
+    member_event_refs: list[NonEmptyString] = Field(min_length=1)
+    access_sets: list[ParticipantJointActionAccessSetModel] = Field(min_length=1)
+    conflict_class: ParticipantRuntimeConflictClass
+    conflict_policy: ParticipantRuntimeJointActionConflictPolicy
+    isolation_guarantee: ParticipantRuntimeIsolationGuarantee
+    atomicity_scope: ParticipantRuntimeAtomicityScope
+    realized_order: list[NonEmptyString] = Field(default_factory=list)
+    simultaneity_group_ref: NonEmptyString | None = None
+    time_management_context_ref: NonEmptyString | None = None
+    participant_observation_refs: list[NonEmptyString] = Field(default_factory=list)
+    rollback_event_refs: list[NonEmptyString] = Field(default_factory=list)
+    retry_limit: NonNegativeInteger | None = None
+    timeout_policy_ref: NonEmptyString | None = None
+    fairness_policy_ref: NonEmptyString | None = None
+    unsupported_disclosure: bool = False
+    exact_concurrency_claim: bool = False
+
+    @model_validator(mode="after")
+    def _validate_joint_action_record(self) -> ParticipantJointActionRecordModel:
+        member_refs = list(self.member_event_refs)
+        member_ref_set = set(member_refs)
+        if len(member_refs) != len(member_ref_set):
+            raise ValueError("joint action member_event_refs must be unique")
+
+        access_event_refs = [access.member_event_ref for access in self.access_sets]
+        if not _exact_string_permutation(access_event_refs, member_ref_set):
+            raise ValueError("joint action access_sets must cover member_event_refs exactly once")
+
+        if self.realized_order and not _exact_string_permutation(self.realized_order, member_ref_set):
+            raise ValueError("joint action realized_order must be an exact permutation of member_event_refs")
+
+        if self.unsupported_disclosure and self.exact_concurrency_claim:
+            raise ValueError("unsupported concurrency disclosure cannot carry an exact concurrency claim")
+        if self.exact_concurrency_claim and self.time_management_context_ref is None:
+            raise ValueError("exact concurrency claims require time_management_context_ref")
+
+        if self.conflict_policy == "unsupported":
+            if not self.unsupported_disclosure or self.exact_concurrency_claim:
+                raise ValueError("unsupported conflict_policy requires unsupported_disclosure and no exact claim")
+            return self
+
+        actual_conflict = _joint_action_actual_conflict(self.access_sets)
+        if not self.unsupported_disclosure and self.conflict_class != actual_conflict:
+            raise ValueError("joint action conflict_class must match declared access-set conflicts")
+        if self.conflict_class == "none" and actual_conflict != "none":
+            raise ValueError("joint action conflict_class cannot be none when access sets conflict")
+        if self.isolation_guarantee == "serializable" and not self.realized_order:
+            raise ValueError("serializable joint action isolation requires realized_order")
+        if self.conflict_policy == "serialize" and not self.realized_order:
+            raise ValueError("serialize conflict_policy requires realized_order")
+        if self.conflict_policy == "retry" and (self.retry_limit is None or not self.rollback_event_refs):
+            raise ValueError("retry conflict_policy requires retry_limit and rollback_event_refs")
+        if self.conflict_policy == "none" and actual_conflict != "none":
+            raise ValueError("none conflict_policy is only valid when access sets do not conflict")
+        if (
+            self.atomicity_scope == "multi_object"
+            and actual_conflict != "none"
+            and not (self.realized_order or self.rollback_event_refs)
+        ):
+            raise ValueError("multi_object conflicting joint actions require realized_order or rollback_event_refs")
+        return self
+
+
+class ParticipantTimeManagementContextModel(ParticipantRuntimeBaseEnvelopeModel):
+    """RUN-308 time-management basis for concurrent or distributed runtime claims."""
+
+    context_id: NonEmptyString
+    mode: ParticipantRuntimeTimeManagementMode
+    claim_strength: ParticipantRuntimeTimeClaimStrength
+    basis: ParticipantRuntimeOrderingBasis
+    clock_ref: NonEmptyString | None = None
+    lookahead: NonNegativeInteger | None = None
+    advance_by: PositiveInteger | None = None
+    rollback_event_refs: list[NonEmptyString] = Field(default_factory=list)
+    unsupported_disclosure: bool = False
+    backend_serialized: bool = False
+
+    @model_validator(mode="after")
+    def _validate_time_management_context(self) -> ParticipantTimeManagementContextModel:
+        if self.unsupported_disclosure and self.claim_strength == "exact":
+            raise ValueError("unsupported time-management disclosure cannot carry an exact claim")
+        if self.basis == "wall_clock_only" and self.claim_strength != "display":
+            raise ValueError("wall_clock_only time basis supports display claims only")
+        if self.claim_strength in {"bounded", "exact"} and self.clock_ref is None:
+            raise ValueError("bounded or exact time-management claims require clock_ref")
+        if self.mode == "backend_serialized" and (
+            not self.backend_serialized or self.basis != "serialized_backend_order" or self.clock_ref is None
+        ):
+            raise ValueError("backend_serialized mode requires serialized_backend_order basis and clock_ref")
+        if self.mode == "lookahead" and self.lookahead is None:
+            raise ValueError("lookahead mode requires lookahead")
+        if self.mode == "pacing" and self.advance_by is None:
+            raise ValueError("pacing mode requires advance_by")
+        if self.mode == "rollback" and not self.rollback_event_refs:
+            raise ValueError("rollback mode requires rollback_event_refs")
+        if self.mode in {"devs", "fmi"} and (self.clock_ref is None or self.basis == "wall_clock_only"):
+            raise ValueError("devs and fmi modes require a non-wall-clock basis and clock_ref")
+        if self.mode == "unsupported" and not self.unsupported_disclosure:
+            raise ValueError("unsupported time-management mode requires unsupported_disclosure")
+        return self
 
 
 class ParticipantOutcomeReportSourceModel(ContractModel):
@@ -1510,6 +1674,8 @@ class RuntimeSnapshotEnvelopeModel(ContractModel):
     participant_behavior_history: dict[str, list[ParticipantBehaviorHistoryEventModel]] = Field(default_factory=dict)
     shared_state_records: dict[str, ParticipantSharedStateRecordModel] = Field(default_factory=dict)
     shared_state_history: dict[str, list[ParticipantSharedStateRecordModel]] = Field(default_factory=dict)
+    joint_action_records: dict[str, ParticipantJointActionRecordModel] = Field(default_factory=dict)
+    time_management_contexts: dict[str, ParticipantTimeManagementContextModel] = Field(default_factory=dict)
     realization_provenance: list[RealizationProvenanceEntryModel] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -5323,6 +5489,8 @@ def schema_bundle() -> dict[str, dict[str, Any]]:
         "participant-lifecycle-event-v1": ParticipantLifecycleEventModel.model_json_schema(),
         "participant-observation-envelope-v1": ParticipantObservationEnvelopeModel.model_json_schema(),
         "participant-shared-state-record-v1": ParticipantSharedStateRecordModel.model_json_schema(),
+        "participant-joint-action-record-v1": ParticipantJointActionRecordModel.model_json_schema(),
+        "participant-time-management-context-v1": ParticipantTimeManagementContextModel.model_json_schema(),
         "participant-outcome-report-v1": ParticipantOutcomeReportModel.model_json_schema(),
         "participant-status-view-v1": ParticipantStatusViewModel.model_json_schema(),
         "participant-history-view-v1": ParticipantHistoryViewModel.model_json_schema(),
@@ -5445,6 +5613,8 @@ __all__ = [
     "ParticipantImplementationManifestModel",
     "ParticipantImplementationProvenanceModel",
     "ParticipantImplementationSelectionModel",
+    "ParticipantJointActionAccessSetModel",
+    "ParticipantJointActionRecordModel",
     "ParticipantLifecycleEventModel",
     "ParticipantObservationEnvelopeModel",
     "ParticipantObservationLossDescriptorModel",
@@ -5462,6 +5632,7 @@ __all__ = [
     "ParticipantStatusViewEpisodeStateModel",
     "ParticipantStatusViewModel",
     "ParticipantTemporalRuntimeContextModel",
+    "ParticipantTimeManagementContextModel",
     "VIEW_SCOPE_PROJECTED_FIELDS",
     "PlanOperationModel",
     "ProcessorFeature",

--- a/implementations/python/packages/aces_contracts/manifest_authority.py
+++ b/implementations/python/packages/aces_contracts/manifest_authority.py
@@ -50,6 +50,8 @@ BACKEND_SUPPORTED_CONTRACT_IDS = (
     "participant-lifecycle-event-v1",
     "participant-observation-envelope-v1",
     "participant-shared-state-record-v1",
+    "participant-joint-action-record-v1",
+    "participant-time-management-context-v1",
     "participant-outcome-report-v1",
 )
 

--- a/implementations/python/packages/aces_contracts/participant_concurrency.py
+++ b/implementations/python/packages/aces_contracts/participant_concurrency.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+
+from .participant_concurrency_time import TIME_CONTEXTS_KEY as _TIME_CONTEXTS_KEY
+from .participant_concurrency_time import time_contexts_violations as _time_contexts_violations
 
 Violation = tuple[str, str]
 
 _JOINT_ACTION_RECORDS_KEY = "runtime.snapshot.joint-action-records"
-_TIME_CONTEXTS_KEY = "runtime.snapshot.time-management-contexts"
 
 
 def iter_participant_concurrency_snapshot_violations(
@@ -61,20 +64,24 @@ def iter_participant_concurrency_transition_violations(
 
 
 def _known_behavior_event_refs(participant_behavior_history: object) -> set[str]:
-    refs: set[str] = set()
     if not isinstance(participant_behavior_history, Mapping):
-        return refs
-    for history in participant_behavior_history.values():
-        if not isinstance(history, list):
-            continue
-        for event in history:
-            if not isinstance(event, Mapping):
-                continue
-            for field_name in ("event_id", "action_instance_id"):
-                ref = event.get(field_name)
-                if isinstance(ref, str) and ref:
-                    refs.add(ref)
-    return refs
+        return set()
+    return {ref for history in participant_behavior_history.values() for ref in _behavior_history_refs(history)}
+
+
+def _behavior_history_refs(history: object) -> Iterator[str]:
+    if not isinstance(history, list):
+        return
+    for event in history:
+        if isinstance(event, Mapping):
+            yield from _behavior_event_refs(event)
+
+
+def _behavior_event_refs(event: Mapping[object, object]) -> Iterator[str]:
+    for field_name in ("event_id", "action_instance_id"):
+        ref = event.get(field_name)
+        if isinstance(ref, str) and ref:
+            yield ref
 
 
 def _known_shared_state_refs(shared_state_records: object, shared_state_history: object) -> set[str]:
@@ -134,28 +141,16 @@ def _joint_action_record_violations(
     known_time_contexts: Mapping[object, object],
 ) -> list[Violation]:
     violations: list[Violation] = []
-    joint_id = record.get("joint_action_set_id")
-    if not isinstance(joint_id, str) or not joint_id:
-        violations.append((locator, "joint action record requires joint_action_set_id"))
-    elif joint_id != outer_key:
-        violations.append((locator, f"joint action record key {outer_key!r} does not match joint_action_set_id"))
+    violations.extend(_joint_action_identity_violations(locator, outer_key, record.get("joint_action_set_id")))
 
     member_refs = record.get("member_event_refs")
     access_sets = record.get("access_sets")
-    if not isinstance(member_refs, list) or not member_refs:
-        violations.append((locator, "joint action member_event_refs must be a non-empty list"))
-        member_ref_set: set[str] = set()
-    elif any(not isinstance(ref, str) or not ref for ref in member_refs):
-        violations.append((locator, "joint action member_event_refs entries must be non-empty strings"))
-        member_ref_set = {ref for ref in member_refs if isinstance(ref, str) and ref}
-    elif len(set(member_refs)) != len(member_refs):
-        violations.append((locator, "joint action member_event_refs must be unique"))
-        member_ref_set = set(member_refs)
-    else:
-        member_ref_set = set(member_refs)
-        missing = sorted(member_ref_set - known_event_refs)
-        for ref in missing:
-            violations.append((locator, f"joint action member_event_ref {ref!r} does not resolve to behavior history"))
+    member_ref_set, member_violations = _joint_action_member_ref_violations(
+        locator,
+        member_refs,
+        known_event_refs=known_event_refs,
+    )
+    violations.extend(member_violations)
 
     access_event_refs, access_violations = _joint_action_access_violations(
         locator,
@@ -167,10 +162,7 @@ def _joint_action_record_violations(
         violations.append((locator, "joint action access_sets must cover member_event_refs exactly once"))
 
     realized_order = record.get("realized_order", [])
-    if not isinstance(realized_order, list):
-        violations.append((locator, "joint action realized_order must be a list"))
-    elif member_ref_set and realized_order and not _exact_string_set(realized_order, member_ref_set):
-        violations.append((locator, "joint action realized_order must be an exact permutation of member_event_refs"))
+    violations.extend(_joint_action_realized_order_violations(locator, realized_order, member_ref_set))
 
     conflict_policy = record.get("conflict_policy")
     conflict_class = record.get("conflict_class")
@@ -180,30 +172,91 @@ def _joint_action_record_violations(
     violations.extend(
         _joint_action_conflict_violations(
             locator,
-            conflict_class=conflict_class,
-            conflict_policy=conflict_policy,
-            actual_conflict=actual_conflict,
-            realized_order=realized_order,
-            unsupported=unsupported,
-            exact_claim=exact_claim,
-            retry_limit=record.get("retry_limit"),
-            rollback_event_refs=record.get("rollback_event_refs", []),
-            atomicity_scope=record.get("atomicity_scope"),
-            isolation_guarantee=record.get("isolation_guarantee"),
+            _JointActionConflictCheck(
+                conflict_class=conflict_class,
+                conflict_policy=conflict_policy,
+                actual_conflict=actual_conflict,
+                realized_order=realized_order,
+                unsupported=unsupported,
+                exact_claim=exact_claim,
+                retry_limit=record.get("retry_limit"),
+                rollback_event_refs=record.get("rollback_event_refs", []),
+                atomicity_scope=record.get("atomicity_scope"),
+                isolation_guarantee=record.get("isolation_guarantee"),
+            ),
         )
     )
 
-    time_context_ref = record.get("time_management_context_ref")
-    if isinstance(time_context_ref, str) and time_context_ref:
-        if time_context_ref not in known_time_context_refs:
-            violations.append((locator, f"time_management_context_ref {time_context_ref!r} does not resolve"))
-        elif exact_claim:
-            time_context = known_time_contexts.get(time_context_ref)
-            if isinstance(time_context, Mapping) and time_context.get("claim_strength") != "exact":
-                violations.append((locator, "exact concurrency claims require exact time-management context"))
-    elif exact_claim:
-        violations.append((locator, "exact concurrency claims require time_management_context_ref"))
+    violations.extend(
+        _joint_action_time_context_violations(
+            locator,
+            record.get("time_management_context_ref"),
+            exact_claim=exact_claim,
+            known_time_context_refs=known_time_context_refs,
+            known_time_contexts=known_time_contexts,
+        )
+    )
     return violations
+
+
+def _joint_action_identity_violations(locator: str, outer_key: str, joint_id: object) -> list[Violation]:
+    if not isinstance(joint_id, str) or not joint_id:
+        return [(locator, "joint action record requires joint_action_set_id")]
+    if joint_id != outer_key:
+        return [(locator, f"joint action record key {outer_key!r} does not match joint_action_set_id")]
+    return []
+
+
+def _joint_action_member_ref_violations(
+    locator: str,
+    member_refs: object,
+    *,
+    known_event_refs: set[str],
+) -> tuple[set[str], list[Violation]]:
+    if not isinstance(member_refs, list) or not member_refs:
+        return set(), [(locator, "joint action member_event_refs must be a non-empty list")]
+
+    valid_refs = [ref for ref in member_refs if isinstance(ref, str) and ref]
+    member_ref_set = set(valid_refs)
+    if len(valid_refs) != len(member_refs):
+        return member_ref_set, [(locator, "joint action member_event_refs entries must be non-empty strings")]
+    if len(member_ref_set) != len(valid_refs):
+        return member_ref_set, [(locator, "joint action member_event_refs must be unique")]
+    return member_ref_set, [
+        (locator, f"joint action member_event_ref {ref!r} does not resolve to behavior history")
+        for ref in sorted(member_ref_set - known_event_refs)
+    ]
+
+
+def _joint_action_realized_order_violations(
+    locator: str, realized_order: object, member_ref_set: set[str]
+) -> list[Violation]:
+    if not isinstance(realized_order, list):
+        return [(locator, "joint action realized_order must be a list")]
+    if member_ref_set and realized_order and not _exact_string_set(realized_order, member_ref_set):
+        return [(locator, "joint action realized_order must be an exact permutation of member_event_refs")]
+    return []
+
+
+def _joint_action_time_context_violations(
+    locator: str,
+    time_context_ref: object,
+    *,
+    exact_claim: bool,
+    known_time_context_refs: set[str],
+    known_time_contexts: Mapping[object, object],
+) -> list[Violation]:
+    if not isinstance(time_context_ref, str) or not time_context_ref:
+        if exact_claim:
+            return [(locator, "exact concurrency claims require time_management_context_ref")]
+        return []
+
+    if time_context_ref not in known_time_context_refs:
+        return [(locator, f"time_management_context_ref {time_context_ref!r} does not resolve")]
+    time_context = known_time_contexts.get(time_context_ref)
+    if exact_claim and isinstance(time_context, Mapping) and time_context.get("claim_strength") != "exact":
+        return [(locator, "exact concurrency claims require exact time-management context")]
+    return []
 
 
 def _joint_action_access_violations(
@@ -218,158 +271,171 @@ def _joint_action_access_violations(
         return event_refs, [(locator, "joint action access_sets must be a non-empty list")]
     for index, access in enumerate(access_sets):
         access_locator = f"{locator}.access_sets[{index}]"
-        if not isinstance(access, Mapping):
-            violations.append((access_locator, "joint action access set must be a mapping"))
-            continue
-        event_ref = access.get("member_event_ref")
-        if not isinstance(event_ref, str) or not event_ref:
-            violations.append((access_locator, "joint action access set requires member_event_ref"))
-        else:
-            event_refs.append(event_ref)
-        for field_name in ("shared_state_read_refs", "shared_state_write_refs"):
-            values = access.get(field_name, [])
-            if not isinstance(values, list):
-                violations.append((access_locator, f"{field_name} must be a list"))
-                continue
-            for state_ref in values:
-                if not isinstance(state_ref, str) or not state_ref:
-                    violations.append((access_locator, f"{field_name} entries must be non-empty strings"))
-                elif state_ref not in known_state_refs:
-                    violations.append((access_locator, f"{field_name} entry {state_ref!r} does not resolve"))
+        access_event_refs, access_violations = _single_access_set_violations(
+            access_locator,
+            access,
+            known_state_refs=known_state_refs,
+        )
+        event_refs.extend(access_event_refs)
+        violations.extend(access_violations)
     return event_refs, violations
 
 
-def _joint_action_conflict_violations(
-    locator: str,
+def _single_access_set_violations(
+    access_locator: str,
+    access: object,
     *,
-    conflict_class: object,
-    conflict_policy: object,
-    actual_conflict: str,
-    realized_order: object,
-    unsupported: bool,
-    exact_claim: bool,
-    retry_limit: object,
-    rollback_event_refs: object,
-    atomicity_scope: object,
-    isolation_guarantee: object,
-) -> list[Violation]:
+    known_state_refs: set[str],
+) -> tuple[list[str], list[Violation]]:
+    if not isinstance(access, Mapping):
+        return [], [(access_locator, "joint action access set must be a mapping")]
+
+    event_ref = access.get("member_event_ref")
+    event_refs: list[str] = []
     violations: list[Violation] = []
-    has_realized_order = isinstance(realized_order, list) and bool(realized_order)
-    if unsupported and exact_claim:
-        violations.append((locator, "unsupported concurrency disclosure cannot carry an exact concurrency claim"))
-    if conflict_policy == "unsupported":
-        if not unsupported or exact_claim:
-            violations.append(
-                (locator, "unsupported conflict_policy requires unsupported_disclosure and no exact claim")
+    if not isinstance(event_ref, str) or not event_ref:
+        violations.append((access_locator, "joint action access set requires member_event_ref"))
+    else:
+        event_refs.append(event_ref)
+
+    for field_name in ("shared_state_read_refs", "shared_state_write_refs"):
+        violations.extend(
+            _access_state_ref_violations(
+                access_locator,
+                field_name,
+                access.get(field_name, []),
+                known_state_refs=known_state_refs,
             )
-        return violations
-    if not unsupported and conflict_class != actual_conflict:
-        violations.append((locator, "joint action conflict_class must match declared access-set conflicts"))
-    if conflict_class == "none" and actual_conflict != "none":
-        violations.append((locator, "joint action conflict_class cannot be none when access sets conflict"))
-    if isolation_guarantee == "serializable" and not has_realized_order:
-        violations.append((locator, "serializable joint action isolation requires realized_order"))
-    if conflict_policy == "serialize" and not has_realized_order:
-        violations.append((locator, "serialize conflict_policy requires realized_order"))
-    if conflict_policy == "retry" and (not isinstance(retry_limit, int) or not rollback_event_refs):
-        violations.append((locator, "retry conflict_policy requires retry_limit and rollback_event_refs"))
-    if conflict_policy == "none" and actual_conflict != "none":
-        violations.append((locator, "none conflict_policy is only valid when access sets do not conflict"))
-    if (
-        atomicity_scope == "multi_object"
-        and actual_conflict != "none"
-        and not (has_realized_order or rollback_event_refs)
-    ):
-        violations.append(
-            (locator, "multi_object conflicting joint actions require realized_order or rollback_event_refs")
         )
-    return violations
+    return event_refs, violations
 
 
-def _time_contexts_violations(contexts: object, *, known_event_refs: set[str]) -> list[Violation]:
-    violations: list[Violation] = []
-    if not isinstance(contexts, Mapping):
-        return [(_TIME_CONTEXTS_KEY, "time_management_contexts must be a mapping")]
-    for outer_key, context in contexts.items():
-        locator = f"{_TIME_CONTEXTS_KEY}.{outer_key}"
-        if not isinstance(outer_key, str) or not outer_key:
-            violations.append((_TIME_CONTEXTS_KEY, "time_management_contexts keys must be non-empty strings"))
-        elif not isinstance(context, Mapping):
-            violations.append((locator, "time management context must be a mapping"))
-        else:
-            violations.extend(_time_context_violations(locator, outer_key, context, known_event_refs=known_event_refs))
-    return violations
-
-
-def _time_context_violations(
-    locator: str,
-    outer_key: str,
-    context: Mapping[object, object],
+def _access_state_ref_violations(
+    access_locator: str,
+    field_name: str,
+    values: object,
     *,
-    known_event_refs: set[str],
+    known_state_refs: set[str],
 ) -> list[Violation]:
-    violations: list[Violation] = []
-    context_id = context.get("context_id")
-    if not isinstance(context_id, str) or not context_id:
-        violations.append((locator, "time management context requires context_id"))
-    elif context_id != outer_key:
-        violations.append((locator, f"time management context key {outer_key!r} does not match context_id"))
+    if not isinstance(values, list):
+        return [(access_locator, f"{field_name} must be a list")]
+    return [
+        violation
+        for state_ref in values
+        for violation in _access_state_ref_violation(access_locator, field_name, state_ref, known_state_refs)
+    ]
 
-    mode = context.get("mode")
-    claim_strength = context.get("claim_strength")
-    basis = context.get("basis")
-    clock_ref = context.get("clock_ref")
-    unsupported = context.get("unsupported_disclosure") is True
-    if unsupported and claim_strength == "exact":
-        violations.append((locator, "unsupported time-management disclosure cannot carry an exact claim"))
-    if basis == "wall_clock_only" and claim_strength != "display":
-        violations.append((locator, "wall_clock_only time basis supports display claims only"))
-    if claim_strength in {"bounded", "exact"} and not isinstance(clock_ref, str):
-        violations.append((locator, "bounded or exact time-management claims require clock_ref"))
-    if mode == "backend_serialized" and (
-        context.get("backend_serialized") is not True
-        or basis != "serialized_backend_order"
-        or not isinstance(clock_ref, str)
-    ):
-        violations.append((locator, "backend_serialized mode requires serialized_backend_order basis and clock_ref"))
-    if mode == "lookahead" and not isinstance(context.get("lookahead"), int):
-        violations.append((locator, "lookahead mode requires lookahead"))
-    if mode == "pacing" and not isinstance(context.get("advance_by"), int):
-        violations.append((locator, "pacing mode requires advance_by"))
-    rollback_refs = context.get("rollback_event_refs", [])
-    if mode == "rollback":
-        if not isinstance(rollback_refs, list) or not rollback_refs:
-            violations.append((locator, "rollback mode requires rollback_event_refs"))
-        else:
-            for ref in rollback_refs:
-                if isinstance(ref, str) and ref and ref not in known_event_refs:
-                    violations.append((locator, f"rollback_event_ref {ref!r} does not resolve"))
-    if mode in {"devs", "fmi"} and (not isinstance(clock_ref, str) or basis == "wall_clock_only"):
-        violations.append((locator, "devs and fmi modes require a non-wall-clock basis and clock_ref"))
-    if mode == "unsupported" and not unsupported:
-        violations.append((locator, "unsupported time-management mode requires unsupported_disclosure"))
+
+def _access_state_ref_violation(
+    access_locator: str,
+    field_name: str,
+    state_ref: object,
+    known_state_refs: set[str],
+) -> list[Violation]:
+    if not isinstance(state_ref, str) or not state_ref:
+        return [(access_locator, f"{field_name} entries must be non-empty strings")]
+    if state_ref not in known_state_refs:
+        return [(access_locator, f"{field_name} entry {state_ref!r} does not resolve")]
+    return []
+
+
+@dataclass(frozen=True)
+class _JointActionConflictCheck:
+    conflict_class: object
+    conflict_policy: object
+    actual_conflict: str
+    realized_order: object
+    unsupported: bool
+    exact_claim: bool
+    retry_limit: object
+    rollback_event_refs: object
+    atomicity_scope: object
+    isolation_guarantee: object
+
+
+def _joint_action_conflict_violations(locator: str, check: _JointActionConflictCheck) -> list[Violation]:
+    violations: list[Violation] = []
+    if check.unsupported and check.exact_claim:
+        violations.append((locator, "unsupported concurrency disclosure cannot carry an exact concurrency claim"))
+    if check.conflict_policy == "unsupported":
+        violations.extend(_unsupported_conflict_policy_violations(locator, check))
+        return violations
+
+    violations.extend(_conflict_class_violations(locator, check))
+    violations.extend(_conflict_policy_violations(locator, check))
+    violations.extend(_conflict_atomicity_violations(locator, check))
     return violations
+
+
+def _unsupported_conflict_policy_violations(locator: str, check: _JointActionConflictCheck) -> list[Violation]:
+    if not check.unsupported or check.exact_claim:
+        return [(locator, "unsupported conflict_policy requires unsupported_disclosure and no exact claim")]
+    return []
+
+
+def _conflict_class_violations(locator: str, check: _JointActionConflictCheck) -> list[Violation]:
+    violations: list[Violation] = []
+    if not check.unsupported and check.conflict_class != check.actual_conflict:
+        violations.append((locator, "joint action conflict_class must match declared access-set conflicts"))
+    if check.conflict_class == "none" and check.actual_conflict != "none":
+        violations.append((locator, "joint action conflict_class cannot be none when access sets conflict"))
+    return violations
+
+
+def _conflict_policy_violations(locator: str, check: _JointActionConflictCheck) -> list[Violation]:
+    violations: list[Violation] = []
+    has_realized_order = _has_realized_order(check.realized_order)
+    if check.isolation_guarantee == "serializable" and not has_realized_order:
+        violations.append((locator, "serializable joint action isolation requires realized_order"))
+    if check.conflict_policy == "serialize" and not has_realized_order:
+        violations.append((locator, "serialize conflict_policy requires realized_order"))
+    if check.conflict_policy == "retry" and (not isinstance(check.retry_limit, int) or not check.rollback_event_refs):
+        violations.append((locator, "retry conflict_policy requires retry_limit and rollback_event_refs"))
+    if check.conflict_policy == "none" and check.actual_conflict != "none":
+        violations.append((locator, "none conflict_policy is only valid when access sets do not conflict"))
+    return violations
+
+
+def _conflict_atomicity_violations(locator: str, check: _JointActionConflictCheck) -> list[Violation]:
+    has_recovery_evidence = _has_realized_order(check.realized_order) or bool(check.rollback_event_refs)
+    if check.atomicity_scope == "multi_object" and check.actual_conflict != "none" and not has_recovery_evidence:
+        return [(locator, "multi_object conflicting joint actions require realized_order or rollback_event_refs")]
+    return []
+
+
+def _has_realized_order(realized_order: object) -> bool:
+    return isinstance(realized_order, list) and bool(realized_order)
 
 
 def _actual_conflict(access_sets: object) -> str:
     if not isinstance(access_sets, list):
         return "none"
+    return _classify_access_conflict(access for access in access_sets if isinstance(access, Mapping))
+
+
+def _classify_access_conflict(access_sets: Iterator[Mapping[object, object]]) -> str:
+    mapped_access_sets = list(access_sets)
     read_write_conflict = False
-    for left_index, left in enumerate(access_sets):
-        if not isinstance(left, Mapping):
-            continue
-        left_reads = _string_set(left.get("shared_state_read_refs", []))
-        left_writes = _write_refs(left)
-        for right in access_sets[left_index + 1 :]:
-            if not isinstance(right, Mapping):
-                continue
-            right_reads = _string_set(right.get("shared_state_read_refs", []))
-            right_writes = _write_refs(right)
-            if left_writes & right_writes:
+    for left_index, left in enumerate(mapped_access_sets):
+        for right in mapped_access_sets[left_index + 1 :]:
+            conflict = _access_pair_conflict(left, right)
+            if conflict == "write_write":
                 return "write_write"
-            if (left_writes & right_reads) or (left_reads & right_writes):
+            if conflict == "read_write":
                 read_write_conflict = True
     return "read_write" if read_write_conflict else "none"
+
+
+def _access_pair_conflict(left: Mapping[object, object], right: Mapping[object, object]) -> str:
+    left_reads = _string_set(left.get("shared_state_read_refs", []))
+    left_writes = _write_refs(left)
+    right_reads = _string_set(right.get("shared_state_read_refs", []))
+    right_writes = _write_refs(right)
+    if left_writes & right_writes:
+        return "write_write"
+    if (left_writes & right_reads) or (left_reads & right_writes):
+        return "read_write"
+    return "none"
 
 
 def _write_refs(access: Mapping[object, object]) -> set[str]:
@@ -406,7 +472,4 @@ def _append_only_mapping_violations(
             yield (locator, f"{field_name} must be append-only; record {record_id!r} changed")
 
 
-__all__ = (
-    "iter_participant_concurrency_snapshot_violations",
-    "iter_participant_concurrency_transition_violations",
-)
+__all__ = ("iter_participant_concurrency_snapshot_violations", "iter_participant_concurrency_transition_violations")

--- a/implementations/python/packages/aces_contracts/participant_concurrency.py
+++ b/implementations/python/packages/aces_contracts/participant_concurrency.py
@@ -1,0 +1,412 @@
+"""RUN-308 participant concurrency runtime validators."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+
+Violation = tuple[str, str]
+
+_JOINT_ACTION_RECORDS_KEY = "runtime.snapshot.joint-action-records"
+_TIME_CONTEXTS_KEY = "runtime.snapshot.time-management-contexts"
+
+
+def iter_participant_concurrency_snapshot_violations(
+    joint_action_records: object,
+    time_management_contexts: object,
+    *,
+    participant_behavior_history: object = None,
+    shared_state_records: object = None,
+    shared_state_history: object = None,
+) -> Iterator[Violation]:
+    """Yield RUN-308 snapshot violations for joint action/time records."""
+
+    known_event_refs = _known_behavior_event_refs(participant_behavior_history)
+    known_state_refs = _known_shared_state_refs(shared_state_records, shared_state_history)
+    known_time_context_refs = _known_mapping_keys(time_management_contexts)
+    known_time_contexts = time_management_contexts if isinstance(time_management_contexts, Mapping) else {}
+    violations: list[Violation] = []
+    violations.extend(
+        _joint_action_records_violations(
+            joint_action_records,
+            known_event_refs=known_event_refs,
+            known_state_refs=known_state_refs,
+            known_time_context_refs=known_time_context_refs,
+            known_time_contexts=known_time_contexts,
+        )
+    )
+    violations.extend(_time_contexts_violations(time_management_contexts, known_event_refs=known_event_refs))
+    return iter(violations)
+
+
+def iter_participant_concurrency_transition_violations(
+    previous_joint_action_records: object,
+    next_joint_action_records: object,
+    previous_time_management_contexts: object,
+    next_time_management_contexts: object,
+) -> Iterator[Violation]:
+    """Yield append-only violations for RUN-308 concurrency records."""
+
+    yield from _append_only_mapping_violations(
+        "joint_action_records",
+        _JOINT_ACTION_RECORDS_KEY,
+        previous_joint_action_records,
+        next_joint_action_records,
+    )
+    yield from _append_only_mapping_violations(
+        "time_management_contexts",
+        _TIME_CONTEXTS_KEY,
+        previous_time_management_contexts,
+        next_time_management_contexts,
+    )
+
+
+def _known_behavior_event_refs(participant_behavior_history: object) -> set[str]:
+    refs: set[str] = set()
+    if not isinstance(participant_behavior_history, Mapping):
+        return refs
+    for history in participant_behavior_history.values():
+        if not isinstance(history, list):
+            continue
+        for event in history:
+            if not isinstance(event, Mapping):
+                continue
+            for field_name in ("event_id", "action_instance_id"):
+                ref = event.get(field_name)
+                if isinstance(ref, str) and ref:
+                    refs.add(ref)
+    return refs
+
+
+def _known_shared_state_refs(shared_state_records: object, shared_state_history: object) -> set[str]:
+    refs: set[str] = set()
+    for candidate in (shared_state_records, shared_state_history):
+        if isinstance(candidate, Mapping):
+            refs.update(str(key) for key in candidate if isinstance(key, str) and key)
+    return refs
+
+
+def _known_mapping_keys(candidate: object) -> set[str]:
+    if not isinstance(candidate, Mapping):
+        return set()
+    return {str(key) for key in candidate if isinstance(key, str) and key}
+
+
+def _joint_action_records_violations(
+    records: object,
+    *,
+    known_event_refs: set[str],
+    known_state_refs: set[str],
+    known_time_context_refs: set[str],
+    known_time_contexts: Mapping[object, object],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if not isinstance(records, Mapping):
+        return [(_JOINT_ACTION_RECORDS_KEY, "joint_action_records must be a mapping")]
+    for outer_key, record in records.items():
+        locator = f"{_JOINT_ACTION_RECORDS_KEY}.{outer_key}"
+        if not isinstance(outer_key, str) or not outer_key:
+            violations.append((_JOINT_ACTION_RECORDS_KEY, "joint_action_records keys must be non-empty strings"))
+        elif not isinstance(record, Mapping):
+            violations.append((locator, "joint action record must be a mapping"))
+        else:
+            violations.extend(
+                _joint_action_record_violations(
+                    locator,
+                    outer_key,
+                    record,
+                    known_event_refs=known_event_refs,
+                    known_state_refs=known_state_refs,
+                    known_time_context_refs=known_time_context_refs,
+                    known_time_contexts=known_time_contexts,
+                )
+            )
+    return violations
+
+
+def _joint_action_record_violations(
+    locator: str,
+    outer_key: str,
+    record: Mapping[object, object],
+    *,
+    known_event_refs: set[str],
+    known_state_refs: set[str],
+    known_time_context_refs: set[str],
+    known_time_contexts: Mapping[object, object],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    joint_id = record.get("joint_action_set_id")
+    if not isinstance(joint_id, str) or not joint_id:
+        violations.append((locator, "joint action record requires joint_action_set_id"))
+    elif joint_id != outer_key:
+        violations.append((locator, f"joint action record key {outer_key!r} does not match joint_action_set_id"))
+
+    member_refs = record.get("member_event_refs")
+    access_sets = record.get("access_sets")
+    if not isinstance(member_refs, list) or not member_refs:
+        violations.append((locator, "joint action member_event_refs must be a non-empty list"))
+        member_ref_set: set[str] = set()
+    elif any(not isinstance(ref, str) or not ref for ref in member_refs):
+        violations.append((locator, "joint action member_event_refs entries must be non-empty strings"))
+        member_ref_set = {ref for ref in member_refs if isinstance(ref, str) and ref}
+    elif len(set(member_refs)) != len(member_refs):
+        violations.append((locator, "joint action member_event_refs must be unique"))
+        member_ref_set = set(member_refs)
+    else:
+        member_ref_set = set(member_refs)
+        missing = sorted(member_ref_set - known_event_refs)
+        for ref in missing:
+            violations.append((locator, f"joint action member_event_ref {ref!r} does not resolve to behavior history"))
+
+    access_event_refs, access_violations = _joint_action_access_violations(
+        locator,
+        access_sets,
+        known_state_refs=known_state_refs,
+    )
+    violations.extend(access_violations)
+    if member_ref_set and not _exact_string_set(access_event_refs, member_ref_set):
+        violations.append((locator, "joint action access_sets must cover member_event_refs exactly once"))
+
+    realized_order = record.get("realized_order", [])
+    if not isinstance(realized_order, list):
+        violations.append((locator, "joint action realized_order must be a list"))
+    elif member_ref_set and realized_order and not _exact_string_set(realized_order, member_ref_set):
+        violations.append((locator, "joint action realized_order must be an exact permutation of member_event_refs"))
+
+    conflict_policy = record.get("conflict_policy")
+    conflict_class = record.get("conflict_class")
+    unsupported = record.get("unsupported_disclosure") is True
+    exact_claim = record.get("exact_concurrency_claim") is True
+    actual_conflict = _actual_conflict(access_sets)
+    violations.extend(
+        _joint_action_conflict_violations(
+            locator,
+            conflict_class=conflict_class,
+            conflict_policy=conflict_policy,
+            actual_conflict=actual_conflict,
+            realized_order=realized_order,
+            unsupported=unsupported,
+            exact_claim=exact_claim,
+            retry_limit=record.get("retry_limit"),
+            rollback_event_refs=record.get("rollback_event_refs", []),
+            atomicity_scope=record.get("atomicity_scope"),
+            isolation_guarantee=record.get("isolation_guarantee"),
+        )
+    )
+
+    time_context_ref = record.get("time_management_context_ref")
+    if isinstance(time_context_ref, str) and time_context_ref:
+        if time_context_ref not in known_time_context_refs:
+            violations.append((locator, f"time_management_context_ref {time_context_ref!r} does not resolve"))
+        elif exact_claim:
+            time_context = known_time_contexts.get(time_context_ref)
+            if isinstance(time_context, Mapping) and time_context.get("claim_strength") != "exact":
+                violations.append((locator, "exact concurrency claims require exact time-management context"))
+    elif exact_claim:
+        violations.append((locator, "exact concurrency claims require time_management_context_ref"))
+    return violations
+
+
+def _joint_action_access_violations(
+    locator: str,
+    access_sets: object,
+    *,
+    known_state_refs: set[str],
+) -> tuple[list[str], list[Violation]]:
+    event_refs: list[str] = []
+    violations: list[Violation] = []
+    if not isinstance(access_sets, list) or not access_sets:
+        return event_refs, [(locator, "joint action access_sets must be a non-empty list")]
+    for index, access in enumerate(access_sets):
+        access_locator = f"{locator}.access_sets[{index}]"
+        if not isinstance(access, Mapping):
+            violations.append((access_locator, "joint action access set must be a mapping"))
+            continue
+        event_ref = access.get("member_event_ref")
+        if not isinstance(event_ref, str) or not event_ref:
+            violations.append((access_locator, "joint action access set requires member_event_ref"))
+        else:
+            event_refs.append(event_ref)
+        for field_name in ("shared_state_read_refs", "shared_state_write_refs"):
+            values = access.get(field_name, [])
+            if not isinstance(values, list):
+                violations.append((access_locator, f"{field_name} must be a list"))
+                continue
+            for state_ref in values:
+                if not isinstance(state_ref, str) or not state_ref:
+                    violations.append((access_locator, f"{field_name} entries must be non-empty strings"))
+                elif state_ref not in known_state_refs:
+                    violations.append((access_locator, f"{field_name} entry {state_ref!r} does not resolve"))
+    return event_refs, violations
+
+
+def _joint_action_conflict_violations(
+    locator: str,
+    *,
+    conflict_class: object,
+    conflict_policy: object,
+    actual_conflict: str,
+    realized_order: object,
+    unsupported: bool,
+    exact_claim: bool,
+    retry_limit: object,
+    rollback_event_refs: object,
+    atomicity_scope: object,
+    isolation_guarantee: object,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    has_realized_order = isinstance(realized_order, list) and bool(realized_order)
+    if unsupported and exact_claim:
+        violations.append((locator, "unsupported concurrency disclosure cannot carry an exact concurrency claim"))
+    if conflict_policy == "unsupported":
+        if not unsupported or exact_claim:
+            violations.append(
+                (locator, "unsupported conflict_policy requires unsupported_disclosure and no exact claim")
+            )
+        return violations
+    if not unsupported and conflict_class != actual_conflict:
+        violations.append((locator, "joint action conflict_class must match declared access-set conflicts"))
+    if conflict_class == "none" and actual_conflict != "none":
+        violations.append((locator, "joint action conflict_class cannot be none when access sets conflict"))
+    if isolation_guarantee == "serializable" and not has_realized_order:
+        violations.append((locator, "serializable joint action isolation requires realized_order"))
+    if conflict_policy == "serialize" and not has_realized_order:
+        violations.append((locator, "serialize conflict_policy requires realized_order"))
+    if conflict_policy == "retry" and (not isinstance(retry_limit, int) or not rollback_event_refs):
+        violations.append((locator, "retry conflict_policy requires retry_limit and rollback_event_refs"))
+    if conflict_policy == "none" and actual_conflict != "none":
+        violations.append((locator, "none conflict_policy is only valid when access sets do not conflict"))
+    if (
+        atomicity_scope == "multi_object"
+        and actual_conflict != "none"
+        and not (has_realized_order or rollback_event_refs)
+    ):
+        violations.append(
+            (locator, "multi_object conflicting joint actions require realized_order or rollback_event_refs")
+        )
+    return violations
+
+
+def _time_contexts_violations(contexts: object, *, known_event_refs: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    if not isinstance(contexts, Mapping):
+        return [(_TIME_CONTEXTS_KEY, "time_management_contexts must be a mapping")]
+    for outer_key, context in contexts.items():
+        locator = f"{_TIME_CONTEXTS_KEY}.{outer_key}"
+        if not isinstance(outer_key, str) or not outer_key:
+            violations.append((_TIME_CONTEXTS_KEY, "time_management_contexts keys must be non-empty strings"))
+        elif not isinstance(context, Mapping):
+            violations.append((locator, "time management context must be a mapping"))
+        else:
+            violations.extend(_time_context_violations(locator, outer_key, context, known_event_refs=known_event_refs))
+    return violations
+
+
+def _time_context_violations(
+    locator: str,
+    outer_key: str,
+    context: Mapping[object, object],
+    *,
+    known_event_refs: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    context_id = context.get("context_id")
+    if not isinstance(context_id, str) or not context_id:
+        violations.append((locator, "time management context requires context_id"))
+    elif context_id != outer_key:
+        violations.append((locator, f"time management context key {outer_key!r} does not match context_id"))
+
+    mode = context.get("mode")
+    claim_strength = context.get("claim_strength")
+    basis = context.get("basis")
+    clock_ref = context.get("clock_ref")
+    unsupported = context.get("unsupported_disclosure") is True
+    if unsupported and claim_strength == "exact":
+        violations.append((locator, "unsupported time-management disclosure cannot carry an exact claim"))
+    if basis == "wall_clock_only" and claim_strength != "display":
+        violations.append((locator, "wall_clock_only time basis supports display claims only"))
+    if claim_strength in {"bounded", "exact"} and not isinstance(clock_ref, str):
+        violations.append((locator, "bounded or exact time-management claims require clock_ref"))
+    if mode == "backend_serialized" and (
+        context.get("backend_serialized") is not True
+        or basis != "serialized_backend_order"
+        or not isinstance(clock_ref, str)
+    ):
+        violations.append((locator, "backend_serialized mode requires serialized_backend_order basis and clock_ref"))
+    if mode == "lookahead" and not isinstance(context.get("lookahead"), int):
+        violations.append((locator, "lookahead mode requires lookahead"))
+    if mode == "pacing" and not isinstance(context.get("advance_by"), int):
+        violations.append((locator, "pacing mode requires advance_by"))
+    rollback_refs = context.get("rollback_event_refs", [])
+    if mode == "rollback":
+        if not isinstance(rollback_refs, list) or not rollback_refs:
+            violations.append((locator, "rollback mode requires rollback_event_refs"))
+        else:
+            for ref in rollback_refs:
+                if isinstance(ref, str) and ref and ref not in known_event_refs:
+                    violations.append((locator, f"rollback_event_ref {ref!r} does not resolve"))
+    if mode in {"devs", "fmi"} and (not isinstance(clock_ref, str) or basis == "wall_clock_only"):
+        violations.append((locator, "devs and fmi modes require a non-wall-clock basis and clock_ref"))
+    if mode == "unsupported" and not unsupported:
+        violations.append((locator, "unsupported time-management mode requires unsupported_disclosure"))
+    return violations
+
+
+def _actual_conflict(access_sets: object) -> str:
+    if not isinstance(access_sets, list):
+        return "none"
+    read_write_conflict = False
+    for left_index, left in enumerate(access_sets):
+        if not isinstance(left, Mapping):
+            continue
+        left_reads = _string_set(left.get("shared_state_read_refs", []))
+        left_writes = _write_refs(left)
+        for right in access_sets[left_index + 1 :]:
+            if not isinstance(right, Mapping):
+                continue
+            right_reads = _string_set(right.get("shared_state_read_refs", []))
+            right_writes = _write_refs(right)
+            if left_writes & right_writes:
+                return "write_write"
+            if (left_writes & right_reads) or (left_reads & right_writes):
+                read_write_conflict = True
+    return "read_write" if read_write_conflict else "none"
+
+
+def _write_refs(access: Mapping[object, object]) -> set[str]:
+    refs = _string_set(access.get("shared_state_write_refs", []))
+    refs.update(f"resource:{ref}" for ref in _string_set(access.get("exclusive_resource_refs", [])))
+    return refs
+
+
+def _string_set(values: object) -> set[str]:
+    if not isinstance(values, list):
+        return set()
+    return {value for value in values if isinstance(value, str) and value}
+
+
+def _exact_string_set(values: object, expected: set[str]) -> bool:
+    return isinstance(values, list) and len(values) == len(expected) and set(values) == expected
+
+
+def _append_only_mapping_violations(
+    field_name: str,
+    address_prefix: str,
+    previous_records: object,
+    next_records: object,
+) -> Iterator[Violation]:
+    if not isinstance(previous_records, Mapping) or not isinstance(next_records, Mapping):
+        return
+    for record_id, previous_record in previous_records.items():
+        if not isinstance(record_id, str) or not record_id:
+            continue
+        locator = f"{address_prefix}.{record_id}"
+        if record_id not in next_records:
+            yield (locator, f"{field_name} must be append-only; record {record_id!r} was removed")
+        elif next_records[record_id] != previous_record:
+            yield (locator, f"{field_name} must be append-only; record {record_id!r} changed")
+
+
+__all__ = (
+    "iter_participant_concurrency_snapshot_violations",
+    "iter_participant_concurrency_transition_violations",
+)

--- a/implementations/python/packages/aces_contracts/participant_concurrency_time.py
+++ b/implementations/python/packages/aces_contracts/participant_concurrency_time.py
@@ -1,0 +1,148 @@
+"""RUN-308 participant concurrency time-management validators."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+Violation = tuple[str, str]
+
+TIME_CONTEXTS_KEY = "runtime.snapshot.time-management-contexts"
+
+
+def time_contexts_violations(contexts: object, *, known_event_refs: set[str]) -> list[Violation]:
+    violations: list[Violation] = []
+    if not isinstance(contexts, Mapping):
+        return [(TIME_CONTEXTS_KEY, "time_management_contexts must be a mapping")]
+    for outer_key, context in contexts.items():
+        locator = f"{TIME_CONTEXTS_KEY}.{outer_key}"
+        if not isinstance(outer_key, str) or not outer_key:
+            violations.append((TIME_CONTEXTS_KEY, "time_management_contexts keys must be non-empty strings"))
+        elif not isinstance(context, Mapping):
+            violations.append((locator, "time management context must be a mapping"))
+        else:
+            violations.extend(_time_context_violations(locator, outer_key, context, known_event_refs=known_event_refs))
+    return violations
+
+
+def _time_context_violations(
+    locator: str,
+    outer_key: str,
+    context: Mapping[object, object],
+    *,
+    known_event_refs: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    violations.extend(_time_context_identity_violations(locator, outer_key, context.get("context_id")))
+
+    mode = context.get("mode")
+    claim_strength = context.get("claim_strength")
+    basis = context.get("basis")
+    clock_ref = context.get("clock_ref")
+    unsupported = context.get("unsupported_disclosure") is True
+    violations.extend(
+        _time_context_claim_violations(
+            locator,
+            claim_strength=claim_strength,
+            basis=basis,
+            clock_ref=clock_ref,
+            unsupported=unsupported,
+        )
+    )
+    violations.extend(
+        _time_context_mode_violations(
+            locator,
+            context,
+            mode=mode,
+            basis=basis,
+            clock_ref=clock_ref,
+            unsupported=unsupported,
+            known_event_refs=known_event_refs,
+        )
+    )
+    return violations
+
+
+def _time_context_identity_violations(locator: str, outer_key: str, context_id: object) -> list[Violation]:
+    if not isinstance(context_id, str) or not context_id:
+        return [(locator, "time management context requires context_id")]
+    if context_id != outer_key:
+        return [(locator, f"time management context key {outer_key!r} does not match context_id")]
+    return []
+
+
+def _time_context_claim_violations(
+    locator: str,
+    *,
+    claim_strength: object,
+    basis: object,
+    clock_ref: object,
+    unsupported: bool,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if unsupported and claim_strength == "exact":
+        violations.append((locator, "unsupported time-management disclosure cannot carry an exact claim"))
+    if basis == "wall_clock_only" and claim_strength != "display":
+        violations.append((locator, "wall_clock_only time basis supports display claims only"))
+    if claim_strength in {"bounded", "exact"} and not isinstance(clock_ref, str):
+        violations.append((locator, "bounded or exact time-management claims require clock_ref"))
+    return violations
+
+
+def _time_context_mode_violations(
+    locator: str,
+    context: Mapping[object, object],
+    *,
+    mode: object,
+    basis: object,
+    clock_ref: object,
+    unsupported: bool,
+    known_event_refs: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if mode == "backend_serialized" and _invalid_backend_serialized_context(context, basis, clock_ref):
+        violations.append((locator, "backend_serialized mode requires serialized_backend_order basis and clock_ref"))
+    if mode == "lookahead" and not isinstance(context.get("lookahead"), int):
+        violations.append((locator, "lookahead mode requires lookahead"))
+    if mode == "pacing" and not isinstance(context.get("advance_by"), int):
+        violations.append((locator, "pacing mode requires advance_by"))
+    if mode == "rollback":
+        violations.extend(
+            _rollback_time_context_violations(
+                locator,
+                context.get("rollback_event_refs", []),
+                known_event_refs=known_event_refs,
+            )
+        )
+    if mode in {"devs", "fmi"} and (not isinstance(clock_ref, str) or basis == "wall_clock_only"):
+        violations.append((locator, "devs and fmi modes require a non-wall-clock basis and clock_ref"))
+    if mode == "unsupported" and not unsupported:
+        violations.append((locator, "unsupported time-management mode requires unsupported_disclosure"))
+    return violations
+
+
+def _invalid_backend_serialized_context(
+    context: Mapping[object, object],
+    basis: object,
+    clock_ref: object,
+) -> bool:
+    return not (
+        context.get("backend_serialized") is True and basis == "serialized_backend_order" and isinstance(clock_ref, str)
+    )
+
+
+def _rollback_time_context_violations(
+    locator: str,
+    rollback_refs: object,
+    *,
+    known_event_refs: set[str],
+) -> list[Violation]:
+    if not isinstance(rollback_refs, list) or not rollback_refs:
+        return [(locator, "rollback mode requires rollback_event_refs")]
+    return [
+        (locator, f"rollback_event_ref {ref!r} does not resolve")
+        for ref in rollback_refs
+        if isinstance(ref, str) and ref and ref not in known_event_refs
+    ]
+
+
+__all__ = ("TIME_CONTEXTS_KEY", "time_contexts_violations")

--- a/implementations/python/packages/aces_contracts/runtime_state.py
+++ b/implementations/python/packages/aces_contracts/runtime_state.py
@@ -73,6 +73,8 @@ class RuntimeSnapshot:
     participant_behavior_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     shared_state_records: dict[str, dict[str, Any]] = field(default_factory=dict)
     shared_state_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    joint_action_records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    time_management_contexts: dict[str, dict[str, Any]] = field(default_factory=dict)
     # SEM-218 invariant I5: per-concern provenance for realized realization
     # concerns recorded across this snapshot's result / history surfaces.
     realization_provenance: tuple[RealizationProvenanceEntry, ...] = ()
@@ -129,6 +131,16 @@ class RuntimeSnapshot:
                 "shared_state_history",
                 self.shared_state_history,
             ),
+            joint_action_records=_mapping_update(
+                updates,
+                "joint_action_records",
+                self.joint_action_records,
+            ),
+            time_management_contexts=_mapping_update(
+                updates,
+                "time_management_contexts",
+                self.time_management_contexts,
+            ),
             realization_provenance=_provenance_update(
                 updates,
                 "realization_provenance",
@@ -148,6 +160,8 @@ _SNAPSHOT_UPDATE_KEYS = {
     "participant_behavior_history",
     "shared_state_records",
     "shared_state_history",
+    "joint_action_records",
+    "time_management_contexts",
     "realization_provenance",
     "metadata",
 }

--- a/implementations/python/packages/aces_runtime/control_plane_api_models.py
+++ b/implementations/python/packages/aces_runtime/control_plane_api_models.py
@@ -156,6 +156,8 @@ def _snapshot_model(envelope: RuntimeSnapshotEnvelope) -> RuntimeSnapshotEnvelop
             "participant_behavior_history": dict(snapshot.participant_behavior_history),
             "shared_state_records": dict(snapshot.shared_state_records),
             "shared_state_history": dict(snapshot.shared_state_history),
+            "joint_action_records": dict(snapshot.joint_action_records),
+            "time_management_contexts": dict(snapshot.time_management_contexts),
             "metadata": dict(snapshot.metadata),
         }
     )

--- a/implementations/python/packages/aces_runtime/control_plane_store.py
+++ b/implementations/python/packages/aces_runtime/control_plane_store.py
@@ -99,6 +99,8 @@ def _snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
         "shared_state_history": {
             state_address: list(records) for state_address, records in snapshot.shared_state_history.items()
         },
+        "joint_action_records": dict(snapshot.joint_action_records),
+        "time_management_contexts": dict(snapshot.time_management_contexts),
         "realization_provenance": [
             {
                 "address": entry.address,
@@ -150,6 +152,8 @@ def _snapshot_from_payload(payload: dict[str, Any]) -> RuntimeSnapshot:
         shared_state_history={
             state_address: list(records) for state_address, records in payload.get("shared_state_history", {}).items()
         },
+        joint_action_records=dict(payload.get("joint_action_records", {})),
+        time_management_contexts=dict(payload.get("time_management_contexts", {})),
         realization_provenance=tuple(
             RealizationProvenanceEntry(
                 address=str(item.get("address", "")),

--- a/implementations/python/packages/aces_runtime/participant_result_contracts.py
+++ b/implementations/python/packages/aces_runtime/participant_result_contracts.py
@@ -7,6 +7,10 @@ from aces_contracts.participant_behavior import (
     iter_participant_behavior_snapshot_violations,
     iter_participant_runtime_history_transition_violations,
 )
+from aces_contracts.participant_concurrency import (
+    iter_participant_concurrency_snapshot_violations,
+    iter_participant_concurrency_transition_violations,
+)
 from aces_contracts.participant_episode import iter_participant_episode_snapshot_violations
 from aces_contracts.participant_shared_state import (
     iter_participant_shared_state_history_transition_violations,
@@ -65,6 +69,13 @@ def participant_runtime_state_contract_diagnostics(
             participant_behavior_history=snapshot.participant_behavior_history,
             metadata=snapshot.metadata,
         ),
+        *iter_participant_concurrency_snapshot_violations(
+            snapshot.joint_action_records,
+            snapshot.time_management_contexts,
+            participant_behavior_history=snapshot.participant_behavior_history,
+            shared_state_records=snapshot.shared_state_records,
+            shared_state_history=snapshot.shared_state_history,
+        ),
     ]
     return [
         _failure_diagnostic("runtime.backend-contract-invalid", address, message) for address, message in violations
@@ -77,18 +88,30 @@ def participant_runtime_history_transition_diagnostics(
 ) -> list[Diagnostic]:
     """Validate append-only participant history preservation across an apply."""
 
-    return [
-        _failure_diagnostic("runtime.backend-contract-invalid", address, message)
-        for address, message in iter_participant_runtime_history_transition_violations(
-            previous_snapshot.participant_episode_history,
-            next_snapshot.participant_episode_history,
-            previous_snapshot.participant_behavior_history,
-            next_snapshot.participant_behavior_history,
-        )
-    ] + [
-        _failure_diagnostic("runtime.backend-contract-invalid", address, message)
-        for address, message in iter_participant_shared_state_history_transition_violations(
-            previous_snapshot.shared_state_history,
-            next_snapshot.shared_state_history,
-        )
-    ]
+    return (
+        [
+            _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+            for address, message in iter_participant_runtime_history_transition_violations(
+                previous_snapshot.participant_episode_history,
+                next_snapshot.participant_episode_history,
+                previous_snapshot.participant_behavior_history,
+                next_snapshot.participant_behavior_history,
+            )
+        ]
+        + [
+            _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+            for address, message in iter_participant_shared_state_history_transition_violations(
+                previous_snapshot.shared_state_history,
+                next_snapshot.shared_state_history,
+            )
+        ]
+        + [
+            _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+            for address, message in iter_participant_concurrency_transition_violations(
+                previous_snapshot.joint_action_records,
+                next_snapshot.joint_action_records,
+                previous_snapshot.time_management_contexts,
+                next_snapshot.time_management_contexts,
+            )
+        ]
+    )

--- a/implementations/python/tests/test_participant_backend_contracts.py
+++ b/implementations/python/tests/test_participant_backend_contracts.py
@@ -15,12 +15,14 @@ from aces_contracts.contracts import (
     ParticipantHistoryViewBehaviorEventModel,
     ParticipantHistoryViewEpisodeEventModel,
     ParticipantHistoryViewModel,
+    ParticipantJointActionRecordModel,
     ParticipantLifecycleEventModel,
     ParticipantObservationEnvelopeModel,
     ParticipantOutcomeReportModel,
     ParticipantSharedStateRecordModel,
     ParticipantStatusViewEpisodeStateModel,
     ParticipantStatusViewModel,
+    ParticipantTimeManagementContextModel,
     schema_bundle,
 )
 from jsonschema import Draft202012Validator
@@ -33,6 +35,8 @@ PARTICIPANT_RUNTIME_FIXTURE_MODELS = {
     "participant-lifecycle-event-v1": ParticipantLifecycleEventModel,
     "participant-observation-envelope-v1": ParticipantObservationEnvelopeModel,
     "participant-shared-state-record-v1": ParticipantSharedStateRecordModel,
+    "participant-joint-action-record-v1": ParticipantJointActionRecordModel,
+    "participant-time-management-context-v1": ParticipantTimeManagementContextModel,
     "participant-outcome-report-v1": ParticipantOutcomeReportModel,
 }
 CONTROL_PLANE_VIEW_FIXTURE_MODELS = {
@@ -425,3 +429,22 @@ def test_participant_shared_state_record_rejects_unknown_conflict_policy():
 
     with pytest.raises(ValidationError, match="conflict_policy"):
         ParticipantSharedStateRecordModel.model_validate(payload)
+
+
+def test_participant_joint_action_record_rejects_implicit_last_writer_wins():
+    payload = _valid_fixture("participant-joint-action-record-v1")
+    payload["conflict_class"] = "none"
+    payload["conflict_policy"] = "none"
+    payload["realized_order"] = []
+
+    with pytest.raises(ValidationError, match="conflict_class"):
+        ParticipantJointActionRecordModel.model_validate(payload)
+
+
+def test_participant_time_management_context_rejects_timestamp_only_exact_claim():
+    payload = _valid_fixture("participant-time-management-context-v1")
+    payload["basis"] = "wall_clock_only"
+    payload["claim_strength"] = "exact"
+
+    with pytest.raises(ValidationError, match="wall_clock_only"):
+        ParticipantTimeManagementContextModel.model_validate(payload)

--- a/implementations/python/tests/test_run_308_concurrent_participant_execution.py
+++ b/implementations/python/tests/test_run_308_concurrent_participant_execution.py
@@ -12,6 +12,10 @@ from aces_contracts.contracts import (
     RuntimeSnapshotEnvelopeModel,
     schema_bundle,
 )
+from aces_contracts.participant_concurrency import (
+    iter_participant_concurrency_snapshot_violations,
+    iter_participant_concurrency_transition_violations,
+)
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
 from aces_runtime.backend_calls import _call_backend_apply
 from aces_runtime.participant_result_contracts import participant_runtime_state_contract_diagnostics
@@ -151,6 +155,19 @@ def _snapshot_payload(**overrides: object) -> dict[str, object]:
     return payload
 
 
+def _concurrency_violation_messages(payload: dict[str, object]) -> list[str]:
+    return [
+        message
+        for _address, message in iter_participant_concurrency_snapshot_violations(
+            payload.get("joint_action_records"),
+            payload.get("time_management_contexts"),
+            participant_behavior_history=payload.get("participant_behavior_history"),
+            shared_state_records=payload.get("shared_state_records"),
+            shared_state_history=payload.get("shared_state_history"),
+        )
+    ]
+
+
 def test_runtime_snapshot_publishes_joint_action_and_time_context_records() -> None:
     payload = _snapshot_payload()
 
@@ -189,6 +206,93 @@ def test_joint_action_record_contract_rejects_exact_claim_without_time_context()
         ParticipantJointActionRecordModel.model_validate(payload)
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"member_event_refs": ["scan-red-0001", "scan-red-0001"]}, "member_event_refs must be unique"),
+        (
+            {"access_sets": [{"member_event_ref": "scan-red-0001"}]},
+            "access_sets must cover member_event_refs",
+        ),
+        ({"realized_order": ["scan-red-0001", "scan-missing-0001"]}, "realized_order"),
+        (
+            {"unsupported_disclosure": True, "exact_concurrency_claim": True},
+            "unsupported concurrency disclosure",
+        ),
+        (
+            {"conflict_policy": "unsupported", "unsupported_disclosure": False},
+            "unsupported conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "retry",
+                "isolation_guarantee": "serializable",
+                "realized_order": [],
+                "retry_limit": 1,
+                "rollback_event_refs": ["scan-red-0001"],
+            },
+            "serializable joint action isolation",
+        ),
+        (
+            {"conflict_policy": "serialize", "isolation_guarantee": "none", "realized_order": []},
+            "serialize conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "retry",
+                "isolation_guarantee": "none",
+                "realized_order": [],
+                "retry_limit": None,
+                "rollback_event_refs": [],
+            },
+            "retry conflict_policy",
+        ),
+        (
+            {"conflict_policy": "none", "isolation_guarantee": "none", "realized_order": []},
+            "none conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "reject",
+                "isolation_guarantee": "none",
+                "atomicity_scope": "multi_object",
+                "realized_order": [],
+            },
+            "multi_object conflicting joint actions",
+        ),
+        (
+            {
+                "conflict_class": "none",
+                "conflict_policy": "reject",
+                "isolation_guarantee": "none",
+                "unsupported_disclosure": True,
+            },
+            "conflict_class cannot be none",
+        ),
+    ],
+)
+def test_joint_action_record_contract_rejects_concurrency_guardrails(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    payload = _joint_action(**overrides)
+
+    with pytest.raises(ValidationError, match=message):
+        ParticipantJointActionRecordModel.model_validate(payload)
+
+
+def test_joint_action_record_contract_accepts_unsupported_policy_disclosure() -> None:
+    payload = _joint_action(
+        conflict_policy="unsupported",
+        unsupported_disclosure=True,
+        exact_concurrency_claim=False,
+    )
+
+    model = ParticipantJointActionRecordModel.model_validate(payload)
+
+    assert model.conflict_policy == "unsupported"
+
+
 def test_time_management_context_contract_rejects_wall_clock_exact_claim() -> None:
     payload = _time_context(
         mode="display",
@@ -199,6 +303,85 @@ def test_time_management_context_contract_rejects_wall_clock_exact_claim() -> No
     )
 
     with pytest.raises(ValidationError, match="wall_clock_only"):
+        ParticipantTimeManagementContextModel.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        (
+            {"mode": "display", "claim_strength": "bounded", "basis": "logical_clock", "clock_ref": None},
+            "clock_ref",
+        ),
+        ({"backend_serialized": False}, "backend_serialized mode"),
+        (
+            {
+                "mode": "lookahead",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "backend_serialized": False,
+            },
+            "lookahead mode",
+        ),
+        (
+            {
+                "mode": "pacing",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "backend_serialized": False,
+            },
+            "pacing mode",
+        ),
+        (
+            {
+                "mode": "rollback",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "rollback_event_refs": [],
+                "backend_serialized": False,
+            },
+            "rollback mode",
+        ),
+        (
+            {
+                "mode": "devs",
+                "claim_strength": "display",
+                "basis": "wall_clock_only",
+                "clock_ref": None,
+                "backend_serialized": False,
+            },
+            "devs and fmi modes",
+        ),
+        (
+            {
+                "mode": "unsupported",
+                "claim_strength": "display",
+                "basis": "wall_clock_only",
+                "clock_ref": None,
+                "backend_serialized": False,
+            },
+            "unsupported time-management mode",
+        ),
+        (
+            {
+                "mode": "display",
+                "claim_strength": "exact",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "unsupported_disclosure": True,
+                "backend_serialized": False,
+            },
+            "unsupported time-management disclosure",
+        ),
+    ],
+)
+def test_time_management_context_contract_rejects_mode_guardrails(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    payload = _time_context(**overrides)
+
+    with pytest.raises(ValidationError, match=message):
         ParticipantTimeManagementContextModel.model_validate(payload)
 
 
@@ -294,6 +477,287 @@ def test_participant_runtime_state_diagnostics_reject_rollback_refs_when_history
     )
 
 
+def test_participant_concurrency_snapshot_validator_rejects_malformed_maps() -> None:
+    violations = list(
+        iter_participant_concurrency_snapshot_violations(
+            joint_action_records=[],
+            time_management_contexts=[],
+            participant_behavior_history=None,
+            shared_state_records=None,
+            shared_state_history=None,
+        )
+    )
+    messages = [message for _address, message in violations]
+
+    assert "joint_action_records must be a mapping" in messages
+    assert "time_management_contexts must be a mapping" in messages
+
+
+def test_participant_concurrency_snapshot_validator_rejects_malformed_records() -> None:
+    payload = _snapshot_payload(
+        joint_action_records={"": {}, "joint-red-blue-0001": "not-a-record"},
+        time_management_contexts={"": {}, "tm-red-blue-0001": "not-a-context"},
+    )
+
+    messages = _concurrency_violation_messages(payload)
+
+    assert "joint_action_records keys must be non-empty strings" in messages
+    assert "joint action record must be a mapping" in messages
+    assert "time_management_contexts keys must be non-empty strings" in messages
+    assert "time management context must be a mapping" in messages
+
+
+def test_participant_concurrency_snapshot_validator_rejects_malformed_joint_action_fields() -> None:
+    payload = _snapshot_payload(
+        joint_action_records={
+            "joint-red-blue-0001": _joint_action(
+                joint_action_set_id="joint-other-0001",
+                member_event_refs=["scan-red-0001", ""],
+                access_sets=[
+                    {},
+                    {
+                        "member_event_ref": "scan-red-0001",
+                        "shared_state_read_refs": "not-a-list",
+                        "shared_state_write_refs": ["", "state.missing"],
+                    },
+                ],
+                realized_order="not-a-list",
+                conflict_class="none",
+                conflict_policy="none",
+                isolation_guarantee="none",
+                time_management_context_ref="tm-missing-0001",
+            ),
+            "joint-missing-id": _joint_action(
+                joint_action_set_id="",
+                member_event_refs=["scan-red-0001", "scan-blue-0001"],
+                access_sets=[],
+                realized_order=["scan-red-0001", "scan-missing-0001"],
+                conflict_class="none",
+                conflict_policy="none",
+                isolation_guarantee="none",
+                time_management_context_ref=None,
+                exact_concurrency_claim=True,
+            ),
+            "joint-bad-access": _joint_action(
+                joint_action_set_id="joint-bad-access",
+                member_event_refs=["scan-red-0001"],
+                access_sets=["not-a-map"],
+                realized_order=[],
+                conflict_class="none",
+                conflict_policy="none",
+                isolation_guarantee="none",
+                time_management_context_ref=None,
+            ),
+        }
+    )
+
+    messages = _concurrency_violation_messages(payload)
+
+    assert any("does not match joint_action_set_id" in message for message in messages)
+    assert "joint action record requires joint_action_set_id" in messages
+    assert "joint action member_event_refs entries must be non-empty strings" in messages
+    assert "joint action access_sets must be a non-empty list" in messages
+    assert "joint action access set must be a mapping" in messages
+    assert "joint action access set requires member_event_ref" in messages
+    assert "shared_state_read_refs must be a list" in messages
+    assert "shared_state_write_refs entries must be non-empty strings" in messages
+    assert "shared_state_write_refs entry 'state.missing' does not resolve" in messages
+    assert "joint action realized_order must be a list" in messages
+    assert "joint action realized_order must be an exact permutation of member_event_refs" in messages
+    assert "time_management_context_ref 'tm-missing-0001' does not resolve" in messages
+    assert "exact concurrency claims require time_management_context_ref" in messages
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        (
+            {
+                "unsupported_disclosure": True,
+                "exact_concurrency_claim": True,
+            },
+            "unsupported concurrency disclosure",
+        ),
+        (
+            {
+                "conflict_policy": "unsupported",
+                "unsupported_disclosure": False,
+                "realized_order": [],
+                "isolation_guarantee": "none",
+            },
+            "unsupported conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "serialize",
+                "realized_order": [],
+                "isolation_guarantee": "none",
+            },
+            "serialize conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "retry",
+                "isolation_guarantee": "serializable",
+                "realized_order": [],
+                "retry_limit": 1,
+                "rollback_event_refs": ["scan-red-0001"],
+            },
+            "serializable joint action isolation",
+        ),
+        (
+            {
+                "conflict_policy": "retry",
+                "realized_order": [],
+                "isolation_guarantee": "none",
+                "retry_limit": None,
+                "rollback_event_refs": [],
+            },
+            "retry conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "none",
+                "realized_order": [],
+                "isolation_guarantee": "none",
+            },
+            "none conflict_policy",
+        ),
+        (
+            {
+                "conflict_policy": "reject",
+                "realized_order": [],
+                "isolation_guarantee": "none",
+                "atomicity_scope": "multi_object",
+            },
+            "multi_object conflicting joint actions",
+        ),
+        (
+            {
+                "access_sets": [
+                    {"member_event_ref": "scan-red-0001", "shared_state_write_refs": [STATE_ADDRESS]},
+                    {"member_event_ref": "scan-blue-0001", "shared_state_write_refs": [STATE_ADDRESS]},
+                ],
+                "conflict_class": "read_write",
+                "conflict_policy": "reject",
+                "isolation_guarantee": "none",
+            },
+            "conflict_class must match",
+        ),
+        (
+            {
+                "conflict_class": "none",
+                "conflict_policy": "reject",
+                "isolation_guarantee": "none",
+                "unsupported_disclosure": True,
+            },
+            "conflict_class cannot be none",
+        ),
+    ],
+)
+def test_participant_concurrency_snapshot_validator_rejects_conflict_guardrails(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    payload = _snapshot_payload(joint_action_records={"joint-red-blue-0001": _joint_action(**overrides)})
+
+    messages = _concurrency_violation_messages(payload)
+
+    assert any(message in violation for violation in messages)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"context_id": ""}, "requires context_id"),
+        ({"context_id": "tm-other-0001"}, "does not match context_id"),
+        (
+            {"mode": "display", "claim_strength": "bounded", "basis": "logical_clock", "clock_ref": None},
+            "clock_ref",
+        ),
+        (
+            {
+                "mode": "display",
+                "claim_strength": "exact",
+                "basis": "wall_clock_only",
+                "clock_ref": "clock.wall",
+                "backend_serialized": False,
+            },
+            "wall_clock_only time basis",
+        ),
+        ({"backend_serialized": False}, "backend_serialized mode"),
+        (
+            {
+                "mode": "lookahead",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "backend_serialized": False,
+            },
+            "lookahead mode",
+        ),
+        (
+            {
+                "mode": "pacing",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "backend_serialized": False,
+            },
+            "pacing mode",
+        ),
+        (
+            {
+                "mode": "rollback",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "rollback_event_refs": [],
+                "backend_serialized": False,
+            },
+            "rollback mode",
+        ),
+        (
+            {
+                "mode": "devs",
+                "claim_strength": "display",
+                "basis": "wall_clock_only",
+                "clock_ref": None,
+                "backend_serialized": False,
+            },
+            "devs and fmi modes",
+        ),
+        (
+            {
+                "mode": "unsupported",
+                "claim_strength": "display",
+                "basis": "wall_clock_only",
+                "clock_ref": None,
+                "backend_serialized": False,
+            },
+            "unsupported time-management mode",
+        ),
+        (
+            {
+                "mode": "display",
+                "claim_strength": "exact",
+                "basis": "logical_clock",
+                "clock_ref": "clock.logical.runtime",
+                "unsupported_disclosure": True,
+                "backend_serialized": False,
+            },
+            "unsupported time-management disclosure",
+        ),
+    ],
+)
+def test_participant_concurrency_snapshot_validator_rejects_time_context_guardrails(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    payload = _snapshot_payload(time_management_contexts={"tm-red-blue-0001": _time_context(**overrides)})
+
+    messages = _concurrency_violation_messages(payload)
+
+    assert any(message in violation for violation in messages)
+
+
 def test_backend_apply_rejects_rewriting_joint_action_records() -> None:
     payload = _snapshot_payload()
     base_snapshot = RuntimeSnapshot(
@@ -324,6 +788,40 @@ def test_backend_apply_rejects_rewriting_joint_action_records() -> None:
 
     assert result.success is False
     assert any("joint_action_records must be append-only" in item.message for item in result.diagnostics)
+
+
+def test_participant_concurrency_transition_validator_rejects_rewriting_records() -> None:
+    assert (
+        list(
+            iter_participant_concurrency_transition_violations(
+                {"": {}},
+                {},
+                [],
+                {},
+            )
+        )
+        == []
+    )
+
+    violations = list(
+        iter_participant_concurrency_transition_violations(
+            {"joint-red-blue-0001": _joint_action()},
+            {"joint-red-blue-0001": _joint_action(conflict_policy="reject")},
+            {"tm-red-blue-0001": _time_context()},
+            {
+                "tm-red-blue-0001": _time_context(
+                    mode="display",
+                    claim_strength="display",
+                    basis="wall_clock_only",
+                    backend_serialized=False,
+                )
+            },
+        )
+    )
+    messages = [message for _address, message in violations]
+
+    assert "joint_action_records must be append-only; record 'joint-red-blue-0001' changed" in messages
+    assert "time_management_contexts must be append-only; record 'tm-red-blue-0001' changed" in messages
 
 
 def test_joint_action_and_time_context_model_round_trip() -> None:

--- a/implementations/python/tests/test_run_308_concurrent_participant_execution.py
+++ b/implementations/python/tests/test_run_308_concurrent_participant_execution.py
@@ -1,0 +1,334 @@
+"""RUN-308 concurrent participant execution integration tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aces_contracts.contracts import (
+    ParticipantJointActionRecordModel,
+    ParticipantTimeManagementContextModel,
+    RuntimeSnapshotEnvelopeModel,
+    schema_bundle,
+)
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot
+from aces_runtime.backend_calls import _call_backend_apply
+from aces_runtime.participant_result_contracts import participant_runtime_state_contract_diagnostics
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STATE_ADDRESS = "hosts.web01.service.http"
+PARTICIPANT_RED = "participants.red.llm"
+PARTICIPANT_BLUE = "participants.blue.llm"
+EPISODE = "episode-main"
+T0 = "2026-06-20T08:00:00Z"
+
+
+def _shared_state_record() -> dict[str, object]:
+    fixture_path = (
+        REPO_ROOT
+        / "contracts"
+        / "fixtures"
+        / "participant-runtime"
+        / "participant-shared-state-record-v1"
+        / "valid"
+        / "serialized-service-state-commit.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _behavior_event(participant_address: str, action_instance_id: str, realized_order: int) -> dict[str, object]:
+    return {
+        "event_type": "action_attempted",
+        "timestamp": T0,
+        "participant_address": participant_address,
+        "episode_id": EPISODE,
+        "action_instance_id": action_instance_id,
+        "action_contract_address": "participant.action-contract.scan",
+        "actor_provenance": f"participant:{participant_address.rsplit('.', 1)[-1]}",
+        "joint_action_set_id": "joint-red-blue-0001",
+        "realized_order": realized_order,
+        "interaction_class": "shared_state_change",
+        "shared_state_refs": [STATE_ADDRESS],
+        "details": {},
+    }
+
+
+def _base_envelope(*, event_id: str, schema_name: str, event_type: str) -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "schema_name": schema_name,
+        "schema_version": f"{schema_name}/v1",
+        "event_type": event_type,
+        "extension_policy": "forbid_unknown_fields",
+        "participant_address": None,
+        "episode_id": None,
+        "sequence_number": None,
+        "occurred_at": T0,
+        "recorded_at": T0,
+        "ingested_at": T0,
+        "clock_authority": "clock.logical.runtime",
+        "ordering_basis": "serialized_backend_order",
+        "logical_order_ref": "order.joint-red-blue-0001",
+        "actor_ref": "runtime.coordinator",
+        "producer_ref": "backend.stub",
+        "authorization_scope": "operators",
+    }
+
+
+def _time_context(**overrides: object) -> dict[str, object]:
+    payload = {
+        **_base_envelope(
+            event_id="tm-red-blue-0001",
+            schema_name="participant-time-management-context",
+            event_type="time_management_context_recorded",
+        ),
+        "context_id": "tm-red-blue-0001",
+        "mode": "backend_serialized",
+        "claim_strength": "bounded",
+        "basis": "serialized_backend_order",
+        "clock_ref": "clock.logical.runtime",
+        "backend_serialized": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _joint_action(**overrides: object) -> dict[str, object]:
+    payload = {
+        **_base_envelope(
+            event_id="joint-red-blue-0001",
+            schema_name="participant-joint-action-record",
+            event_type="joint_action_recorded",
+        ),
+        "joint_action_set_id": "joint-red-blue-0001",
+        "member_event_refs": ["scan-red-0001", "scan-blue-0001"],
+        "access_sets": [
+            {
+                "member_event_ref": "scan-red-0001",
+                "shared_state_write_refs": [STATE_ADDRESS],
+            },
+            {
+                "member_event_ref": "scan-blue-0001",
+                "shared_state_read_refs": [STATE_ADDRESS],
+            },
+        ],
+        "conflict_class": "read_write",
+        "conflict_policy": "serialize",
+        "isolation_guarantee": "serializable",
+        "atomicity_scope": "single_object",
+        "realized_order": ["scan-red-0001", "scan-blue-0001"],
+        "time_management_context_ref": "tm-red-blue-0001",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _snapshot_payload(**overrides: object) -> dict[str, object]:
+    shared_state = _shared_state_record()
+    payload = {
+        "schema_version": "runtime-snapshot/v1",
+        "entries": {},
+        "orchestration_results": {},
+        "orchestration_history": {},
+        "evaluation_results": {},
+        "evaluation_history": {},
+        "participant_episode_results": {},
+        "participant_episode_history": {},
+        "participant_behavior_history": {
+            PARTICIPANT_RED: [_behavior_event(PARTICIPANT_RED, "scan-red-0001", 0)],
+            PARTICIPANT_BLUE: [_behavior_event(PARTICIPANT_BLUE, "scan-blue-0001", 1)],
+        },
+        "shared_state_records": {STATE_ADDRESS: shared_state},
+        "shared_state_history": {STATE_ADDRESS: [shared_state]},
+        "joint_action_records": {"joint-red-blue-0001": _joint_action()},
+        "time_management_contexts": {"tm-red-blue-0001": _time_context()},
+        "metadata": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_runtime_snapshot_publishes_joint_action_and_time_context_records() -> None:
+    payload = _snapshot_payload()
+
+    model = RuntimeSnapshotEnvelopeModel.model_validate(payload)
+    assert model.joint_action_records["joint-red-blue-0001"].conflict_policy == "serialize"
+    assert model.time_management_contexts["tm-red-blue-0001"].mode == "backend_serialized"
+
+    validator = Draft202012Validator(schema_bundle()["runtime-snapshot-v1"])
+    assert list(validator.iter_errors(payload)) == []
+
+
+def test_joint_action_record_contract_rejects_unordered_conflicting_writes() -> None:
+    payload = _joint_action(
+        access_sets=[
+            {"member_event_ref": "scan-red-0001", "shared_state_write_refs": [STATE_ADDRESS]},
+            {"member_event_ref": "scan-blue-0001", "shared_state_write_refs": [STATE_ADDRESS]},
+        ],
+        conflict_class="none",
+        conflict_policy="none",
+        isolation_guarantee="none",
+        realized_order=[],
+        exact_concurrency_claim=True,
+    )
+
+    with pytest.raises(ValidationError, match="conflict_class"):
+        ParticipantJointActionRecordModel.model_validate(payload)
+
+
+def test_joint_action_record_contract_rejects_exact_claim_without_time_context() -> None:
+    payload = _joint_action(
+        exact_concurrency_claim=True,
+        time_management_context_ref=None,
+    )
+
+    with pytest.raises(ValidationError, match="time_management_context_ref"):
+        ParticipantJointActionRecordModel.model_validate(payload)
+
+
+def test_time_management_context_contract_rejects_wall_clock_exact_claim() -> None:
+    payload = _time_context(
+        mode="display",
+        claim_strength="exact",
+        basis="wall_clock_only",
+        clock_ref="clock.wall",
+        backend_serialized=False,
+    )
+
+    with pytest.raises(ValidationError, match="wall_clock_only"):
+        ParticipantTimeManagementContextModel.model_validate(payload)
+
+
+def test_participant_runtime_state_diagnostics_reject_unresolved_concurrency_refs() -> None:
+    payload = _snapshot_payload(
+        joint_action_records={
+            "joint-red-blue-0001": _joint_action(
+                member_event_refs=["scan-red-0001", "scan-missing-0001"],
+                access_sets=[
+                    {"member_event_ref": "scan-red-0001", "shared_state_write_refs": [STATE_ADDRESS]},
+                    {"member_event_ref": "scan-missing-0001", "shared_state_read_refs": [STATE_ADDRESS]},
+                ],
+                realized_order=["scan-red-0001", "scan-missing-0001"],
+            )
+        }
+    )
+    snapshot = RuntimeSnapshot(
+        participant_behavior_history=dict(payload["participant_behavior_history"]),
+        shared_state_records=dict(payload["shared_state_records"]),
+        shared_state_history=dict(payload["shared_state_history"]),
+        joint_action_records=dict(payload["joint_action_records"]),
+        time_management_contexts=dict(payload["time_management_contexts"]),
+    )
+
+    diagnostics = participant_runtime_state_contract_diagnostics(snapshot)
+
+    assert any("scan-missing-0001" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_participant_runtime_state_diagnostics_reject_shared_state_refs_when_index_empty() -> None:
+    payload = _snapshot_payload(
+        shared_state_records={},
+        shared_state_history={},
+    )
+    snapshot = RuntimeSnapshot(
+        participant_behavior_history=dict(payload["participant_behavior_history"]),
+        shared_state_records={},
+        shared_state_history={},
+        joint_action_records=dict(payload["joint_action_records"]),
+        time_management_contexts=dict(payload["time_management_contexts"]),
+    )
+
+    diagnostics = participant_runtime_state_contract_diagnostics(snapshot)
+
+    assert any(f"{STATE_ADDRESS!r} does not resolve" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_participant_runtime_state_diagnostics_reject_exact_claim_with_bounded_time_context() -> None:
+    payload = _snapshot_payload(
+        joint_action_records={
+            "joint-red-blue-0001": _joint_action(
+                exact_concurrency_claim=True,
+            )
+        }
+    )
+    snapshot = RuntimeSnapshot(
+        participant_behavior_history=dict(payload["participant_behavior_history"]),
+        shared_state_records=dict(payload["shared_state_records"]),
+        shared_state_history=dict(payload["shared_state_history"]),
+        joint_action_records=dict(payload["joint_action_records"]),
+        time_management_contexts=dict(payload["time_management_contexts"]),
+    )
+
+    diagnostics = participant_runtime_state_contract_diagnostics(snapshot)
+
+    assert any("exact time-management context" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_participant_runtime_state_diagnostics_reject_rollback_refs_when_history_empty() -> None:
+    payload = _snapshot_payload(
+        participant_behavior_history={},
+        time_management_contexts={
+            "tm-red-blue-0001": _time_context(
+                mode="rollback",
+                claim_strength="bounded",
+                rollback_event_refs=["scan-red-0001"],
+                backend_serialized=False,
+            )
+        },
+    )
+    snapshot = RuntimeSnapshot(
+        participant_behavior_history={},
+        shared_state_records=dict(payload["shared_state_records"]),
+        shared_state_history=dict(payload["shared_state_history"]),
+        joint_action_records={},
+        time_management_contexts=dict(payload["time_management_contexts"]),
+    )
+
+    diagnostics = participant_runtime_state_contract_diagnostics(snapshot)
+
+    assert any(
+        "rollback_event_ref 'scan-red-0001' does not resolve" in diagnostic.message for diagnostic in diagnostics
+    )
+
+
+def test_backend_apply_rejects_rewriting_joint_action_records() -> None:
+    payload = _snapshot_payload()
+    base_snapshot = RuntimeSnapshot(
+        participant_behavior_history=dict(payload["participant_behavior_history"]),
+        shared_state_records=dict(payload["shared_state_records"]),
+        shared_state_history=dict(payload["shared_state_history"]),
+        joint_action_records=dict(payload["joint_action_records"]),
+        time_management_contexts=dict(payload["time_management_contexts"]),
+    )
+
+    def _backend_apply(_request: object, snapshot: RuntimeSnapshot) -> ApplyResult:
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                joint_action_records={},
+                time_management_contexts=dict(snapshot.time_management_contexts),
+            ),
+        )
+
+    result = _call_backend_apply(
+        _backend_apply,
+        object(),
+        base_snapshot,
+        address="runtime.control-plane.concurrent-participants",
+        snapshot=base_snapshot,
+    )
+
+    assert result.success is False
+    assert any("joint_action_records must be append-only" in item.message for item in result.diagnostics)
+
+
+def test_joint_action_and_time_context_model_round_trip() -> None:
+    joint_action = ParticipantJointActionRecordModel.model_validate(_joint_action())
+    time_context = ParticipantTimeManagementContextModel.model_validate(_time_context())
+
+    assert joint_action.model_dump(mode="json")["conflict_class"] == "read_write"
+    assert time_context.model_dump(mode="json")["claim_strength"] == "bounded"

--- a/tools/generate_contract_schemas.py
+++ b/tools/generate_contract_schemas.py
@@ -41,6 +41,8 @@ def _schema_output_path(schemas_dir: Path, name: str) -> Path:
         "participant-lifecycle-event-v1",
         "participant-observation-envelope-v1",
         "participant-shared-state-record-v1",
+        "participant-joint-action-record-v1",
+        "participant-time-management-context-v1",
         "participant-outcome-report-v1",
     }:
         return schemas_dir / "participant-runtime" / f"{name}.json"


### PR DESCRIPTION
## Summary

Adds schema-first participant concurrency evidence to the runtime snapshot so backends can make falsifiable claims about joint actions, shared-state contention, isolation, ordering, and time-management basis.

## Requirement UIDs

- `RUN-308`

## Related Issues

Closes #195

## ADR Impact

- ADR-054
- ADR-060

## Changes

- Add participant joint-action and time-management contract models, generated schemas, publication-manifest hashes, and valid/invalid fixtures.
- Thread `joint_action_records` and `time_management_contexts` through runtime snapshots, control-plane serialization/API models, conformance diagnostics, and backend apply diagnostics.
- Require participant interaction capability claims to advertise the new concurrency contracts alongside behavior history, shared-state records, and runtime snapshots.
- Add RUN-308 regression tests for schema publication, conflict-policy validation, exact concurrency/time evidence, fail-closed reference validation, append-only backend apply behavior, and backend manifest capability checks.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused RUN-308/contract suite: 77 passed. Full `tools/verify_all.py` passed, including policy, schema publication, generated-schema drift, JSON artifact validation, full pytest, integration pytest, and docs build. `tools/check_requirement_governance.py` used the repo's Ground Control timeout skip path locally; server-side Ground Control gates were available and passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: RUN-308 ← implementations/python/packages/aces_contracts/contracts.py, RUN-308 ← implementations/python/packages/aces_contracts/participant_concurrency.py, RUN-308 ← implementations/python/packages/aces_contracts/runtime_state.py, RUN-308 ← contracts/schemas/participant-runtime/participant-joint-action-record-v1.json, RUN-308 ← contracts/schemas/participant-runtime/participant-time-management-context-v1.json
- TESTS: RUN-308 ← implementations/python/tests/test_run_308_concurrent_participant_execution.py, RUN-308 ← implementations/python/tests/test_participant_backend_contracts.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/195.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
