### PR TITLE
Note APTL as a worked ACES SDL example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The repository is not a managed cyber range and does not include a production
 backend. Backend contracts, stubs, conformance checks, and examples are present;
 real deployment backends remain separate implementations.
 
+A worked example of ACES SDL driving a concrete range is
+[APTL (Advanced Purple Team Lab)](https://github.com/Brad-Edwards/aptl), a
+separate project that specifies its scenarios as ACES SDL documents and
+realizes the selected topology on a Docker Compose backend.
+
 ## Contents
 
 - [What ACES SDL Describes](#what-aces-sdl-describes)

--- a/changelog.d/+readme-aptl-example.added.md
+++ b/changelog.d/+readme-aptl-example.added.md
@@ -1,0 +1,1 @@
+Noted in the README that APTL (Advanced Purple Team Lab) is a worked example of a separate project specifying its scenarios as ACES SDL documents and realizing the selected topology on a concrete Docker Compose backend.


### PR DESCRIPTION
## What

The README states that real deployment backends remain separate implementations but does not point to one. APTL (Advanced Purple Team Lab) is exactly that: a separate project that specifies its scenarios as ACES SDL documents and realizes the selected topology on a Docker Compose backend.

## Changes

- `README.md`: added a sentence after the "separate implementations" paragraph pointing to [APTL](https://github.com/Brad-Edwards/aptl) as a worked example of ACES SDL driving a concrete range.
- `changelog.d/` fragment (`+slug`, `added`).

No code or contract changes.