### PR TITLE
added: add SEM-225 augmentation disclosure semantics

### DIFF
--- a/changelog.d/335.added.md
+++ b/changelog.d/335.added.md
@@ -1,1 +1,2 @@
 Added SEM-225 run-level augmentation disclosures to `experiment-run-v1`, with validation for processor/backend authority, environment-visible carriers, participant-visible markings, comparability observer effects, and run-traced evidence provenance.
+Refactored the SEM-225 disclosure validator into focused helper checks so the published contract validation stays maintainable.

--- a/changelog.d/335.added.md
+++ b/changelog.d/335.added.md
@@ -1,0 +1,1 @@
+Added SEM-225 run-level augmentation disclosures to `experiment-run-v1`, with validation for processor/backend authority, environment-visible carriers, participant-visible markings, comparability observer effects, and run-traced evidence provenance.

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -102,10 +102,10 @@
       "contract_id": "experiment-run-v1",
       "schema_path": "contracts/schemas/experiment-core/experiment-run-v1.json",
       "stability": "draft",
-      "content_hash": "9d4d86dfcbe6cca5e93bb4ae2005b07876dcd0fc2acbaf2f6c3aba945ecec4e5",
+      "content_hash": "e1e7ca5e74439140cd27340a7754d8b871266e518ce93c98bf6ff0dbaa8bd134",
       "last_change": {
-        "summary": "Added EXP-710/EXP-720/EXP-722 run provenance traceability and realized-form disclosure surfaces.",
-        "content_hash": "9d4d86dfcbe6cca5e93bb4ae2005b07876dcd0fc2acbaf2f6c3aba945ecec4e5"
+        "summary": "Added SEM-225 run-level augmentation disclosures for processor/backend augmentation classification, visibility, observer-effect, comparability, and evidence provenance.",
+        "content_hash": "e1e7ca5e74439140cd27340a7754d8b871266e518ce93c98bf6ff0dbaa8bd134"
       }
     },
     {

--- a/contracts/schemas/experiment-core/experiment-run-v1.json
+++ b/contracts/schemas/experiment-core/experiment-run-v1.json
@@ -429,6 +429,319 @@
       "title": "ExperimentArtifactRefModel",
       "type": "object"
     },
+    "ExperimentAugmentationDisclosureModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "properties": {
+            "augmented_by_ref": {
+              "properties": {
+                "ref_kind": {
+                  "enum": [
+                    "processor",
+                    "backend"
+                  ]
+                }
+              },
+              "required": [
+                "ref_kind"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "classifications": {
+                "contains": {
+                  "const": "environment_visible"
+                }
+              }
+            },
+            "required": [
+              "classifications"
+            ]
+          },
+          "then": {
+            "properties": {
+              "carrier_refs": {
+                "contains": {
+                  "properties": {
+                    "ref_kind": {
+                      "enum": [
+                        "apparatus-context",
+                        "capture-spec",
+                        "derived-measure",
+                        "evidence-record",
+                        "manifest",
+                        "measurement-channel",
+                        "profile",
+                        "run",
+                        "scenario-snapshot"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ref_kind"
+                  ]
+                }
+              },
+              "environment_effect": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "evidence_refs": {
+                "minItems": 1
+              }
+            },
+            "required": [
+              "carrier_refs",
+              "environment_effect",
+              "evidence_refs"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "classifications": {
+                "contains": {
+                  "const": "participant_visible"
+                }
+              }
+            },
+            "required": [
+              "classifications"
+            ]
+          },
+          "then": {
+            "properties": {
+              "evidence_refs": {
+                "minItems": 1
+              },
+              "markings": {
+                "minItems": 1
+              },
+              "participant_visibility": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "participant_visibility",
+              "markings",
+              "evidence_refs"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "classifications": {
+                "contains": {
+                  "const": "comparability_relevant"
+                }
+              }
+            },
+            "required": [
+              "classifications"
+            ]
+          },
+          "then": {
+            "properties": {
+              "comparability_effect": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "evidence_refs": {
+                "minItems": 1
+              },
+              "observer_effect": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "comparability_effect",
+              "observer_effect",
+              "evidence_refs"
+            ]
+          }
+        }
+      ],
+      "description": "Disclosure for processor/backend augmentation used by a run.",
+      "properties": {
+        "affected_refs": {
+          "items": {
+            "$ref": "#/$defs/ExperimentReferenceModel"
+          },
+          "title": "Affected Refs",
+          "type": "array"
+        },
+        "augmentation_id": {
+          "minLength": 1,
+          "title": "Augmentation Id",
+          "type": "string"
+        },
+        "augmented_by_ref": {
+          "$ref": "#/$defs/ExperimentReferenceModel"
+        },
+        "carrier_refs": {
+          "items": {
+            "$ref": "#/$defs/ExperimentReferenceModel"
+          },
+          "minItems": 1,
+          "title": "Carrier Refs",
+          "type": "array"
+        },
+        "classifications": {
+          "items": {
+            "enum": [
+              "apparatus_only",
+              "environment_visible",
+              "participant_visible",
+              "comparability_relevant"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Classifications",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "comparability_effect": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Comparability Effect"
+        },
+        "disclosure_policy": {
+          "minLength": 1,
+          "title": "Disclosure Policy",
+          "type": "string"
+        },
+        "environment_effect": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Environment Effect"
+        },
+        "evidence_refs": {
+          "items": {
+            "$ref": "#/$defs/ExperimentEvidenceRecordReferenceModel"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "markings": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Markings",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "notes": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Notes",
+          "type": "array"
+        },
+        "observer_effect": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observer Effect"
+        },
+        "participant_visibility": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Participant Visibility"
+        },
+        "purpose": {
+          "enum": [
+            "evidence",
+            "evaluation",
+            "operational",
+            "comparability",
+            "other"
+          ],
+          "title": "Purpose",
+          "type": "string"
+        },
+        "realization_layer": {
+          "enum": [
+            "processor",
+            "backend",
+            "apparatus",
+            "runtime-environment",
+            "participant-runtime",
+            "measurement-channel",
+            "analysis",
+            "other"
+          ],
+          "title": "Realization Layer",
+          "type": "string"
+        }
+      },
+      "required": [
+        "augmentation_id",
+        "purpose",
+        "realization_layer",
+        "classifications",
+        "augmented_by_ref",
+        "carrier_refs",
+        "disclosure_policy"
+      ],
+      "title": "ExperimentAugmentationDisclosureModel",
+      "type": "object",
+      "x-aces-invariants": [
+        {
+          "description": "Augmentation disclosures must keep environment-visible, participant-visible, and comparability-relevant semantics explicit and must use processor/backend authority.",
+          "id": "augmentation-disclosure-semantics-valid",
+          "inputs": [
+            {
+              "contract_id": "experiment-run-v1",
+              "instance_path": "#/augmentation_disclosures"
+            }
+          ],
+          "level": "error",
+          "validator": "aces_contracts.contracts.ExperimentAugmentationDisclosureModel._validate_augmentation_disclosure"
+        }
+      ]
+    },
     "ExperimentCaptureSpecReferenceModel": {
       "additionalProperties": false,
       "description": "Reference constrained to a declarative capture specification.",
@@ -2053,6 +2366,13 @@
     "apparatus_context": {
       "$ref": "#/$defs/ExperimentApparatusContextModel"
     },
+    "augmentation_disclosures": {
+      "items": {
+        "$ref": "#/$defs/ExperimentAugmentationDisclosureModel"
+      },
+      "title": "Augmentation Disclosures",
+      "type": "array"
+    },
     "clock_context": {
       "$ref": "#/$defs/ExperimentClockContextModel"
     },
@@ -2271,6 +2591,18 @@
     {
       "description": "Every realized-form disclosure evidence ref must also appear in the run traceability evidence refs.",
       "id": "realized-form-evidence-refs-traced",
+      "inputs": [
+        {
+          "contract_id": "experiment-run-v1",
+          "instance_path": "#"
+        }
+      ],
+      "level": "error",
+      "validator": "aces_contracts.contracts.ExperimentRunModel._validate_archival_run"
+    },
+    {
+      "description": "Every augmentation disclosure evidence ref must also appear in the run traceability evidence refs, and augmentation_id values must be unique within the run.",
+      "id": "augmentation-disclosure-evidence-refs-traced",
       "inputs": [
         {
           "contract_id": "experiment-run-v1",

--- a/docs/decisions/adrs/adr-066-observability-evidence-plane-separation.md
+++ b/docs/decisions/adrs/adr-066-observability-evidence-plane-separation.md
@@ -236,3 +236,4 @@ participant-visible, or comparability-relevant.
 
 | Date | Commit/PR | Summary |
 |------|-----------|---------|
+| 2026-06-23 | #335 | Implemented SEM-225 run-level augmentation disclosures in `experiment-run-v1`, including separate environment-visible, participant-visible, and comparability-relevant validation. |

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -268,3 +268,7 @@ adrs:
   - id: ADR-066
     path: docs/decisions/adrs/adr-066-observability-evidence-plane-separation.md
     pin: c2a8cf0bafdf53007df8a6c40f60bd63114656887b3c2feaca6f678ef6ae6d65
+    amendments:
+      - date: 2026-06-23
+        ref: "#335"
+        summary: "Recorded SEM-225 run-level augmentation disclosure implementation coverage."

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -3906,6 +3906,162 @@ class ExperimentRealizedFormDisclosureModel(ContractModel):
         return json_schema
 
 
+_SEM_225_PORTABLE_CARRIER_KINDS = frozenset(
+    {
+        "apparatus-context",
+        "capture-spec",
+        "derived-measure",
+        "evidence-record",
+        "manifest",
+        "measurement-channel",
+        "profile",
+        "run",
+        "scenario-snapshot",
+    }
+)
+
+
+class ExperimentAugmentationDisclosureModel(ContractModel):
+    """Disclosure for processor/backend augmentation used by a run."""
+
+    augmentation_id: NonEmptyString
+    purpose: Literal["evidence", "evaluation", "operational", "comparability", "other"]
+    realization_layer: Literal[
+        "processor",
+        "backend",
+        "apparatus",
+        "runtime-environment",
+        "participant-runtime",
+        "measurement-channel",
+        "analysis",
+        "other",
+    ]
+    classifications: list[
+        Literal["apparatus_only", "environment_visible", "participant_visible", "comparability_relevant"]
+    ] = Field(min_length=1, json_schema_extra={"uniqueItems": True})
+    augmented_by_ref: ExperimentReferenceModel
+    carrier_refs: list[ExperimentReferenceModel] = Field(min_length=1)
+    affected_refs: list[ExperimentReferenceModel] = Field(default_factory=list)
+    evidence_refs: list[ExperimentEvidenceRecordReferenceModel] = Field(default_factory=list)
+    disclosure_policy: NonEmptyString
+    markings: list[NonEmptyString] = Field(default_factory=list, json_schema_extra={"uniqueItems": True})
+    observer_effect: NonEmptyString | None = None
+    environment_effect: NonEmptyString | None = None
+    participant_visibility: NonEmptyString | None = None
+    comparability_effect: NonEmptyString | None = None
+    notes: list[NonEmptyString] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_augmentation_disclosure(self) -> ExperimentAugmentationDisclosureModel:
+        _validate_unique_string_values("augmentation classifications", self.classifications)
+        _validate_unique_string_values("augmentation disclosure markings", self.markings)
+        _validate_unique_string_values("augmentation disclosure notes", self.notes)
+        _validate_unique_experiment_references("augmentation disclosure carrier_refs", self.carrier_refs)
+        _validate_unique_experiment_references("augmentation disclosure affected_refs", self.affected_refs)
+        _validate_unique_experiment_references("augmentation disclosure evidence_refs", self.evidence_refs)
+
+        if self.augmented_by_ref.ref_kind not in {"processor", "backend"}:
+            raise ValueError("augmentation disclosures must use a processor or backend augmented_by_ref")
+
+        classification_set = set(self.classifications)
+        claim_bearing = classification_set - {"apparatus_only"}
+        if claim_bearing and not self.evidence_refs:
+            raise ValueError("environment, participant, or comparability augmentations require evidence_refs")
+        if "environment_visible" in classification_set:
+            if self.environment_effect is None:
+                raise ValueError("environment_visible augmentation disclosures require environment_effect")
+            if not any(ref.ref_kind in _SEM_225_PORTABLE_CARRIER_KINDS for ref in self.carrier_refs):
+                raise ValueError("environment_visible augmentation disclosures require a portable carrier_ref")
+        if "participant_visible" in classification_set:
+            if self.participant_visibility is None:
+                raise ValueError("participant_visible augmentation disclosures require participant_visibility")
+            if not self.markings:
+                raise ValueError("participant_visible augmentation disclosures require markings")
+        if "comparability_relevant" in classification_set:
+            if self.comparability_effect is None:
+                raise ValueError("comparability_relevant augmentation disclosures require comparability_effect")
+            if self.observer_effect is None:
+                raise ValueError("comparability_relevant augmentation disclosures require observer_effect")
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.setdefault("allOf", []).extend(
+            [
+                {
+                    "properties": {
+                        "augmented_by_ref": {
+                            "required": ["ref_kind"],
+                            "properties": {"ref_kind": {"enum": ["processor", "backend"]}},
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {"classifications": {"contains": {"const": "environment_visible"}}},
+                        "required": ["classifications"],
+                    },
+                    "then": {
+                        "required": ["carrier_refs", "environment_effect", "evidence_refs"],
+                        "properties": {
+                            "environment_effect": {"type": "string", "minLength": 1},
+                            "carrier_refs": {
+                                "contains": {
+                                    "required": ["ref_kind"],
+                                    "properties": {"ref_kind": {"enum": sorted(_SEM_225_PORTABLE_CARRIER_KINDS)}},
+                                }
+                            },
+                            "evidence_refs": {"minItems": 1},
+                        },
+                    },
+                },
+                {
+                    "if": {
+                        "properties": {"classifications": {"contains": {"const": "participant_visible"}}},
+                        "required": ["classifications"],
+                    },
+                    "then": {
+                        "required": ["participant_visibility", "markings", "evidence_refs"],
+                        "properties": {
+                            "participant_visibility": {"type": "string", "minLength": 1},
+                            "markings": {"minItems": 1},
+                            "evidence_refs": {"minItems": 1},
+                        },
+                    },
+                },
+                {
+                    "if": {
+                        "properties": {"classifications": {"contains": {"const": "comparability_relevant"}}},
+                        "required": ["classifications"],
+                    },
+                    "then": {
+                        "required": ["comparability_effect", "observer_effect", "evidence_refs"],
+                        "properties": {
+                            "comparability_effect": {"type": "string", "minLength": 1},
+                            "observer_effect": {"type": "string", "minLength": 1},
+                            "evidence_refs": {"minItems": 1},
+                        },
+                    },
+                },
+            ]
+        )
+        _add_aces_invariant(
+            json_schema,
+            "augmentation-disclosure-semantics-valid",
+            "Augmentation disclosures must keep environment-visible, participant-visible, and "
+            "comparability-relevant semantics explicit and must use processor/backend authority.",
+            validator="aces_contracts.contracts.ExperimentAugmentationDisclosureModel._validate_augmentation_disclosure",
+            inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#/augmentation_disclosures"}],
+        )
+        return json_schema
+
+
 class ExperimentMetricDefinitionModel(ContractModel):
     """Metric definition bound to a measured construct and unit of analysis."""
 
@@ -4620,6 +4776,7 @@ class ExperimentRunModel(ContractModel):
     outcome_status: Literal["succeeded", "failed", "partial", "inconclusive", "not-evaluated"]
     traceability: ExperimentRunTraceabilityModel
     realized_form_disclosures: list[ExperimentRealizedFormDisclosureModel] = Field(default_factory=list)
+    augmentation_disclosures: list[ExperimentAugmentationDisclosureModel] = Field(default_factory=list)
     evidence_artifacts: list[ExperimentArtifactRefModel] = Field(min_length=1)
     result_summaries: dict[NonEmptyString, ExperimentResultSummaryModel] = Field(min_length=1)
     deviations: list[NonEmptyString] = Field(default_factory=list)
@@ -4694,6 +4851,21 @@ class ExperimentRunModel(ContractModel):
             raise ValueError(
                 f"realized_form_disclosures evidence_refs must be listed in traceability evidence_record_refs: {joined}"
             )
+        _validate_unique_string_values(
+            "augmentation_disclosures augmentation_id",
+            [disclosure.augmentation_id for disclosure in self.augmentation_disclosures],
+        )
+        missing_augmentation_evidence_refs = sorted(
+            _format_reference(evidence_ref)
+            for disclosure in self.augmentation_disclosures
+            for evidence_ref in disclosure.evidence_refs
+            if _experiment_reference_key(evidence_ref) not in traced_evidence_record_refs
+        )
+        if missing_augmentation_evidence_refs:
+            joined = ", ".join(missing_augmentation_evidence_refs)
+            raise ValueError(
+                f"augmentation_disclosures evidence_refs must be listed in traceability evidence_record_refs: {joined}"
+            )
         return self
 
     @classmethod
@@ -4741,6 +4913,14 @@ class ExperimentRunModel(ContractModel):
             json_schema,
             "realized-form-evidence-refs-traced",
             "Every realized-form disclosure evidence ref must also appear in the run traceability evidence refs.",
+            validator="aces_contracts.contracts.ExperimentRunModel._validate_archival_run",
+            inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#"}],
+        )
+        _add_aces_invariant(
+            json_schema,
+            "augmentation-disclosure-evidence-refs-traced",
+            "Every augmentation disclosure evidence ref must also appear in the run traceability evidence refs, "
+            "and augmentation_id values must be unique within the run.",
             validator="aces_contracts.contracts.ExperimentRunModel._validate_archival_run",
             inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#"}],
         )
@@ -6490,6 +6670,7 @@ __all__ = [
     "ExperimentApparatusConstraintModel",
     "ExperimentApparatusContextModel",
     "ExperimentArtifactRefModel",
+    "ExperimentAugmentationDisclosureModel",
     "ExperimentBackendReferenceModel",
     "ExperimentCaptureRequirementModel",
     "ExperimentCaptureSpecModel",

--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -3921,6 +3921,35 @@ _SEM_225_PORTABLE_CARRIER_KINDS = frozenset(
 )
 
 
+def _validate_sem_225_claim_evidence(
+    classifications: set[str],
+    evidence_refs: list[ExperimentEvidenceRecordReferenceModel],
+) -> None:
+    if classifications - {"apparatus_only"} and not evidence_refs:
+        raise ValueError("environment, participant, or comparability augmentations require evidence_refs")
+
+
+def _validate_sem_225_environment_visible(disclosure: ExperimentAugmentationDisclosureModel) -> None:
+    if disclosure.environment_effect is None:
+        raise ValueError("environment_visible augmentation disclosures require environment_effect")
+    if not any(ref.ref_kind in _SEM_225_PORTABLE_CARRIER_KINDS for ref in disclosure.carrier_refs):
+        raise ValueError("environment_visible augmentation disclosures require a portable carrier_ref")
+
+
+def _validate_sem_225_participant_visible(disclosure: ExperimentAugmentationDisclosureModel) -> None:
+    if disclosure.participant_visibility is None:
+        raise ValueError("participant_visible augmentation disclosures require participant_visibility")
+    if not disclosure.markings:
+        raise ValueError("participant_visible augmentation disclosures require markings")
+
+
+def _validate_sem_225_comparability_relevant(disclosure: ExperimentAugmentationDisclosureModel) -> None:
+    if disclosure.comparability_effect is None:
+        raise ValueError("comparability_relevant augmentation disclosures require comparability_effect")
+    if disclosure.observer_effect is None:
+        raise ValueError("comparability_relevant augmentation disclosures require observer_effect")
+
+
 class ExperimentAugmentationDisclosureModel(ContractModel):
     """Disclosure for processor/backend augmentation used by a run."""
 
@@ -3964,24 +3993,13 @@ class ExperimentAugmentationDisclosureModel(ContractModel):
             raise ValueError("augmentation disclosures must use a processor or backend augmented_by_ref")
 
         classification_set = set(self.classifications)
-        claim_bearing = classification_set - {"apparatus_only"}
-        if claim_bearing and not self.evidence_refs:
-            raise ValueError("environment, participant, or comparability augmentations require evidence_refs")
+        _validate_sem_225_claim_evidence(classification_set, self.evidence_refs)
         if "environment_visible" in classification_set:
-            if self.environment_effect is None:
-                raise ValueError("environment_visible augmentation disclosures require environment_effect")
-            if not any(ref.ref_kind in _SEM_225_PORTABLE_CARRIER_KINDS for ref in self.carrier_refs):
-                raise ValueError("environment_visible augmentation disclosures require a portable carrier_ref")
+            _validate_sem_225_environment_visible(self)
         if "participant_visible" in classification_set:
-            if self.participant_visibility is None:
-                raise ValueError("participant_visible augmentation disclosures require participant_visibility")
-            if not self.markings:
-                raise ValueError("participant_visible augmentation disclosures require markings")
+            _validate_sem_225_participant_visible(self)
         if "comparability_relevant" in classification_set:
-            if self.comparability_effect is None:
-                raise ValueError("comparability_relevant augmentation disclosures require comparability_effect")
-            if self.observer_effect is None:
-                raise ValueError("comparability_relevant augmentation disclosures require observer_effect")
+            _validate_sem_225_comparability_relevant(self)
         return self
 
     @classmethod
@@ -4056,7 +4074,9 @@ class ExperimentAugmentationDisclosureModel(ContractModel):
             "augmentation-disclosure-semantics-valid",
             "Augmentation disclosures must keep environment-visible, participant-visible, and "
             "comparability-relevant semantics explicit and must use processor/backend authority.",
-            validator="aces_contracts.contracts.ExperimentAugmentationDisclosureModel._validate_augmentation_disclosure",
+            validator=(
+                "aces_contracts.contracts.ExperimentAugmentationDisclosureModel._validate_augmentation_disclosure"
+            ),
             inputs=[{"contract_id": "experiment-run-v1", "instance_path": "#/augmentation_disclosures"}],
         )
         return json_schema

--- a/implementations/python/tests/test_sem_225_augmentation_semantics.py
+++ b/implementations/python/tests/test_sem_225_augmentation_semantics.py
@@ -1,0 +1,176 @@
+"""SEM-225 realization augmentation and visibility semantics."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from aces_contracts.contracts import (
+    ExperimentAugmentationDisclosureModel,
+    ExperimentRunModel,
+    schema_bundle,
+)
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _experiment_fixture(contract_id: str, fixture_name: str = "reference.json") -> dict:
+    fixture_path = REPO_ROOT / "contracts" / "fixtures" / "experiment-core" / contract_id / "valid" / fixture_name
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _base_augmentation_disclosure() -> dict:
+    return {
+        "augmentation_id": "packet-capture-sidecar",
+        "purpose": "evidence",
+        "realization_layer": "backend",
+        "classifications": ["apparatus_only", "comparability_relevant"],
+        "augmented_by_ref": {
+            "ref_kind": "backend",
+            "ref_id": "stub-backend",
+            "ref_version": "0.1.0",
+        },
+        "carrier_refs": [
+            {
+                "ref_kind": "measurement-channel",
+                "ref_id": "evaluation-history-channel",
+                "ref_version": "1.0.0",
+            },
+            {
+                "ref_kind": "evidence-record",
+                "ref_id": "evidence-techvault-network-trace-001",
+                "ref_version": "1.0.0",
+            },
+        ],
+        "affected_refs": [
+            {
+                "ref_kind": "capture-spec",
+                "ref_id": "capture-techvault-evidence-v1",
+                "ref_version": "1.0.0",
+            }
+        ],
+        "evidence_refs": [
+            {
+                "ref_kind": "evidence-record",
+                "ref_id": "evidence-techvault-network-trace-001",
+                "ref_version": "1.0.0",
+            }
+        ],
+        "disclosure_policy": "Internal run-provenance disclosure; no raw packet content is embedded.",
+        "markings": ["internal"],
+        "observer_effect": "The sidecar observes run traffic without modifying scenario services.",
+        "comparability_effect": "Compare only with runs that declare equivalent capture support.",
+    }
+
+
+def _assert_schema_and_model_reject(payload: dict) -> None:
+    validator = Draft202012Validator(schema_bundle()["experiment-run-v1"])
+    assert list(validator.iter_errors(payload))
+    with pytest.raises(ValidationError):
+        ExperimentRunModel.model_validate(payload)
+
+
+def _conditional_then_for(disclosure_schema: dict, classification: str) -> dict:
+    for branch in disclosure_schema["allOf"]:
+        contains = branch.get("if", {}).get("properties", {}).get("classifications", {}).get("contains", {})
+        if contains.get("const") == classification:
+            return branch["then"]
+    raise AssertionError(f"missing conditional schema branch for {classification!r}")
+
+
+def test_sem_225_accepts_run_augmentation_disclosure():
+    payload = _experiment_fixture("experiment-run-v1")
+    payload["augmentation_disclosures"] = [_base_augmentation_disclosure()]
+
+    schema = schema_bundle()["experiment-run-v1"]
+    assert not list(Draft202012Validator(schema).iter_errors(payload))
+    run = ExperimentRunModel.model_validate(payload)
+
+    disclosure = run.augmentation_disclosures[0]
+    assert disclosure.augmentation_id == "packet-capture-sidecar"
+    assert "comparability_relevant" in disclosure.classifications
+
+
+def test_experiment_run_schema_publishes_sem_225_augmentation_surface():
+    run_schema = schema_bundle()["experiment-run-v1"]
+
+    assert run_schema["properties"]["augmentation_disclosures"]["items"]["$ref"] == (
+        "#/$defs/ExperimentAugmentationDisclosureModel"
+    )
+    disclosure_schema = run_schema["$defs"]["ExperimentAugmentationDisclosureModel"]
+    assert disclosure_schema["additionalProperties"] is False
+    invariant_ids = {invariant["id"] for invariant in disclosure_schema.get("x-aces-invariants", [])}
+    assert "augmentation-disclosure-semantics-valid" in invariant_ids
+    run_invariant_ids = {invariant["id"] for invariant in run_schema.get("x-aces-invariants", [])}
+    assert "augmentation-disclosure-evidence-refs-traced" in run_invariant_ids
+    environment_then = _conditional_then_for(disclosure_schema, "environment_visible")
+    assert {"carrier_refs", "environment_effect", "evidence_refs"} <= set(environment_then["required"])
+    participant_then = _conditional_then_for(disclosure_schema, "participant_visible")
+    assert {"participant_visibility", "markings", "evidence_refs"} <= set(participant_then["required"])
+
+
+def test_sem_225_rejects_environment_visible_backend_log_only_disclosure():
+    payload = _experiment_fixture("experiment-run-v1")
+    disclosure = _base_augmentation_disclosure()
+    disclosure["classifications"] = ["environment_visible"]
+    disclosure["environment_effect"] = "Instrumentation adds an in-world sensor service."
+    disclosure["carrier_refs"] = [{"ref_kind": "other", "ref_id": "backend-log"}]
+    payload["augmentation_disclosures"] = [disclosure]
+
+    _assert_schema_and_model_reject(payload)
+
+
+def test_sem_225_rejects_participant_visible_augmentation_without_markings():
+    payload = _experiment_fixture("experiment-run-v1")
+    disclosure = _base_augmentation_disclosure()
+    disclosure["classifications"] = ["participant_visible"]
+    disclosure["participant_visibility"] = "Participant sees the monitoring dashboard."
+    disclosure["markings"] = []
+    payload["augmentation_disclosures"] = [disclosure]
+
+    _assert_schema_and_model_reject(payload)
+
+
+def test_sem_225_rejects_comparability_relevant_augmentation_without_observer_effect():
+    payload = _experiment_fixture("experiment-run-v1")
+    disclosure = _base_augmentation_disclosure()
+    disclosure["observer_effect"] = None
+    payload["augmentation_disclosures"] = [disclosure]
+
+    _assert_schema_and_model_reject(payload)
+
+
+def test_sem_225_rejects_non_processor_backend_augmentation_authority():
+    payload = _experiment_fixture("experiment-run-v1")
+    disclosure = _base_augmentation_disclosure()
+    disclosure["augmented_by_ref"] = {
+        "ref_kind": "participant-implementation",
+        "ref_id": "reference-red-agent",
+        "ref_version": "1.0.0",
+    }
+    payload["augmentation_disclosures"] = [disclosure]
+
+    _assert_schema_and_model_reject(payload)
+
+
+def test_sem_225_augmentation_evidence_refs_must_be_run_traced():
+    payload = _experiment_fixture("experiment-run-v1")
+    disclosure = _base_augmentation_disclosure()
+    disclosure["evidence_refs"] = [{"ref_kind": "evidence-record", "ref_id": "untraced-evidence"}]
+    payload["augmentation_disclosures"] = [disclosure]
+
+    assert not list(Draft202012Validator(schema_bundle()["experiment-run-v1"]).iter_errors(payload))
+    with pytest.raises(ValidationError, match="augmentation_disclosures evidence_refs must be listed"):
+        ExperimentRunModel.model_validate(payload)
+
+
+def test_sem_225_rejects_duplicate_disclosure_references():
+    duplicate = deepcopy(_base_augmentation_disclosure())
+    duplicate["carrier_refs"].append(deepcopy(duplicate["carrier_refs"][0]))
+
+    with pytest.raises(ValidationError, match="augmentation disclosure carrier_refs must not contain duplicates"):
+        ExperimentAugmentationDisclosureModel.model_validate(duplicate)

--- a/specs/formal/observability-evidence-plane.md
+++ b/specs/formal/observability-evidence-plane.md
@@ -135,9 +135,9 @@ The minimum adversarial fixture set for implementation is:
   analysis engines, or backend adapters.
 - This design does not replace ADR-022, ADR-054, ADR-064, ADR-065, SEM-218, or
   existing control-plane security and diagnostics.
-- This design does not transition SEM-224, SEM-225, DSL-123, or DSL-124 to
-  implementation coverage. It records the criteria the spawned issues must
-  satisfy.
+- The design criteria above do not by themselves transition SEM-224, SEM-225,
+  DSL-123, or DSL-124 to implementation coverage. The implementation coverage
+  sections below record realized subsets as spawned issues land.
 
 ## Implementation Coverage (#334 / SEM-224)
 
@@ -163,6 +163,33 @@ probe set.
 | OE-06 derived analysis must cite source evidence | `ExperimentDerivedMeasureModel.source_evidence_refs` (`min_length=1`) | `test_derived_measure_without_source_evidence_is_rejected`, `test_reference_derived_measure_cites_source_evidence` | pre-existing rule, SEM-224 probe |
 | Plane traceability published portably | `x-aces-plane` on the three experiment-core schemas | `test_claim_bearing_contracts_publish_their_plane_annotation` | yes |
 
-SEM-225 augmentation carriers (#335), DSL-123 scenario-native authoring
-surfaces (#336), and DSL-124 authored evidence-requirement surfaces (#337)
-extend the carrier→plane registry rather than re-implementing it.
+## Implementation Coverage (#335 / SEM-225)
+
+SEM-225 is realized as run-level augmentation disclosure on
+`experiment-run-v1`. `ExperimentAugmentationDisclosureModel` records the
+augmentation purpose, realization layer, additive classifications, processor or
+backend authority, first-class carrier refs, disclosure policy, markings,
+observer/comparability effects, and evidence-record refs. The run validator
+keeps augmentation evidence refs tied to `traceability.evidence_record_refs` so
+augmentation claims do not float free of captured evidence.
+
+The model keeps the three SEM-225 axes separate:
+
+- `environment_visible` requires an explicit environment effect and a portable
+  carrier ref rather than a backend-log-only reference;
+- `participant_visible` requires participant visibility text plus markings; and
+- `comparability_relevant` requires both comparability impact and observer
+  effect disclosure.
+
+| Invariant / matrix row | Realizing artifact | Test | New in #335? |
+| --- | --- | --- | --- |
+| OE-09 first-class augmentation disclosure | `ExperimentAugmentationDisclosureModel`, `ExperimentRunModel.augmentation_disclosures` | `test_sem_225_accepts_run_augmentation_disclosure`, `test_experiment_run_schema_publishes_sem_225_augmentation_surface` | yes |
+| Environment-visible augmentation is not backend-log-only | portable carrier validation in `ExperimentAugmentationDisclosureModel` | `test_sem_225_rejects_environment_visible_backend_log_only_disclosure` | yes |
+| Participant-visible augmentation carries visibility/marking context | participant visibility and marking validation | `test_sem_225_rejects_participant_visible_augmentation_without_markings` | yes |
+| Comparability-relevant augmentation names observer effect | comparability and observer-effect validation | `test_sem_225_rejects_comparability_relevant_augmentation_without_observer_effect` | yes |
+| Processor/backend authority boundary | `augmented_by_ref` constrained to processor/backend refs | `test_sem_225_rejects_non_processor_backend_augmentation_authority` | yes |
+| Evidence provenance remains traced | run-level augmentation evidence refs checked against traceability | `test_sem_225_augmentation_evidence_refs_must_be_run_traced` | yes |
+
+DSL-123 scenario-native authoring surfaces (#336) and DSL-124 authored
+evidence-requirement surfaces (#337) extend the carrier-to-plane registry rather
+than re-implementing it.

--- a/specs/sdl/observability-and-evidence.md
+++ b/specs/sdl/observability-and-evidence.md
@@ -112,6 +112,14 @@ augmentation MUST have first-class provenance or evidence disclosure. They MUST
 NOT be hidden in metadata, diagnostics, audit blobs, backend-native DTOs, or
 raw logs.
 
+Run-level processor/backend augmentation disclosures are carried by
+`experiment-run-v1` `augmentation_disclosures`. That carrier records the
+augmentation purpose, realization layer, additive classifications, portable
+carrier refs, disclosure policy, markings, observer/comparability effects, and
+run-traced evidence refs. SDL authoring that depends on augmentation output
+must map to that run-provenance carrier rather than relying on backend logs,
+free-form metadata, evaluator internals, or untyped diagnostic text.
+
 ## Reference And Validation Requirements
 
 Future SDL fields for this catalog must satisfy the existing SDL gates:


### PR DESCRIPTION
## Summary

Adds run-level augmentation disclosure semantics to experiment-run-v1 so processor/backend augmentations can declare environment visibility, participant visibility, comparability impact, observer effect, evidence provenance, and portable carriers.

## Requirement UIDs

- `SEM-225`

## Related Issues

Closes #335

## ADR Impact

- ADR-066 (amended)

## Changes

- Added ExperimentAugmentationDisclosureModel and run-level augmentation_disclosures validation in aces_contracts.
- Published the new experiment-run-v1 schema surface and schema manifest hash.
- Documented SEM-225 coverage in the formal observability/evidence plane, SDL observability prose, and ADR-066 amendment history.
- Added SEM-225 schema/model regression coverage for visibility, markings, comparability, authority, evidence tracing, and duplicate references.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification: focused SEM-225 pytest suite; full `ACES_REQUIREMENT_UID=SEM-225 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`; `ACES_REQUIREMENT_UID=SEM-225 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s policy`; pre-commit all-files. Test-quality review was clean; Codex review findings were fixed and self-verified before user-authorized continuation without an over-cap cycle.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SEM-225 ← implementations/python/packages/aces_contracts/contracts.py, SEM-225 ← contracts/schemas/experiment-core/experiment-run-v1.json, SEM-225 ← specs/formal/observability-evidence-plane.md, SEM-225 ← specs/sdl/observability-and-evidence.md, SEM-225 ← docs/decisions/adrs/adr-066-observability-evidence-plane-separation.md
- TESTS: SEM-225 ← implementations/python/tests/test_sem_225_augmentation_semantics.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/335.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
