### PR TITLE
feat: register API-406 backend carrier contracts

### DIFF
--- a/changelog.d/200.added.md
+++ b/changelog.d/200.added.md
@@ -1,0 +1,5 @@
+### Added
+
+- Made the API-406 participant lifecycle-event, observation-envelope, and
+  shared-state record contracts required by the full remote control-plane
+  backend profile and registered their conformance model validators.

--- a/contracts/profiles/backend/full-remote-control-plane.json
+++ b/contracts/profiles/backend/full-remote-control-plane.json
@@ -15,6 +15,9 @@
     "evaluation-history-event-stream-v1",
     "participant-episode-state-envelope-v1",
     "participant-episode-history-event-stream-v1",
-    "participant-behavior-history-event-stream-v1"
+    "participant-behavior-history-event-stream-v1",
+    "participant-lifecycle-event-v1",
+    "participant-observation-envelope-v1",
+    "participant-shared-state-record-v1"
   ]
 }

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -31,6 +31,9 @@ from aces_contracts.contracts import (
     ParticipantEpisodeStateModel,
     ParticipantImplementationManifestModel,
     ParticipantImplementationProvenanceModel,
+    ParticipantLifecycleEventModel,
+    ParticipantObservationEnvelopeModel,
+    ParticipantSharedStateRecordModel,
     ProvisioningPlanModel,
     RuntimeSnapshotEnvelopeModel,
     WorkflowExecutionStateModel,
@@ -162,6 +165,9 @@ _MODEL_VALIDATORS = {
     "workflow-result-envelope-v1": WorkflowExecutionStateModel.model_validate,
     "evaluation-result-envelope-v1": EvaluationResultStateModel.model_validate,
     "participant-episode-state-envelope-v1": ParticipantEpisodeStateModel.model_validate,
+    "participant-lifecycle-event-v1": ParticipantLifecycleEventModel.model_validate,
+    "participant-observation-envelope-v1": ParticipantObservationEnvelopeModel.model_validate,
+    "participant-shared-state-record-v1": ParticipantSharedStateRecordModel.model_validate,
 }
 
 

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -19,6 +19,12 @@ from aces.core.runtime.conformance import (
 )
 from aces.core.runtime.registry import RuntimeTarget
 
+API_406_CARRIER_CONTRACTS = {
+    "participant-lifecycle-event-v1",
+    "participant-observation-envelope-v1",
+    "participant-shared-state-record-v1",
+}
+
 
 def test_fixture_suite_passes_for_orchestration_evaluation_profile():
     report = run_fixture_suite(profile=BackendCapabilityProfile.ORCHESTRATION_EVALUATION)
@@ -59,6 +65,46 @@ def test_target_conformance_passes_for_stub_target():
                 f"Live participant probe case {case.name!r} must succeed for the stub backend; "
                 f"diagnostics: {[diag.message for diag in case.diagnostics]}"
             )
+
+
+def test_full_remote_control_plane_profile_requires_api_406_carriers():
+    contracts = required_contracts(BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE)
+
+    assert contracts >= API_406_CARRIER_CONTRACTS
+    assert {
+        "runtime-snapshot-v1",
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
+    } <= contracts
+
+
+def test_fixture_suite_validates_api_406_carrier_fixtures(tmp_path: Path):
+    backend_dir = tmp_path / "backend"
+    backend_dir.mkdir()
+    (backend_dir / "provisioning-only.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "backend-profile/v1",
+                "profile": "provisioning-only",
+                "required_contracts": sorted(API_406_CARRIER_CONTRACTS),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = run_fixture_suite(
+        profile=BackendCapabilityProfile.PROVISIONING_ONLY,
+        profiles_root=backend_dir,
+    )
+
+    assert report.passed is True
+    assert {case.contract_name for case in report.cases} == API_406_CARRIER_CONTRACTS
+    assert any(case.valid is False for case in report.cases)
+    assert all(
+        diagnostic.code != "conformance.contract-unknown" for case in report.cases for diagnostic in case.diagnostics
+    )
 
 
 def test_profile_is_inferred_as_full_when_manifest_declares_participant_runtime():
@@ -701,6 +747,9 @@ def test_target_conformance_fails_when_declared_contracts_do_not_cover_profile_r
         "participant-behavior-history-event-stream-v1",
         "participant-episode-history-event-stream-v1",
         "participant-episode-state-envelope-v1",
+        "participant-lifecycle-event-v1",
+        "participant-observation-envelope-v1",
+        "participant-shared-state-record-v1",
         "provisioning-plan-v1",
         "runtime-snapshot-v1",
         "workflow-history-event-stream-v1",


### PR DESCRIPTION
## Summary

Registers the API-406 participant carrier contracts with conformance validation and makes them part of the full remote control-plane backend profile.

## Requirement UIDs

- `API-406`

## Related Issues

Closes #200

## ADR Impact

- ADR-060

## Changes

- Require participant lifecycle-event, observation-envelope, and shared-state carrier contracts in the full remote control-plane backend profile.
- Register conformance validators for the API-406 carrier schema models.
- Add runtime-conformance tests for API-406 profile coverage and carrier fixture-suite validation.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Validated with targeted runtime-conformance tests, full runtime-conformance tests, pre-commit, repo-policy checks, verify_all, and the configured nox verify command. The requirement-governance command exited 0 while its Ground Control availability probe timed out and skipped.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: API-406 ← contracts/profiles/backend/full-remote-control-plane.json, API-406 ← implementations/python/packages/aces_conformance/conformance.py
- TESTS: API-406 ← implementations/python/tests/test_runtime_conformance.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/200.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
