### PR TITLE
added: expose API-408 participant retrieval views

### DIFF
--- a/changelog.d/202.added.md
+++ b/changelog.d/202.added.md
@@ -1,0 +1,1 @@
+Expose API-408 participant status, history, and reference/provenance context retrieval views through the runtime control plane and HTTP API.

--- a/implementations/python/packages/aces_runtime/control_plane.py
+++ b/implementations/python/packages/aces_runtime/control_plane.py
@@ -51,6 +51,7 @@ from .control_plane_store import (
 )
 from .control_plane_timeouts import workflow_timeout_update
 from .control_plane_workflows import maybe_apply_compensation
+from .participant_retrieval import ParticipantRetrievalMixin
 from .registry import RuntimeTarget
 
 _NO_PARTICIPANT_RUNTIME_MESSAGE = "Target does not provide a participant runtime."
@@ -66,7 +67,7 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-class RuntimeControlPlane:
+class RuntimeControlPlane(ParticipantRetrievalMixin):
     """Reference control plane for async runtime submission and observation."""
 
     def __init__(

--- a/implementations/python/packages/aces_runtime/control_plane_api.py
+++ b/implementations/python/packages/aces_runtime/control_plane_api.py
@@ -33,6 +33,7 @@ from .control_plane_api_models import (
     _request_fingerprint,
     _snapshot_model,
 )
+from .control_plane_api_participant_retrieval import register_participant_retrieval_routes
 from .control_plane_security import (
     ControlPlaneIdentity,
     ControlPlaneRole,
@@ -162,6 +163,7 @@ def create_control_plane_app(
     _register_operation_routes(app, control_plane)
     _register_workflow_routes(app, control_plane)
     _register_participant_episode_routes(app, control_plane)
+    register_participant_retrieval_routes(app, control_plane)
     return app
 
 

--- a/implementations/python/packages/aces_runtime/control_plane_api_participant_retrieval.py
+++ b/implementations/python/packages/aces_runtime/control_plane_api_participant_retrieval.py
@@ -1,0 +1,103 @@
+"""HTTP routes for API-408 participant retrieval views."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from aces_contracts.contracts import (
+    ParticipantContextViewModel,
+    ParticipantHistoryViewModel,
+    ParticipantStatusViewModel,
+)
+from fastapi import Depends, FastAPI, HTTPException, Request
+
+from .control_plane import RuntimeControlPlane
+from .control_plane_security import ControlPlaneIdentity
+
+_NOT_FOUND_RESPONSES = {404: {"description": "Not found"}}
+
+
+def _read_identity_dependency(request: Request) -> ControlPlaneIdentity:
+    return request.app.state.control_plane_api_auth.read_identity(request)
+
+
+_ReadIdentity = Annotated[ControlPlaneIdentity, Depends(_read_identity_dependency)]
+
+
+def register_participant_retrieval_routes(
+    app: FastAPI,
+    control_plane: RuntimeControlPlane,
+) -> None:
+    @app.get(
+        "/participants/{participant_address}/status",
+        responses=_NOT_FOUND_RESPONSES,
+    )
+    async def get_participant_status_view(
+        participant_address: str,
+        request: Request,
+        identity: _ReadIdentity,
+    ) -> ParticipantStatusViewModel:
+        view = control_plane.get_participant_status_view(participant_address)
+        if view is None:
+            raise HTTPException(status_code=404, detail=f"Unknown participant: {participant_address}")
+        control_plane.record_audit(
+            action="get_participant_status_view",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+        )
+        return view
+
+    @app.get(
+        "/participants/{participant_address}/episodes/{episode_id}/history",
+        responses=_NOT_FOUND_RESPONSES,
+    )
+    async def get_participant_history_view(
+        participant_address: str,
+        episode_id: str,
+        request: Request,
+        identity: _ReadIdentity,
+    ) -> ParticipantHistoryViewModel:
+        view = control_plane.get_participant_history_view(participant_address, episode_id)
+        if view is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Unknown participant episode: {participant_address}/{episode_id}",
+            )
+        control_plane.record_audit(
+            action="get_participant_history_view",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+        )
+        return view
+
+    @app.get(
+        "/participants/{participant_address}/context",
+        responses=_NOT_FOUND_RESPONSES,
+    )
+    async def get_participant_context_view(
+        participant_address: str,
+        view_ref: str,
+        request: Request,
+        identity: _ReadIdentity,
+        episode_id: str | None = None,
+        derivation_basis_ref: str | None = None,
+        payload_ref: str | None = None,
+    ) -> ParticipantContextViewModel:
+        view = control_plane.get_participant_context_view(
+            participant_address,
+            view_ref=view_ref,
+            episode_id=episode_id,
+            derivation_basis_ref=derivation_basis_ref,
+            payload_ref=payload_ref,
+        )
+        if view is None:
+            raise HTTPException(status_code=404, detail=f"Unknown participant: {participant_address}")
+        control_plane.record_audit(
+            action="get_participant_context_view",
+            identity=identity.identity,
+            allowed=True,
+            target=str(request.url.path),
+        )
+        return view

--- a/implementations/python/packages/aces_runtime/control_plane_execution.py
+++ b/implementations/python/packages/aces_runtime/control_plane_execution.py
@@ -36,12 +36,14 @@ def execute_participant_action(
         return existing
     operation_id = str(uuid4())
     submitted_at = _utc_now()
+    target_address = getattr(request, "participant_address", "")
     status = OperationStatus(
         operation_id=operation_id,
         domain=RuntimeDomain.PARTICIPANT,
         state=OperationState.RUNNING,
         submitted_at=submitted_at,
         updated_at=submitted_at,
+        changed_addresses=[target_address] if isinstance(target_address, str) and target_address else [],
     )
     receipt = OperationReceipt(
         operation_id=operation_id,

--- a/implementations/python/packages/aces_runtime/participant_retrieval.py
+++ b/implementations/python/packages/aces_runtime/participant_retrieval.py
@@ -1,0 +1,166 @@
+"""Participant retrieval projections for the runtime control plane."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+
+from aces_contracts.contracts import (
+    ParticipantContextViewModel,
+    ParticipantHistoryViewModel,
+    ParticipantStatusViewModel,
+)
+from aces_contracts.planning import RuntimeDomain
+from aces_contracts.runtime_state import OperationState, RuntimeSnapshot
+
+from .control_plane_store import ControlPlaneOperationRecord
+
+_CURRENT_SNAPSHOT_REF = "runtime.snapshot.current"
+
+
+class ParticipantRetrievalMixin:
+    """API-408 participant retrieval projections over recorded runtime state."""
+
+    _snapshot: RuntimeSnapshot
+    _operations: dict[str, ControlPlaneOperationRecord]
+
+    def get_participant_status_view(self, participant_address: str) -> ParticipantStatusViewModel | None:
+        if not _participant_exists(self._snapshot, participant_address):
+            return None
+        episode_state = self._snapshot.participant_episode_results.get(participant_address)
+        episode_id = _string_value(episode_state, "episode_id") if episode_state is not None else None
+        return ParticipantStatusViewModel.model_validate(
+            {
+                "view_id": _view_id("status", participant_address, episode_id),
+                "participant_address": participant_address,
+                "episode_id": episode_id,
+                "generated_at": _utc_now(),
+                "source_snapshot_ref": _CURRENT_SNAPSHOT_REF,
+                "episode_state": _project_scope(episode_state) if episode_state is not None else None,
+                "open_operation_refs": _open_participant_operation_refs(self._operations, participant_address),
+                "visibility_projection_ref": _visibility_projection_ref(participant_address, "status"),
+                "marking_definition_refs": [],
+                "redaction_policy_ref": None,
+            }
+        )
+
+    def get_participant_history_view(
+        self,
+        participant_address: str,
+        episode_id: str,
+    ) -> ParticipantHistoryViewModel | None:
+        if not _participant_episode_exists(self._snapshot, participant_address, episode_id):
+            return None
+        episode_history = [
+            _project_scope(event)
+            for event in self._snapshot.participant_episode_history.get(participant_address, [])
+            if event.get("episode_id") == episode_id
+        ]
+        behavior_history = [
+            _project_scope(event)
+            for event in self._snapshot.participant_behavior_history.get(participant_address, [])
+            if event.get("episode_id") == episode_id
+        ]
+        return ParticipantHistoryViewModel.model_validate(
+            {
+                "view_id": _view_id("history", participant_address, episode_id),
+                "participant_address": participant_address,
+                "episode_id": episode_id,
+                "generated_at": _utc_now(),
+                "source_snapshot_ref": _CURRENT_SNAPSHOT_REF,
+                "episode_history": episode_history,
+                "behavior_history": behavior_history,
+                "visibility_projection_ref": _visibility_projection_ref(participant_address, "history"),
+                "redaction_policy_ref": None,
+                "completeness": "complete",
+                "completeness_basis": None,
+                "marking_definition_refs": [],
+            }
+        )
+
+    def get_participant_context_view(
+        self,
+        participant_address: str,
+        *,
+        view_ref: str,
+        episode_id: str | None = None,
+        derivation_basis_ref: str | None = None,
+        payload_ref: str | None = None,
+        derived_from_refs: tuple[str, ...] = (),
+    ) -> ParticipantContextViewModel | None:
+        if episode_id is not None:
+            if not _participant_episode_exists(self._snapshot, participant_address, episode_id):
+                return None
+        elif not _participant_exists(self._snapshot, participant_address):
+            return None
+        return ParticipantContextViewModel.model_validate(
+            {
+                "view_id": _view_id("context", participant_address, episode_id or view_ref),
+                "participant_address": participant_address,
+                "episode_id": episode_id,
+                "generated_at": _utc_now(),
+                "source_snapshot_ref": _CURRENT_SNAPSHOT_REF,
+                "view_ref": view_ref,
+                "derived_from_refs": list(derived_from_refs or (_CURRENT_SNAPSHOT_REF,)),
+                "derivation_basis_ref": derivation_basis_ref,
+                "payload_ref": payload_ref,
+                "visibility_projection_ref": _visibility_projection_ref(participant_address, "context"),
+                "marking_definition_refs": [],
+                "redaction_policy_ref": None,
+            }
+        )
+
+
+def _string_value(payload: dict[str, object] | None, key: str) -> str | None:
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _participant_exists(snapshot: RuntimeSnapshot, participant_address: str) -> bool:
+    return (
+        participant_address in snapshot.participant_episode_results
+        or participant_address in snapshot.participant_episode_history
+        or participant_address in snapshot.participant_behavior_history
+    )
+
+
+def _participant_episode_exists(snapshot: RuntimeSnapshot, participant_address: str, episode_id: str) -> bool:
+    episode_state = snapshot.participant_episode_results.get(participant_address)
+    if _string_value(episode_state, "episode_id") == episode_id:
+        return True
+    histories = (
+        snapshot.participant_episode_history.get(participant_address, []),
+        snapshot.participant_behavior_history.get(participant_address, []),
+    )
+    return any(event.get("episode_id") == episode_id for history in histories for event in history)
+
+
+def _project_scope(payload: dict[str, object]) -> dict[str, object]:
+    return {key: value for key, value in payload.items() if key not in {"participant_address", "episode_id"}}
+
+
+def _open_participant_operation_refs(
+    operations: Mapping[str, ControlPlaneOperationRecord],
+    participant_address: str,
+) -> list[str]:
+    return [
+        operation_id
+        for operation_id, record in sorted(operations.items())
+        if record.status.domain == RuntimeDomain.PARTICIPANT
+        and record.status.state in {OperationState.ACCEPTED, OperationState.RUNNING}
+        and participant_address in record.status.changed_addresses
+    ]
+
+
+def _view_id(kind: str, participant_address: str, suffix: str | None) -> str:
+    return f"runtime.participant-view.{kind}.{participant_address}.{suffix or 'current'}"
+
+
+def _visibility_projection_ref(participant_address: str, kind: str) -> str:
+    return f"runtime.visibility-projection.{kind}.{participant_address}.v1"

--- a/implementations/python/tests/test_runtime_control_plane.py
+++ b/implementations/python/tests/test_runtime_control_plane.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 import textwrap
 
 from aces_backend_stubs.stubs import create_stub_components, create_stub_manifest
+from aces_contracts.contracts import (
+    ParticipantContextViewModel,
+    ParticipantHistoryViewModel,
+    ParticipantStatusViewModel,
+)
+from aces_contracts.runtime_state import RuntimeSnapshot
 from aces_processor.models import iter_participant_episode_snapshot_violations
 
 from aces.backends.stubs import create_stub_target
 from aces.core.runtime.compiler import compile_runtime_model
 from aces.core.runtime.control_plane import RuntimeControlPlane
+from aces.core.runtime.control_plane_store import ControlPlaneOperationRecord
 from aces.core.runtime.models import (
+    OperationReceipt,
     OperationState,
+    OperationStatus,
     ParticipantEpisodeTerminalReason,
     RuntimeDomain,
 )
@@ -22,6 +31,66 @@ from aces.core.sdl import parse_sdl
 
 def _scenario(yaml_str: str):
     return parse_sdl(textwrap.dedent(yaml_str))
+
+
+def _episode_state(participant_address: str, episode_id: str) -> dict[str, object]:
+    return {
+        "state_schema_version": "participant-episode-state/v1",
+        "participant_address": participant_address,
+        "episode_id": episode_id,
+        "sequence_number": 0,
+        "status": "running",
+        "terminal_reason": None,
+        "initialized_at": "2026-06-05T10:00:00Z",
+        "updated_at": "2026-06-05T10:00:00Z",
+        "terminated_at": None,
+        "last_control_action": "initialize",
+        "previous_episode_id": None,
+    }
+
+
+def _episode_history_event(participant_address: str, episode_id: str) -> dict[str, object]:
+    return {
+        "event_type": "episode_running",
+        "timestamp": "2026-06-05T10:00:00Z",
+        "participant_address": participant_address,
+        "episode_id": episode_id,
+        "sequence_number": 0,
+        "terminal_reason": None,
+        "control_action": None,
+        "details": {},
+    }
+
+
+def _behavior_history_event(participant_address: str, episode_id: str) -> dict[str, object]:
+    return {
+        "event_type": "action_attempted",
+        "timestamp": "2026-06-05T10:00:01Z",
+        "participant_address": participant_address,
+        "episode_id": episode_id,
+        "action_instance_id": f"{participant_address}.action-1",
+        "details": {},
+    }
+
+
+def _participant_operation_record(operation_id: str, participant_address: str) -> ControlPlaneOperationRecord:
+    submitted_at = "2026-06-05T10:00:00Z"
+    return ControlPlaneOperationRecord(
+        receipt=OperationReceipt(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            submitted_at=submitted_at,
+            accepted=True,
+        ),
+        status=OperationStatus(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            state=OperationState.RUNNING,
+            submitted_at=submitted_at,
+            updated_at=submitted_at,
+            changed_addresses=[participant_address],
+        ),
+    )
 
 
 def test_control_plane_submits_provisioning_and_updates_snapshot():
@@ -299,3 +368,105 @@ class TestParticipantEpisodeControlPlane:
             "episode_initialized",
             "episode_running",
         ]
+
+    def test_status_view_projects_current_participant_episode_state(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        view = control_plane.get_participant_status_view("participant.alice")
+
+        assert isinstance(view, ParticipantStatusViewModel)
+        assert view.participant_address == "participant.alice"
+        assert view.episode_id == "participant.alice-episode-1"
+        assert view.source_snapshot_ref == "runtime.snapshot.current"
+        assert view.episode_state is not None
+        assert view.episode_state.status == "running"
+        episode_state = view.episode_state.model_dump(mode="json")
+        assert "participant_address" not in episode_state
+        assert "episode_id" not in episode_state
+
+    def test_status_view_scopes_open_operations_to_participant(self):
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": _episode_state("participant.alice", "episode-1"),
+                "participant.bob": _episode_state("participant.bob", "episode-1"),
+            }
+        )
+        control_plane = RuntimeControlPlane(create_stub_target(), initial_snapshot=snapshot)
+        control_plane._operations = {
+            "op-alice": _participant_operation_record("op-alice", "participant.alice"),
+            "op-bob": _participant_operation_record("op-bob", "participant.bob"),
+        }
+
+        view = control_plane.get_participant_status_view("participant.alice")
+
+        assert view is not None
+        assert view.open_operation_refs == ["op-alice"]
+
+    def test_history_view_filters_to_one_participant_episode_and_projects_scope(self):
+        snapshot = RuntimeSnapshot(
+            participant_episode_results={
+                "participant.alice": _episode_state("participant.alice", "episode-1"),
+                "participant.bob": _episode_state("participant.bob", "episode-1"),
+            },
+            participant_episode_history={
+                "participant.alice": [
+                    _episode_history_event("participant.alice", "episode-1"),
+                    _episode_history_event("participant.alice", "episode-2"),
+                ],
+                "participant.bob": [_episode_history_event("participant.bob", "episode-1")],
+            },
+            participant_behavior_history={
+                "participant.alice": [
+                    _behavior_history_event("participant.alice", "episode-1"),
+                    _behavior_history_event("participant.alice", "episode-2"),
+                ],
+                "participant.bob": [_behavior_history_event("participant.bob", "episode-1")],
+            },
+        )
+        control_plane = RuntimeControlPlane(create_stub_target(), initial_snapshot=snapshot)
+
+        view = control_plane.get_participant_history_view("participant.alice", "episode-1")
+
+        assert isinstance(view, ParticipantHistoryViewModel)
+        assert view.participant_address == "participant.alice"
+        assert view.episode_id == "episode-1"
+        assert view.completeness == "complete"
+        assert len(view.episode_history) == 1
+        assert len(view.behavior_history) == 1
+        for event in [*view.episode_history, *view.behavior_history]:
+            payload = event.model_dump(mode="json")
+            assert "participant_address" not in payload
+            assert "episode_id" not in payload
+
+    def test_context_view_is_reference_and_provenance_only(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode("participant.alice")
+
+        view = control_plane.get_participant_context_view(
+            "participant.alice",
+            view_ref="views.context.network-posture.v1",
+            episode_id="participant.alice-episode-1",
+            derivation_basis_ref="rules.context.network-posture.v1",
+            payload_ref="evidence.context.alice.network-posture",
+        )
+
+        assert isinstance(view, ParticipantContextViewModel)
+        assert view.participant_address == "participant.alice"
+        assert view.episode_id == "participant.alice-episode-1"
+        assert view.view_ref == "views.context.network-posture.v1"
+        assert view.derived_from_refs == ["runtime.snapshot.current"]
+        assert view.payload_ref == "evidence.context.alice.network-posture"
+
+    def test_participant_retrieval_views_return_none_for_unknown_participant(self):
+        control_plane = RuntimeControlPlane(create_stub_target())
+
+        assert control_plane.get_participant_status_view("participant.unknown") is None
+        assert control_plane.get_participant_history_view("participant.unknown", "episode-1") is None
+        assert (
+            control_plane.get_participant_context_view(
+                "participant.unknown",
+                view_ref="views.context.network-posture.v1",
+            )
+            is None
+        )

--- a/implementations/python/tests/test_runtime_control_plane_api.py
+++ b/implementations/python/tests/test_runtime_control_plane_api.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+from aces_contracts.contracts import (
+    ParticipantContextViewModel,
+    ParticipantHistoryViewModel,
+    ParticipantStatusViewModel,
+)
 from starlette.testclient import TestClient
 
 from aces.backends.stubs import create_stub_target
@@ -16,13 +21,34 @@ from aces.core.runtime.control_plane_security import (
     ControlPlaneRole,
     ControlPlaneSecurityConfig,
 )
-from aces.core.runtime.control_plane_store import LocalControlPlaneStore
+from aces.core.runtime.control_plane_store import ControlPlaneOperationRecord, LocalControlPlaneStore
+from aces.core.runtime.models import OperationReceipt, OperationState, OperationStatus, RuntimeDomain
 from aces.core.runtime.planner import plan
 from aces.core.sdl import parse_sdl
 
 
 def _scenario(yaml_str: str):
     return parse_sdl(textwrap.dedent(yaml_str))
+
+
+def _participant_operation_record(operation_id: str, participant_address: str) -> ControlPlaneOperationRecord:
+    submitted_at = "2026-06-05T10:00:00Z"
+    return ControlPlaneOperationRecord(
+        receipt=OperationReceipt(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            submitted_at=submitted_at,
+            accepted=True,
+        ),
+        status=OperationStatus(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            state=OperationState.RUNNING,
+            submitted_at=submitted_at,
+            updated_at=submitted_at,
+            changed_addresses=[participant_address],
+        ),
+    )
 
 
 def _test_security(target_name: str, *, max_request_bytes: int = 1_000_000) -> ControlPlaneSecurityConfig:
@@ -101,6 +127,10 @@ def test_control_plane_api_openapi_documents_explicit_error_responses():
     ]
     assert "400" in terminate_responses
     assert "409" in terminate_responses
+    assert "404" in operation_responses["/participants/{participant_address}/status"]["get"]["responses"]
+    history_path = "/participants/{participant_address}/episodes/{episode_id}/history"
+    assert "404" in operation_responses[history_path]["get"]["responses"]
+    assert "404" in operation_responses["/participants/{participant_address}/context"]["get"]["responses"]
 
 
 def test_control_plane_api_accepts_orchestration_plan_and_exposes_snapshot():
@@ -440,12 +470,22 @@ workflows:
             },
             headers=headers,
         )
