### PR TITLE
chore: enable review-cap disposition gate in shadow mode (judge on)

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -6,6 +6,12 @@ workflow:
   completion_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
   lint_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s lint
   format_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s hygiene
+  review_disposition:
+    enabled: true
+    mode: shadow
+    max_auto_overrides: 1
+    judge:
+      enabled: true
 docs:
   adr_dir: docs/decisions/adrs/
 example_paths:


### PR DESCRIPTION
## Shadow enablement of the review-cap disposition gate

Enables `workflow.review_disposition` in the repo's `.ground-control.yaml`:

```yaml
review_disposition:
  enabled: true
  mode: shadow
  max_auto_overrides: 1
  judge:
    enabled: true
```

In **shadow** mode the gate records its would-be cap-boundary disposition (with the judge on) but still escalates to the human — it takes **no auto-action**. This collects readiness data on how the gate would behave before any enforcement is turned on.

---

**DO NOT MERGE until autarchy-ai/Ground-Control#1246 is merged and the MCP server is restarted on that code — until then the older .ground-control.yaml parser rejects the review_disposition key and breaks gc_get_repo_ground_control_context.**

Do NOT merge.
