### PR TITLE
changed: require API-411 outcome state relationships

### DIFF
--- a/changelog.d/203.changed.md
+++ b/changelog.d/203.changed.md
@@ -1,0 +1,1 @@
+Require API-411 participant outcome reports to carry at least one explicit state relationship in the published contract model and generated schema.

--- a/contracts/fixtures/participant-runtime/participant-outcome-report-v1/invalid/empty-state-relationships.json
+++ b/contracts/fixtures/participant-runtime/participant-outcome-report-v1/invalid/empty-state-relationships.json
@@ -1,0 +1,71 @@
+{
+  "event_id": "outcome-red-17",
+  "schema_name": "aces.participant_runtime.outcome_report",
+  "schema_version": "1.0.0",
+  "event_type": "outcome_report",
+  "extension_policy": "reject_unknown_required",
+  "event_classification": null,
+  "source_status": {
+    "status_id": 1,
+    "status": "success",
+    "status_code": "outcome_interpreted",
+    "status_detail": "interpretation rule grounded the outcome in recorded sources",
+    "source_status_label": "outcome_interpreted",
+    "source_status_mapping": "aces.outcome.interpreted"
+  },
+  "participant_address": "participants.red.llm",
+  "episode_id": "ep-red-004",
+  "sequence_number": 19,
+  "occurred_at": "2026-05-26T10:15:05Z",
+  "recorded_at": "2026-05-26T10:15:06Z",
+  "ingested_at": "2026-05-26T10:15:06Z",
+  "clock_authority": "backend.logical_clock.red-range",
+  "temporal_context": "tick-118",
+  "ordering_basis": "logical_clock",
+  "logical_order_ref": "order.red.118.19",
+  "predecessor_event_refs": ["evt-llm-17-exec"],
+  "actor_ref": "runtime.outcome-interpreter",
+  "producer_ref": "adapters.llm-tool-runtime.v2",
+  "source_system_ref": "tool-gateway.red",
+  "source_record_ref": "gateway-call-992",
+  "source_raw_ref": null,
+  "source_pipeline": {
+    "product_ref": "products.tool-gateway.red",
+    "product_version": "2.4.1",
+    "log_provider": "tool-gateway",
+    "log_source": "tool-gateway.red",
+    "log_name": "outcome-report",
+    "original_event_uid": "gateway-call-992",
+    "original_time": "2026-05-26T10:15:01Z",
+    "processed_time": "2026-05-26T10:15:06Z",
+    "logged_time": "2026-05-26T10:15:06Z",
+    "transmit_time": "2026-05-26T10:15:06Z",
+    "correlation_uid": "corr-tool-call-992",
+    "sequence": 993
+  },
+  "raw_data_integrity": {
+    "raw_data_hash": null,
+    "raw_data_hash_algorithm": null,
+    "raw_data_size": null,
+    "raw_data_is_truncated": null,
+    "raw_data_untruncated_size": null
+  },
+  "confidence": 0.9,
+  "provenance_refs": ["provenance.backend_realized"],
+  "evidence_refs": ["evidence.tool-call-992-redacted"],
+  "marking_definition_refs": ["markings.internal.v1"],
+  "object_marking_refs": ["markings.internal.v1"],
+  "markings": ["internal"],
+  "granular_markings": {},
+  "redaction_policy_ref": "redaction.no-prompts-or-secrets.v1",
+  "authorization_scope": "runtime_review",
+  "outcome_id": "outcomes.red.exfiltration.17",
+  "interpretation_rule_ref": "rules.outcome.exfiltration.v1",
+  "outcome_sources": [
+    {
+      "source_kind": "action_result",
+      "source_ref": "results.red.act-17"
+    }
+  ],
+  "state_relationships": []
+}

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -198,10 +198,10 @@
       "contract_id": "participant-outcome-report-v1",
       "schema_path": "contracts/schemas/participant-runtime/participant-outcome-report-v1.json",
       "stability": "draft",
