### PR TITLE
added: experiment-capture-spec negative conformance coverage for EXP-707

### DIFF
--- a/changelog.d/233.added.md
+++ b/changelog.d/233.added.md
@@ -1,0 +1,1 @@
+Add negative conformance coverage and an invalid fixture for the EXP-707 experiment-capture-spec-v1 contract: a dedicated rejection test exercising the capture-requirement key-equality, window-reference resolution, capture-window time-ordering, and under-specified-window invariants, plus a schema-and-model invalid fixture for a window that declares no start, end, or trigger.

--- a/contracts/fixtures/experiment-core/experiment-capture-spec-v1/invalid/under-specified-capture-window.json
+++ b/contracts/fixtures/experiment-core/experiment-capture-spec-v1/invalid/under-specified-capture-window.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "experiment-capture-spec/v1",
+  "capture_spec_id": "capture-techvault-evidence-v1",
+  "spec_version": "1.0.0",
+  "title": "TechVault evidence capture specification",
+  "description": "Invalid capture spec whose capture window declares no start, end, or trigger.",
+  "scope_refs": [
+    {
+      "ref_kind": "task",
+      "ref_id": "task-techvault-red-team-v1",
+      "ref_version": "1.0.0"
+    }
+  ],
+  "capture_windows": [
+    {
+      "window_id": "run-window",
+      "window_kind": "run",
+      "description": "Window with no start, end, or trigger declared."
+    }
+  ],
+  "capture_requirements": {
+    "network-trace": {
+      "requirement_id": "network-trace",
+      "title": "Network trace evidence",
+      "capture_kind": "trace",
+      "capture_scope": "network",
+      "channel_ref": {
+        "ref_kind": "measurement-channel",
+        "ref_id": "evaluation-history-channel",
+        "ref_version": "1.0.0"
+      },
+      "window_refs": [
+        "run-window"
+      ],
+      "expected_media_types": [
+        "application/json"
+      ],
+      "required_artifact_roles": [
+        "observation"
+      ],
+      "sensitivity": "internal",
+      "integrity_requirements": [
+        "sha256-digest"
+      ],
+      "retention_policy": "Retain raw evidence for the experiment review window.",
+      "loss_disclosure_required": true
+    }
+  }
+}

--- a/docs/research/experiment-core/index.md
+++ b/docs/research/experiment-core/index.md
@@ -15,4 +15,5 @@ design-criteria-for-exp-701-705
 traceability-matrix-exp-701-705
 preflight-guardrails
 issue-88-evidence-measure-preflight-guardrails