+        workflow_address = "orchestration.workflow.response"
+        seeded = dict(control_plane._snapshot.orchestration_results[workflow_address])
+        seeded["started_at"] = "2000-01-01T00:00:00Z"
+        seeded["updated_at"] = "2000-01-01T00:00:01Z"
+        control_plane._snapshot = control_plane._snapshot.with_entries(
+            dict(control_plane._snapshot.entries),
+            orchestration_results={
+                **control_plane._snapshot.orchestration_results,
+                workflow_address: seeded,
+            },
+        )
         reconcile = client.post(
             "/workflows/reconcile-timeouts",
             headers=headers,
         )
         assert reconcile.status_code == 200
-        control_plane.reconcile_workflow_timeouts(now="2099-01-01T00:00:00Z")
         snapshot = client.get("/snapshot", headers=headers).json()
 
     result = snapshot["orchestration_results"]["orchestration.workflow.response"]
@@ -833,3 +873,114 @@ class TestParticipantEpisodeHttpRoutes:
             json={"episode_id": "alice-1", "unknown": "value"},
         )
         assert response.status_code == 422
+
+    def test_status_route_returns_api_408_status_view(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.get(
+            "/participants/participant.alice/status",
+            headers=self._headers,
+        )
+
+        assert response.status_code == 200
+        view = ParticipantStatusViewModel.model_validate(response.json())
+        assert view.participant_address == "participant.alice"
+        assert view.episode_id == "participant.alice-episode-1"
+        assert view.episode_state is not None
+        assert view.episode_state.status == "running"
+
+    def test_status_route_scopes_open_operations_to_participant(self):
+        target = create_stub_target()
+        control_plane = RuntimeControlPlane(target)
+        control_plane.initialize_participant_episode("participant.alice")
+        control_plane.initialize_participant_episode("participant.bob")
+        control_plane._operations = {
+            "op-alice": _participant_operation_record("op-alice", "participant.alice"),
+            "op-bob": _participant_operation_record("op-bob", "participant.bob"),
+        }
+        client = TestClient(
+            create_control_plane_app(
+                control_plane,
+                security=_test_security(target.name),
+            )
+        )
+
+        response = client.get(
+            "/participants/participant.alice/status",
+            headers=self._headers,
+        )
+
+        assert response.status_code == 200
+        view = ParticipantStatusViewModel.model_validate(response.json())
+        assert view.open_operation_refs == ["op-alice"]
+
+    def test_history_route_returns_api_408_history_view(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.get(
+            "/participants/participant.alice/episodes/participant.alice-episode-1/history",
+            headers=self._headers,
+        )
+
+        assert response.status_code == 200
+        view = ParticipantHistoryViewModel.model_validate(response.json())
+        assert view.participant_address == "participant.alice"
+        assert view.episode_id == "participant.alice-episode-1"
+        assert [event.event_type for event in view.episode_history] == [
+            "episode_initialized",
+            "episode_running",
+        ]
+        assert view.completeness == "complete"
+
+    def test_context_route_returns_api_408_reference_view(self):
+        client = self._build_client()
+        client.post(
+            "/participants/participant.alice/episodes/initialize",
+            headers=self._headers,
+            json={},
+        )
+
+        response = client.get(
+            "/participants/participant.alice/context",
+            params={
+                "view_ref": "views.context.network-posture.v1",
+                "episode_id": "participant.alice-episode-1",
+                "payload_ref": "evidence.context.alice.network-posture",
+            },
+            headers=self._headers,
+        )
+
+        assert response.status_code == 200
+        view = ParticipantContextViewModel.model_validate(response.json())
+        assert view.participant_address == "participant.alice"
+        assert view.view_ref == "views.context.network-posture.v1"
+        assert view.derived_from_refs == ["runtime.snapshot.current"]
+        assert view.payload_ref == "evidence.context.alice.network-posture"
+
+    def test_retrieval_routes_return_404_for_unknown_participants(self):
+        client = self._build_client()
+
+        status = client.get("/participants/participant.unknown/status", headers=self._headers)
+        history = client.get(
+            "/participants/participant.unknown/episodes/episode-1/history",
+            headers=self._headers,
+        )
+        context = client.get(
+            "/participants/participant.unknown/context",
+            params={"view_ref": "views.context.network-posture.v1"},
+            headers=self._headers,
+        )
+
+        assert status.status_code == 404
+        assert history.status_code == 404
+        assert context.status_code == 404


### PR DESCRIPTION
## Summary

Expose participant status, history, and context retrieval views through the runtime control plane and authenticated HTTP API using the published API-408 contract models.

## Requirement UIDs

- `API-408`

## Related Issues

Closes #202

## ADR Impact

- No ADR required

## Changes

- Add runtime participant retrieval projections over recorded snapshot state and participant operation records.
- Register authenticated HTTP GET routes for participant status, episode history, and reference/provenance context views.
- Scope open participant operation refs to the requested participant and cover the API/control-plane retrieval behavior with regression tests.
- Tighten the workflow timeout API test so the HTTP route drives the observed reconciliation.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pre-commit run --all-files; ACES_REQUIREMENT_UID=API-408 implementations/python/.venv/bin/python tools/verify_all.py --requirement-uid API-408; targeted runtime/API/participant suites passed. Requirement governance timed out in local nox and was skipped by the repo gate.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: API-408 ← implementations/python/packages/aces_runtime/participant_retrieval.py, API-408 ← implementations/python/packages/aces_runtime/control_plane_api_participant_retrieval.py, API-408 ← implementations/python/packages/aces_runtime/control_plane.py, API-408 ← implementations/python/packages/aces_runtime/control_plane_api.py, API-408 ← implementations/python/packages/aces_runtime/control_plane_execution.py
- TESTS: API-408 ← implementations/python/tests/test_runtime_control_plane.py, API-408 ← implementations/python/tests/test_runtime_control_plane_api.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/202.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
