### PR TITLE
feat: bind participant implementations to runtime actions

### DIFF
--- a/changelog.d/599.added.md
+++ b/changelog.d/599.added.md
@@ -1,1 +1,1 @@
-Added a participant action-admission binding path that lets runtime backends record SDL-declared participant behavior through a selected participant implementation.
+Added a participant action-admission binding path that lets runtime backends record SDL-declared participant behavior through a selected participant implementation, including a request DTO control-plane surface.

--- a/changelog.d/599.added.md
+++ b/changelog.d/599.added.md
@@ -1,0 +1,1 @@
+Added a participant action-admission binding path that lets runtime backends record SDL-declared participant behavior through a selected participant implementation.

--- a/docs/decisions/issue-599-participant-implementation-binding-preflight.md
+++ b/docs/decisions/issue-599-participant-implementation-binding-preflight.md
@@ -1,0 +1,273 @@
+# Issue 599 Participant Implementation Binding Preflight
+
+Date: 2026-06-28
+
+Issue: #599.
+
+Requirement: none. The GitHub issue title, body, and acceptance criteria are
+the contract.
+
+This note records architecture guardrails for binding a compiled SDL-declared
+participant to a selected participant implementation. It is guidance only: it
+does not implement the binding, add schemas, change runtime behavior, or define
+an implementation plan.
+
+## Binding Sources
+
+- ADR-013 owns participant episode lifecycle. The binding must run inside that
+  lifecycle rather than treating a backend process, adapter process, or tool
+  invocation as the episode.
+- ADR-022 owns participant behavior semantics. Action names, tool labels,
+  backend commands, timestamps, rewards, and logs are not portable action or
+  observation semantics unless bound through action contracts, observation
+  boundaries, and evidence/provenance records.
+- ADR-041 owns participant implementation manifests and run-level provenance.
+  A participant implementation is apparatus; it is distinct from authored SDL
+  `agents`, backend manifests, processor manifests, control-plane callers, and
+  evaluator identity.
+- ADR-054 and `specs/formal/participant-runtime/` own participant runtime
+  lifecycle, behavior history, shared state, concurrency, visibility, and
+  no-leakage invariants.
+- ADR-060 and `specs/formal/runtime-contracts/participant-backend-contracts.md`
+  own the backend-facing participant carrier/retrieval surface.
+- ADR-067 and
+  `docs/decisions/issue-206-act-606-behavior-specifications-preflight.md` own
+  behavior specifications as aggregates over existing participant behavior
+  surfaces; runtime evidence must not become the authored behavior spec.
+- `docs/decisions/issue-598-paper-reference-scenario-preflight.md` owns the
+  authored paper scenario guardrails. Issue #599 consumes that compiled
+  scenario shape; it must not add scenario-local backend or agent-runner syntax.
+- ADR-063 and
+  `docs/decisions/issue-197-run-314-reference-emulation-backend-preflight.md`
+  own the reference backend boundary: portable ACES facts flow through manifests,
+  snapshots, diagnostics, conformance, and runtime result contracts.
+- `specs/agent-guidance/agent-guidance.yaml` forbids guidance/authoring tools
+  as a route to scan, exploit, SSH, execute commands, reveal hidden state, or
+  bypass backend controls.
+
+## Architecture Decisions
+
+- The binding is a narrow participant action-admission boundary. It consumes a
+  compiled `ParticipantBehaviorRuntime`, the compiled action/observation
+  addresses permitted by that behavior, and a selected participant implementation
+  manifest/provenance record. It is not a general shell, RPC, or command
+  execution API.
+- The binding must enter through `RuntimeControlPlane` and the target's
+  `ParticipantRuntime` component, so it inherits operation receipt/status,
+  idempotency, persistence, audit, diagnostics, and snapshot validation.
+- A backend may host or mediate the adapter, but the actor provenance emitted
+  in behavior history must identify the participant implementation selection,
+  not the backend component. Backend identity remains in `BackendManifest`;
+  processor/control-plane/evaluator identities remain separate.
+- Reference tests may use a deterministic in-process fake participant
+  implementation. Any live coding-agent proof must be opt-in, injected, and
+  bounded behind the same admission contract; default verification must stay
+  hermetic and must not require a local agent binary, daemon, credentials, or
+  network.
+- Emitted state belongs in existing first-class surfaces:
+  `RuntimeSnapshot.participant_episode_results`,
+  `RuntimeSnapshot.participant_episode_history`, and
+  `RuntimeSnapshot.participant_behavior_history`. Do not smuggle binding state
+  through `RuntimeSnapshot.metadata`, `ApplyResult.details`, backend-private
+  handles, or history `details` keys that duplicate first-class runtime fields.
+- Behavior events must preserve compiled SDL addresses:
+  `participant_address`, `episode_id`, `action_contract_address`,
+  `observation_boundary_address`, action instance id, lifecycle phase,
+  action/observation evidence refs, limitations, and actor provenance.
+- Unsupported, missing, incompatible, or unsafe bindings fail as structured
+  `Diagnostic` values and control-plane failed/rejected operations. They must
+  not escape as backend-private exceptions or raw adapter tracebacks.
+- The reusable seam for APTL and libvirt is the participant implementation
+  selection plus action-admission request, not a backend-specific action runner.
+  APTL, the reference backend, and libvirt should be able to consume the same
+  compiled behavior/action/observation/provenance inputs and differ only behind
+  injected adapter/provider leaves.
+
+## Required Incumbents
+
+- SDL and compiler ingress: `parse_sdl()` / `parse_sdl_file()`,
+  `compile_scenario_runtime_model()`, `compile_runtime_model()`,
+  `RuntimeModel.participant_behaviors`, `ParticipantBehaviorRuntime`,
+  `ParticipantBehaviorSpecificationRuntime`,
+  `ParticipantActionContractRuntime`, and
+  `ParticipantObservationBoundaryRuntime`.
+- Runtime/control-plane path: `RuntimeControlPlane`,
+  `execute_participant_action()`, `ParticipantRuntime`,
+  `ReferenceParticipantRuntime`, `RuntimeTarget`, `BackendRegistry`,
+  `RuntimeTargetComponents`, and `_validate_runtime_target_shape()`.
+- Backend result gate: `_call_backend_apply()`, `_call_backend_diagnostics()`,
+  `ApplyResult`, `RuntimeSnapshot`, `participant_runtime_state_contract_diagnostics()`,
+  and `participant_runtime_history_transition_diagnostics()`.
+- Participant history validators:
+  `ParticipantBehaviorHistoryEvent`,
+  `ParticipantBehaviorHistoryEventModel`,
+  `iter_participant_behavior_snapshot_violations()`,
+  `iter_participant_behavior_history_violations()`,
+  participant episode validators, shared-state validators, concurrency
+  validators, and participant retrieval view models.
+- Participant implementation apparatus:
+  `ParticipantImplementationManifestModel`,
+  `ParticipantImplementationProvenanceModel`,
+  `ParticipantImplementationSelectionModel`,
+  `ExperimentApparatusContextModel`, `ExperimentRunModel`, and
+  `validate_experiment_apparatus_context_against_manifests()`.
+- Backend capability and manifest authority:
+  `ParticipantRuntimeCapabilities`, `ParticipantFeatureSupport`,
+  `BackendManifest`, `BackendManifestV2Model`, `backend_manifest_payload()`,
+  `BACKEND_SUPPORTED_CONTRACT_IDS`, controlled-vocabulary validation, and
+  concept bindings.
+- Control-plane security and persistence:
+  `ControlPlaneSecurityConfig.strict_defaults()`, `ControlPlaneIdentity`,
+  `ControlPlaneRole`, request-size guards, request fingerprints, idempotency
+  keys, `AuditEvent`, `ControlPlaneStore`, `InMemoryControlPlaneStore`,
+  `LocalControlPlaneStore`, and redacted FastAPI internal-error handling.
+- Diagnostics and public error shape: `Diagnostic`, `Severity`,
+  `_failure_diagnostic()`, `OperationReceipt`, `OperationStatus`, existing
+  HTTP `HTTPException` mappings, and conformance diagnostics.
+- Repository workflow and policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `noxfile.py`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, `tools/check_generated_schemas.py`,
+  `tools/check_schema_publication.py`, `tools/check_json_artifacts.py`, and
+  `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- SDL/config ingress: binding tests must start from parsed/compiled SDL or a
+  deliberately constructed compiled model. Do not compile directly from raw
+  dicts, skip `SDLModel(extra="forbid")`, or derive runtime addresses from
+  free-form YAML names.
+- Compiled behavior gate: the admitted action must be a compiled action
+  contract address present in the selected `ParticipantBehaviorRuntime` or
+  behavior specification. The selected observation boundary must be one of the
+  compiled boundaries for that participant behavior.
+- Participant implementation manifest gate: selected implementations must
+  validate through `ParticipantImplementationManifestModel`; implementation
+  kind, supported contracts, decision-surface modes, tool affordances, exposure
+  policy kinds, concept bindings, and compatibility claims must use governed
+  vocabularies.
+- Provenance gate: run-level selection must use
+  `ParticipantImplementationProvenanceModel` fields: implementation identity,
+  manifest ref/digest, optional config ref/digest, decision-surface mode,
+  participant contract versions, exposure policy, and processor/backend manifest
+  refs. Hidden prompts, credentials, raw configuration, and decision-surface
+  contents stay out of this portable record.
+- Backend capability gate: backend support is read from `BackendManifest` /
+  `BackendManifestV2Model` and `capabilities.participant_runtime`, including
+  feature-support disclosures. A backend support claim is not proof that the
+  selected participant implementation ran.
+- Runtime target gate: target component presence must match the manifest. The
+  binding must not bypass `RuntimeTarget` shape validation or import a concrete
+  backend from core runtime packages.
+- Backend apply/snapshot gate: participant binding methods must return
+  `ApplyResult` with a `RuntimeSnapshot`. `_call_backend_apply()` must be able
+  to deep-copy the baseline, wrap unexpected exceptions as diagnostics, validate
+  result shape, validate participant state/history, enforce append-only history,
+  and reject invalid snapshots without persisting them.
+- Participant semantic gate: emitted behavior history must also pass the
+  existing SEM validators when supplied with compiled action contracts and
+  observation boundaries. The runtime gate checks portable snapshot integrity;
+  it does not replace deeper action, observation, visibility, temporal,
+  attribution, outcome, shared-state, or concurrency validation.
+- Control-plane security gate: any HTTP route added later must reuse
+  `create_control_plane_app()`, strict fail-closed security defaults, mutating
+  role checks, request-size limits, idempotency fingerprints, audit records, and
+  redacted internal errors. Participant authority is scenario meaning, not
+  control-plane authorization.
+- Secret and OS-exposure gate: adapter config, credentials, prompts, bearer
+  tokens, private keys, hidden answers, environment dumps, process argv, raw
+  stdout/stderr, backend-native object reprs, and full tracebacks must not
+  enter SDL, snapshots, diagnostics, audit details, fixtures, docs, or
+  changelog fragments. If a live local adapter must invoke a process, use fixed
+  argv, no `shell=True`, no secrets in argv or environment dumps, bounded
+  timeouts, controlled working directories, and redacted diagnostics.
+- Persistence gate: live state uses `ControlPlaneStore` and `RuntimeSnapshot`.
+  Archival apparatus/run evidence uses experiment and participant
+  implementation provenance contracts. Do not add a participant-binding store,
+  log, cache, or artifact database as a side channel.
+- Error-envelope gate: expected binding failures are `Diagnostic` values in
+  `OperationReceipt`/`OperationStatus` or bounded HTTP conflict/bad-request
+  details if an API is exposed. Do not introduce a participant-binding exception
+  hierarchy or public adapter-specific error payload.
+- Contract/schema gate: do not publish a new schema unless the implementation
+  truly introduces a portable payload that existing contracts cannot carry. If
+  a schema is necessary, it must be a closed `ContractModel`, generated through
+  `schema_bundle()`, covered by valid/invalid fixtures, and recorded in
+  `contracts/schema-publication-manifest.json`.
+- Verification gate: tests should stitch together existing fixtures and
+  validators rather than copying validation logic. Policy, generated-schema,
+  JSON-artifact, and full verify gates remain authoritative.
+
+## Relationship To Linked Issues
+
+- #598 provides the authored enterprise participant/evidence scenario. #599 is
+  the runtime/backend binding that consumes the compiled participant behavior,
+  selected participant implementation, and declared action/observation
+  addresses from that scenario.
+- #600 is the cross-backend corpus/proof direction. #599 should keep the binding
+  substrate-neutral so APTL and libvirt can consume the same compiled and
+  provenance inputs.
+- #614 and APTL #557 are downstream proof/consumer issues. They must not require
+  a different participant-action schema or a backend-hardcoded actor.
+- #343, #344, and #345 are related through the repo's current participant
+  runtime and apparatus surfaces: participant episode lifecycle, participant
+  behavior/runtime history, backend-facing participant contracts, and
+  participant implementation manifest/provenance. #599 composes those surfaces;
+  it does not redefine or fork them.
+
+## Extensibility Seam
+
+The seam is a typed participant action-admission request plus participant
+implementation selection. It should be parameterized by participant address,
+episode id, compiled behavior/spec address, action contract address,
+observation boundary address, action instance/correlation id, implementation
+identity or provenance ref, decision-surface mode, exposure-policy refs, and
+evidence/limitation refs.
+
+Future variations should add another adapter behind that seam, another
+participant implementation manifest/provenance selection, another governed
+feature-support/disclosure term, or another compiled action/observation
+address. They should not require changing SDL syntax, published participant
+history schemas, `RuntimeControlPlane`, conformance runners, or backend
+manifests solely to support APTL vs libvirt vs in-process execution.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating the backend, control plane, evaluator, OS account, or bearer-token
+  principal as the participant implementation actor;
+- treating `agents.*.actions` or behavior-spec refs as proof that an
+  implementation ran;
+- admitting arbitrary commands, prompt text, shell fragments, paths, env vars,
+  or backend-native action names through the portable binding;
+- using backend logs, timestamps, scheduler order, stdout, stderr, tracebacks,
+  container/VM ids, ATT&CK/CVE labels, or reward values as participant behavior
+  semantics without governed contracts and limitations;
+- writing participant episode or behavior state into metadata, generic details,
+  backend-private stores, or README prose instead of first-class snapshot and
+  provenance fields;
+- adding duplicate DTOs, schemas, validators, exception hierarchies, operation
+  stores, audit logs, conformance runners, or HTTP adapters;
+- bypassing `RuntimeControlPlane`, `execute_participant_action()`,
+  `_call_backend_apply()`, or the snapshot validators for convenience;
+- importing concrete backend or live-agent adapter packages from `aces_runtime`,
+  `aces_contracts`, `aces_processor`, or compatibility wrappers;
+- exposing hidden truth, prompts, credentials, private runner config, raw
+  environment, process argv, backend-native object reprs, or full tracebacks in
+  diagnostics, snapshots, fixtures, docs, logs, or changelog text.
+
+## Non-Goals
+
+- Implementing the binding, fake participant implementation, live coding-agent
+  adapter, APTL adapter, libvirt participant runtime, HTTP route, CLI, tests, or
+  proof artifacts in this preflight.
+- Adding SDL syntax, published schemas, backend profiles, controlled
+  vocabularies, contract fixtures, conformance runners, persistence stores, or
+  authentication mechanisms unless a later implementation proves an existing
+  surface cannot carry the portable fact.
+- Redesigning participant framing, behavior specifications, action contracts,
+  observation boundaries, participant episode lifecycle, runtime behavior
+  history, participant implementation manifest/provenance, backend manifests,
+  control-plane security, runtime persistence, or experiment-run provenance.
+- Making default verification depend on local agent installation, network
+  access, host daemon state, privileged execution, or external credentials.

--- a/implementations/python/packages/aces_backend_protocols/protocols.py
+++ b/implementations/python/packages/aces_backend_protocols/protocols.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
 from aces_contracts.participant_episode import (
     ParticipantEpisodeInitializeRequest,
     ParticipantEpisodeResetRequest,
@@ -140,6 +141,14 @@ class ParticipantRuntime(Protocol):
         snapshot: RuntimeSnapshot,
     ) -> ApplyResult:
         """Drive the current episode to ``TERMINATED`` with the given reason."""
+        ...
+
+    def admit_action(
+        self,
+        request: ParticipantActionAdmissionRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        """Admit one implementation-bound participant action attempt."""
         ...
 
     def status(self) -> dict[str, object]:

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -1,6 +1,7 @@
 """Stub runtime backends for compiler/planner testing."""
 
 from datetime import UTC, datetime
+from hashlib import sha256
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
@@ -22,6 +23,11 @@ from aces_backend_protocols.capabilities import (
 from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
+from aces_contracts.participant_binding import (
+    ParticipantActionAdmissionRequest,
+    participant_action_binding_events,
+    participant_behavior_event_payload,
+)
 from aces_contracts.participant_episode import (
     ParticipantEpisodeControlAction,
     ParticipantEpisodeExecutionState,
@@ -778,6 +784,54 @@ class StubParticipantRuntime:
         ]
         return self._apply(snapshot, address, new_state, events, replace_history=False)
 
+    def admit_action(
+        self,
+        request: ParticipantActionAdmissionRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        if not address:
+            return self._reject(snapshot, "participant_address must be non-empty", address)
+        current = snapshot.participant_episode_results.get(address)
+        if current is None:
+            return self._reject(
+                snapshot,
+                f"cannot admit participant action for {address!r}: no live episode",
+                address,
+            )
+        try:
+            current_state = ParticipantEpisodeExecutionState.from_payload(current)
+        except (TypeError, ValueError) as exc:
+            return self._reject(snapshot, f"current state is invalid: {exc}", address)
+        if current_state.status == ParticipantEpisodeStatus.TERMINATED:
+            return self._reject(
+                snapshot,
+                f"cannot admit participant action for terminated participant {address!r}",
+                address,
+            )
+        now = _now_iso()
+        post_state_digest = request.post_state_digest or _participant_binding_post_state_digest(request)
+        events = participant_action_binding_events(
+            request,
+            episode_id=current_state.episode_id,
+            timestamp=now,
+            post_state_digest=post_state_digest,
+        )
+        behavior_history = {
+            participant_address: list(events)
+            for participant_address, events in snapshot.participant_behavior_history.items()
+        }
+        behavior_history.setdefault(address, [])
+        behavior_history[address].extend(participant_behavior_event_payload(event) for event in events)
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                participant_behavior_history=behavior_history,
+            ),
+            changed_addresses=[address],
+        )
+
     def status(self) -> dict[str, object]:
         return {
             "participants": len(self._results),
@@ -847,6 +901,18 @@ _PARTICIPANT_TERMINAL_EVENT_FOR_REASON: dict[
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _participant_binding_post_state_digest(request: ParticipantActionAdmissionRequest) -> str:
+    digest_input = "|".join(
+        (
+            request.participant_address,
+            request.action_contract_address,
+            request.observation_boundary_address,
+            request.action_instance_id,
+        )
+    )
+    return "sha256:" + sha256(digest_input.encode("utf-8")).hexdigest()
 
 
 def create_stub_components(

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -790,19 +790,13 @@ class StubParticipantRuntime:
         snapshot: RuntimeSnapshot,
     ) -> ApplyResult:
         address = request.participant_address
-        if not address:
-            return self._reject(snapshot, "participant_address must be non-empty", address)
-        current = snapshot.participant_episode_results.get(address)
-        if current is None:
-            return self._reject(
-                snapshot,
-                f"cannot admit participant action for {address!r}: no live episode",
-                address,
-            )
-        try:
-            current_state = ParticipantEpisodeExecutionState.from_payload(current)
-        except (TypeError, ValueError) as exc:
-            return self._reject(snapshot, f"current state is invalid: {exc}", address)
+        current_state = self._live_predecessor(
+            snapshot,
+            address,
+            "cannot admit participant action for {address!r}: no live episode",
+        )
+        if isinstance(current_state, ApplyResult):
+            return current_state
         if current_state.status == ParticipantEpisodeStatus.TERMINATED:
             return self._reject(
                 snapshot,
@@ -843,6 +837,23 @@ class StubParticipantRuntime:
 
     def history(self) -> dict[str, list[dict[str, object]]]:
         return {address: list(events) for address, events in self._history.items()}
+
+    def _live_predecessor(
+        self,
+        snapshot: RuntimeSnapshot,
+        address: str,
+        no_episode_message: str,
+    ) -> ParticipantEpisodeExecutionState | ApplyResult:
+        current = snapshot.participant_episode_results.get(address) if address else None
+        if current is None:
+            message = (
+                "participant_address must be non-empty" if not address else no_episode_message.format(address=address)
+            )
+            return self._reject(snapshot, message, address)
+        try:
+            return ParticipantEpisodeExecutionState.from_payload(current)
+        except (TypeError, ValueError) as exc:
+            return self._reject(snapshot, f"current state is invalid: {exc}", address)
 
     def _apply(
         self,

--- a/implementations/python/packages/aces_contracts/participant_binding.py
+++ b/implementations/python/packages/aces_contracts/participant_binding.py
@@ -89,6 +89,14 @@ def participant_action_admission_request_violations(
 ) -> tuple[str, ...]:
     """Return manifest/selection compatibility violations for a binding request."""
 
+    return (
+        *_implementation_selection_violations(request),
+        *_exposure_policy_violations(request),
+        *_action_result_violations(request),
+    )
+
+
+def _implementation_selection_violations(request: ParticipantActionAdmissionRequest) -> tuple[str, ...]:
     violations: list[str] = []
     manifest = request.implementation_manifest
     selection = request.implementation_selection
@@ -115,7 +123,12 @@ def participant_action_admission_request_violations(
         violations.append(
             "implementation exposure policy uses kinds unsupported by the manifest: " + ", ".join(unsupported_policies)
         )
-    policy = selection.exposure_policy
+    return tuple(violations)
+
+
+def _exposure_policy_violations(request: ParticipantActionAdmissionRequest) -> tuple[str, ...]:
+    violations: list[str] = []
+    policy = request.implementation_selection.exposure_policy
     action_result_evidence_refs = _action_result_evidence_refs(request.action_result)
     observation_evidence_refs = set(request.evidence_refs) | action_result_evidence_refs
     emitted_refs = set(request.visible_refs) | set(request.disclosed_refs) | observation_evidence_refs
@@ -143,13 +156,20 @@ def participant_action_admission_request_violations(
             "evidence_refs must be declared by the compiled observation boundary: "
             + ", ".join(unauthorized_evidence_refs)
         )
-    if request.action_result is not None:
-        if request.action_result.participant_address != request.participant_address:
-            violations.append("action_result participant_address must match the binding participant_address")
-        if request.action_result.action_instance_id != request.action_instance_id:
-            violations.append("action_result action_instance_id must match the binding action_instance_id")
-        if request.action_result.action_contract_address != request.action_contract_address:
-            violations.append("action_result action_contract_address must match the binding action_contract_address")
+    return tuple(violations)
+
+
+def _action_result_violations(request: ParticipantActionAdmissionRequest) -> tuple[str, ...]:
+    violations: list[str] = []
+    action_result = request.action_result
+    if action_result is None:
+        return ()
+    if action_result.participant_address != request.participant_address:
+        violations.append("action_result participant_address must match the binding participant_address")
+    if action_result.action_instance_id != request.action_instance_id:
+        violations.append("action_result action_instance_id must match the binding action_instance_id")
+    if action_result.action_contract_address != request.action_contract_address:
+        violations.append("action_result action_contract_address must match the binding action_contract_address")
     return tuple(violations)
 
 

--- a/implementations/python/packages/aces_contracts/participant_binding.py
+++ b/implementations/python/packages/aces_contracts/participant_binding.py
@@ -1,0 +1,258 @@
+"""Neutral participant implementation binding DTOs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .contracts import (
+    ParticipantActionResultModel,
+    ParticipantBehaviorHistoryEventModel,
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
+    ParticipantObservationDetailsModel,
+)
+from .participant_behavior import (
+    ParticipantAdmissionDisposition,
+    ParticipantBehaviorHistoryEventType,
+    ParticipantObservationStatus,
+    ParticipantPhaseRealization,
+    ParticipantRuntimeLifecyclePhase,
+)
+
+_ACTION_CONTRACT_PREFIX = "participant.action-contract."
+_OBSERVATION_BOUNDARY_PREFIX = "participant.observation-boundary."
+
+
+@dataclass(frozen=True)
+class ParticipantActionAdmissionRequest:
+    """Backend-neutral request to admit one compiled participant action."""
+
+    participant_address: str
+    action_contract_address: str
+    observation_boundary_address: str
+    action_instance_id: str
+    implementation_manifest: ParticipantImplementationManifestModel
+    implementation_selection: ParticipantImplementationSelectionModel
+    evidence_refs: tuple[str, ...] = ()
+    visible_refs: tuple[str, ...] = ()
+    disclosed_refs: tuple[str, ...] = ()
+    observation_boundary_evidence_refs: tuple[str, ...] = ()
+    action_result: ParticipantActionResultModel | None = None
+    state_transition_kind: str = "participant_action_admitted"
+    post_state_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.participant_address, "participant_address")
+        _require_prefixed(
+            self.action_contract_address,
+            _ACTION_CONTRACT_PREFIX,
+            "action_contract_address",
+        )
+        _require_prefixed(
+            self.observation_boundary_address,
+            _OBSERVATION_BOUNDARY_PREFIX,
+            "observation_boundary_address",
+        )
+        _require_non_empty(self.action_instance_id, "action_instance_id")
+        _require_non_empty(self.state_transition_kind, "state_transition_kind")
+        if self.post_state_digest is not None:
+            _require_non_empty(self.post_state_digest, "post_state_digest")
+        if not isinstance(self.implementation_manifest, ParticipantImplementationManifestModel):
+            raise TypeError("implementation_manifest must be a ParticipantImplementationManifestModel")
+        if not isinstance(self.implementation_selection, ParticipantImplementationSelectionModel):
+            raise TypeError("implementation_selection must be a ParticipantImplementationSelectionModel")
+        if self.action_result is not None and not isinstance(self.action_result, ParticipantActionResultModel):
+            raise TypeError("action_result must be a ParticipantActionResultModel or None")
+        object.__setattr__(self, "evidence_refs", _string_tuple(self.evidence_refs, "evidence_refs"))
+        object.__setattr__(self, "visible_refs", _string_tuple(self.visible_refs, "visible_refs"))
+        object.__setattr__(self, "disclosed_refs", _string_tuple(self.disclosed_refs, "disclosed_refs"))
+        object.__setattr__(
+            self,
+            "observation_boundary_evidence_refs",
+            _string_tuple(self.observation_boundary_evidence_refs, "observation_boundary_evidence_refs"),
+        )
+        violations = participant_action_admission_request_violations(self)
+        if violations:
+            raise ValueError(violations[0])
+
+
+def participant_implementation_actor_provenance(selection: ParticipantImplementationSelectionModel) -> str:
+    """Return the portable actor provenance ref for a selected implementation."""
+
+    identity = selection.implementation_identity
+    return f"participant-implementation:{identity.name}@{identity.version}"
+
+
+def participant_action_admission_request_violations(
+    request: ParticipantActionAdmissionRequest,
+) -> tuple[str, ...]:
+    """Return manifest/selection compatibility violations for a binding request."""
+
+    violations: list[str] = []
+    manifest = request.implementation_manifest
+    selection = request.implementation_selection
+    if selection.participant_address != request.participant_address:
+        violations.append(
+            "implementation selection participant_address must match the compiled participant behavior address"
+        )
+    if manifest.identity.model_dump(mode="json") != selection.implementation_identity.model_dump(mode="json"):
+        violations.append("implementation selection identity must match the participant implementation manifest")
+    unsupported_contracts = sorted(
+        set(selection.participant_contract_versions) - set(manifest.capabilities.supported_participant_contracts)
+    )
+    if unsupported_contracts:
+        violations.append(
+            "implementation selection declares participant contracts unsupported by the manifest: "
+            + ", ".join(unsupported_contracts)
+        )
+    if selection.selected_decision_surface_mode not in manifest.capabilities.supported_decision_surface_modes:
+        violations.append("selected decision-surface mode is not supported by the participant implementation manifest")
+    unsupported_policies = sorted(
+        set(selection.exposure_policy.exposure_policy_kinds) - set(manifest.capabilities.exposure_policy_kinds)
+    )
+    if unsupported_policies:
+        violations.append(
+            "implementation exposure policy uses kinds unsupported by the manifest: " + ", ".join(unsupported_policies)
+        )
+    policy = selection.exposure_policy
+    action_result_evidence_refs = _action_result_evidence_refs(request.action_result)
+    observation_evidence_refs = set(request.evidence_refs) | action_result_evidence_refs
+    emitted_refs = set(request.visible_refs) | set(request.disclosed_refs) | observation_evidence_refs
+    withheld_refs = sorted(emitted_refs & set(policy.withheld_refs))
+    if withheld_refs:
+        violations.append(
+            "participant binding refs must not include exposure policy withheld_refs: " + ", ".join(withheld_refs)
+        )
+    visible_allowed_refs = set(policy.disclosed_refs) | set(policy.visibility_scope_refs)
+    unauthorized_visible_refs = sorted(set(request.visible_refs) - visible_allowed_refs)
+    if unauthorized_visible_refs:
+        violations.append(
+            "visible_refs must be declared by exposure policy disclosed_refs or visibility_scope_refs: "
+            + ", ".join(unauthorized_visible_refs)
+        )
+    unauthorized_disclosed_refs = sorted(set(request.disclosed_refs) - set(policy.disclosed_refs))
+    if unauthorized_disclosed_refs:
+        violations.append(
+            "disclosed_refs must be declared by exposure policy disclosed_refs: "
+            + ", ".join(unauthorized_disclosed_refs)
+        )
+    unauthorized_evidence_refs = sorted(observation_evidence_refs - set(request.observation_boundary_evidence_refs))
+    if unauthorized_evidence_refs:
+        violations.append(
+            "evidence_refs must be declared by the compiled observation boundary: "
+            + ", ".join(unauthorized_evidence_refs)
+        )
+    if request.action_result is not None:
+        if request.action_result.participant_address != request.participant_address:
+            violations.append("action_result participant_address must match the binding participant_address")
+        if request.action_result.action_instance_id != request.action_instance_id:
+            violations.append("action_result action_instance_id must match the binding action_instance_id")
+        if request.action_result.action_contract_address != request.action_contract_address:
+            violations.append("action_result action_contract_address must match the binding action_contract_address")
+    return tuple(violations)
+
+
+def _action_result_evidence_refs(action_result: ParticipantActionResultModel | None) -> set[str]:
+    if action_result is None:
+        return set()
+    evidence_refs = set(action_result.evidence_refs)
+    for precondition in action_result.preconditions:
+        evidence_refs.update(precondition.evidence_refs)
+    for effect in action_result.effects:
+        evidence_refs.update(effect.evidence_refs)
+    return evidence_refs
+
+
+def participant_action_binding_events(
+    request: ParticipantActionAdmissionRequest,
+    *,
+    episode_id: str,
+    timestamp: str,
+    post_state_digest: str,
+) -> tuple[ParticipantBehaviorHistoryEventModel, ...]:
+    """Build the portable behavior-history events for an admitted action."""
+
+    actor_provenance = participant_implementation_actor_provenance(request.implementation_selection)
+    return (
+        ParticipantBehaviorHistoryEventModel(
+            event_type=ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED,
+            timestamp=timestamp,
+            participant_address=request.participant_address,
+            episode_id=episode_id,
+            action_instance_id=request.action_instance_id,
+            action_contract_address=request.action_contract_address,
+            actor_provenance=actor_provenance,
+            lifecycle_phase=ParticipantRuntimeLifecyclePhase.SELECTION_OR_ADMISSION,
+            phase_realization=ParticipantPhaseRealization.RUNTIME_MEDIATED,
+            admission_disposition=ParticipantAdmissionDisposition.ADMITTED,
+        ),
+        ParticipantBehaviorHistoryEventModel(
+            event_type=ParticipantBehaviorHistoryEventType.STATE_TRANSITION_RECORDED,
+            timestamp=timestamp,
+            participant_address=request.participant_address,
+            episode_id=episode_id,
+            action_instance_id=request.action_instance_id,
+            action_contract_address=request.action_contract_address,
+            lifecycle_phase=ParticipantRuntimeLifecyclePhase.STATE_UPDATE_COMMIT,
+            phase_realization=ParticipantPhaseRealization.RUNTIME_MEDIATED,
+            state_transition_kind=request.state_transition_kind,
+            post_state_digest=post_state_digest,
+        ),
+        ParticipantBehaviorHistoryEventModel(
+            event_type=ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED,
+            timestamp=timestamp,
+            participant_address=request.participant_address,
+            episode_id=episode_id,
+            action_instance_id=request.action_instance_id,
+            action_contract_address=request.action_contract_address,
+            observation_boundary_address=request.observation_boundary_address,
+            observation_status=ParticipantObservationStatus.TERMINAL,
+            lifecycle_phase=ParticipantRuntimeLifecyclePhase.OBSERVATION_EMISSION,
+            phase_realization=ParticipantPhaseRealization.RUNTIME_MEDIATED,
+            post_state_digest=post_state_digest,
+            action_result=request.action_result,
+            details=ParticipantObservationDetailsModel(
+                visible_refs=list(request.visible_refs),
+                disclosed_refs=list(request.disclosed_refs),
+                evidence_refs=list(request.evidence_refs),
+            ),
+        ),
+    )
+
+
+def participant_behavior_event_payload(event: ParticipantBehaviorHistoryEventModel) -> dict[str, object]:
+    """Serialize a behavior event without empty optional/default fields."""
+
+    return event.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{field_name} must be a non-empty string")
+
+
+def _require_prefixed(value: str, prefix: str, field_name: str) -> None:
+    _require_non_empty(value, field_name)
+    if not value.startswith(prefix):
+        raise ValueError(f"{field_name} must be a compiled {prefix.removesuffix('.')} address")
+
+
+def _string_tuple(value: Iterable[str], field_name: str) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
+        raise TypeError(f"{field_name} must be an iterable of strings")
+    values = tuple(value)
+    if any(not isinstance(item, str) or not item for item in values):
+        raise TypeError(f"{field_name} entries must be non-empty strings")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} entries must be unique")
+    return values
+
+
+__all__ = (
+    "ParticipantActionAdmissionRequest",
+    "participant_action_admission_request_violations",
+    "participant_action_binding_events",
+    "participant_behavior_event_payload",
+    "participant_implementation_actor_provenance",
+)

--- a/implementations/python/packages/aces_reference_backend/participant_runtime.py
+++ b/implementations/python/packages/aces_reference_backend/participant_runtime.py
@@ -10,8 +10,14 @@ current result is the head of the history chain. Independent of the stub.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from hashlib import sha256
 
 from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.participant_binding import (
+    ParticipantActionAdmissionRequest,
+    participant_action_binding_events,
+    participant_behavior_event_payload,
+)
 from aces_contracts.participant_episode import (
     ParticipantEpisodeControlAction,
     ParticipantEpisodeExecutionState,
@@ -215,6 +221,48 @@ class ReferenceParticipantRuntime:
         ]
         return self._apply(snapshot, address, new_state, events, replace_history=False)
 
+    def admit_action(
+        self,
+        request: ParticipantActionAdmissionRequest,
+        snapshot: RuntimeSnapshot,
+    ) -> ApplyResult:
+        address = request.participant_address
+        current_state = self._live_predecessor(
+            snapshot,
+            address,
+            "cannot admit participant action for {address!r}: no live episode",
+        )
+        if isinstance(current_state, ApplyResult):
+            return current_state
+        if current_state.status == ParticipantEpisodeStatus.TERMINATED:
+            return self._reject(
+                snapshot,
+                f"cannot admit participant action for terminated participant {address!r}",
+                address,
+            )
+        now = _now_iso()
+        post_state_digest = request.post_state_digest or _participant_binding_post_state_digest(request)
+        events = participant_action_binding_events(
+            request,
+            episode_id=current_state.episode_id,
+            timestamp=now,
+            post_state_digest=post_state_digest,
+        )
+        behavior_history = {
+            participant_address: list(events)
+            for participant_address, events in snapshot.participant_behavior_history.items()
+        }
+        behavior_history.setdefault(address, [])
+        behavior_history[address].extend(participant_behavior_event_payload(event) for event in events)
+        return ApplyResult(
+            success=True,
+            snapshot=snapshot.with_entries(
+                dict(snapshot.entries),
+                participant_behavior_history=behavior_history,
+            ),
+            changed_addresses=[address],
+        )
+
     def status(self) -> dict[str, object]:
         return {
             "participants": len(self._results),
@@ -292,3 +340,15 @@ class ReferenceParticipantRuntime:
         next_index = self._episode_counter.get(address, 0) + 1
         self._episode_counter[address] = next_index
         return f"{address}-episode-{next_index}"
+
+
+def _participant_binding_post_state_digest(request: ParticipantActionAdmissionRequest) -> str:
+    digest_input = "|".join(
+        (
+            request.participant_address,
+            request.action_contract_address,
+            request.observation_boundary_address,
+            request.action_instance_id,
+        )
+    )
+    return "sha256:" + sha256(digest_input.encode("utf-8")).hexdigest()

--- a/implementations/python/packages/aces_runtime/control_plane.py
+++ b/implementations/python/packages/aces_runtime/control_plane.py
@@ -12,13 +12,6 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.participant_episode import (
-    ParticipantEpisodeInitializeRequest,
-    ParticipantEpisodeResetRequest,
-    ParticipantEpisodeRestartRequest,
-    ParticipantEpisodeTerminalReason,
-    ParticipantEpisodeTerminateRequest,
-)
 from aces_contracts.planning import EvaluationPlan, OrchestrationPlan, ProvisioningPlan, RuntimeDomain
 from aces_contracts.runtime_state import (
     OperationReceipt,
@@ -40,7 +33,6 @@ from .control_plane_execution import (
     OperationExecutionRequest,
     SucceededOperationRequest,
     execute_operation,
-    execute_participant_action,
     persist_succeeded_operation,
 )
 from .control_plane_store import (
@@ -51,10 +43,10 @@ from .control_plane_store import (
 )
 from .control_plane_timeouts import workflow_timeout_update
 from .control_plane_workflows import maybe_apply_compensation
+from .participant_control import ParticipantControlMixin
 from .participant_retrieval import ParticipantRetrievalMixin
 from .registry import RuntimeTarget
 
-_NO_PARTICIPANT_RUNTIME_MESSAGE = "Target does not provide a participant runtime."
 _TERMINAL_WORKFLOW_STATUSES = {
     WorkflowStatus.SUCCEEDED,
     WorkflowStatus.FAILED,
@@ -67,7 +59,7 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-class RuntimeControlPlane(ParticipantRetrievalMixin):
+class RuntimeControlPlane(ParticipantControlMixin, ParticipantRetrievalMixin):
     """Reference control plane for async runtime submission and observation."""
 
     def __init__(
@@ -395,124 +387,6 @@ class RuntimeControlPlane(ParticipantRetrievalMixin):
         )
         return receipt
 
-    def initialize_participant_episode(
-        self,
-        participant_address: str,
-        *,
-        episode_id: str | None = None,
-        idempotency_key: str = "",
-        request_fingerprint: str = "",
-    ) -> OperationReceipt:
-        if self._target.participant_runtime is None:
-            return self._reject_submission(
-                domain=RuntimeDomain.PARTICIPANT,
-                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
-            )
-        request = ParticipantEpisodeInitializeRequest(
-            participant_address=participant_address,
-            episode_id=episode_id,
-        )
-        return execute_participant_action(
-            self,
-            method=self._target.participant_runtime.initialize,
-            request=request,
-            address=f"runtime.control-plane.participant.{participant_address}.initialize",
-            idempotency_key=idempotency_key,
-            request_fingerprint=request_fingerprint,
-        )
-
-    def reset_participant_episode(
-        self,
-        participant_address: str,
-        *,
-        episode_id: str | None = None,
-        reason: str = "reset by operator",
-        idempotency_key: str = "",
-        request_fingerprint: str = "",
-    ) -> OperationReceipt:
-        if self._target.participant_runtime is None:
-            return self._reject_submission(
-                domain=RuntimeDomain.PARTICIPANT,
-                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
-            )
-        request = ParticipantEpisodeResetRequest(
-            participant_address=participant_address,
-            episode_id=episode_id,
-            reason=reason,
-        )
-        return execute_participant_action(
-            self,
-            method=self._target.participant_runtime.reset,
-            request=request,
-            address=f"runtime.control-plane.participant.{participant_address}.reset",
-            idempotency_key=idempotency_key,
-            request_fingerprint=request_fingerprint,
-        )
-
-    def restart_participant_episode(
-        self,
-        participant_address: str,
-        *,
-        episode_id: str | None = None,
-        reason: str = "restarted by operator",
-        idempotency_key: str = "",
-        request_fingerprint: str = "",
-    ) -> OperationReceipt:
-        if self._target.participant_runtime is None:
-            return self._reject_submission(
-                domain=RuntimeDomain.PARTICIPANT,
-                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
-            )
-        request = ParticipantEpisodeRestartRequest(
-            participant_address=participant_address,
-            episode_id=episode_id,
-            reason=reason,
-        )
-        return execute_participant_action(
-            self,
-            method=self._target.participant_runtime.restart,
-            request=request,
-            address=f"runtime.control-plane.participant.{participant_address}.restart",
-            idempotency_key=idempotency_key,
-            request_fingerprint=request_fingerprint,
-        )
-
-    def terminate_participant_episode(
-        self,
-        participant_address: str,
-        *,
-        terminal_reason: ParticipantEpisodeTerminalReason = ParticipantEpisodeTerminalReason.INTERRUPTED,
-        detail: str = "terminated by operator",
-        idempotency_key: str = "",
-        request_fingerprint: str = "",
-    ) -> OperationReceipt:
-        if self._target.participant_runtime is None:
-            return self._reject_submission(
-                domain=RuntimeDomain.PARTICIPANT,
-                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
-            )
-        request = ParticipantEpisodeTerminateRequest(
-            participant_address=participant_address,
-            terminal_reason=terminal_reason,
-            detail=detail,
-        )
-        return execute_participant_action(
-            self,
-            method=self._target.participant_runtime.terminate,
-            request=request,
-            address=f"runtime.control-plane.participant.{participant_address}.terminate",
-            idempotency_key=idempotency_key,
-            request_fingerprint=request_fingerprint,
-        )
-
     def record_audit(
         self,
         *,
@@ -545,20 +419,35 @@ class RuntimeControlPlane(ParticipantRetrievalMixin):
         idempotency_key: str = "",
         request_fingerprint: str = "",
     ) -> OperationReceipt:
-        operation_id = str(uuid4())
-        submitted_at = _utc_now()
         diagnostic = Diagnostic(
             code="runtime.control-plane.rejected",
             domain="runtime",
             address=f"runtime.control-plane.{domain.value}",
             message=message,
         )
+        return self._reject_diagnostics(
+            domain=domain,
+            diagnostics=[diagnostic],
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def _reject_diagnostics(
+        self,
+        *,
+        domain: RuntimeDomain,
+        diagnostics: list[Diagnostic],
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        operation_id = str(uuid4())
+        submitted_at = _utc_now()
         receipt = OperationReceipt(
             operation_id=operation_id,
             domain=domain,
             submitted_at=submitted_at,
             accepted=False,
-            diagnostics=[diagnostic],
+            diagnostics=list(diagnostics),
         )
         status = OperationStatus(
             operation_id=operation_id,
@@ -566,7 +455,7 @@ class RuntimeControlPlane(ParticipantRetrievalMixin):
             state=OperationState.FAILED,
             submitted_at=submitted_at,
             updated_at=submitted_at,
-            diagnostics=[diagnostic],
+            diagnostics=list(diagnostics),
         )
         self._persist_record(
             ControlPlaneOperationRecord(

--- a/implementations/python/packages/aces_runtime/participant_control.py
+++ b/implementations/python/packages/aces_runtime/participant_control.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-from aces_contracts.contracts import (
-    ParticipantActionResultModel,
-    ParticipantImplementationManifestModel,
-    ParticipantImplementationSelectionModel,
-)
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
 from aces_contracts.participant_episode import (
@@ -43,21 +38,100 @@ def _participant_binding_diagnostic(address: str, message: str) -> Diagnostic:
 def _participant_binding_diagnostics(
     participant_behavior: object,
     *,
-    implementation_manifest: ParticipantImplementationManifestModel,
-    implementation_selection: ParticipantImplementationSelectionModel,
-    action_contract_address: str,
-    observation_boundary_address: str,
-) -> list[Diagnostic]:
+    admission_request: object,
+    admission_fields: dict[str, object],
+) -> tuple[ParticipantActionAdmissionRequest | None, list[Diagnostic]]:
     address = _participant_binding_address(participant_behavior)
-    diagnostics: list[Diagnostic] = []
     if not isinstance(participant_behavior, ParticipantBehaviorRuntime):
-        return [
+        return None, [
             _participant_binding_diagnostic(
                 address,
                 "participant_behavior must be a compiled ParticipantBehaviorRuntime",
             )
         ]
-    if action_contract_address not in participant_behavior.action_contract_addresses:
+    request, diagnostics = _participant_admission_request(
+        participant_behavior,
+        admission_request=admission_request,
+        admission_fields=admission_fields,
+    )
+    if diagnostics:
+        return None, diagnostics
+    diagnostics.extend(_participant_binding_request_diagnostics(participant_behavior, request))
+    return (request if not diagnostics else None), diagnostics
+
+
+def _participant_admission_request(
+    participant_behavior: ParticipantBehaviorRuntime,
+    *,
+    admission_request: object,
+    admission_fields: dict[str, object],
+) -> tuple[ParticipantActionAdmissionRequest | None, list[Diagnostic]]:
+    address = _participant_binding_address(participant_behavior)
+    if admission_request is not None:
+        return _explicit_participant_admission_request(address, admission_request, admission_fields)
+    field_diagnostics = _participant_binding_field_diagnostics(participant_behavior, admission_fields)
+    if field_diagnostics:
+        return None, field_diagnostics
+    return _participant_admission_request_from_fields(participant_behavior, admission_fields)
+
+
+def _explicit_participant_admission_request(
+    address: str,
+    admission_request: object,
+    admission_fields: dict[str, object],
+) -> tuple[ParticipantActionAdmissionRequest | None, list[Diagnostic]]:
+    if admission_fields:
+        return None, [
+            _participant_binding_diagnostic(
+                address,
+                "admission_request cannot be combined with admission keyword fields",
+            )
+        ]
+    return _validated_participant_admission_request(address, admission_request)
+
+
+def _participant_admission_request_from_fields(
+    participant_behavior: ParticipantBehaviorRuntime,
+    admission_fields: dict[str, object],
+) -> tuple[ParticipantActionAdmissionRequest | None, list[Diagnostic]]:
+    address = _participant_binding_address(participant_behavior)
+    try:
+        return (
+            ParticipantActionAdmissionRequest(
+                participant_address=participant_behavior.address,
+                **admission_fields,
+            ),
+            [],
+        )
+    except (TypeError, ValueError) as exc:
+        return None, [_participant_binding_diagnostic(address, str(exc))]
+
+
+def _validated_participant_admission_request(
+    address: str,
+    admission_request: object,
+) -> tuple[ParticipantActionAdmissionRequest | None, list[Diagnostic]]:
+    if isinstance(admission_request, ParticipantActionAdmissionRequest):
+        return admission_request, []
+    return None, [
+        _participant_binding_diagnostic(
+            address,
+            "admission_request must be a ParticipantActionAdmissionRequest",
+        )
+    ]
+
+
+def _participant_binding_field_diagnostics(
+    participant_behavior: ParticipantBehaviorRuntime,
+    admission_fields: dict[str, object],
+) -> list[Diagnostic]:
+    address = _participant_binding_address(participant_behavior)
+    diagnostics: list[Diagnostic] = []
+    action_contract_address = admission_fields.get("action_contract_address")
+    if (
+        isinstance(action_contract_address, str)
+        and action_contract_address not in participant_behavior.action_contract_addresses
+    ):
         diagnostics.append(
             _participant_binding_diagnostic(
                 address,
@@ -67,7 +141,11 @@ def _participant_binding_diagnostics(
                 ),
             )
         )
-    if observation_boundary_address not in participant_behavior.observation_boundary_addresses:
+    observation_boundary_address = admission_fields.get("observation_boundary_address")
+    if (
+        isinstance(observation_boundary_address, str)
+        and observation_boundary_address not in participant_behavior.observation_boundary_addresses
+    ):
         diagnostics.append(
             _participant_binding_diagnostic(
                 address,
@@ -77,18 +155,42 @@ def _participant_binding_diagnostics(
                 ),
             )
         )
-    if not isinstance(implementation_manifest, ParticipantImplementationManifestModel):
+    return diagnostics
+
+
+def _participant_binding_request_diagnostics(
+    participant_behavior: ParticipantBehaviorRuntime,
+    request: ParticipantActionAdmissionRequest | None,
+) -> list[Diagnostic]:
+    if request is None:
+        return []
+    address = _participant_binding_address(participant_behavior)
+    diagnostics: list[Diagnostic] = []
+    if request.participant_address != participant_behavior.address:
         diagnostics.append(
             _participant_binding_diagnostic(
                 address,
-                "implementation_manifest must be a ParticipantImplementationManifestModel",
+                "admission_request participant_address must match the compiled participant behavior address",
             )
         )
-    if not isinstance(implementation_selection, ParticipantImplementationSelectionModel):
+    if request.action_contract_address not in participant_behavior.action_contract_addresses:
         diagnostics.append(
             _participant_binding_diagnostic(
                 address,
-                "implementation_selection must be a ParticipantImplementationSelectionModel",
+                (
+                    f"action_contract_address {request.action_contract_address!r} is not declared by compiled "
+                    f"participant behavior {participant_behavior.address!r}"
+                ),
+            )
+        )
+    if request.observation_boundary_address not in participant_behavior.observation_boundary_addresses:
+        diagnostics.append(
+            _participant_binding_diagnostic(
+                address,
+                (
+                    f"observation_boundary_address {request.observation_boundary_address!r} is not declared by compiled "
+                    f"participant behavior {participant_behavior.address!r}"
+                ),
             )
         )
     return diagnostics
@@ -218,19 +320,11 @@ class ParticipantControlMixin:
     def admit_participant_action(
         self,
         participant_behavior: ParticipantBehaviorRuntime,
+        admission_request: ParticipantActionAdmissionRequest | None = None,
         *,
-        implementation_manifest: ParticipantImplementationManifestModel,
-        implementation_selection: ParticipantImplementationSelectionModel,
-        action_contract_address: str,
-        observation_boundary_address: str,
-        action_instance_id: str,
-        observation_boundary_evidence_refs: tuple[str, ...] = (),
-        evidence_refs: tuple[str, ...] = (),
-        visible_refs: tuple[str, ...] = (),
-        disclosed_refs: tuple[str, ...] = (),
-        action_result: ParticipantActionResultModel | None = None,
         idempotency_key: str = "",
         request_fingerprint: str = "",
+        **admission_fields: object,
     ) -> OperationReceipt:
         if self._target.participant_runtime is None:
             return self._reject_submission(
@@ -239,12 +333,10 @@ class ParticipantControlMixin:
                 idempotency_key=idempotency_key,
                 request_fingerprint=request_fingerprint,
             )
-        diagnostics = _participant_binding_diagnostics(
+        request, diagnostics = _participant_binding_diagnostics(
             participant_behavior,
-            implementation_manifest=implementation_manifest,
-            implementation_selection=implementation_selection,
-            action_contract_address=action_contract_address,
-            observation_boundary_address=observation_boundary_address,
+            admission_request=admission_request,
+            admission_fields=admission_fields,
         )
         if diagnostics:
             return self._reject_diagnostics(
@@ -253,37 +345,12 @@ class ParticipantControlMixin:
                 idempotency_key=idempotency_key,
                 request_fingerprint=request_fingerprint,
             )
-        try:
-            request = ParticipantActionAdmissionRequest(
-                participant_address=participant_behavior.address,
-                action_contract_address=action_contract_address,
-                observation_boundary_address=observation_boundary_address,
-                action_instance_id=action_instance_id,
-                implementation_manifest=implementation_manifest,
-                implementation_selection=implementation_selection,
-                evidence_refs=evidence_refs,
-                visible_refs=visible_refs,
-                disclosed_refs=disclosed_refs,
-                observation_boundary_evidence_refs=observation_boundary_evidence_refs,
-                action_result=action_result,
-            )
-        except (TypeError, ValueError) as exc:
-            return self._reject_diagnostics(
-                domain=RuntimeDomain.PARTICIPANT,
-                diagnostics=[
-                    _participant_binding_diagnostic(
-                        _participant_binding_address(participant_behavior),
-                        str(exc),
-                    )
-                ],
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
-            )
+        assert request is not None
         return execute_participant_action(
             self,
             method=self._target.participant_runtime.admit_action,
             request=request,
-            address=f"runtime.control-plane.participant.{participant_behavior.address}.admit-action",
+            address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
             idempotency_key=idempotency_key,
             request_fingerprint=request_fingerprint,
         )

--- a/implementations/python/packages/aces_runtime/participant_control.py
+++ b/implementations/python/packages/aces_runtime/participant_control.py
@@ -1,0 +1,289 @@
+"""Participant runtime control-plane operations."""
+
+from __future__ import annotations
+
+from aces_contracts.contracts import (
+    ParticipantActionResultModel,
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
+)
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
+from aces_contracts.participant_episode import (
+    ParticipantEpisodeInitializeRequest,
+    ParticipantEpisodeResetRequest,
+    ParticipantEpisodeRestartRequest,
+    ParticipantEpisodeTerminalReason,
+    ParticipantEpisodeTerminateRequest,
+)
+from aces_contracts.planning import RuntimeDomain
+from aces_contracts.runtime_state import OperationReceipt
+from aces_processor.models import ParticipantBehaviorRuntime
+
+from .control_plane_execution import execute_participant_action
+
+_NO_PARTICIPANT_RUNTIME_MESSAGE = "Target does not provide a participant runtime."
+_PARTICIPANT_BINDING_REJECTED = "runtime.participant-binding.rejected"
+
+
+def _participant_binding_address(participant_behavior: object) -> str:
+    address = getattr(participant_behavior, "address", None)
+    return address if isinstance(address, str) and address else "runtime.control-plane.participant-binding"
+
+
+def _participant_binding_diagnostic(address: str, message: str) -> Diagnostic:
+    return Diagnostic(
+        code=_PARTICIPANT_BINDING_REJECTED,
+        domain="runtime",
+        address=address,
+        message=message,
+    )
+
+
+def _participant_binding_diagnostics(
+    participant_behavior: object,
+    *,
+    implementation_manifest: ParticipantImplementationManifestModel,
+    implementation_selection: ParticipantImplementationSelectionModel,
+    action_contract_address: str,
+    observation_boundary_address: str,
+) -> list[Diagnostic]:
+    address = _participant_binding_address(participant_behavior)
+    diagnostics: list[Diagnostic] = []
+    if not isinstance(participant_behavior, ParticipantBehaviorRuntime):
+        return [
+            _participant_binding_diagnostic(
+                address,
+                "participant_behavior must be a compiled ParticipantBehaviorRuntime",
+            )
+        ]
+    if action_contract_address not in participant_behavior.action_contract_addresses:
+        diagnostics.append(
+            _participant_binding_diagnostic(
+                address,
+                (
+                    f"action_contract_address {action_contract_address!r} is not declared by compiled "
+                    f"participant behavior {participant_behavior.address!r}"
+                ),
+            )
+        )
+    if observation_boundary_address not in participant_behavior.observation_boundary_addresses:
+        diagnostics.append(
+            _participant_binding_diagnostic(
+                address,
+                (
+                    f"observation_boundary_address {observation_boundary_address!r} is not declared by compiled "
+                    f"participant behavior {participant_behavior.address!r}"
+                ),
+            )
+        )
+    if not isinstance(implementation_manifest, ParticipantImplementationManifestModel):
+        diagnostics.append(
+            _participant_binding_diagnostic(
+                address,
+                "implementation_manifest must be a ParticipantImplementationManifestModel",
+            )
+        )
+    if not isinstance(implementation_selection, ParticipantImplementationSelectionModel):
+        diagnostics.append(
+            _participant_binding_diagnostic(
+                address,
+                "implementation_selection must be a ParticipantImplementationSelectionModel",
+            )
+        )
+    return diagnostics
+
+
+class ParticipantControlMixin:
+    """Participant runtime methods for the shared runtime control plane."""
+
+    def initialize_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeInitializeRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+        )
+        return execute_participant_action(
+            self,
+            method=self._target.participant_runtime.initialize,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.initialize",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def reset_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        reason: str = "reset by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeResetRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+            reason=reason,
+        )
+        return execute_participant_action(
+            self,
+            method=self._target.participant_runtime.reset,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.reset",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def restart_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        episode_id: str | None = None,
+        reason: str = "restarted by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeRestartRequest(
+            participant_address=participant_address,
+            episode_id=episode_id,
+            reason=reason,
+        )
+        return execute_participant_action(
+            self,
+            method=self._target.participant_runtime.restart,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.restart",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def terminate_participant_episode(
+        self,
+        participant_address: str,
+        *,
+        terminal_reason: ParticipantEpisodeTerminalReason = ParticipantEpisodeTerminalReason.INTERRUPTED,
+        detail: str = "terminated by operator",
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        request = ParticipantEpisodeTerminateRequest(
+            participant_address=participant_address,
+            terminal_reason=terminal_reason,
+            detail=detail,
+        )
+        return execute_participant_action(
+            self,
+            method=self._target.participant_runtime.terminate,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_address}.terminate",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def admit_participant_action(
+        self,
+        participant_behavior: ParticipantBehaviorRuntime,
+        *,
+        implementation_manifest: ParticipantImplementationManifestModel,
+        implementation_selection: ParticipantImplementationSelectionModel,
+        action_contract_address: str,
+        observation_boundary_address: str,
+        action_instance_id: str,
+        observation_boundary_evidence_refs: tuple[str, ...] = (),
+        evidence_refs: tuple[str, ...] = (),
+        visible_refs: tuple[str, ...] = (),
+        disclosed_refs: tuple[str, ...] = (),
+        action_result: ParticipantActionResultModel | None = None,
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        diagnostics = _participant_binding_diagnostics(
+            participant_behavior,
+            implementation_manifest=implementation_manifest,
+            implementation_selection=implementation_selection,
+            action_contract_address=action_contract_address,
+            observation_boundary_address=observation_boundary_address,
+        )
+        if diagnostics:
+            return self._reject_diagnostics(
+                domain=RuntimeDomain.PARTICIPANT,
+                diagnostics=diagnostics,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        try:
+            request = ParticipantActionAdmissionRequest(
+                participant_address=participant_behavior.address,
+                action_contract_address=action_contract_address,
+                observation_boundary_address=observation_boundary_address,
+                action_instance_id=action_instance_id,
+                implementation_manifest=implementation_manifest,
+                implementation_selection=implementation_selection,
+                evidence_refs=evidence_refs,
+                visible_refs=visible_refs,
+                disclosed_refs=disclosed_refs,
+                observation_boundary_evidence_refs=observation_boundary_evidence_refs,
+                action_result=action_result,
+            )
+        except (TypeError, ValueError) as exc:
+            return self._reject_diagnostics(
+                domain=RuntimeDomain.PARTICIPANT,
+                diagnostics=[
+                    _participant_binding_diagnostic(
+                        _participant_binding_address(participant_behavior),
+                        str(exc),
+                    )
+                ],
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        return execute_participant_action(
+            self,
+            method=self._target.participant_runtime.admit_action,
+            request=request,
+            address=f"runtime.control-plane.participant.{participant_behavior.address}.admit-action",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )

--- a/implementations/python/packages/aces_runtime/participant_control.py
+++ b/implementations/python/packages/aces_runtime/participant_control.py
@@ -188,7 +188,8 @@ def _participant_binding_request_diagnostics(
             _participant_binding_diagnostic(
                 address,
                 (
-                    f"observation_boundary_address {request.observation_boundary_address!r} is not declared by compiled "
+                    f"observation_boundary_address {request.observation_boundary_address!r} "
+                    "is not declared by compiled "
                     f"participant behavior {participant_behavior.address!r}"
                 ),
             )

--- a/implementations/python/packages/aces_runtime/registry.py
+++ b/implementations/python/packages/aces_runtime/registry.py
@@ -12,6 +12,11 @@ from aces_backend_protocols.protocols import (
     ParticipantRuntime,
     Provisioner,
 )
+from aces_contracts.contracts import (
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
+)
+from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
 
 
 def _require_invokable_method(
@@ -68,10 +73,13 @@ def _validate_runtime_target_shape(
     sample_plan = object()
     sample_snapshot = object()
     sample_request = object()
+    sample_admission_request = _sample_participant_action_admission_request()
     _validate_provisioner_methods(provisioner, sample_plan, sample_snapshot)
     _validate_orchestrator_methods(orchestrator, sample_plan, sample_snapshot)
     _validate_evaluator_methods(evaluator, sample_plan, sample_snapshot)
-    _validate_participant_runtime_methods(participant_runtime, sample_request, sample_snapshot)
+    _validate_participant_runtime_methods(
+        participant_runtime, sample_request, sample_admission_request, sample_snapshot
+    )
 
 
 def _validate_optional_component_presence(
@@ -185,6 +193,7 @@ def _validate_evaluator_methods(
 def _validate_participant_runtime_methods(
     participant_runtime: ParticipantRuntime | None,
     sample_request: object,
+    sample_admission_request: ParticipantActionAdmissionRequest,
     sample_snapshot: object,
 ) -> None:
     _require_invokable_method(
@@ -214,6 +223,12 @@ def _validate_participant_runtime_methods(
     _require_invokable_method(
         participant_runtime,
         label="participant_runtime",
+        method_name="admit_action",
+        invocation_args=(sample_admission_request, sample_snapshot),
+    )
+    _require_invokable_method(
+        participant_runtime,
+        label="participant_runtime",
         method_name="status",
         invocation_args=(),
     )
@@ -228,6 +243,74 @@ def _validate_participant_runtime_methods(
         label="participant_runtime",
         method_name="history",
         invocation_args=(),
+    )
+
+
+def _sample_participant_action_admission_request() -> ParticipantActionAdmissionRequest:
+    manifest = ParticipantImplementationManifestModel.model_validate(
+        {
+            "schema_version": "participant-implementation-manifest/v1",
+            "identity": {"name": "registry-shape-probe", "version": "1.0.0"},
+            "implementation_kind": "agent",
+            "supported_contract_versions": [
+                "participant-implementation-manifest-v1",
+                "participant-implementation-provenance-v1",
+                "participant-episode-state-envelope-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "compatibility": {"participant_runtimes": ["registry"], "processors": [], "backends": []},
+            "concept_bindings": [
+                {"scope": "implementation_kind", "family": "apparatus-declarations"},
+                {
+                    "scope": "capabilities.supported_participant_contracts",
+                    "family": "apparatus-declarations",
+                },
+                {
+                    "scope": "capabilities.supported_decision_surface_modes",
+                    "family": "apparatus-declarations",
+                },
+                {
+                    "scope": "capabilities.tool_affordance_expectations",
+                    "family": "tools-and-artifacts",
+                },
+                {"scope": "capabilities.exposure_policy_kinds", "family": "provenance-and-evidence"},
+            ],
+            "capabilities": {
+                "supported_participant_contracts": [
+                    "participant-episode-state-envelope-v1",
+                    "participant-behavior-history-event-stream-v1",
+                ],
+                "supported_decision_surface_modes": ["policy-directed"],
+                "tool_affordance_expectations": ["shell"],
+                "exposure_policy_kinds": ["task-statement"],
+            },
+        }
+    )
+    selection = ParticipantImplementationSelectionModel.model_validate(
+        {
+            "participant_address": "participant.behavior.registry-probe",
+            "implementation_identity": {"name": "registry-shape-probe", "version": "1.0.0"},
+            "manifest_ref": "registry://participant-implementation-manifest",
+            "manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "selected_decision_surface_mode": "policy-directed",
+            "participant_contract_versions": [
+                "participant-episode-state-envelope-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "exposure_policy": {
+                "policy_id": "registry-shape-probe-policy",
+                "exposure_policy_kinds": ["task-statement"],
+                "disclosed_refs": ["scenario.registry-probe"],
+            },
+        }
+    )
+    return ParticipantActionAdmissionRequest(
+        participant_address="participant.behavior.registry-probe",
+        action_contract_address="participant.action-contract.registry-probe",
+        observation_boundary_address="participant.observation-boundary.registry-probe",
+        action_instance_id="registry-probe-action",
+        implementation_manifest=manifest,
+        implementation_selection=selection,
     )
 
 

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -159,6 +159,9 @@ def test_live_probe_catches_participant_runtime_that_does_not_populate_snapshot(
         def terminate(self, request, snapshot):
             return ApplyResult(success=True, snapshot=snapshot)
 
+        def admit_action(self, request, snapshot):
+            return ApplyResult(success=True, snapshot=snapshot)
+
         def status(self):
             return {}
 

--- a/implementations/python/tests/test_runtime_control_plane.py
+++ b/implementations/python/tests/test_runtime_control_plane.py
@@ -6,12 +6,18 @@ import textwrap
 
 from aces_backend_stubs.stubs import create_stub_components, create_stub_manifest
 from aces_contracts.contracts import (
+    ParticipantActionResultModel,
     ParticipantContextViewModel,
     ParticipantHistoryViewModel,
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
     ParticipantStatusViewModel,
 )
 from aces_contracts.runtime_state import RuntimeSnapshot
-from aces_processor.models import iter_participant_episode_snapshot_violations
+from aces_processor.models import (
+    iter_participant_behavior_history_violations,
+    iter_participant_episode_snapshot_violations,
+)
 
 from aces.backends.stubs import create_stub_target
 from aces.core.runtime.compiler import compile_runtime_model
@@ -31,6 +37,164 @@ from aces.core.sdl import parse_sdl
 
 def _scenario(yaml_str: str):
     return parse_sdl(textwrap.dedent(yaml_str))
+
+
+def _participant_binding_scenario_yaml() -> str:
+    return """
+name: participant-binding
+nodes:
+  web:
+    type: VM
+    resources: {ram: 1 GiB, cpu: 1}
+    services: [{port: 80, name: http}]
+entities:
+  red-team:
+    role: red
+action-contracts:
+  scan:
+    semantic-version: 1.0.0
+    lifecycle-state: active
+    behavioral-granularity: atomic
+    procedure-basis: governed service discovery
+    realization-profile: backend-declared
+    fidelity-claim: records participant discovery intent and terminal observation
+    preconditions:
+      - precondition-id: authority-in-scope
+        precondition-class: authority
+        description: red participant is authorized to scan the web service
+    effects:
+      - effect-id: terminal-scan-observation
+        effect-class: observation_effect
+        description: terminal scan observation
+        evidence-refs: [evidence.scan-output]
+    failure-classes: [backend_error, unknown]
+observation-boundaries:
+  red-view:
+    projection-basis: participant-local projection over observed services
+    evidence-refs: [evidence.scan-output]
+    redaction-policy: hidden refs never project without explicit disclosure
+    latency-profile: terminal observation emitted after state transition commit
+agents:
+  red-agent:
+    entity: red-team
+    actions: [scan]
+    observation-boundaries: [red-view]
+"""
+
+
+def _participant_implementation_manifest() -> ParticipantImplementationManifestModel:
+    return ParticipantImplementationManifestModel.model_validate(
+        {
+            "schema_version": "participant-implementation-manifest/v1",
+            "identity": {"name": "reference-red-agent", "version": "1.0.0"},
+            "implementation_kind": "agent",
+            "supported_contract_versions": [
+                "participant-implementation-manifest-v1",
+                "participant-implementation-provenance-v1",
+                "participant-episode-state-envelope-v1",
+                "participant-episode-history-event-stream-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "compatibility": {
+                "participant_runtimes": ["stub-participant-runtime"],
+                "processors": ["aces-reference-processor"],
+                "backends": ["stub"],
+            },
+            "concept_bindings": [
+                {"scope": "implementation_kind", "family": "apparatus-declarations"},
+                {
+                    "scope": "capabilities.supported_participant_contracts",
+                    "family": "apparatus-declarations",
+                },
+                {
+                    "scope": "capabilities.supported_decision_surface_modes",
+                    "family": "apparatus-declarations",
+                },
+                {
+                    "scope": "capabilities.tool_affordance_expectations",
+                    "family": "tools-and-artifacts",
+                },
+                {"scope": "capabilities.exposure_policy_kinds", "family": "provenance-and-evidence"},
+            ],
+            "constraints": {"max_parallel_episodes": "1"},
+            "capabilities": {
+                "supported_participant_contracts": [
+                    "participant-episode-state-envelope-v1",
+                    "participant-episode-history-event-stream-v1",
+                    "participant-behavior-history-event-stream-v1",
+                ],
+                "supported_decision_surface_modes": ["autonomous", "policy-directed"],
+                "tool_affordance_expectations": ["shell", "http-api"],
+                "exposure_policy_kinds": ["task-statement", "observation-stream"],
+            },
+        }
+    )
+
+
+def _participant_implementation_selection(participant_address: str) -> ParticipantImplementationSelectionModel:
+    return ParticipantImplementationSelectionModel.model_validate(
+        {
+            "participant_address": participant_address,
+            "implementation_identity": {"name": "reference-red-agent", "version": "1.0.0"},
+            "manifest_ref": "contracts/fixtures/participant-implementation-manifest/reference.json",
+            "manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "selected_decision_surface_mode": "policy-directed",
+            "participant_contract_versions": [
+                "participant-episode-state-envelope-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "exposure_policy": {
+                "policy_id": "red-agent-policy",
+                "policy_version": "1.0.0",
+                "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+                "exposure_policy_kinds": ["task-statement", "observation-stream"],
+                "disclosed_refs": ["scenario.tasks.red"],
+                "withheld_refs": ["scenario.hidden.answer-key"],
+                "tool_affordance_refs": ["tool.shell"],
+                "visibility_scope_refs": ["participants.red.visible"],
+            },
+        }
+    )
+
+
+def _succeeded_scan_result(
+    *,
+    participant_address: str,
+    episode_id: str,
+    action_instance_id: str,
+    action_contract_address: str,
+) -> ParticipantActionResultModel:
+    return ParticipantActionResultModel.model_validate(
+        {
+            "status": "succeeded",
+            "participant_address": participant_address,
+            "episode_id": episode_id,
+            "action_instance_id": action_instance_id,
+            "action_contract_address": action_contract_address,
+            "observation_point": f"{action_instance_id}:terminal-observation",
+            "preconditions": [
+                {
+                    "precondition_id": "authority-in-scope",
+                    "precondition_class": "authority",
+                    "status": "satisfied",
+                    "participant_address": participant_address,
+                    "episode_id": episode_id,
+                    "action_contract_address": action_contract_address,
+                    "observation_point": f"{action_instance_id}:precondition-authority",
+                }
+            ],
+            "effects": [
+                {
+                    "effect_id": "terminal-scan-observation",
+                    "effect_class": "observation_effect",
+                    "description": "terminal scan observation",
+                    "evidence_refs": ["evidence.scan-output"],
+                }
+            ],
+            "observations": [f"{action_instance_id}:terminal-observation"],
+            "evidence_refs": ["evidence.scan-output"],
+        }
+    )
 
 
 def _episode_state(participant_address: str, episode_id: str) -> dict[str, object]:
@@ -194,6 +358,117 @@ class TestParticipantEpisodeControlPlane:
             "episode_running",
         ]
 
+    def test_admit_participant_action_records_implementation_bound_behavior_history(self):
+        runtime_model = compile_runtime_model(_scenario(_participant_binding_scenario_yaml()))
+        behavior = runtime_model.participant_behaviors["participant.behavior.red-agent"]
+        action_address = behavior.action_contract_addresses[0]
+        observation_address = behavior.observation_boundary_addresses[0]
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode(behavior.address, episode_id="episode-1")
+
+        receipt = control_plane.admit_participant_action(
+            behavior,
+            implementation_manifest=_participant_implementation_manifest(),
+            implementation_selection=_participant_implementation_selection(behavior.address),
+            action_contract_address=action_address,
+            observation_boundary_address=observation_address,
+            action_instance_id="scan-0001",
+            observation_boundary_evidence_refs=("evidence.scan-output",),
+            evidence_refs=("evidence.scan-output",),
+            action_result=_succeeded_scan_result(
+                participant_address=behavior.address,
+                episode_id="episode-1",
+                action_instance_id="scan-0001",
+                action_contract_address=action_address,
+            ),
+        )
+        status = control_plane.get_operation(receipt.operation_id)
+        snapshot = control_plane.get_snapshot().snapshot
+
+        assert receipt.accepted is True
+        assert status is not None
+        assert status.state == OperationState.SUCCEEDED
+        behavior_history = snapshot.participant_behavior_history[behavior.address]
+        assert [event["event_type"] for event in behavior_history] == [
+            "action_attempted",
+            "state_transition_recorded",
+            "observation_emitted",
+        ]
+        assert behavior_history[0]["participant_address"] == behavior.address
+        assert behavior_history[0]["action_contract_address"] == action_address
+        assert behavior_history[0]["actor_provenance"] == "participant-implementation:reference-red-agent@1.0.0"
+        assert "stub" not in behavior_history[0]["actor_provenance"]
+        assert behavior_history[-1]["observation_boundary_address"] == observation_address
+        assert behavior_history[-1]["details"]["evidence_refs"] == ["evidence.scan-output"]
+        assert (
+            list(
+                iter_participant_episode_snapshot_violations(
+                    snapshot.participant_episode_results,
+                    snapshot.participant_episode_history,
+                )
+            )
+            == []
+        )
+        assert (
+            list(
+                iter_participant_behavior_history_violations(
+                    behavior_history,
+                    action_contracts=runtime_model.action_contracts,
+                    observation_boundaries=runtime_model.observation_boundaries,
+                    participant_episode_history=snapshot.participant_episode_history[behavior.address],
+                    expected_participant_address=behavior.address,
+                )
+            )
+            == []
+        )
+
+    def test_admit_participant_action_rejects_action_outside_compiled_behavior(self):
+        runtime_model = compile_runtime_model(_scenario(_participant_binding_scenario_yaml()))
+        behavior = runtime_model.participant_behaviors["participant.behavior.red-agent"]
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode(behavior.address, episode_id="episode-1")
+
+        receipt = control_plane.admit_participant_action(
+            behavior,
+            implementation_manifest=_participant_implementation_manifest(),
+            implementation_selection=_participant_implementation_selection(behavior.address),
+            action_contract_address="participant.action-contract.not-declared",
+            observation_boundary_address=behavior.observation_boundary_addresses[0],
+            action_instance_id="scan-0001",
+            evidence_refs=("evidence.scan-output",),
+        )
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert receipt.accepted is False
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("is not declared by compiled participant behavior" in diag.message for diag in status.diagnostics)
+
+    def test_admit_participant_action_rejects_withheld_observation_refs(self):
+        runtime_model = compile_runtime_model(_scenario(_participant_binding_scenario_yaml()))
+        behavior = runtime_model.participant_behaviors["participant.behavior.red-agent"]
+        action_address = behavior.action_contract_addresses[0]
+        observation_address = behavior.observation_boundary_addresses[0]
+        control_plane = RuntimeControlPlane(create_stub_target())
+        control_plane.initialize_participant_episode(behavior.address, episode_id="episode-1")
+
+        receipt = control_plane.admit_participant_action(
+            behavior,
+            implementation_manifest=_participant_implementation_manifest(),
+            implementation_selection=_participant_implementation_selection(behavior.address),
+            action_contract_address=action_address,
+            observation_boundary_address=observation_address,
+            action_instance_id="scan-0001",
+            observation_boundary_evidence_refs=("scenario.hidden.answer-key",),
+            evidence_refs=("scenario.hidden.answer-key",),
+        )
+        status = control_plane.get_operation(receipt.operation_id)
+
+        assert receipt.accepted is False
+        assert status is not None
+        assert status.state == OperationState.FAILED
+        assert any("withheld_refs" in diag.message for diag in status.diagnostics)
+
     def test_initialize_twice_rejects_duplicate(self):
         control_plane = RuntimeControlPlane(create_stub_target())
         control_plane.initialize_participant_episode("participant.alice")
@@ -336,6 +611,21 @@ class TestParticipantEpisodeControlPlane:
         control_plane.restart_participant_episode("participant.alice")
 
         snapshot = control_plane.get_snapshot().snapshot
+        assert set(snapshot.participant_episode_results) == {"participant.alice"}
+        state = snapshot.participant_episode_results["participant.alice"]
+        assert state["sequence_number"] == 2
+        assert state["status"] == "running"
+        assert state["last_control_action"] == "restart"
+        assert state["previous_episode_id"] == "participant.alice-episode-2"
+        assert [event["event_type"] for event in snapshot.participant_episode_history["participant.alice"]] == [
+            "episode_initialized",
+            "episode_running",
+            "episode_reset",
+            "episode_running",
+            "episode_completed",
+            "episode_restarted",
+            "episode_running",
+        ]
         violations = list(
             iter_participant_episode_snapshot_violations(
                 snapshot.participant_episode_results,

--- a/implementations/python/tests/test_runtime_control_plane.py
+++ b/implementations/python/tests/test_runtime_control_plane.py
@@ -13,6 +13,7 @@ from aces_contracts.contracts import (
     ParticipantImplementationSelectionModel,
     ParticipantStatusViewModel,
 )
+from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
 from aces_contracts.runtime_state import RuntimeSnapshot
 from aces_processor.models import (
     iter_participant_behavior_history_violations,
@@ -366,8 +367,8 @@ class TestParticipantEpisodeControlPlane:
         control_plane = RuntimeControlPlane(create_stub_target())
         control_plane.initialize_participant_episode(behavior.address, episode_id="episode-1")
 
-        receipt = control_plane.admit_participant_action(
-            behavior,
+        admission_request = ParticipantActionAdmissionRequest(
+            participant_address=behavior.address,
             implementation_manifest=_participant_implementation_manifest(),
             implementation_selection=_participant_implementation_selection(behavior.address),
             action_contract_address=action_address,
@@ -382,6 +383,7 @@ class TestParticipantEpisodeControlPlane:
                 action_contract_address=action_address,
             ),
         )
+        receipt = control_plane.admit_participant_action(behavior, admission_request)
         status = control_plane.get_operation(receipt.operation_id)
         snapshot = control_plane.get_snapshot().snapshot
 


### PR DESCRIPTION
## Summary

Adds a provider-neutral participant action-admission path so compiled SDL participant behavior can be driven by a selected participant implementation while preserving runtime lifecycle and provenance boundaries.

## Requirement UIDs

- `RUN-311`

## Related Issues

Closes #599

## ADR Impact

- ADR-013
- ADR-041
- ADR-054
- ADR-060

## Changes

- Add a neutral participant action-admission DTO with manifest, selection, exposure-policy, and observation-boundary validation.
- Route participant action admission through RuntimeControlPlane and ParticipantRuntime, with stub and reference backends appending behavior-history events.
- Validate participant runtime target shape against the new admission request contract.
- Extend runtime tests for implementation-bound behavior history, rejected bindings, exposure-policy failures, registry shape probing, and non-vacuous lifecycle invariants.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

ACES_REQUIREMENT_UID=RUN-311 pre-commit run --all-files; ACES_REQUIREMENT_UID=RUN-311 implementations/python/.venv/bin/python tools/verify_all.py; targeted pytest for runtime control plane, registry, conformance, and reference backend suites.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: RUN-311 ← implementations/python/packages/aces_contracts/participant_binding.py, RUN-311 ← implementations/python/packages/aces_runtime/participant_control.py, RUN-311 ← implementations/python/packages/aces_backend_protocols/protocols.py, RUN-311 ← implementations/python/packages/aces_backend_stubs/stubs.py, RUN-311 ← implementations/python/packages/aces_reference_backend/participant_runtime.py, RUN-311 ← implementations/python/packages/aces_runtime/registry.py
- TESTS: RUN-311 ← implementations/python/tests/test_runtime_control_plane.py, RUN-311 ← implementations/python/tests/test_runtime_conformance.py, RUN-311 ← implementations/python/tests/test_runtime_registry.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/599.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
