### PR TITLE
docs(experiment-core): define replication and replay claims

### DIFF
--- a/changelog.d/105.added.md
+++ b/changelog.d/105.added.md
@@ -1,0 +1,3 @@
+Add EXP-706/EXP-712 trial, replication, reproducibility, and replay-claim
+design guidance for experiment-core ADRs, formal specs, and preflight
+guardrails.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -112,6 +112,7 @@ adr-064-experiment-evidence-and-measure-contract-boundary
 adr-065-experiment-run-provenance-contract-boundary
 adr-066-observability-evidence-plane-separation
 adr-067-participant-behavior-model
+adr-068-experiment-trials-replication-and-replay-claims
 ```
 
 | ADR | Title | Status | Date |
@@ -184,3 +185,4 @@ adr-067-participant-behavior-model
 | [065](adr-065-experiment-run-provenance-contract-boundary.md) | Experiment Run Provenance Contract Boundary | accepted | 2026-06-22 |
 | [066](adr-066-observability-evidence-plane-separation.md) | Observability and Evidence Plane Separation | accepted | 2026-06-23 |
 | [067](adr-067-participant-behavior-model.md) | Participant Behavior Model | proposed | 2026-06-23 |
+| [068](adr-068-experiment-trials-replication-and-replay-claims.md) | Experiment Trials, Replication, and Replay Claims | accepted | 2026-06-25 |

--- a/docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
+++ b/docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
@@ -1,0 +1,226 @@
+# ADR-068: Experiment Trials, Replication, and Replay Claims
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-25
+
+## Classification
+
+Classification: FM2
+Required artifacts: ADR, formal spec, preflight guardrails, clause matrix
+Waivers: No new schema, fixture, contract-source, or runtime artifacts are
+required because the existing experiment-core contracts already carry the
+trial, replication, reproducibility, and replay-claim support surfaces. This
+ADR fixes the interpretation boundary and leaves future producer, storage,
+API, and replay-execution work to spawned implementation issues.
+
+## Context
+
+Issue #105 is the joint design surface for:
+
+- EXP-706: repeated runs, replications, and controlled variation across runs of
+  the same task or study.
+- EXP-712: reproducibility and replay claims through preserved run context,
+  evidence, provenance, and derived-result lineage.
+
+ADR-055 established experiment tasks, runs, studies, and apparatus context.
+ADR-064 separated capture specifications, raw evidence records, derived
+measures, and backend observation capability. ADR-065 made
+`experiment-run-v1` the canonical archival run provenance record with
+traceability and realized-form disclosures. ADR-066 separated authored,
+operational, captured-evidence, and derived-analysis planes.
+
+Those decisions intentionally avoid a parallel run or provenance stack. The
+remaining issue is how to name trials, replications, controlled variation,
+reproducibility support, and replay support without adding duplicate root
+schemas for facts already carried by task, run, study, evidence, derived
+measure, apparatus, and traceability contracts.
+
+## Decision
+
+### 1. A trial is one archival run
+
+For the current experiment-core model, one trial is one archival
+`experiment-run-v1` record. The run is the record that binds the task reference,
+scenario snapshot, apparatus context, participant implementation provenance,
+parameters, stochastic controls, clocks, timestamps, evidence artifacts, result
+summaries, traceability, disclosures, and lineage refs for a specific
+execution.
+
+ACES does not add `experiment-trial-v1`, a trial root schema, or a trial
+service for the same execution facts. Future terminology may call a run a
+trial in user-facing research workflows, but the portable artifact remains the
+run contract.
+
+### 2. Repeated runs are multiple run records
+
+Repeated runs of the same task are represented by multiple
+`experiment-run-v1` records with distinct `run_id` values, a shared `task_ref`,
+and a compatible `scenario_snapshot_ref`. A repeated run must not be modeled as
+a mutable status update, tag, operation id, workflow id, runtime snapshot id,
+participant episode id, or backend-native execution id.
+
+The existing task/run validator remains the semantic gate for task identity,
+scenario snapshot compatibility, apparatus constraints, declared metrics, and
+evidence requirements.
+
+### 3. Replication and controlled variation are study allocation semantics
+
+Replication, cohort, benchmark, comparison, and controlled-variation claims
+belong in `experiment-study-v1`, especially:
+
+- study membership entries with `evaluation-run` roles and condition
+  groupings;
+- declared factors, factor levels, blocking factors, and analysis plans;
+- `run_allocation.compared_conditions`;
+- condition assignments with auditable run-level criteria;
+- `target_runs_per_condition`;
+- `replication_policy`; and
+- `stopping_rule`.
+
+Condition-assignment evidence must be grounded in inspectable run-level facts
+such as participant implementation provenance, processor or backend identity,
+apparatus context, selected manifests, capability declarations, measurement
+channels, task or scenario snapshot identity, non-opaque parameters, and
+stochastic controls. It must not depend on free-form tags, opaque `other`
+parameters, runtime metadata, audit blobs, or backend-private logs.
+
+### 4. Replay support is claim support, not replay execution
+
+ACES supports reproducibility and replay claims by preserving enough context,
+evidence, provenance, and lineage to inspect the claim. It does not claim that
+the current contracts can execute a replay workflow, fetch external artifacts,
+recreate hidden backend state, or recompute every derived result.
+
+Replay and reproducibility support use the existing claim-support chain:
+
+1. `experiment-run-v1` binds the task, scenario snapshot, apparatus,
+   participant implementation, parameters, stochastic controls, timestamps,
+   evidence artifacts, result summaries, realized-form disclosures,
+   augmentation disclosures, and lineage refs.
+2. `experiment-run-v1.traceability` links capture specifications, raw evidence
+   records, derived measures, and claim/report/analysis refs.
+3. `experiment-evidence-record-v1` records raw captured observations and the
+   capture requirement they claim to satisfy.
+4. `experiment-derived-measure-v1` records interpreted outputs and cites source
+   evidence records.
+5. Claim refs in run traceability are valid only when grounded by
+   derived-measure refs.
+
+Claim strength is limited by preserved artifacts, redaction, loss disclosure,
+observer effects, unsupported runtime surfaces, availability of external
+artifacts, and disclosed apparatus limitations.
+
+### 5. Runtime surfaces remain future work
+
+Future producer, retrieval, storage, or replay-execution APIs must emit and
+validate the same canonical task, run, study, evidence, derived-measure,
+apparatus, and traceability contracts. They must reuse the existing
+control-plane identity, authorization, request-size, audit, idempotency,
+diagnostic, and redacted-error patterns before dereferencing or publishing
+evidence content.
+
+## Required Boundaries
+
+- Trial identity is run identity.
+- Repetition is a set of distinct run records, not a mutation of one run.
+- Replication and controlled variation are study allocation facts, not tags.
+- Replay support is the preserved claim-support graph, not guaranteed
+  re-execution.
+- Raw evidence, derived measures, run summaries, and claims remain separate.
+- Capture specifications state intent; evidence records state captured raw
+  observations; derived measures state interpretation.
+- Live control-plane state, runtime snapshots, operation statuses, participant
+  histories, workflow ids, audit logs, diagnostics, and backend-native logs are
+  not canonical trial, replication, or replay-claim records.
+- Secrets, hidden answers, raw prompts, bearer tokens, private keys, raw
+  environment dumps, process argv, backend-private objects, and full tracebacks
+  must not be serialized into portable experiment records, fixtures, logs, or
+  examples.
+
+## Implementation Mapping
+
+Issue #105 is satisfied by this ADR, the experiment-core formal specification,
+the preflight guardrail notes for EXP-706 and EXP-712, and the
+EXP-706/EXP-712 clause matrix in
+`docs/research/experiment-core/traceability-matrix-exp-706-712.md`.
+
+Existing executable gates already enforce the load-bearing clauses:
+
+- `ExperimentRunModel._validate_archival_run()` keeps one run archival and
+  complete, including timestamps, evidence, result summaries, participant
+  implementation provenance, and disclosure evidence.
+- `validate_experiment_run_against_task()` binds runs to task identity,
+  scenario snapshot compatibility, apparatus constraints, declared metrics, and
+  evidence requirements.
+- `ExperimentRunAllocationPlanModel._validate_condition_assignments()` and
+  `validate_experiment_study_against_tasks_and_runs()` validate compared
+  conditions, condition assignments, blocking factors, target runs per
+  condition, evaluation-run eligibility, and analysis metric grounding.
+- `ExperimentRunTraceabilityModel._validate_run_traceability()` requires run
+  traceability through capture specifications and evidence records, and
+  prevents claim refs from floating free of derived-measure refs.
+- `ExperimentDerivedMeasureModel._validate_derived_measure()` requires derived
+  measures to cite source evidence records.
+
+The structural test coverage for those gates remains in
+`implementations/python/tests/test_runtime_contracts.py`.
+
+## Alternatives Considered
+
+### Add `experiment-trial-v1`
+
+Rejected. The proposed trial artifact would duplicate `experiment-run-v1`
+identity, apparatus, timestamps, evidence, results, provenance, and lineage.
+The run is already the archival record for one task execution.
+
+### Add a replay or reproducibility-claim root schema
+
+Rejected. The existing traceability chain already separates capture
+specifications, raw evidence, derived measures, and claim refs. A new root
+would split claim authority and make consumers reconcile parallel provenance
+graphs.
+
+### Encode replications with tags or free-form notes
+
+Rejected. Replication and controlled variation need declared factors,
+condition assignments, run allocation, target counts, stopping rules, analysis
+plans, and validity notes. Tags cannot express those constraints or support
+semantic validation.
+
+### Implement runtime replay with this issue
+
+Rejected. Issue #105 fixes the design boundary. Runtime replay, artifact
+retrieval, retention storage, query APIs, scheduling, and derived-measure
+recalculation require separate producer and control-plane work.
+
+## Consequences
+
+### Positive
+
+- The experiment-core model has one authoritative meaning for trial,
+  repetition, replication, controlled variation, reproducibility support, and
+  replay support.
+- Existing contract validators remain the executable authority instead of
+  adding duplicate schema and runtime stacks.
+- Future replay or reproducibility tooling can add producer and API behavior
+  without changing the portable artifact identities.
+
+### Negative / Costs
+
+- User-facing tools that prefer the term "trial" must map it explicitly to a
+  run record.
+- Reproducibility and replay claims remain reviewable support claims, not
+  guarantees of executable replay.
+
+### Risks
+
+- Implementers may overstate replayability by treating sealed references as
+  proof that external artifacts still exist or are authorized for dereference.
+- Study authors may try to infer replication from repeated operations without
+  publishing run records and study allocation. Validators and review guidance
+  must continue to reject those shortcuts.

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -272,3 +272,6 @@ adrs:
       - date: 2026-06-23
         ref: "#335"
         summary: "Recorded SEM-225 run-level augmentation disclosure implementation coverage."
+  - id: ADR-068
+    path: docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
+    pin: 2cd46b67fb86a8d5d5c089e2b2f492a94e6141470706f33a2bb14d7268c49d02

--- a/docs/research/experiment-core/index.md
+++ b/docs/research/experiment-core/index.md
@@ -13,8 +13,11 @@ provenance-and-data-format-supports
 cyber-range-scientific-instrument
 design-criteria-for-exp-701-705
 traceability-matrix-exp-701-705
+traceability-matrix-exp-706-712
 preflight-guardrails
 issue-88-evidence-measure-preflight-guardrails
+issue-267-exp-706-trial-replication-preflight-guardrails
+issue-105-exp-706-712-reproducibility-replay-preflight-guardrails
 issue-233-exp-707-capture-spec-preflight-guardrails
 issue-234-exp-708-evidence-record-preflight-guardrails
 issue-235-exp-709-derived-measure-preflight-guardrails

--- a/docs/research/experiment-core/issue-105-exp-706-712-reproducibility-replay-preflight-guardrails.md
+++ b/docs/research/experiment-core/issue-105-exp-706-712-reproducibility-replay-preflight-guardrails.md
@@ -1,0 +1,203 @@
+# Issue #105 EXP-706/EXP-712 Reproducibility And Replay Preflight Guardrails
+
+Date: 2026-06-25
+
+Issue: #105.
+
+Requirements: EXP-706, EXP-712.
+
+This preflight narrows the joint trial/replication and reproducibility/replay
+design issue to the architecture boundary implementation must preserve. ADR-055,
+ADR-064, ADR-065, ADR-066, and `specs/formal/experiment-core/README.md` remain
+the design authority. This note is implementation guidance only.
+
+## Architecture Decisions
+
+- Treat reproducibility and replay as claim disciplines over preserved
+  experiment context, evidence, provenance, and lineage. Do not add a parallel
+  replay-run, replay-claim, or provenance-graph root schema unless a later ADR
+  deliberately supersedes the current run-provenance boundary.
+- Keep `experiment-run-v1` as the canonical archival join point for one task
+  execution. It already carries task/scenario snapshot refs, apparatus context,
+  participant implementation provenance, parameters, stochastic controls,
+  clocks, timestamps, evidence artifacts, result summaries, run traceability,
+  realized-form disclosures, augmentation disclosures, and generic lineage refs.
+- Keep replay distinct from re-execution. A preserved run record can support a
+  replay claim only by naming what context and evidence were sealed, what
+  lineage was preserved, and what limitations, redactions, observer effects, or
+  unsupported surfaces weaken the claim. It must not imply that ACES can execute
+  a replay workflow, fetch external artifacts, or reproduce hidden backend state.
+- Keep raw evidence, derived measures, and claims separate:
+  `experiment-evidence-record-v1` is captured evidence,
+  `experiment-derived-measure-v1` is interpreted output, and
+  `experiment-run-v1.traceability.claim_refs` is a pointer to claim/report
+  artifacts grounded by derived-measure refs.
+- Treat trial, replication, cohort, and benchmark grouping as study/allocation
+  concerns in `experiment-study-v1`, not as tags or duplicated run fields.
+  Where grouped claims depend on repeated executions, use study membership,
+  run allocation, factors, analysis plans, validity notes, and explicit
+  inclusion criteria.
+- EXP-712 does not implement runtime replay, capture storage, artifact
+  dereference APIs, schedulers, statistical analysis, or a new persistence
+  service. Later producers or APIs must emit and validate the existing
+  contracts through the existing control-plane, diagnostics, redaction, audit,
+  and idempotency gates.
+
+## Required Incumbents
+
+- Contract source:
+  `implementations/python/packages/aces_contracts/contracts.py`, especially
+  `ContractModel`, `ExperimentRunModel`, `ExperimentRunTraceabilityModel`,
+  `ExperimentTaskModel`, `ExperimentStudyModel`, `ExperimentCaptureSpecModel`,
+  `ExperimentEvidenceRecordModel`, `ExperimentDerivedMeasureModel`,
+  `ExperimentApparatusContextModel`,
+  `ExperimentRealizedFormDisclosureModel`,
+  `ExperimentAugmentationDisclosureModel`, constrained experiment references,
+  artifact refs, checksums, redaction-aware `ExperimentParameterModel`,
+  stochastic controls, clock context, RFC 3339 parsing,
+  `validate_experiment_run_against_task()`,
+  `validate_experiment_apparatus_context_against_manifests()`, and
+  `validate_experiment_study_against_tasks_and_runs()`.
+- Published contract surface:
+  `contracts/schemas/experiment-core/`, `contracts/fixtures/experiment-core/`,
+  `contracts/schema-publication-manifest.json`,
+  `implementations/python/packages/aces_contracts/versions.py`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `tools/check_schema_publication.py`, and `tools/check_json_artifacts.py`.
+- Adjacent runtime and participant evidence surfaces:
+  participant implementation manifest/provenance contracts, participant
+  runtime history and observation contracts, runtime snapshot
+  `realization_provenance`, workflow/evaluation result envelopes, structured
+  `Diagnostic` values, and control-plane operation records. These are inputs or
+  observation surfaces; they are not replacement archival run records.
+- Manifest, capability, and vocabulary authority:
+  `aces_contracts.manifest_authority`, processor/backend manifest models,
+  backend observation capability declarations, controlled vocabularies, concept
+  families such as `tasks-runs-studies`, `apparatus-declarations`,
+  `provenance-and-evidence`, `realization-and-disclosure`, and
+  `time-and-apparatus`.
+- Runtime/API incumbents for future producer or retrieval work:
+  `aces_runtime.control_plane_api`, `control_plane_api_guards`,
+  `control_plane_security`, `control_plane_store`, request fingerprints,
+  idempotency keys, audit events, response models, redacted FastAPI error
+  handling, and runtime redaction/config validators.
+
+## Whole-Repo Scope
+
+- Repo workflow policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `tools/check_repo_policy.py`, `tools/check_requirement_governance.py`, and
+  `tools/verify_all.py`.
+- Design authority: ADR-055, ADR-064, ADR-065, ADR-066,
+  `specs/formal/experiment-core/README.md`, and
+  `specs/formal/observability-evidence-plane.md`.
+- Contract publication authority: Pydantic contract source, generated schemas,
+  fixtures, schema publication manifest, semantic invariant annotations, and
+  schema drift checks.
+- Concept and capability authority: concept-authority catalogs, manifest
+  authority lists, backend/processor manifest payloads, backend protocol
+  capability dataclasses, and observation capability gap checks.
+- Runtime/API boundary for future work: control-plane auth, request-size guard,
+  idempotency, audit store, diagnostics, redacted error envelopes, runtime
+  redaction/config validators, and OS-level command exposure rules.
+
+## Cross-Cutting Layers
+
+- Structural validation: external payloads must pass closed-world
+  `ContractModel` validation and the generated draft 2020-12 JSON Schemas.
+  Unknown fields remain errors.
+- Semantic validation: reuse the existing model validators for run time
+  ordering, invalidation details, succeeded-result reporting, participant
+  implementation provenance resolution, result evidence resolution,
+  traceability uniqueness, realized-form evidence tracing, augmentation
+  evidence tracing, derived-measure source evidence, and study allocation
+  grounding.
+- Cross-artifact validation: `validate_experiment_run_against_task()` remains
+  the task/run gate for task identity, scenario snapshot compatibility,
+  apparatus constraints, declared metrics, and evidence requirements.
+  `validate_experiment_study_against_tasks_and_runs()` remains the grouped
+  claim gate for membership, allocation, analysis metrics, invalidated-run
+  exclusion, and condition coverage.
+- Claim grounding: a run claim reference must be grounded by at least one
+  derived-measure ref in `traceability`; derived measures must cite raw
+  evidence-record refs; evidence records must cite capture specs and
+  requirements. Do not accept claim refs that float free of this chain.
+- Manifest and digest validation: use constrained experiment reference models
+  and apparatus-context manifest validation. Digest-bound manifest refs are
+  limited to processor/backend manifests whose payloads can be checked.
+- Auth surface: future create/read/dereference APIs must use existing
+  control-plane identity and role checks. Publishing replay/reproducibility
+  metadata is a run-provenance mutation; dereferencing evidence content is a
+  separate authorized read.
+- Secret-handling surface: preserved context may include sensitivity-aware
+  artifact references, checksums, redacted parameters, bounded summaries, and
+  disclosure text. It must not include credentials, bearer tokens, private keys,
+  hidden answers, raw prompts, environment dumps, backend-private object
+  reprs, full tracebacks, raw process argv, or unredacted capture payloads.
+- Config/env-binding surface: configuration provenance must use existing
+  redaction-aware experiment parameters, runtime configuration shapes, and
+  observed-value redaction helpers. Never serialize raw `os.environ`, CLI argv,
+  process tables, or backend-local config objects into run, study, evidence,
+  diagnostics, audit, fixture, or example payloads.
+- OS-level exposure: producers, validation helpers, and examples must not pass
+  tokens, secrets, or large raw evidence payloads through command-line
+  arguments. Use content-addressed artifacts, files, URIs, checksums, and
+  synthetic fixtures.
+- Error-envelope surface: validation and runtime failures must use Pydantic
+  validation errors, existing `Diagnostic` values, or existing redacted HTTP
+  error envelopes. Do not echo full run records, evidence payloads, secrets,
+  tracebacks, or backend internals.
+- Persistence surface: do not store reproducibility or replay records in
+  `RuntimeSnapshot.metadata`, operation status, workflow history, participant
+  history, audit details, free-form tags, or backend-private logs. A future
+  durable store must preserve schema-versioned experiment artifacts and their
+  references intact.
+
+## Extensibility Guardrail
+
+The extension seam is the existing claim-support graph, not a new replay stack.
+Future variation should extend governed dimensions such as study kind/allocation
+metadata, `ExperimentReferenceModel.ref_kind`, run `traceability`, evidence
+record kinds, derived-measure method metadata, realized-form and augmentation
+classifications, artifact roles, manifest capability declarations, or
+concept-authority terms. Producer code should be parameterized by source
+surface, replay/claim strength, artifact locator, sealing policy, and redaction
+policy so future backends can emit the same canonical contracts without leaking
+backend-native state into the archival model.
+
+## Gotchas And Anti-Patterns
+
+- Do not introduce a generic `replay_record`, `reproducibility_claim`, or
+  provenance graph schema that duplicates `experiment-run-v1`,
+  `experiment-study-v1`, evidence records, or derived measures.
+- Do not confuse replayability with successful re-execution. Claim strength must
+  be limited by preserved context, artifact availability, redaction, loss,
+  observer effects, and unsupported runtime surfaces.
+- Do not reconstruct archival run or claim support lazily from mutable
+  control-plane state, runtime snapshots, operation statuses, participant
+  histories, audit logs, or backend-private logs.
+- Do not treat capture specs, evidence-record refs, derived-measure refs, or
+  claim refs as proof that external artifacts exist or are authorized for
+  dereference.
+- Do not use tags, free-form notes, evaluator `detail`, `RuntimeSnapshot`
+  metadata, backend-native IDs, operation ids, workflow ids, participant
+  episode ids, or snapshot addresses as portable trial, replication, run, or
+  claim identity.
+- Do not duplicate schema registries, validation helpers, exception
+  hierarchies, logging stacks, audit formats, storage stacks, manifest
+  renderers, or workflow logic.
+- Do not hand-edit `contracts/schemas/`; update contract sources, regenerate,
+  update the publication manifest when hashes change, and keep fixtures and
+  tests aligned.
+
+## Non-Goals
+
+- Runtime replay execution, replay scheduling, capture orchestration, artifact
+  retrieval, retention storage, query services, or HTTP APIs.
+- New root schemas for replay, reproducibility claims, provenance graphs,
+  trial records, or replication records.
+- Statistical analysis, evaluator behavior, score calculation, derived-measure
+  computation, or study comparison algorithms.
+- SDL syntax changes, new SDL root sections, or changes to participant runtime
+  semantics.
+- New exception hierarchy, auth model, secret-handling surface, persistence
+  stack, logging stack, audit stack, manifest renderer, or workflow pipeline.

--- a/docs/research/experiment-core/issue-267-exp-706-trial-replication-preflight-guardrails.md
+++ b/docs/research/experiment-core/issue-267-exp-706-trial-replication-preflight-guardrails.md
@@ -1,0 +1,175 @@
+# Issue #267 EXP-706 Trial And Replication Preflight Guardrails
+
+Date: 2026-06-25
+
+Issue: #267.
+
+Requirement: EXP-706.
+
+This preflight narrows ADR-055 and the experiment-core formal specification to
+repeated runs, replications, and controlled variation. ADR-055, ADR-064,
+ADR-065, and `specs/formal/experiment-core/README.md` remain the normative
+design authority. This note is guidance for implementation only.
+
+## Architecture Decisions
+
+- Treat one trial as one archival `experiment-run-v1` record unless a later ADR
+  introduces a different meaning. Do not add `experiment-trial-v1` or a trial
+  root schema for the same execution facts.
+- Represent repeated runs of the same task by multiple `ExperimentRunModel`
+  records with distinct `run_id` values and a shared `task_ref`/compatible
+  `scenario_snapshot_ref`.
+- Represent replication and controlled variation at the study layer through
+  `ExperimentStudyModel.run_allocation`, `membership` entries with
+  `evaluation-run` roles and condition groupings, study factors, blocking
+  factors, condition assignments, `target_runs_per_condition`,
+  `replication_policy`, and `stopping_rule`.
+- Ground controlled variation in auditable run-level criteria: participant
+  implementation, processor, backend, apparatus context, selected manifests,
+  capabilities, measurement channels, scenario snapshots, task refs,
+  non-opaque parameters, and stochastic controls.
+- Preserve the current split: task defines protocol and metric requirements;
+  run records a single execution; apparatus context records instrument setup;
+  evidence records and derived measures carry observation and interpretation;
+  study allocation defines comparison, replication, and grouping semantics.
+- EXP-706 does not implement replay execution, schedulers, storage, HTTP APIs,
+  statistical analysis, or a provenance graph service.
+
+## Required Incumbents
+
+- Contract source:
+  `implementations/python/packages/aces_contracts/contracts.py`, especially
+  `ContractModel`, `ExperimentTaskModel`, `ExperimentRunModel`,
+  `ExperimentStudyModel`, `ExperimentRunAllocationPlanModel`,
+  `ExperimentConditionAssignmentModel`, `ExperimentParameterModel`,
+  `ExperimentStochasticControlModel`, `ExperimentApparatusContextModel`,
+  typed experiment reference models, and `schema_bundle()`.
+- Cross-artifact validators:
+  `validate_experiment_run_against_task()`,
+  `validate_experiment_study_against_tasks_and_runs()`, and
+  `validate_experiment_apparatus_context_against_manifests()`.
+- Published contract surface:
+  `contracts/schemas/experiment-core/experiment-task-v1.json`,
+  `contracts/schemas/experiment-core/experiment-run-v1.json`,
+  `contracts/schemas/experiment-core/experiment-study-v1.json`,
+  `contracts/schemas/experiment-core/experiment-apparatus-context-v1.json`,
+  `contracts/schema-publication-manifest.json`, and
+  `tools/generate_contract_schemas.py`.
+- Fixture and conformance corpus:
+  `contracts/fixtures/experiment-core/` and
+  `implementations/python/tests/test_runtime_contracts.py`.
+- Adjacent evidence/provenance contracts:
+  `experiment-capture-spec-v1`, `experiment-evidence-record-v1`,
+  `experiment-derived-measure-v1`, run `traceability`,
+  `realized_form_disclosures`, `augmentation_disclosures`, and participant
+  implementation manifest/provenance contracts.
+- Concept and manifest authority:
+  concept families `tasks-runs-studies`, `apparatus-declarations`,
+  `provenance-and-evidence`, `realization-and-disclosure`, and
+  `time-and-apparatus`; processor/backend/participant manifest authority; and
+  governed observation capability vocabularies.
+
+## Whole-Repo Scope
+
+- Repo workflow policy: `.ground-control.yaml`, `.gc/plan-rules.md`, and the
+  repo policy and verification scripts.
+- Normative design authority: ADR-055, ADR-064, ADR-065, and
+  `specs/formal/experiment-core/README.md`.
+- Contract publication authority: contract source, generated schemas, fixtures,
+  schema publication manifest, schema drift checks, and ACES semantic-invariant
+  annotations.
+- Runtime/API boundary for future work: control-plane auth, request-size
+  guards, idempotency, audit store, response models, diagnostics, redacted error
+  envelopes, and existing runtime redaction/config validators.
+
+## Cross-Cutting Layers
+
+- Structural validation: every external payload must pass the closed-world
+  `ContractModel` source and the generated draft 2020-12 JSON Schema. Unknown
+  fields remain errors.
+- Run validation: `ExperimentRunModel._validate_archival_run()` enforces run
+  interval ordering, invalidation details, participant implementation
+  provenance resolution, result evidence resolution, and traced disclosure
+  evidence.
+- Task/run validation: `validate_experiment_run_against_task()` is the gate for
+  task identity/version, scenario snapshot compatibility, apparatus
+  constraints, task-declared metric ids, and task/metric evidence requirements.
+- Study allocation validation: `ExperimentRunAllocationPlanModel` and
+  `validate_experiment_study_against_tasks_and_runs()` enforce compared
+  conditions, condition assignments, blocking factors, target runs per
+  condition, evaluation-run eligibility, one-condition-per-run assignment, and
+  analysis metric grounding.
+- Manifest and digest validation: apparatus variations must use
+  `ExperimentManifestReferenceModel` and
+  `validate_experiment_apparatus_context_against_manifests()` for canonical
+  processor/backend manifest identity and digest binding.
+- Secret-handling surface: parameters may use redaction-aware
+  `ExperimentParameterModel`; condition-assignment parameters must be
+  auditable and non-redacted. Do not serialize credentials, bearer tokens,
+  private keys, hidden answer keys, raw prompts, environment dumps, process
+  argv, backend-private payloads, or full tracebacks into task/run/study
+  records, diagnostics, audit details, logs, fixtures, or examples.
+- Config/env-binding surface: run variation may cite bounded configuration,
+  apparatus, protocol, or analysis parameters. It must not introduce a new
+  environment-binding shape or store raw `os.environ`, CLI arguments, process
+  tables, or backend-local config objects.
+- API/auth surface: any future create/read/update path for trial, run, or
+  study records must reuse `aces_runtime.control_plane_api`,
+  `control_plane_api_guards`, `control_plane_security`,
+  `control_plane_store`, request fingerprints, idempotency keys, audit events,
+  response models, and redacted FastAPI error handling.
+- OS-level exposure: command helpers must not pass tokens, credentials, raw
+  evidence payloads, or large private run artifacts through process arguments.
+  Use content-addressed files, URIs, checksums, and synthetic fixtures.
+- Error-envelope surface: failures must use existing Pydantic validation
+  errors, structured `Diagnostic` values, or the existing redacted HTTP error
+  pattern. Do not echo full experiment records, evidence payloads, secrets,
+  tracebacks, or backend internals.
+- Persistence surface: archival trial/run/replication records must not be
+  stored in `RuntimeSnapshot.metadata`, operation records, participant
+  histories, audit details, or backend-private logs. Any future durable store
+  must preserve schema-versioned experiment artifacts and their refs.
+
+## Extensibility Guardrail
+
+The extension seam is `experiment-study-v1.run_allocation` plus existing run
+provenance fields, not a parallel trial service or schema. If a future change
+needs more than the current `replication_policy` string, `target_runs_per_condition`,
+condition assignments, membership groupings, parameters, and stochastic controls
+can express, extend the study allocation contract through the normal schema
+publication path. Producer code should parameterize the run producer source and
+artifact locator/sealing policy so additional replay backends, replication
+types, or apparatus variations emit the same canonical task/run/study shapes.
+
+## Gotchas And Anti-Patterns
+
+- Do not create duplicate trial, replication, or replay schemas for facts
+  already carried by task, run, apparatus, evidence, derived-measure, or study
+  contracts.
+- Do not treat operation ids, workflow run ids, participant episode ids,
+  snapshot addresses, or backend-native execution ids as portable trial ids.
+- Do not use tags, folders, evaluator `detail`, runtime metadata, or audit log
+  entries as study allocation or replication authority.
+- Do not make controlled variation depend on opaque `other` references,
+  redacted condition parameters, or unbounded free-text criteria.
+- Do not infer replication from repeated backend operations unless sealed
+  `experiment-run-v1` records and study membership/allocation refs exist.
+- Do not hand-edit `contracts/schemas/`; update contract sources, regenerate,
+  update the publication manifest when hashes change, and keep fixtures/tests
+  aligned.
+- Do not duplicate schema registries, validation helpers, exception
+  hierarchies, logging/audit stacks, manifest renderers, persistence stores, or
+  workflow logic for EXP-706.
+
+## Non-Goals
+
+- New trial root schema, new run-provenance root, or new study/collection
+  service.
+- Replay execution, schedulers, workers, runtime orchestration, capture
+  execution, retention jobs, HTTP APIs, or durable storage implementation.
+- Statistical analysis engines, derived-measure computation, evaluator behavior,
+  or benchmark reporting.
+- SDL syntax changes, scenario root sections, objective semantics, or runtime
+  snapshot changes.
+- New security model, exception hierarchy, logging pipeline, audit format,
+  manifest renderer, schema registry, or persistence stack.

--- a/docs/research/experiment-core/traceability-matrix-exp-706-712.md
+++ b/docs/research/experiment-core/traceability-matrix-exp-706-712.md
@@ -1,0 +1,38 @@
+# EXP-706/EXP-712 Clause Matrix
+
+Date: 2026-06-25
+
+Issue: #105.
+
+Requirements: EXP-706, EXP-712.
+
+This matrix maps the joint trial/replication and reproducibility/replay design
+to the documentation artifacts and incumbent executable gates. It is a
+docs-only acceptance artifact for ADR-068; it does not add new contract,
+schema, fixture, runtime, storage, or API behavior.
+
+## Matrix
+
+| Requirement | Clause | Design Artifact | Existing Gate Or Evidence |
+|-------------|--------|-----------------|---------------------------|
+| EXP-706 | One trial is one archival run record, not a new trial schema. | ADR-068 decision 1; experiment-core formal spec `Run` definition and separation invariants 21-22. | `ExperimentRunModel._validate_archival_run()` keeps a run archival and complete. |
+| EXP-706 | Repeated runs of the same task are distinct run records with distinct `run_id` values, shared `task_ref`, and compatible scenario snapshots. | ADR-068 decision 2; formal spec separation invariant 22; EXP-706 preflight guardrails. | `validate_experiment_run_against_task()` checks task identity, scenario snapshot compatibility, apparatus constraints, declared metrics, and evidence requirements. |
+| EXP-706 | Replication, cohort, benchmark, comparison, and controlled variation are study allocation semantics. | ADR-068 decision 3; formal spec `Study Or Collection` definition; provenance invariants 13-15 and 21. | `ExperimentRunAllocationPlanModel._validate_condition_assignments()` and `validate_experiment_study_against_tasks_and_runs()`. |
+| EXP-706 | Controlled variation must be grounded in auditable run-level facts, not tags or opaque metadata. | ADR-068 decision 3 and required boundaries; formal spec provenance invariants 13 and 21; EXP-706 preflight guardrails. | Existing study allocation validation rejects opaque catch-all references and invalid condition assignment evidence. |
+| EXP-706 | Runtime replay, schedulers, storage, HTTP APIs, statistical analysis, and provenance services remain out of scope. | ADR-068 decision 5 and alternatives; formal spec non-goals; EXP-706 preflight non-goals. | Docs-only diff confirmed; no contract source, schema, fixture, runtime, or API files changed. |
+| EXP-712 | Reproducibility and replay are claim-support disciplines over preserved context, evidence, provenance, and lineage. | ADR-068 decision 4; formal spec `Run Traceability` definition; EXP-712 preflight guardrails. | Existing run traceability, evidence-record, and derived-measure models remain the claim-support graph. |
+| EXP-712 | Replay support is distinct from executable replay or hidden backend-state reconstruction. | ADR-068 decision 4 and required boundaries; formal spec separation invariant 23 and provenance invariant 22. | No replay-run, replay-claim, reproducibility-claim, provenance-graph, storage, scheduler, or dereference API artifacts were added. |
+| EXP-712 | Claims must follow the chain from run context to capture specs, evidence records, derived measures, and claim/report refs. | ADR-068 decision 4; formal spec separation invariant 19 and 23; EXP-712 preflight cross-cutting layers. | `ExperimentRunTraceabilityModel._validate_run_traceability()` requires capture/evidence traceability and grounded claim refs. |
+| EXP-712 | Derived results must cite raw evidence records and cannot stand in for raw observations. | ADR-068 decision 4; formal spec `Evidence Record` and `Derived Measure` definitions; separation invariants 15-16. | `ExperimentDerivedMeasureModel._validate_derived_measure()` requires `source_evidence_refs`. |
+| EXP-712 | Claim strength is limited by preserved artifacts, redaction, loss, observer effects, unsupported surfaces, and apparatus limitations. | ADR-068 decision 4; formal spec provenance invariant 22; EXP-712 preflight architecture decisions and cross-cutting layers. | Existing evidence-record loss/redaction validation, artifact sensitivity metadata, traceability notes, disclosures, and validity notes remain the review surface. |
+
+## Non-Goals Checked
+
+- No `experiment-trial-v1` root schema.
+- No replay-run, reproducibility-claim, replay-claim, or provenance-graph root
+  schema.
+- No runtime replay execution, capture orchestration, scheduler, artifact
+  dereference API, retention store, query service, statistical analysis, or
+  derived-measure computation.
+- No SDL syntax, participant runtime, control-plane persistence, auth, error
+  envelope, exception hierarchy, or logging changes.

--- a/specs/formal/experiment-core/README.md
+++ b/specs/formal/experiment-core/README.md
@@ -1,8 +1,10 @@
 # Experiment Core Formal Specification
 
 This domain specifies the EXP-701 through EXP-705 experiment-core contract
-boundary plus the EXP-707, EXP-708, EXP-709, and EXP-715 evidence/measure
-extension and the EXP-710, EXP-720, and EXP-722 run provenance extension:
+boundary plus the EXP-706 trial/replication interpretation, the EXP-707,
+EXP-708, EXP-709, and EXP-715 evidence/measure extension, the EXP-710,
+EXP-720, and EXP-722 run provenance extension, and the EXP-712
+reproducibility/replay claim-support interpretation:
 
 - `experiment-task-v1`
 - `experiment-apparatus-context-v1`
@@ -41,7 +43,9 @@ Rationale:
   `docs/decisions/adrs/adr-055-experiment-core-contract-boundary.md` and
   `docs/decisions/adrs/adr-064-experiment-evidence-and-measure-contract-boundary.md`,
   and
-  `docs/decisions/adrs/adr-065-experiment-run-provenance-contract-boundary.md`.
+  `docs/decisions/adrs/adr-065-experiment-run-provenance-contract-boundary.md`,
+  and
+  `docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md`.
 - Machine-readable schemas: `contracts/schemas/experiment-core/`.
 - Contract source: `implementations/python/packages/aces_contracts/contracts.py`.
 - Schema generation: `tools/generate_contract_schemas.py`.
@@ -135,6 +139,12 @@ task. It binds:
 A run may reference live observation artifacts captured at a seal point. It
 must not be reconstructed from mutable live control-plane state.
 
+For EXP-706, one trial is one archival run record. Repeated runs of the same
+task are represented by multiple run records with distinct `run_id` values, a
+shared `task_ref`, and a compatible `scenario_snapshot_ref`. A repeated run
+MUST NOT be represented by mutating one run record, by a tag, or by a backend
+operation/workflow/episode identifier.
+
 Archival run records require a completed time interval, clock context, at least
 one evidence artifact, and at least one result summary. Reported result
 summaries must identify the metric, carry a value, and link to evidence. Every
@@ -162,6 +172,13 @@ Traceability belongs in the run because the run is the record that knows the
 task, scenario snapshot, apparatus, evidence, result summaries, and generated
 artifacts together. It is not a separate graph service and not an alternative
 run schema.
+
+For EXP-712, run traceability is the support surface for reproducibility and
+replay claims. It records what capture specifications, raw evidence records,
+derived measures, claim/report artifacts, disclosures, and lineage refs are
+available for review. It does not guarantee executable replay, artifact
+dereference, hidden backend-state reconstruction, or derived-result
+recomputation.
 
 ### Realized Form Disclosure
 
@@ -260,6 +277,17 @@ Studies carry accountable analysis context:
 - validity notes;
 - report and export artifact refs.
 
+For EXP-706, replications, cohorts, benchmarks, comparisons, and controlled
+variation are study allocation semantics. They are expressed through
+evaluation-run membership groupings, declared factors and factor levels,
+blocking factors, condition assignments, `target_runs_per_condition`,
+`replication_policy`, `stopping_rule`, and the analysis plan. Condition
+assignment evidence must be grounded in auditable run-level facts such as
+participant implementation provenance, processor/backend identity, apparatus
+context, selected manifests, capability declarations, measurement channels,
+task/scenario snapshot identity, non-opaque parameters, and stochastic
+controls.
+
 ## Invariants
 
 ### Separation
@@ -334,6 +362,19 @@ Studies carry accountable analysis context:
     value summary. Processor-realized disclosures MUST be attributed to a
     processor reference, and backend-realized disclosures MUST be attributed to
     a backend reference.
+21. `experiment-run-v1` is the trial record for the current model. ACES MUST
+    NOT publish a parallel trial root schema for the same task execution facts
+    unless a later ADR supersedes this boundary.
+22. Repeated executions of the same task MUST be represented by distinct run
+    records with distinct `run_id` values, a shared `task_ref`, and compatible
+    scenario snapshot identity. Operation ids, workflow ids, runtime snapshot
+    ids, participant episode ids, backend-native execution ids, tags, and
+    mutable run statuses MUST NOT stand in for repeated-run identity.
+23. Reproducibility and replay claims MUST use the run traceability chain from
+    run context to capture specs, evidence records, derived measures, and
+    claim/report refs. ACES MUST NOT publish parallel replay-run,
+    reproducibility-claim, replay-claim, or provenance-graph root schemas for
+    the same facts unless a later ADR supersedes this boundary.
 
 ### Provenance
 
@@ -417,6 +458,16 @@ Studies carry accountable analysis context:
     modes.
 20. Realized-form disclosure evidence refs MUST be present in the containing
     run's traceability evidence-record refs.
+21. Replication, cohort, benchmark, comparison, and controlled-variation claims
+    MUST be grounded in study membership and run allocation. Study membership
+    and allocation MUST NOT be replaced by tags, folders, evaluator detail,
+    runtime metadata, audit details, diagnostics, backend-private logs, or
+    free-form notes.
+22. Replay and reproducibility claim strength MUST be limited by the preserved
+    run context, evidence availability, redaction, loss disclosure, observer
+    effects, unsupported runtime surfaces, external artifact availability, and
+    apparatus limitations recorded in the relevant run, evidence, derived
+    measure, disclosure, and study artifacts.
 
 ### Closed-World Contracts
 
@@ -476,3 +527,7 @@ base. The most load-bearing criteria are:
   schedulers.
 - Backend-native packet/log/trace parsers.
 - Processor logic that computes derived measures from evidence records.
+- New trial, replay-run, reproducibility-claim, replay-claim, or provenance
+  graph root schemas for facts already carried by experiment-core contracts.
+- Runtime replay execution, replay scheduling, artifact dereference APIs,
+  retention storage, or query services.


### PR DESCRIPTION
## Summary

Defines the EXP-706/EXP-712 trial, replication, reproducibility, and replay-claim interpretation boundary over the existing experiment-core run, study, evidence, derived-measure, and traceability contracts.

## Requirement UIDs

- `EXP-706`
- `EXP-712`

## Related Issues

- Closes #105
- Closes #267

## ADR Impact

- docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md

## Changes

- Add ADR-068 for experiment trials, replication, and replay claims.
- Update the experiment-core formal spec with trial/run, study allocation, and replay claim-support definitions, invariants, and non-goals.
- Add EXP-706 and EXP-712 preflight guardrails plus a clause matrix that maps the requirements to ADR/spec/preflight artifacts and incumbent validators.
- Update ADR and research indexes plus the changelog fragment.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

pre-commit run --all-files; ACES_REQUIREMENT_UID=EXP-706 implementations/python/.venv/bin/python tools/check_repo_policy.py; ACES_REQUIREMENT_UID=EXP-706 implementations/python/.venv/bin/python tools/check_requirement_governance.py (exited 0; remote governance check skipped after Ground Control timeout); ACES_REQUIREMENT_UID=EXP-706 implementations/python/.venv/bin/python tools/verify_all.py; uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s lint; uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s hygiene

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.