+issue-233-exp-707-capture-spec-preflight-guardrails
 ```

--- a/docs/research/experiment-core/issue-233-exp-707-capture-spec-preflight-guardrails.md
+++ b/docs/research/experiment-core/issue-233-exp-707-capture-spec-preflight-guardrails.md
@@ -1,0 +1,133 @@
+# Issue #233 EXP-707 Capture Specification Preflight Guardrails
+
+Date: 2026-06-22
+
+Issue: #233.
+
+Requirement: EXP-707.
+
+This preflight narrows the issue #88 evidence and measure boundary to the
+capture-specification work for EXP-707. ADR-064 and
+`specs/formal/experiment-core/README.md` remain the normative design authority.
+This note is guidance for implementation only.
+
+## Architecture Decisions
+
+- Treat `experiment-capture-spec-v1` as declarative intent: it records what
+  evidence should be captured, over what scope and window, with sensitivity,
+  integrity, retention, redaction, and loss-disclosure expectations.
+- Keep capture specifications distinct from scenario-internal logging,
+  monitoring setup, raw evidence records, derived measures, run summaries, and
+  backend observation capability claims.
+- Reuse the existing schema-first contract surface in
+  `aces_contracts.contracts`; do not add a second capture-spec schema, parser,
+  registry, or validation stack.
+- Keep EXP-707 out of live runtime state. A capture spec may reference a task,
+  run, apparatus context, participant, backend, processor, network, or service
+  scope, but it must not mutate `RuntimeSnapshot`, `ControlPlaneStore`, or
+  scenario runtime configuration.
+- Future capture backends, retention stores, APIs, and capture success records
+  are separate work. EXP-707 is only the specification surface.
+
+## Required Incumbents
+
+- Contract source:
+  `implementations/python/packages/aces_contracts/contracts.py`, especially
+  `ContractModel`, `ExperimentCaptureSpecModel`,
+  `ExperimentCaptureRequirementModel`, `ExperimentCaptureWindowModel`,
+  `ExperimentMeasurementChannelReferenceModel`, and
+  `ExperimentReferenceModel`.
+- Published schemas:
+  `schema_bundle()`, `tools/generate_contract_schemas.py`,
+  `contracts/schemas/experiment-core/experiment-capture-spec-v1.json`, and
+  `contracts/schema-publication-manifest.json`.
+- Fixture and conformance corpus:
+  `contracts/fixtures/experiment-core/experiment-capture-spec-v1/` and the
+  experiment-core schema tests in `implementations/python/tests/`.
+- Semantic invariants:
+  `x-aces-invariants` entries for capture requirement key equality, capture
+  window resolution, and capture window time ordering.
+- Adjacent concept boundaries:
+  `experiment-evidence-record-v1` for raw captured evidence,
+  `experiment-derived-measure-v1` for interpreted outputs,
+  `experiment-run-v1` evidence artifacts for archival run summaries, and
+  `backend-manifest-v2` `capabilities.observation` for backend support claims.
+- If any API surface is added later:
+  `aces_runtime.control_plane_api`, `control_plane_api_guards`,
+  `control_plane_security`, request fingerprints, audit events, response
+  models, and redacted error handling.
+
+## Cross-Cutting Layers
+
+- Structural validation: every external payload must pass closed-world
+  Pydantic `ContractModel` validation and the generated draft 2020-12 JSON
+  Schema. Unknown fields remain errors.
+- Semantic validation: capture requirement map keys must match embedded
+  `requirement_id` values; every `window_refs` value must resolve to a
+  declared capture window; each window must declare a start, end, or trigger;
+  and windows with both timestamps must not end before they start.
+- Reference shape: use typed `ExperimentReferenceModel` variants and existing
+  reference-kind constraints. Do not encode scope or channel meaning in
+  free-form strings when a typed reference already exists.
+- Security and redaction: capture specs may declare sensitivity, redaction
+  policy, retention policy, and loss-disclosure expectations, but must not
+  carry real credentials, bearer tokens, private keys, environment dumps, raw
+  process argv, backend-private payloads, or full tracebacks in fields,
+  fixtures, diagnostics, logs, or examples.
+- API/auth surface: if a capture-spec endpoint is later introduced, mutating
+  requests must use the existing control-plane identity and role checks,
+  request-size guard, idempotency fingerprint, audit logging, closed DTOs, and
+  redacted FastAPI error envelope. Do not create a capture-specific auth or
+  error stack.
+- Persistence: do not put capture specs in `RuntimeSnapshot.metadata`, operation
+  records, participant histories, or backend-private logs. Any future durable
+  store must preserve schema-versioned artifacts and avoid treating the current
+  in-memory control-plane store as archival experiment persistence.
+- OS-level exposure: command-line helpers and examples must not pass secrets or
+  captured raw payloads through process arguments. Use checked-in fixtures with
+  synthetic data and content references with checksums.
+- Governance: schema changes must update the contract source, regenerate
+  schemas through `schema_bundle()`, preserve fixture coverage, and update the
+  schema publication manifest when published schema hashes change.
+
+## Extensibility Guardrail
+
+The extension point belongs in declared capture dimensions, not in new
+parallel surfaces. Preserve and extend the existing parameters:
+`capture_kind`, `capture_scope`, `channel_ref`, `window_refs`,
+`expected_media_types`, `required_artifact_roles`, `sensitivity`,
+`redaction_policy`, `integrity_requirements`, `retention_policy`, and
+`loss_disclosure_required`. New portable vocabulary should go through concept
+authority only when comparison or backend capability claims depend on bounded
+terms.
+
+## Gotchas And Anti-Patterns
+
+- Do not treat a capture spec as proof that evidence was captured.
+- Do not put metric values, scores, evaluation decisions, or derived summaries
+  in a capture spec.
+- Do not collapse capture specs, evidence records, and derived measures into a
+  single blob.
+- Do not duplicate task observation requirements or run evidence artifacts as a
+  second source of truth. Capture specs may reference those artifacts or
+  requirements but must not redefine their contracts.
+- Do not infer capture scope from scenario logging configuration, monitoring
+  declarations, backend defaults, or participant observation history.
+- Do not add new SDL root sections or scenario syntax for EXP-707 without a new
+  ADR.
+- Do not hand-edit `contracts/schemas/`.
+- Do not create new exception hierarchies, logging stacks, audit formats,
+  schema registries, persistence stores, or workflow logic for this issue.
+
+## Non-Goals
+
+- Runtime evidence capture, packet/log collection, telemetry streaming, and
+  storage retention implementation.
+- HTTP APIs, schedulers, workers, or background capture orchestration.
+- Raw evidence publication, redaction execution, loss accounting, chain of
+  custody, and derived-measure computation.
+- Statistical analysis, evaluator behavior, score calculation, or study
+  comparison logic.
+- Scenario-internal monitoring or logging configuration.
+- Backend capability declaration beyond consuming the existing
+  `capabilities.observation` boundary where relevant.

--- a/implementations/python/tests/test_runtime_contracts.py
+++ b/implementations/python/tests/test_runtime_contracts.py
@@ -731,6 +731,32 @@ def test_experiment_core_rejects_under_specified_apparatus_contexts():
         ExperimentApparatusContextModel.model_validate(extra_digest_manifest_with_supported_processor_subject)
 
 
+def test_experiment_core_rejects_under_specified_capture_specs():
+    payload = _experiment_fixture("experiment-capture-spec-v1")
+
+    mismatched_requirement_key = deepcopy(payload)
+    mismatched_requirement_key["capture_requirements"]["network-trace"]["requirement_id"] = "different-id"
+    with pytest.raises(ValidationError, match="capture_requirements keys"):
+        ExperimentCaptureSpecModel.model_validate(mismatched_requirement_key)
+
+    unresolved_window_ref = deepcopy(payload)
+    unresolved_window_ref["capture_requirements"]["network-trace"]["window_refs"] = ["missing-window"]
+    with pytest.raises(ValidationError, match="window_refs must resolve"):
+        ExperimentCaptureSpecModel.model_validate(unresolved_window_ref)
+
+    reversed_capture_window = deepcopy(payload)
+    reversed_capture_window["capture_windows"][0]["starts_at"] = "2026-05-26T00:40:00Z"
+    reversed_capture_window["capture_windows"][0]["ends_at"] = "2026-05-26T00:10:00Z"
+    with pytest.raises(ValidationError, match="ends_at must be greater"):
+        ExperimentCaptureSpecModel.model_validate(reversed_capture_window)
+
+    under_specified_window = deepcopy(payload)
+    under_specified_window["capture_windows"][0].pop("starts_at", None)
+    under_specified_window["capture_windows"][0].pop("ends_at", None)
+    under_specified_window["capture_windows"][0].pop("trigger_ref", None)
+    _assert_schema_and_model_reject("experiment-capture-spec-v1", under_specified_window)
+
+
 def test_experiment_core_rejects_under_specified_task_disclosure_surfaces():
     payload = _experiment_fixture("experiment-task-v1")
 


### PR DESCRIPTION
## Summary

Complete EXP-707 (experiment evidence capture specification) by closing the conformance and traceability gaps the sibling #88 contract merge left open. The ExperimentCaptureSpecModel and its published experiment-capture-spec-v1 schema already shipped under #88; this PR adds dedicated negative conformance coverage and an invalid fixture so every capture-spec semantic invariant has explicit, named test coverage matching the apparatus/task/run sibling pattern. No production model or published schema changes.

## Requirement UIDs

- `EXP-707`

## Related Issues

Closes #233

## ADR Impact

- ADR-064

## Changes

- Add test_experiment_core_rejects_under_specified_capture_specs() in implementations/python/tests/test_runtime_contracts.py covering the capture-requirement key-equality, window-reference resolution, capture-window time-ordering, and under-specified-window invariants
- Add contracts/fixtures/experiment-core/experiment-capture-spec-v1/invalid/under-specified-capture-window.json, a schema-and-model invalid fixture for a capture window declaring no start, end, or trigger (auto-discovered by the invalid-fixture iterator test)
- Record the EXP-707 capture-spec preflight guardrails note under docs/research/experiment-core/ and index it

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full nox verify green (requirement governance, schema-publication manifest, generated-schema drift, pytest 494s, integration, sphinx docs). The new rejection test and the invalid-fixture iterator both pass; published schemas and the schema-publication manifest are unchanged.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: EXP-707 ← implementations/python/packages/aces_contracts/contracts.py
- TESTS: EXP-707 ← implementations/python/tests/test_runtime_contracts.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/233.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