-      "content_hash": "1b65d36136812ae18c80ba7822df69b0ca65b569fd4cc2e2bd6c1fd07e5e4abf",
+      "content_hash": "e7c8cb7fa41803e16c7fd99f71365621cce9e1cf21f13701c8d482cc030dcea7",
       "last_change": {
-        "summary": "Initial publication of the participant outcome-report runtime contract: participant outcome reporting in the backend-facing contract family (ADR-060, issue #76).",
-        "content_hash": "1b65d36136812ae18c80ba7822df69b0ca65b569fd4cc2e2bd6c1fd07e5e4abf"
+        "summary": "Require participant outcome reports to carry at least one explicit state relationship for API-411.",
+        "content_hash": "e7c8cb7fa41803e16c7fd99f71365621cce9e1cf21f13701c8d482cc030dcea7"
       }
     },
     {

--- a/contracts/schemas/participant-runtime/participant-outcome-report-v1.json
+++ b/contracts/schemas/participant-runtime/participant-outcome-report-v1.json
@@ -747,6 +747,7 @@
       "items": {
         "$ref": "#/$defs/ParticipantOutcomeReportStateRelationshipModel"
       },
+      "minItems": 1,
       "title": "State Relationships",
       "type": "array"
     },
@@ -780,7 +781,8 @@
     "authorization_scope",
     "outcome_id",
     "interpretation_rule_ref",
-    "outcome_sources"
+    "outcome_sources",
+    "state_relationships"
   ],
   "title": "ParticipantOutcomeReportModel",
   "type": "object"

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -1401,7 +1401,7 @@ class ParticipantOutcomeReportModel(ParticipantRuntimeBaseEnvelopeModel):
     outcome_id: NonEmptyString
     interpretation_rule_ref: NonEmptyString
     outcome_sources: list[ParticipantOutcomeReportSourceModel] = Field(min_length=1)
-    state_relationships: list[ParticipantOutcomeReportStateRelationshipModel] = Field(default_factory=list)
+    state_relationships: list[ParticipantOutcomeReportStateRelationshipModel] = Field(min_length=1)
 
 
 class ParticipantStatusViewEpisodeStateModel(ContractModel):

--- a/implementations/python/tests/test_participant_backend_contracts.py
+++ b/implementations/python/tests/test_participant_backend_contracts.py
@@ -140,6 +140,15 @@ def test_participant_outcome_report_publishes_no_score_or_reward_surface():
     source_schema = schema["$defs"]["ParticipantOutcomeReportSourceModel"]
     assert source_schema["properties"]["source_kind"]["enum"] == ["action_result", "episode_status", "evidence"]
     assert schema["properties"]["outcome_sources"]["minItems"] == 1
+    assert schema["properties"]["state_relationships"]["minItems"] == 1
+
+
+def test_participant_outcome_report_requires_state_relationships():
+    payload = _valid_fixture("participant-outcome-report-v1")
+    payload["state_relationships"] = []
+
+    with pytest.raises(ValidationError, match="state_relationships"):
+        ParticipantOutcomeReportModel.model_validate(payload)
 
 
 def test_participant_history_view_schema_requires_completeness_basis_when_not_complete():


### PR DESCRIPTION
## Summary

Tightens the API-411 participant outcome report contract so every report must carry at least one explicit state relationship, matching the participant-backend contract design and architecture preflight guardrails.

## Requirement UIDs

- `API-411`

## Related Issues

Closes #203

## ADR Impact

- ADR-060
- ADR-022
- ADR-054

## Changes

- Require `ParticipantOutcomeReportModel.state_relationships` to be non-empty.
- Regenerate `participant-outcome-report-v1` so the published schema requires `state_relationships` with `minItems: 1`.
- Add an invalid empty-state-relationships fixture and focused tests proving model and schema enforcement.
- Update the schema publication manifest ledger and add a changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused participant backend contract tests passed. `verify_all.py`, pre-commit, and the configured nox verify gate passed with `ACES_REQUIREMENT_UID=API-411`; requirement governance reached its documented Ground Control timeout-skip path but exited successfully.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: API-411 <- implementations/python/packages/aces_contracts/contracts.py, API-411 <- contracts/schemas/participant-runtime/participant-outcome-report-v1.json, API-411 <- contracts/schema-publication-manifest.json
- TESTS: API-411 <- implementations/python/tests/test_participant_backend_contracts.py, API-411 <- contracts/fixtures/participant-runtime/participant-outcome-report-v1/invalid/empty-state-relationships.json

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/203.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
