### PR TITLE
changed: add observability evidence conformance

### DIFF
--- a/changelog.d/128.changed.md
+++ b/changelog.d/128.changed.md
@@ -1,0 +1,1 @@
+Added experiment-run observability/evidence conformance diagnostics for run-level augmentation disclosures and evidence-requirement refinements.

--- a/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
+++ b/contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
@@ -27,7 +27,8 @@
     "participant-outcome-report-v1",
     "experiment-capture-spec-v1",
     "experiment-evidence-record-v1",
-    "experiment-derived-measure-v1"
+    "experiment-derived-measure-v1",
+    "experiment-run-v1"
   ],
   "compatibility": {
     "processors": [
@@ -233,7 +234,8 @@
       "supported_evidence_contracts": [
         "experiment-capture-spec-v1",
         "experiment-derived-measure-v1",
-        "experiment-evidence-record-v1"
+        "experiment-evidence-record-v1",
+        "experiment-run-v1"
       ],
       "supported_media_types": [
         "application/json",

--- a/contracts/fixtures/experiment-core/experiment-run-v1/invalid/augmentation-without-affected-refs.json
+++ b/contracts/fixtures/experiment-core/experiment-run-v1/invalid/augmentation-without-affected-refs.json
@@ -1,0 +1,263 @@
+{
+  "schema_version": "experiment-run/v1",
+  "run_id": "run-observability-invalid-001",
+  "run_version": "1.0.0",
+  "task_ref": {
+    "ref_kind": "task",
+    "ref_id": "task-observability-v1",
+    "ref_version": "1.0.0"
+  },
+  "scenario_snapshot_ref": {
+    "ref_kind": "scenario-snapshot",
+    "ref_id": "scenario-observability",
+    "ref_version": "2026-06-28"
+  },
+  "apparatus_context": {
+    "schema_version": "experiment-apparatus-context/v1",
+    "apparatus_context_id": "apparatus-observability-invalid",
+    "context_version": "1.0.0",
+    "declared_at": "2026-06-28T00:00:00Z",
+    "components": {
+      "processor": {
+        "component_kind": "processor",
+        "identity": {
+          "name": "aces-reference-processor",
+          "version": "0.1.0"
+        },
+        "manifest_ref": {
+          "ref_kind": "manifest",
+          "ref_id": "aces-reference-processor",
+          "ref_version": "processor-manifest/v2",
+          "subject_ref": {
+            "ref_kind": "processor",
+            "ref_id": "aces-reference-processor",
+            "ref_version": "0.1.0"
+          }
+        },
+        "observed": true
+      },
+      "backend": {
+        "component_kind": "backend",
+        "identity": {
+          "name": "stub-backend",
+          "version": "0.1.0"
+        },
+        "manifest_ref": {
+          "ref_kind": "manifest",
+          "ref_id": "stub-backend",
+          "ref_version": "backend-manifest/v2",
+          "subject_ref": {
+            "ref_kind": "backend",
+            "ref_id": "stub-backend",
+            "ref_version": "0.1.0"
+          }
+        },
+        "observed": true
+      }
+    },
+    "selected_manifests": [
+      {
+        "ref_kind": "manifest",
+        "ref_id": "aces-reference-processor",
+        "ref_version": "processor-manifest/v2",
+        "subject_ref": {
+          "ref_kind": "processor",
+          "ref_id": "aces-reference-processor",
+          "ref_version": "0.1.0"
+        }
+      },
+      {
+        "ref_kind": "manifest",
+        "ref_id": "stub-backend",
+        "ref_version": "backend-manifest/v2",
+        "subject_ref": {
+          "ref_kind": "backend",
+          "ref_id": "stub-backend",
+          "ref_version": "0.1.0"
+        }
+      }
+    ],
+    "compatibility_declarations": [
+      {
+        "ref_kind": "profile",
+        "ref_id": "reference-stack-v1",
+        "ref_version": "semantic-profile/v1"
+      }
+    ],
+    "configuration_parameters": [
+      {
+        "name": "worker-count",
+        "value": 1,
+        "value_kind": "apparatus"
+      }
+    ],
+    "stochastic_controls": [
+      {
+        "control_id": "task-seed",
+        "role": "seed",
+        "value": 128
+      }
+    ],
+    "clocks": [
+      {
+        "clock_id": "range-wall-clock",
+        "authority": "backend wall clock",
+        "time_domain": "wall-clock"
+      }
+    ],
+    "measurement_channels": [
+      {
+        "ref_kind": "measurement-channel",
+        "ref_id": "evaluation-history-channel",
+        "ref_version": "1.0.0"
+      }
+    ],
+    "observed_setup_evidence": [
+      {
+        "artifact_id": "setup-attestation",
+        "role": "apparatus-evidence",
+        "media_type": "application/json",
+        "uri": "runs/run-observability-invalid-001/setup.json",
+        "checksum": {
+          "algorithm": "sha256",
+          "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "size_bytes": 1024,
+        "created_at": "2026-06-28T00:01:00Z",
+        "source": "stub-backend setup attestation",
+        "sensitivity": "internal"
+      }
+    ],
+    "known_limitations": [
+      {
+        "category": "apparatus",
+        "note": "Fixture intentionally omits augmentation affected_refs while preserving schema validity."
+      }
+    ]
+  },
+  "parameter_set": [
+    {
+      "name": "difficulty",
+      "value": "standard",
+      "value_kind": "protocol"
+    }
+  ],
+  "stochastic_controls": [
+    {
+      "control_id": "task-seed",
+      "role": "seed",
+      "value": 128
+    }
+  ],
+  "started_at": "2026-06-28T00:10:00Z",
+  "ended_at": "2026-06-28T00:20:00Z",
+  "clock_context": {
+    "clock_id": "range-wall-clock",
+    "authority": "backend wall clock",
+    "time_domain": "wall-clock"
+  },
+  "run_status": "completed",
+  "outcome_status": "succeeded",
+  "traceability": {
+    "capture_spec_refs": [
+      {
+        "ref_kind": "capture-spec",
+        "ref_id": "capture-observability-v1",
+        "ref_version": "1.0.0"
+      }
+    ],
+    "evidence_record_refs": [
+      {
+        "ref_kind": "evidence-record",
+        "ref_id": "evidence-observability-001",
+        "ref_version": "1.0.0"
+      }
+    ],
+    "notes": [
+      "The augmentation disclosure is traced but does not name affected_refs."
+    ]
+  },
+  "augmentation_disclosures": [
+    {
+      "augmentation_id": "packet-capture-sidecar",
+      "purpose": "evidence",
+      "realization_layer": "backend",
+      "classifications": [
+        "apparatus_only"
+      ],
+      "augmented_by_ref": {
+        "ref_kind": "backend",
+        "ref_id": "stub-backend",
+        "ref_version": "0.1.0"
+      },
+      "carrier_refs": [
+        {
+          "ref_kind": "measurement-channel",
+          "ref_id": "evaluation-history-channel",
+          "ref_version": "1.0.0"
+        }
+      ],
+      "affected_refs": [],
+      "evidence_refs": [
+        {
+          "ref_kind": "evidence-record",
+          "ref_id": "evidence-observability-001",
+          "ref_version": "1.0.0"
+        }
+      ],
+      "disclosure_policy": "Internal run-provenance disclosure; no raw packet content is embedded.",
+      "markings": [
+        "internal"
+      ],
+      "observer_effect": "The sidecar observes run traffic without modifying scenario services."
+    }
+  ],
+  "evidence_artifacts": [
+    {
+      "artifact_id": "evaluation-history",
+      "role": "observation",
+      "media_type": "application/json",
+      "uri": "runs/run-observability-invalid-001/evaluation-history.json",
+      "checksum": {
+        "algorithm": "sha256",
+        "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "size_bytes": 2048,
+      "created_at": "2026-06-28T00:20:00Z",
+      "source": "stub-backend evaluator history export",
+      "satisfies_refs": [
+        {
+          "ref_kind": "evidence",
+          "ref_id": "evaluation-history"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "result_summaries": {
+    "observation-result": {
+      "metric_id": "observation-complete",
+      "value": true,
+      "value_status": "reported",
+      "evidence_refs": [
+        {
+          "ref_kind": "evidence",
+          "ref_id": "evaluation-history"
+        }
+      ]
+    }
+  },
+  "used_refs": [
+    {
+      "ref_kind": "task",
+      "ref_id": "task-observability-v1",
+      "ref_version": "1.0.0"
+    }
+  ],
+  "generated_refs": [
+    {
+      "ref_kind": "result",
+      "ref_id": "observation-result"
+    }
+  ]
+}

--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -12,20 +12,20 @@
       "contract_id": "backend-manifest-v2",
       "schema_path": "contracts/schemas/backend-manifest/backend-manifest-v2.json",
       "stability": "draft",
-      "content_hash": "645831fb013c9450a1354a609b0645f6d045c85b3d92edcdd3cdbce19a0e3064",
+      "content_hash": "4485bf2485e1f98be2c540552d42828a170dc6ff5beeb6b091a4e87a55b922ab",
       "last_change": {
-        "summary": "Added the EXP-715 observation capability declaration and experiment evidence contract identifiers to backend manifest v2.",
-        "content_hash": "645831fb013c9450a1354a609b0645f6d045c85b3d92edcdd3cdbce19a0e3064"
+        "summary": "Added experiment-run-v1 to the governed backend manifest contract vocabulary for run-level observability and augmentation evidence disclosure.",
+        "content_hash": "4485bf2485e1f98be2c540552d42828a170dc6ff5beeb6b091a4e87a55b922ab"
       }
     },
     {
       "contract_id": "backend-profile-v1",
       "schema_path": "contracts/schemas/profiles/backend-profile-v1.json",
       "stability": "draft",
-      "content_hash": "85ddac10a896b39cc9c5ef3f73141e84566236d12d0127511007610ccd700694",
+      "content_hash": "3f4152b2d7f1e4a01b30e2782a4d6001654e2785f4b9fe54121ed7e84a37c604",
       "last_change": {
-        "summary": "Added the EXP-707/EXP-708/EXP-709 experiment evidence contracts to the backend profile contract vocabulary.",
-        "content_hash": "85ddac10a896b39cc9c5ef3f73141e84566236d12d0127511007610ccd700694"
+        "summary": "Added experiment-run-v1 to the backend profile contract vocabulary so profile fixture conformance can exercise run-level observability semantics.",
+        "content_hash": "3f4152b2d7f1e4a01b30e2782a4d6001654e2785f4b9fe54121ed7e84a37c604"
       }
     },
     {

--- a/contracts/schemas/backend-manifest/backend-manifest-v2.json
+++ b/contracts/schemas/backend-manifest/backend-manifest-v2.json
@@ -872,7 +872,8 @@
           "participant-outcome-report-v1",
           "experiment-capture-spec-v1",
           "experiment-evidence-record-v1",
-          "experiment-derived-measure-v1"
+          "experiment-derived-measure-v1",
+          "experiment-run-v1"
         ],
         "minLength": 1,
         "type": "string"

--- a/contracts/schemas/profiles/backend-profile-v1.json
+++ b/contracts/schemas/profiles/backend-profile-v1.json
@@ -34,7 +34,8 @@
           "participant-outcome-report-v1",
           "experiment-capture-spec-v1",
           "experiment-evidence-record-v1",
-          "experiment-derived-measure-v1"
+          "experiment-derived-measure-v1",
+          "experiment-run-v1"
         ],
         "type": "string"
       },

--- a/docs/decisions/issue-338-run-316-operational-apparatus-observability-preflight.md
+++ b/docs/decisions/issue-338-run-316-operational-apparatus-observability-preflight.md
@@ -1,0 +1,204 @@
+# Issue 338 RUN-316 Operational Apparatus Observability Preflight
+
+Date: 2026-06-28
+
+Issue: #338.
+
+Requirement: RUN-316.
+
+This note records architecture preflight guardrails for operational
+observability surfaces used by processors and backends. It is implementation
+guidance only: it does not add runtime behavior, schemas, endpoints, storage,
+fixtures, tests, or coverage claims.
+
+## Binding Sources
+
+- ADR-008 defines the processor as the semantics-bearing middle layer and
+  separates live execution state from archival run provenance.
+- ADR-036 defines package ownership: processor logic in `aces_processor`, live
+  control in `aces_runtime`, backend protocol declarations in
+  `aces_backend_protocols`, and neutral DTOs in `aces_contracts`.
+- ADR-066 defines the processor/backend operational observability plane and
+  requires it to remain distinct from scenario-native observability, authored
+  evidence requirements, captured evidence, and derived analysis.
+- `docs/decisions/issue-334-sem-224-observability-plane-preflight.md`,
+  `docs/decisions/issue-336-dsl-123-scenario-native-observability-preflight.md`,
+  and `aces_sdl.observability_plane_semantics` define the carrier-oriented
+  classifier and forbid token-based plane decisions.
+- ADR-055, ADR-064, and ADR-065 define experiment apparatus context, capture
+  specs, evidence records, derived measures, run traceability, realized-form
+  disclosures, and augmentation disclosures.
+- ADR-054 and ADR-060 define participant-visible observations, participant
+  runtime retrieval views, visibility projection, markings, redaction, loss,
+  and information guarantees. Operational apparatus telemetry is not a
+  participant observation unless projected through those carriers.
+- ADR-063 records backend implementation guardrails: portable facts only,
+  `Diagnostic`/`OperationReceipt`/`OperationStatus` public failures, no
+  backend-specific exception hierarchy, no raw native output in diagnostics.
+- `.ground-control.yaml`, `.gc/plan-rules.md`, ADR-009, ADR-019, ADR-061,
+  `contracts/schema-publication-manifest.json`, and `tools/policy/adr_policy.yaml`
+  define workflow, schema, publication, and module-boundary gates.
+
+## Architecture Decisions
+
+- RUN-316 is the processor/backend operational plane from ADR-066. Do not add a
+  generic top-level `observability`, `telemetry`, `logs`, or `traces` model.
+- Plane ownership must stay carrier-oriented. `backend-manifest-v2`,
+  `processor-manifest-v2`, and `experiment-apparatus-context-v1` already map to
+  `PROCESSOR_BACKEND_OPERATIONAL` through
+  `classify_contract_plane()`. Do not infer the plane from words such as
+  `log`, `trace`, `telemetry`, `observation`, or `evidence`.
+- Static apparatus declarations belong in existing manifest surfaces:
+  `ProcessorManifestV2Model`, `BackendManifestV2Model`, concept bindings,
+  supported contract versions, compatibility declarations, constraints, and
+  capability blocks. `ObservationCapabilities` is specifically EXP-715 evidence
+  capture support, not a catch-all operational log capability.
+- Live operational state belongs in existing runtime/control-plane surfaces:
+  `RuntimeManager.status()`, `RuntimeControlPlane`, `RuntimeSnapshot`,
+  `OperationReceipt`, `OperationStatus`, backend component
+  `status()`/`results()`/`history()` methods, `ControlPlaneStore`, and
+  append-only `AuditEvent` records.
+- Archival or reviewable apparatus facts must be projected through experiment
+  contracts: `ExperimentApparatusContextModel` for run-scoped instrument
+  context, `ExperimentEvidenceRecordModel` for raw captured evidence,
+  `ExperimentDerivedMeasureModel` for interpreted analysis,
+  `ExperimentRunModel.traceability`, realized-form disclosures, and
+  augmentation disclosures.
+- Public exposure must reuse `create_control_plane_app()`,
+  `ControlPlaneSecurityConfig`, control-plane role checks, request-size guards,
+  idempotency keys, request fingerprints, audit events, response models, and
+  redacted FastAPI error envelopes.
+- Backend/public failures remain `Diagnostic`, `ApplyResult`,
+  `OperationReceipt`, and `OperationStatus`. Do not introduce a new exception,
+  logging, or error-envelope hierarchy for operational observability.
+
+## Required Incumbents
+
+- Plane classification: `ObservabilityEvidencePlane`,
+  `PLANE_BY_CONTRACT_ID`, `classify_contract_plane()`,
+  `assert_single_primary_plane()`, and `token_decides_plane()`.
+- Manifest and capability authority: `ProcessorManifest`,
+  `ProcessorCapabilitySet`, `reference_processor_manifest_payload()`,
+  `BackendManifest`, `BackendCapabilitySet`, `ObservationCapabilities`,
+  `backend_manifest_payload()`, supported contract validators, controlled
+  vocabulary validators, and concept bindings.
+- Runtime and backend boundaries: `RuntimeTarget`, `_validate_runtime_target_shape()`,
+  `Provisioner`, `Orchestrator`, `Evaluator`, `ParticipantRuntime`,
+  `_call_backend_diagnostics()`, `_call_backend_apply()`,
+  `RuntimeManager`, and `RuntimeControlPlane`.
+- Live-state DTOs and persistence: `RuntimeSnapshot`, `SnapshotEntry`,
+  `ApplyResult`, `OperationReceipt`, `OperationStatus`, `ControlPlaneStore`,
+  `InMemoryControlPlaneStore`, `LocalControlPlaneStore`, and `AuditEvent`.
+- HTTP exposure: `create_control_plane_app()`, `_ControlPlaneApiAuth`,
+  `ControlPlaneIdentity`, `ControlPlaneRole`, `request_size_guard_response()`,
+  `_request_fingerprint()`, OpenAPI response declarations, and redacted 500
+  handling.
+- Contract authority: `ContractModel`, `schema_bundle()`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `contracts/schemas/`, `contracts/fixtures/`, and
+  `contracts/schema-publication-manifest.json`.
+- Experiment projection: `ExperimentApparatusContextModel`,
+  `ExperimentCaptureSpecModel`, `ExperimentEvidenceRecordModel`,
+  `ExperimentDerivedMeasureModel`, `ExperimentRunModel`,
+  `ExperimentAugmentationDisclosureModel`, and
+  `validate_experiment_run_against_task()`.
+- Conformance and workflow: `aces_conformance.conformance`,
+  `observation_capability_contract_gaps()`,
+  `participant_runtime_capability_contract_gaps()`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, and `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- Auth and authorization: any HTTP/API surface must pass
+  `ControlPlaneSecurityConfig` authentication, target scoping, and
+  `BACKEND`/`OPERATOR`/`AUDITOR` role gates. Mutating observability actions are
+  not auditor-readable shortcuts.
+- Secret handling and redaction: diagnostics, audit details, examples,
+  fixtures, status payloads, snapshots, and experiment records must not expose
+  bearer tokens, private keys, credentials, operator secrets, environment
+  dumps, raw evidence payloads, hidden truth, private traces, prompts, backend
+  private object reprs, or full tracebacks.
+- Config and manifest validation: processor/backend declarations must pass
+  supported contract version checks, controlled vocabulary scopes, concept
+  binding scope checks, compatibility checks, and closed `ContractModel` shapes.
+- OS-level exposure: operational capture must not place secrets in process
+  argv, shell command strings, environment dumps, native stdout/stderr,
+  daemon inspect payloads, host paths, or backend-native handles returned to
+  portable surfaces.
+- Error envelopes: backend exceptions must flow through
+  `_call_backend_diagnostics()` or `_call_backend_apply()` into `Diagnostic`;
+  HTTP failures must use explicit 4xx responses or the existing redacted 500
+  envelope; public payloads must not include stack traces.
+- Runtime validation: backend apply results must pass `ApplyResult` shape
+  checks, snapshot/result contract diagnostics, participant transition checks,
+  and SEM-218 realization disclosure gates before becoming live state.
+- Persistence: mutable operational state stays in `RuntimeSnapshot`,
+  operation records, and audit logs through `ControlPlaneStore`. Archival
+  evidence, run provenance, and analysis stay in experiment-core contracts.
+  Do not use `RuntimeSnapshot.metadata`, operation `details`, audit blobs,
+  backend DTOs, or raw logs as portable claim carriers.
+- Schema publication: any published schema change must preserve
+  `schema_bundle()` parity, add fixtures, and update
+  `contracts/schema-publication-manifest.json` with the required ledger entry.
+- Module boundaries: new code must respect ADR-036 import rules in
+  `tools/policy/adr_policy.yaml`; no implementation logic belongs in
+  `implementations/python/src/aces/`.
+
+## Extension Boundary
+
+The extensibility seam is existing carrier kind plus explicit references, not
+a new observability taxonomy:
+
+- static support claims vary by processor/backend identity, component kind,
+  supported contract versions, capability block, constraint ref, and concept
+  binding;
+- live operational views vary by target, component role, operation id,
+  domain, snapshot address, history scope, audit scope, and authorization role;
+- archival projections vary by apparatus component ref, selected manifest ref,
+  measurement channel ref, capture requirement ref, evidence record ref,
+  provenance ref, redaction/loss disclosure, and comparability or augmentation
+  classification.
+
+Future processors, backends, probes, health checks, setup attestations, or
+measurement-channel observations should add parameters on those seams. They
+must not hard-code a vendor, driver, protocol, log format, or backend adapter
+as the portable ACES concept boundary.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating `ObservationCapabilities` as generic operational observability
+  instead of evidence-capture capability;
+- making backend logs, traces, health checks, audit records, or stack traces
+  participant-visible observations without a participant observation/context
+  projection;
+- treating control-plane audit events as captured experiment evidence unless
+  projected through `experiment-evidence-record-v1` with provenance and
+  sensitivity;
+- treating a capture spec, measurement channel, or apparatus context as proof
+  that evidence was captured;
+- placing portable claims only in `metadata`, `details`, diagnostics, audit
+  blobs, backend-native DTOs, raw logs, or free-form tags;
+- adding duplicate schemas, validators, stores, exception hierarchies,
+  observability registries, manifest renderers, conformance logic, or
+  workflow logic;
+- exposing operational data through a route that bypasses control-plane auth,
+  request-size limits, idempotency, auditing, response models, or redacted
+  error handling;
+- weakening accepted ADRs in place instead of following ADR-059 amendment or
+  supersedure rules.
+
+## Non-Goals
+
+- Implementing RUN-316 behavior, APIs, schemas, persistence, collection
+  agents, exporters, fixtures, tests, or status transitions in this preflight.
+- Implementing DSL-123 scenario-native observability, DSL-124 authored
+  evidence requirements, SEM-225 augmentation behavior, or experiment evidence
+  capture scheduling.
+- Creating a generic observability bag, universal evidence taxonomy, new
+  runtime telemetry store, new backend exception hierarchy, new logging
+  channel, new conformance authority, or new schema authority.
+- Redesigning participant visibility semantics, experiment-core contracts,
+  control-plane security, backend protocols, processor manifests, concept
+  authority, or Ground Control workflow policy.

--- a/docs/decisions/issue-339-api-419-observation-augmentation-disclosure-contracts-preflight.md
+++ b/docs/decisions/issue-339-api-419-observation-augmentation-disclosure-contracts-preflight.md
@@ -1,0 +1,207 @@
+# Issue 339 API-419 Observation Augmentation Disclosure Contracts Preflight
+
+Date: 2026-06-28
+
+Issue: #339.
+
+Requirement: API-419.
+
+This note records architecture preflight guardrails for portable declaration
+and reporting contracts for processor or backend observation augmentation. It
+is implementation guidance only: it does not add schemas, validators, runtime
+behavior, APIs, storage, fixtures, tests, or coverage claims.
+
+## Binding Sources
+
+- ADR-066 is the semantic authority for observability/evidence plane
+  separation and augmentation classifications.
+- `specs/formal/observability-evidence-plane.md` records the SEM-225
+  augmentation invariant set and realized implementation coverage.
+- `specs/sdl/observability-and-evidence.md` states that run-level
+  processor/backend augmentation disclosures are carried by
+  `experiment-run-v1` `augmentation_disclosures`.
+- ADR-055, ADR-064, and ADR-065 define experiment-core task, apparatus
+  context, capture, raw evidence, derived measure, run traceability,
+  realized-form, and augmentation boundaries.
+- ADR-060, ADR-022, and ADR-054 define participant-visible observations,
+  participant context views, visibility projection, markings, redaction, loss,
+  and comparability disclosure.
+- ADR-036 defines package ownership: SDL language logic belongs in `aces_sdl`,
+  live runtime control in `aces_runtime`, and neutral boundary DTOs in
+  `aces_contracts`.
+- ADR-056 and ADR-057 define observed-value and secret-handling boundaries.
+- ADR-009, ADR-061, ADR-062, `contracts/schema-publication-manifest.json`,
+  and `.gc/plan-rules.md` define schema authority, publication governance,
+  concept authority, and workflow gates.
+
+## Architecture Decisions
+
+- API-419 is a portable contract-boundary requirement. Do not create a
+  backend-local augmentation model, raw telemetry endpoint, or generic
+  observability bag.
+- Keep declaration-time capability/support separate from run-time reporting:
+  manifest declarations say what an apparatus can support; run disclosures say
+  what augmentation was actually used for a run.
+- Reuse existing report carriers. Actual processor/backend augmentation is
+  reported through `ExperimentRunModel.augmentation_disclosures` and
+  `ExperimentAugmentationDisclosureModel`, not a second run-provenance root.
+- Reuse existing declaration carriers. Backend observation capability claims
+  belong under `BackendManifestV2Model.capabilities.observation` and the
+  backend manifest authority/conformance helpers. If processor-side
+  declarations are needed, extend `ProcessorManifestV2Model` through its
+  manifest authority surface deliberately; do not model them as backend-only
+  constraints or free-form processor metadata.
+- Added capture surfaces and apparatus must be first-class references:
+  measurement channels, apparatus context components, capture specs, evidence
+  records, manifests, profiles, scenario snapshots, or run refs. Backend logs,
+  raw DTOs, and diagnostic text are not portable carriers.
+- Constraints, side effects, observer effects, participant visibility, and
+  comparability implications must remain separate fields. Do not collapse them
+  into a prose note, tag list, or `metadata` object.
+- Participant-visible augmentation must route through participant visibility
+  projection and participant observation/context carriers. A backend observing
+  something is not the same as a participant observing it.
+- Comparability-relevant augmentation must have explicit observer-effect and
+  comparability-effect disclosure, evidence refs, and run traceability.
+- Any new portable term must be governed by concept authority or controlled
+  vocabularies only when cross-implementation comparison needs a bounded
+  shared term.
+
+## Required Incumbents
+
+- Plane classifier: `ObservabilityEvidencePlane`,
+  `classify_contract_plane()`, `classify_runtime_family()`,
+  `assert_single_primary_plane()`, `token_decides_plane()`,
+  `PLANE_BY_CONTRACT_ID`, and
+  `SCENARIO_NATIVE_OBSERVABILITY_FAMILIES`.
+- Run-level reporting: `ExperimentAugmentationDisclosureModel`,
+  `_SEM_225_PORTABLE_CARRIER_KINDS`, `ExperimentRunModel`,
+  `ExperimentRunTraceabilityModel`, and `validate_experiment_run_against_task()`.
+- Experiment-core carriers: `ExperimentReferenceModel`,
+  `ExperimentApparatusContextModel`, `ExperimentCaptureSpecModel`,
+  `ExperimentCaptureRequirementModel`, `ExperimentEvidenceRecordModel`,
+  `ExperimentDerivedMeasureModel`, and `ExperimentRealizedFormDisclosureModel`.
+- Declaration-time apparatus contracts: `BackendManifestV2Model`,
+  `ProcessorManifestV2Model`, `ObservationCapabilitiesModel`,
+  `ObservationCapabilities`, `OBSERVATION_CAPABILITY_REQUIRED_CONTRACTS`,
+  `BACKEND_SUPPORTED_CONTRACT_IDS`, `PROCESSOR_SUPPORTED_CONTRACT_IDS`,
+  `backend_manifest_payload()`, and `observation_capability_contract_gaps()`.
+- Participant-visible contracts: `ParticipantObservationEnvelopeModel`,
+  `ParticipantContextViewModel`, `ParticipantContextComparabilityModel`,
+  `ParticipantHistoryViewModel`, `ParticipantStatusViewModel`, markings,
+  redaction-policy refs, source-layer validation, and comparability disclosure
+  validation.
+- Schema authority: `ContractModel`, `schema_bundle()`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `contracts/schemas/`, `contracts/fixtures/`, and
+  `contracts/schema-publication-manifest.json`.
+- Runtime/API surfaces for any future exposure:
+  `ControlPlaneSecurityConfig`, `ControlPlaneIdentity`, `ControlPlaneRole`,
+  request-size guards, request fingerprints, idempotency keys, audit events,
+  response models, `ControlPlaneStore`, `Diagnostic`, `Severity`, and the
+  redacted FastAPI error envelope.
+
+## Cross-Cutting Layers
+
+- Contract shape layer: external payloads must be closed-world
+  `ContractModel` descendants. Published JSON Schemas must stay in parity with
+  `schema_bundle()` and must update the schema publication manifest when
+  changed.
+- Manifest authority layer: declaration-time support must pass supported
+  contract allowlists, concept bindings, controlled vocabulary validation,
+  duplicate checks, and conformance gap helpers. New processor declaration
+  fields must update the same authority sets rather than bypassing them.
+- Experiment-run layer: report-time disclosures must pass SEM-225
+  classification validation, processor/backend `augmented_by_ref` authority,
+  portable `carrier_refs`, unique ids/refs, required evidence refs, and run
+  traceability binding.
+- Participant visibility layer: participant-visible output must pass
+  participant observation/context/history/status contracts, visibility
+  projection, source-layer mediation, markings, redaction, loss, authorization
+  scope, and comparability disclosure.
+- Apparatus/control-plane layer: operational telemetry remains apparatus data
+  until projected through manifests, apparatus context, diagnostics, evidence
+  records, run traceability, or participant-visible contracts.
+- Auth/API layer: any future HTTP route must reuse fail-closed bearer/proxy
+  auth, backend/operator/auditor role checks, request-size limits, idempotency,
+  request fingerprints, audit events, response models, and redacted 500
+  envelopes.
+- Secret and OS-exposure layer: contracts, fixtures, logs, diagnostics, audit
+  details, command examples, process argv, environment captures, and backend
+  inspect payloads must not expose tokens, private keys, credentials, hidden
+  truth, prompts, raw traces, raw evidence payloads, full stack traces, or
+  backend-private object representations.
+- Persistence layer: portable augmentation claims must not live only in
+  `RuntimeSnapshot.metadata`, operation details, audit blobs, backend-native
+  DTOs, raw logs, or free-form tags. Live state stays in `RuntimeSnapshot` and
+  `ControlPlaneStore`; archival claims use experiment-core contracts.
+- Error-envelope layer: contract validation errors should identify structural
+  contract violations without echoing raw captured payloads or secrets. Runtime
+  and HTTP failures must use existing diagnostics or redacted error envelopes.
+- Policy layer: implementation must satisfy Ground Control policy checks,
+  module-boundary policy, generated-schema parity, schema-publication
+  governance, concept-authority governance, semantic coverage, and requirement
+  traceability.
+
+## Extension Boundary
+
+The extensibility seam is the existing declaration/reporting split:
+
+- declaration-time support is parameterized by apparatus identity, supported
+  contract ids, observation capability terms, concept bindings, constraints,
+  and conformance gap checks;
+- report-time use is parameterized by augmentation id, purpose, realization
+  layer, additive classifications, processor/backend authority, portable
+  carrier refs, affected refs, evidence refs, disclosure policy, markings,
+  environment effect, participant visibility, observer effect, and
+  comparability effect; and
+- participant/audience projection is parameterized by source layers,
+  transformation rule, audience scope, evidence/provenance refs, redaction
+  policy, and comparability backend-disclosure refs.
+
+Future capture-surface, apparatus, channel, sealing, redaction, observer-effect,
+or comparability variants should extend those parameters or their governed
+vocabularies. A new root contract is appropriate only if both the manifest
+declaration surface and `experiment-run-v1` reporting surface cannot represent
+the boundary without concept confusion, and that decision needs an ADR update.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- adding `observation_augmentation`, `telemetry`, `logs`, `traces`, or
+  `evidence` as a generic free-form bag;
+- creating a duplicate augmentation schema, manifest renderer, plane
+  classifier, reference resolver, exception hierarchy, logging/audit path,
+  persistence store, fixture loader, or workflow pipeline;
+- treating backend logs, health checks, stack traces, audit records, raw
+  packet captures, process argv, or environment dumps as portable
+  participant-visible observations;
+- treating a manifest capability claim, capture spec, or run traceability ref
+  as proof that evidence was captured;
+- reporting environment-visible or comparability-relevant augmentation with
+  only backend-local logs or diagnostics;
+- omitting evidence refs for environment-visible, participant-visible, or
+  comparability-relevant augmentation;
+- using `apparatus_only` as the default when the augmentation changes the
+  realized environment, participant-visible information, or comparison basis;
+- placing constraints, side effects, redaction, loss, observer effects, or
+  comparability implications only in prose notes;
+- adding published schemas without fixtures, `schema_bundle()` parity, and a
+  schema publication manifest ledger update;
+- leaking hidden truth, answer keys, evaluator state, prompts, private traces,
+  credentials, operator secrets, raw evidence payloads, environment dumps, or
+  full tracebacks through SDL, contracts, schemas, fixtures, diagnostics,
+  audit records, logs, examples, or HTTP responses.
+
+## Non-Goals
+
+- Implementing API-419 behavior, schemas, validators, endpoints, storage,
+  producers, conformance checks, fixtures, or tests in this preflight note.
+- Updating API-419 status or claiming implementation coverage.
+- Redesigning SEM-225, experiment-core run provenance, participant visibility
+  semantics, schema authority, concept authority, control-plane security,
+  diagnostics, audit, persistence, or workflow policy.
+- Implementing capture scheduling, telemetry collection, packet/log/trace
+  parsing, retention, sealing, redaction execution, analysis engines, scoring,
+  or study comparison logic.

--- a/docs/decisions/issue-340-asr-525-observability-conformance-preflight.md
+++ b/docs/decisions/issue-340-asr-525-observability-conformance-preflight.md
@@ -1,0 +1,213 @@
+# Issue 340 ASR-525 Observability Conformance Preflight
+
+Date: 2026-06-28
+
+Issue: #340.
+
+Requirement: ASR-525.
+
+This note records architecture preflight guardrails for conformance fixtures
+and checks that distinguish scenario-native observability, authored evidence
+requirements, processor/backend augmentation, and required augmentation
+disclosure. It is implementation guidance only: it does not add fixtures,
+tests, schemas, validators, runtime behavior, APIs, storage, or coverage
+claims.
+
+## Binding Sources
+
+- ADR-066 is the semantic authority for observability/evidence plane
+  separation and augmentation classification.
+- `specs/formal/observability-evidence-plane.md` defines OE invariants, the
+  source-to-contract-to-test matrix, negative probes, and implemented coverage
+  for SEM-224, SEM-225, DSL-123, and DSL-124.
+- `specs/sdl/observability-and-evidence.md` defines the SDL authoring rules
+  for scenario-native observability, authored evidence requirements, and
+  augmentation disclosure boundaries.
+- `docs/decisions/issue-334-sem-224-observability-plane-preflight.md`,
+  `docs/decisions/issue-336-dsl-123-scenario-native-observability-preflight.md`,
+  and
+  `docs/decisions/issue-337-dsl-124-authored-evidence-requirements-preflight.md`
+  define the adjacent implementation guardrails ASR-525 must bind together.
+- `aces_sdl.observability_plane_semantics` is the carrier-oriented plane
+  classifier. ASR-525 conformance checks must consume it, not replace it.
+- `experiment-run-v1` `augmentation_disclosures` and
+  `ExperimentAugmentationDisclosureModel` are the SEM-225 disclosure carrier
+  and validator.
+- `aces_conformance.conformance`, `contracts/fixtures/`,
+  `contracts/profiles/backend/`, and `schema_bundle()` are the existing
+  conformance, fixture, profile, and contract-validation surfaces.
+- ADR-009, ADR-019, ADR-061, `contracts/schema-publication-manifest.json`, and
+  `.gc/plan-rules.md` govern published schema authority and workflow gates.
+
+## Architecture Decisions
+
+- ASR-525 is an executable conformance requirement over existing semantics and
+  carriers. It should prove the distinction and disclosure rules are enforced;
+  it should not invent a new observability, evidence, or augmentation model.
+- Plane ownership must remain carrier-oriented. Use
+  `classify_contract_plane()`, `classify_runtime_family()`,
+  `classify_sdl_section_plane()`, and existing validators rather than
+  classifying strings such as `log`, `trace`, `telemetry`, `observation`, or
+  `evidence`.
+- Conformance fixtures should reuse the canonical fixture corpus shape:
+  `contracts/fixtures/<family>/<contract-id>/valid/*.json` and
+  `invalid/*.json`, with schema validation first and semantic diagnostics only
+  after schema-valid payloads.
+- Backend/profile fixture conformance must remain profile-artifact driven.
+  `contracts/profiles/backend/*.json` is the authority for profile contract
+  sets; do not reintroduce an in-code profile requirements table.
+- SDL conformance checks must route through `parse_sdl()`,
+  `SemanticValidator`, fail-closed reference resolution, and instantiated
+  revalidation where applicable. Do not add a second SDL fixture loader,
+  reference resolver, or exception hierarchy.
+- Augmentation disclosure checks must exercise `experiment-run-v1`
+  `augmentation_disclosures`, including environment-visible,
+  participant-visible, and comparability-relevant cases. Do not hide
+  augmentation claims in backend logs, diagnostics, metadata, operation
+  details, or free-form tags.
+- Conformance failures exposed through the runner or CLI must use the existing
+  `Diagnostic` envelope and sanitized messages. Do not leak rejected payload
+  contents, fixture secrets, hidden truth, backend-private ids, or tracebacks.
+- If implementation changes a published schema to make a conformance case
+  expressible, the published schema remains the authority and the change must
+  update the reference implementation, fixtures, and
+  `contracts/schema-publication-manifest.json` ledger together.
+
+## Required Incumbents
+
+- Plane classifier and SDL seams: `ObservabilityEvidencePlane`,
+  `PLANE_BY_CONTRACT_ID`, `PLANE_BY_SDL_SECTION`,
+  `SCENARIO_NATIVE_OBSERVABILITY_FAMILIES`, `token_decides_plane()`,
+  `collect_scenario_native_observability_refs()`, `RUNTIME_SERVICE_FAMILIES`,
+  `collect_qualified_runtime_family_refs()`, `parse_sdl()`, `SDLModel`,
+  `SemanticValidator`, and `SDLParseError` / `SDLValidationError`.
+- Experiment-core carriers: `ExperimentCaptureSpecModel`,
+  `ExperimentEvidenceRecordModel`, `ExperimentDerivedMeasureModel`,
+  `ExperimentRunTraceabilityModel`, `ExperimentRealizedFormDisclosureModel`,
+  `ExperimentAugmentationDisclosureModel`, `ExperimentRunModel`, and
+  `validate_experiment_run_against_task()`.
+- Participant visibility and audience-view contracts:
+  `ParticipantObservationEnvelopeModel`, `ParticipantContextViewModel`,
+  `ParticipantHistoryViewModel`, `ParticipantStatusViewModel`, source-layer,
+  transformation, marking, redaction, loss, and comparability validators.
+- Apparatus and operational observability contracts:
+  `BackendManifestV2Model`, `ProcessorManifestV2Model`,
+  `ExperimentApparatusContextModel`, backend observation capabilities,
+  measurement-channel refs, selected-manifest validation, `Diagnostic`, and
+  `Severity`.
+- Conformance runner and CLI: `fixtures_root()`, `profiles_root()`,
+  `required_contracts()`, `run_fixture_suite()`, `run_target_conformance()`,
+  `_fixture_case_diagnostics()`, `_semantic_diagnostics()`,
+  `aces conformance backend`, and the legacy `aces_conformance.runner`
+  delegate.
+- Contract and corpus governance: `ContractModel`, `schema_bundle()`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `tools/check_json_artifacts.py`, `contracts/schemas/`,
+  `contracts/fixtures/`, `contracts/profiles/`,
+  `contracts/schema-publication-manifest.json`, controlled vocabularies, and
+  concept-authority validators.
+- Workflow and policy gates: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `tools/check_repo_policy.py`, `tools/check_requirement_governance.py`,
+  `tools/check_schema_publication.py`, `tools/check_semantic_coverage.py`, and
+  `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- Fixture/config layer: conformance inputs must be JSON or SDL fixtures under
+  canonical corpus roots, loaded through existing corpus/profile helpers or
+  safe SDL parsing. Override roots must stay explicit parameters such as
+  `--fixtures-root` and `--profiles-root`; do not add environment-variable
+  discovery or path heuristics.
+- Schema layer: valid fixtures must pass the checked-in published schema and
+  matching `ContractModel`; invalid fixtures must fail schema and/or model
+  validation. Published schema edits require generated-schema parity and a
+  manifest ledger entry.
+- Semantic layer: cross-artifact checks must reuse the SEM-224 classifier,
+  DSL-123 runtime-family refs, DSL-124 evidence-requirement validation,
+  SEM-225 augmentation validators, participant visibility rules, and
+  experiment-core run/evidence traceability validators.
+- Conformance runner layer: schema validation must run before semantic checks,
+  profile load failures must become `conformance.profile-load-failed`, missing
+  fixtures must become `conformance.fixture-missing`, and unknown contracts
+  must fail closed as `conformance.contract-unknown`.
+- Auth surface: ASR-525 should be offline fixture conformance by default and
+  should not add an HTTP endpoint. If a future live-target probe is added, it
+  must reuse `RuntimeControlPlane`, `ControlPlaneSecurityConfig`,
+  `ControlPlaneIdentity`, `ControlPlaneRole`, request-size guards, idempotency,
+  request fingerprints, audit events, response models, and redacted FastAPI
+  error envelopes.
+- Secret-handling layer: fixtures must be synthetic and redacted. Do not place
+  bearer tokens, private keys, operator secrets, hidden answer keys, prompts,
+  raw trace payloads, raw evidence payloads, backend-private ids, environment
+  dumps, or full stack traces in fixtures, diagnostics, logs, CLI output, or
+  assertion messages.
+- Config/env-binding layer: do not introduce new runtime configuration,
+  environment binding, or secret-binding shapes for conformance. Policy-only
+  settings such as `ACES_REQUIREMENT_UID` remain workflow inputs, not contract
+  or fixture data.
+- OS-exposure layer: CLI and tool invocations should pass profile ids and
+  filesystem paths only. Do not pass fixture payloads, raw evidence, tokens, or
+  backend-private content through process argv.
+- Error-envelope layer: runner and CLI failures must preserve structured
+  diagnostic codes and sanitized messages. Parser failures should remain SDL
+  errors. Pydantic validation details must not echo rejected confidential
+  payloads when surfaced through public conformance reports.
+- Persistence layer: ASR-525 does not add persistent state. Portable claims
+  must live in SDL, contract fixtures, evidence records, run provenance, and
+  schema-versioned artifacts; never only in `RuntimeSnapshot.metadata`, audit
+  blobs, backend DTOs, raw logs, or operation details.
+- Policy layer: changes must satisfy Ground Control policy, module-boundary
+  policy, schema-publication governance, generated-schema parity, JSON artifact
+  checks, semantic coverage, and requirement traceability.
+
+## Extension Boundary
+
+The extensibility seam is a small conformance probe catalog, not a new domain
+model. Each probe should be parameterized by requirement UID or invariant id,
+carrier contract id or SDL section, fixture path, expected plane or
+augmentation classification, and expected diagnostic outcome.
+
+Future probes should add rows and fixtures for new carriers, classifications,
+or profile contract sets. They should not require editing every validator, a
+second fixture runner, duplicate schema registries, or hard-coded string
+classification.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating this issue as permission to redesign SEM-224, SEM-225, DSL-123, or
+  DSL-124;
+- adding a generic observability/evidence/augmentation super-schema;
+- adding duplicate plane classifiers, reference resolvers, fixture loaders,
+  profile requirement tables, validators, diagnostics, exception hierarchies,
+  logging stacks, audit stacks, or persistence stores;
+- deciding plane ownership from ambiguous tokens instead of carriers and
+  registered runtime families;
+- accepting backend logs, traces, health checks, diagnostics, audit records, or
+  stack traces as participant observations or authored scenario meaning;
+- treating scenario-native observability or authored evidence requirements as
+  proof that evidence was captured;
+- accepting environment-visible, participant-visible, or
+  comparability-relevant augmentation without first-class disclosure,
+  evidence refs, markings where required, and run traceability;
+- putting portable semantics only in metadata, details, diagnostic text,
+  backend DTOs, raw logs, or free-form tags;
+- making conformance pass by weakening valid/invalid fixtures rather than
+  exercising the existing validators;
+- hand-editing published schemas without updating source models, generated
+  parity, fixtures, and schema-publication manifest entries.
+
+## Non-Goals
+
+- Implementing ASR-525 fixtures, tests, runner changes, schemas, validators,
+  CLI behavior, runtime probes, endpoints, persistence, or telemetry
+  collection in this preflight note.
+- Updating ASR-525 status or claiming implementation coverage.
+- Changing the SEM-224 plane definitions, SEM-225 augmentation carrier,
+  DSL-123 runtime-family model, or DSL-124 evidence-requirement syntax.
+- Adding a new backend telemetry API, evidence capture scheduler, analysis
+  engine, raw evidence storage layer, or participant visibility model.
+- Replacing control-plane security, diagnostics, schema authority,
+  concept-authority governance, conformance profile governance, or workflow
+  policy.

--- a/docs/decisions/issue-341-exp-731-evidence-requirement-refinement-preflight.md
+++ b/docs/decisions/issue-341-exp-731-evidence-requirement-refinement-preflight.md
@@ -1,0 +1,186 @@
+# Issue 341 EXP-731 Evidence Requirement Refinement Preflight
+
+Date: 2026-06-28
+
+Issue: #341.
+
+Requirement: EXP-731.
+
+This note records architecture preflight guardrails for supporting task-, run-,
+or study-level refinement and extension of authored data and evidence
+requirements without silently rewriting authored scenario meaning. It is
+implementation guidance only: it does not add schemas, validators, SDL syntax,
+runtime behavior, APIs, storage, fixtures, tests, or coverage claims.
+
+## Binding Sources
+
+- ADR-066 is the semantic authority for observability/evidence plane
+  separation.
+- `docs/decisions/issue-337-dsl-124-authored-evidence-requirements-preflight.md`
+  is the base authored evidence-requirement guardrail.
+- `specs/sdl/observability-and-evidence.md`,
+  `specs/sdl/references.md`, and `specs/sdl/sections.md` define the SDL
+  authoring, reference-resolution, and section boundaries.
+- ADR-055, ADR-064, and ADR-065 define experiment task, capture spec, evidence
+  record, derived measure, run traceability, realized-form, augmentation, and
+  study boundaries.
+- ADR-012, ADR-061, ADR-062, ADR-009, `contracts/schema-publication-manifest.json`,
+  and `.gc/plan-rules.md` define concept authority, schema governance,
+  authority boundaries, and workflow gates.
+- ADR-056 and ADR-057 define explicit redaction and secret-handling boundaries.
+
+## Architecture Decisions
+
+- EXP-731 is a scoped overlay problem, not a new authored-scenario meaning
+  root. A refinement or extension must point back to the authored requirement,
+  task/capture requirement, run, or study scope it constrains.
+- The authored SDL `evidence_requirements` map remains the base capture-intent
+  declaration. Task-, run-, and study-level changes must not mutate that map or
+  reuse the same requirement id with changed meaning.
+- Refinement means a stricter or more specific obligation over an existing
+  requirement dimension such as scope, window, channel, media type, integrity,
+  sensitivity, redaction, retention, loss disclosure, or satisfaction evidence.
+  Extension means an explicitly additional obligation in a scoped context.
+- Weakening a base requirement is not refinement. If a later context cannot
+  satisfy the base requirement, represent that as a new task/study version,
+  explicit supersedure, run deviation, loss disclosure, invalidation, or
+  exclusion criterion.
+- Task-level refinements belong with experiment task/capture intent:
+  `ExperimentTaskModel.evaluation_protocol`, metric evidence requirements,
+  observation requirements, and `experiment-capture-spec-v1` concepts. They
+  must preserve the scenario/snapshot reference chain.
+- Run-level refinements belong with run provenance: selected capture specs,
+  evidence records, run `traceability`, `realized_form_disclosures`, and
+  `augmentation_disclosures`. They must not rewrite the referenced task.
+- Study-level refinements belong with study inclusion criteria, run allocation,
+  analysis plans, validity notes, and membership constraints. They must cite
+  task/run/evidence/analysis refs rather than changing the task protocol by
+  implication.
+- Existing satisfaction validation remains authoritative. New refinement checks
+  must compose with `validate_experiment_run_against_task()` and the
+  experiment-core model validators instead of adding a parallel evidence
+  satisfaction algorithm.
+- Reference identity must be explicit. Use constrained `ExperimentReferenceModel`
+  subclasses and existing digest/path qualifier rules; do not identify
+  requirements by title text, tag strings, fixture paths, backend ids, or log
+  messages.
+
+## Required Incumbents
+
+- SDL base authoring: `EvidenceRequirement`, `Scenario.evidence_requirements`,
+  `parse_sdl()`, `parse_sdl_file()`, `SDLModel`, `_HASHMAP_SECTIONS`,
+  `SemanticValidator`, `_verify_evidence_requirements()`,
+  `_named_ref_index()`, `_validate_named_ref()`, and post-instantiation
+  semantic revalidation.
+- Plane ownership: `ObservabilityEvidencePlane`, `PLANE_BY_SDL_SECTION`,
+  `PLANE_BY_CONTRACT_ID`, `classify_sdl_section_plane()`,
+  `classify_contract_plane()`, `assert_single_primary_plane()`, and
+  `token_decides_plane()`.
+- Experiment-core contracts: `ExperimentReferenceModel` and constrained
+  reference subclasses, `ExperimentTaskModel`,
+  `ExperimentEvaluationProtocolModel`, `ExperimentCaptureSpecModel`,
+  `ExperimentCaptureRequirementModel`, `ExperimentEvidenceRecordModel`,
+  `ExperimentDerivedMeasureModel`, `ExperimentRunTraceabilityModel`,
+  `ExperimentRunModel`, `ExperimentStudyModel`, and
+  `validate_experiment_run_against_task()`.
+- Schema authority: `ContractModel`, `schema_bundle()`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `contracts/schemas/`, `contracts/fixtures/`, and
+  `contracts/schema-publication-manifest.json`.
+- Runtime/API exposure, if later needed: `ControlPlaneSecurityConfig`,
+  `ControlPlaneIdentity`, `ControlPlaneRole`, request-size guards,
+  idempotency/request fingerprints, audit records, `Diagnostic`, `Severity`,
+  and the redacted FastAPI error envelope.
+- Secret handling: `enforce_observed_value_redaction()`, sensitivity/redaction
+  fields on experiment evidence contracts, and ADR-056/057 explicit-redaction
+  discipline.
+
+## Cross-Cutting Layers
+
+- SDL/config layer: base authored requirements must pass safe YAML loading,
+  normalized keys, closed `SDLModel` shapes, symbol-key rejection, fail-closed
+  reference resolution, and instantiated revalidation.
+- Plane-classifier layer: refinements remain in the authored evidence,
+  captured evidence, derived analysis, processor/backend operational, or
+  scenario-native planes by carrier role, never by words such as `log`,
+  `trace`, `telemetry`, or `evidence`.
+- Contract/schema layer: any new portable carrier must be a closed
+  `ContractModel` with `schema_bundle()` parity, fixtures, semantic invariant
+  annotations where needed, and a schema-publication manifest ledger entry.
+- Experiment-core layer: refinement satisfaction must reuse capture-spec key
+  equality, window resolution, evidence-record redaction/loss, derived-measure
+  source-evidence, run traceability, and task/run cross-artifact validators.
+- Study layer: study-level constraints must use membership, inclusion
+  criteria, run allocation, analysis plans, validity notes, and metric/run
+  grounding. They must not create hidden task protocol changes.
+- Auth/control-plane layer: future API exposure must reuse bearer/proxy
+  authentication, backend/operator/auditor role gates, request-size limits,
+  idempotency fingerprints, audit records, response DTOs, and redacted 500
+  envelopes.
+- Secret/env/OS exposure layer: refinement artifacts, diagnostics, fixtures,
+  logs, command examples, and process argv must not carry operator secrets,
+  bearer tokens, private keys, environment dumps, raw backend payloads, hidden
+  answer keys, full tracebacks, or large raw evidence payloads. Use content
+  refs, checksums, sensitivity, redaction state, and bounded summaries.
+- Persistence layer: scoped refinements are portable contract data, not live
+  runtime state. Do not store the only authoritative copy in
+  `RuntimeSnapshot.metadata`, operation details, backend DTOs, audit blobs,
+  raw logs, or free-form tags.
+- Policy layer: implementation must satisfy Ground Control checks, module
+  boundary policy, concept-authority governance, generated-schema parity,
+  schema-publication governance, semantic coverage, and requirement
+  traceability.
+
+## Extension Boundary
+
+The extension seam is a scoped refinement overlay with explicit provenance:
+
+- stable refinement id and version;
+- `scope_kind` constrained to task, run, or study;
+- base requirement refs to authored SDL evidence requirements, experiment
+  capture requirements, task observation requirements, or study/run refs;
+- operation kind such as stricter constraint, additive requirement, or explicit
+  supersedure;
+- dimension-specific fields for source, scope, window, channel, media type,
+  sensitivity, redaction, integrity, retention, loss disclosure, satisfaction,
+  or comparability impact;
+- rationale and provenance/evidence refs; and
+- conflict policy that rejects silent loosening or ambiguous overlaps.
+
+Future variations should add dimensions or governed terms through this seam.
+Do not add a second evidence-requirement registry, resolver, schema family,
+exception hierarchy, logging/audit path, persistence store, or workflow engine.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- rewriting authored SDL `evidence_requirements` during task, run, or study
+  generation;
+- changing a requirement's meaning while preserving its id;
+- treating capture specs, backend capability claims, observability systems,
+  audit records, diagnostics, or raw logs as proof of capture;
+- loosening base requirements without explicit supersedure, deviation, loss,
+  invalidation, or study exclusion semantics;
+- resolving overlaps by first match, title text, tag strings, or backend-native
+  object ids;
+- putting refinement semantics only in `notes`, `metadata`, diagnostics,
+  audit blobs, backend DTOs, or free-form tags;
+- duplicating experiment-core capture, evidence-record, derived-measure, run,
+  study, reference, or plane-classifier validators; and
+- leaking secrets, hidden truth, answer keys, prompts, private traces,
+  environment dumps, process argv, full tracebacks, or raw evidence payloads
+  through schemas, fixtures, diagnostics, logs, examples, or comments.
+
+## Non-Goals
+
+- Implementing EXP-731 behavior, schemas, validators, endpoints, persistence,
+  capture scheduling, fixtures, tests, or requirement status changes in this
+  preflight note.
+- Adding a new top-level SDL section, generic evidence bag, universal
+  observability model, archival provenance root, or study protocol override
+  model.
+- Replacing DSL-124 authored evidence requirements, experiment-core contracts,
+  run provenance, study analysis semantics, control-plane security, schema
+  authority, concept authority, diagnostics, audit, persistence, or workflow
+  policy.

--- a/docs/research/experiment-core/index.md
+++ b/docs/research/experiment-core/index.md
@@ -23,4 +23,5 @@ issue-234-exp-708-evidence-record-preflight-guardrails
 issue-235-exp-709-derived-measure-preflight-guardrails
 issue-238-exp-720-run-provenance-preflight-guardrails
 issue-239-exp-722-realized-form-preflight-guardrails
+issue-342-exp-732-evidence-source-augmentation-provenance-preflight-guardrails
 ```

--- a/docs/research/experiment-core/issue-342-exp-732-evidence-source-augmentation-provenance-preflight-guardrails.md
+++ b/docs/research/experiment-core/issue-342-exp-732-evidence-source-augmentation-provenance-preflight-guardrails.md
@@ -1,0 +1,172 @@
+# Issue #342 EXP-732 Evidence Source And Augmentation Provenance Preflight Guardrails
+
+Date: 2026-06-28
+
+Issue: #342.
+
+Requirement: EXP-732.
+
+This preflight narrows issue #128 to preserving authored evidence
+requirements, the realized evidence sources that satisfied them, and
+processor/backend augmentation added for capture, evaluation, or operation.
+It is implementation guidance only: it does not add schemas, fields,
+validators, storage, APIs, fixtures, tests, or coverage claims.
+
+## Architecture Decisions
+
+- Treat `experiment-run-v1` as the canonical archival join point. Do not add an
+  `experiment-evidence-provenance-v1`, `run-evidence-satisfaction-v1`, or
+  parallel apparatus-provenance root.
+- Preserve the distinction between authored requirement, executable capture
+  specification, raw evidence record, run evidence artifact, derived measure,
+  realized-form disclosure, and augmentation disclosure. None is a synonym for
+  another.
+- Preserve authored evidence requirements by reference to their authored SDL
+  carrier and generated `experiment-capture-spec-v1` / capture requirement
+  binding. A capture specification or authored requirement remains intent; it
+  is not proof that capture occurred.
+- Preserve realized evidence sources through `experiment-evidence-record-v1`
+  `source_refs`, `capture_spec_ref`, `capture_requirement_ref`, raw-content
+  metadata, redaction/loss state, and run `traceability.evidence_record_refs`.
+  Do not treat backend logs, operation records, or audit events as realized
+  evidence unless they are projected through evidence records or artifact refs.
+- Preserve augmentation through existing run-level
+  `augmentation_disclosures`. Environment-visible, participant-visible, or
+  comparability-relevant augmentation must have evidence refs traced through
+  the run; apparatus-only augmentation may remain apparatus/control-plane data
+  only when no claim depends on it.
+- Apparatus provenance remains `experiment-apparatus-context-v1` plus manifest
+  identity, selected manifests, measurement channels, observed setup evidence,
+  backend observation capability declarations, and run-level augmentation or
+  realized-form disclosures. Apparatus context alone must not become a hidden
+  satisfaction ledger.
+
+## Required Incumbents
+
+- SDL authored requirement surface: `aces_sdl.evidence_requirements`,
+  `Scenario.evidence_requirements`, `SemanticValidator._verify_evidence_requirements`,
+  `parse_sdl()`, `instantiate_scenario()`, fail-closed targetable refs, and
+  `aces_sdl.observability_plane_semantics`.
+- Experiment contracts:
+  `ContractModel`, `ExperimentCaptureSpecModel`,
+  `ExperimentCaptureRequirementModel`, `ExperimentEvidenceRecordModel`,
+  `ExperimentRunTraceabilityModel`, `ExperimentRealizedFormDisclosureModel`,
+  `ExperimentAugmentationDisclosureModel`, `ExperimentRunModel`,
+  `ExperimentApparatusContextModel`, `ExperimentArtifactRefModel`,
+  `ExperimentReferenceModel`, `schema_bundle()`, and
+  `validate_experiment_run_against_task()`.
+- Apparatus and capability authority:
+  processor/backend manifest models, `ObservationCapabilitiesModel`,
+  `ObservationCapabilities`, `OBSERVATION_CAPABILITY_REQUIRED_CONTRACTS`,
+  `observation_capability_contract_gaps()`, manifest-authority helpers,
+  concept-authority catalogs, and governed observation vocabularies.
+- Runtime/API incumbents for any future producer or publication path:
+  `RuntimeControlPlane`, `ControlPlaneStore`, `ControlPlaneSecurityConfig`,
+  `ControlPlaneIdentity`, `ControlPlaneRole`, request-size guards,
+  idempotency keys, request fingerprints, audit events, closed FastAPI DTOs,
+  `Diagnostic`, and the redacted HTTP 500 envelope.
+- Backend/OS boundary incumbents:
+  `DeploymentDriver`, fixed-argv OCI driver patterns, bounded timeouts,
+  image trust policy, portable handles, and sanitized diagnostics.
+- Governance:
+  `contracts/schemas/`, `contracts/fixtures/`, `contracts/schema-publication-manifest.json`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `tools/check_schema_publication.py`, `tools/check_json_artifacts.py`,
+  `tools/check_repo_policy.py`, `tools/check_requirement_governance.py`,
+  `tools/verify_all.py`, `.ground-control.yaml`, and `.gc/plan-rules.md`.
+
+## Cross-Cutting Layers
+
+- SDL/config layer: authored evidence requirements must pass safe parsing,
+  closed `SDLModel` shapes, no variable placeholders in symbol keys,
+  fail-closed reference resolution, and instantiated semantic revalidation.
+- Plane-classifier layer: source and carrier meaning must come from
+  `ObservabilityEvidencePlane` and carrier-role classifiers, not words such as
+  `log`, `trace`, `telemetry`, `observation`, or `evidence`.
+- Contract structural layer: external artifacts must pass generated draft
+  2020-12 schemas and closed-world `ContractModel` validation. Unknown fields
+  remain errors.
+- Contract semantic layer: run traceability, evidence-record content/loss
+  disclosure, augmentation disclosure semantics, realized-form evidence refs,
+  apparatus manifest binding, task/run protocol binding, and task evidence
+  satisfaction must use existing validators and `x-aces-invariants`.
+- Auth surface: any future HTTP create/read path must use existing
+  control-plane identity and role checks. Publishing provenance is a mutating
+  operation; dereferencing evidence content is a separate authorized read.
+- Request/idempotency surface: future HTTP paths must keep request-size guards,
+  idempotency keys, request fingerprints, audit recording, and closed DTOs.
+  Do not add a provenance-specific request pipeline.
+- Secret-handling surface: provenance may carry sensitivity-aware refs,
+  checksums, bounded summaries, redaction state, loss disclosures, and
+  non-secret provenance refs. It must not carry credentials, bearer tokens,
+  private keys, hidden answer keys, prompts, raw trace payloads, environment
+  dumps, backend-private object reprs, full tracebacks, process argv, or raw
+  captured payloads.
+- Config/env-binding surface: do not introduce a new environment, token, or
+  secret-binding shape. If runtime values contribute evidence, use existing
+  runtime sensitivity classifications and observed-value redaction helpers.
+- OS-level exposure: producers, fixtures, and CLIs must not pass tokens,
+  credentials, backend-private payloads, or large raw evidence content through
+  process arguments. Use content files, URIs, checksums, bounded summaries, and
+  synthetic fixtures.
+- Error-envelope surface: validation failures should surface as Pydantic
+  errors or existing `Diagnostic` values; HTTP failures use the existing
+  redacted error envelope. Do not echo full run records, evidence payloads,
+  stderr, tracebacks, argv, secrets, or backend internals.
+- Persistence surface: do not store the only copy of authored requirements,
+  realized source satisfaction, evidence records, or augmentation provenance in
+  `RuntimeSnapshot.metadata`, operation records, participant histories, audit
+  details, backend DTOs, raw logs, or free-form tags. Durable persistence, if
+  added later, must preserve schema-versioned experiment artifacts and refs.
+
+## Extension Boundary
+
+The extensibility seam is a typed run-level relationship over existing
+experiment references, not a new provenance stack. If existing traceability,
+evidence records, and augmentation disclosures are insufficient, extend the
+existing run contract with a typed satisfaction relation that links:
+
+- authored requirement or capture-spec requirement identity;
+- realized evidence-record refs;
+- realized source refs;
+- relevant evidence artifact refs;
+- augmentation disclosure ids or refs; and
+- loss/redaction/observer-effect notes when the satisfaction claim depends on
+  them.
+
+Producer code should parameterize the authored-requirement source, capture-spec
+binding, artifact locator/sealing policy, redaction policy, and augmentation
+source. Future backend, processor, storage, or analysis variants should emit
+the same canonical contract shape rather than changing the authority surface.
+
+## Gotchas And Anti-Patterns
+
+- Do not treat authored evidence requirements, capture specs, backend
+  capability claims, traceability refs, or scenario-native observability
+  declarations as proof of capture.
+- Do not treat an evidence artifact id as equivalent to an evidence record,
+  capture requirement, source ref, derived measure, or augmentation disclosure.
+- Do not let backend logs, operation statuses, audit records, diagnostics,
+  participant histories, runtime snapshot metadata, or backend-native DTOs be
+  the only portable satisfaction carrier.
+- Do not use `augmentation_disclosures` or `realized_form_disclosures` as
+  unstructured log lists.
+- Do not duplicate schema registries, validators, reference resolvers,
+  exception hierarchies, persistence stacks, manifest renderers, logging/audit
+  pipelines, or workflow logic.
+- Do not hand-edit `contracts/schemas/`; update contract source, regenerate
+  schemas, keep `schema_bundle()` parity, update fixtures/tests, and record
+  schema-publication manifest ledger entries when published hashes change.
+
+## Non-Goals
+
+- Implementing EXP-732 behavior, schema fields, validators, producers,
+  storage, APIs, fixtures, tests, or status changes in this preflight.
+- Implementing runtime evidence capture, packet/log/trace collection,
+  retention, sealing, redaction execution, retrieval, schedulers, workers, or
+  background capture orchestration.
+- Implementing derived-measure computation, evaluator behavior, statistical
+  analysis, study comparison, replay, or artifact dereference authorization.
+- Replacing DSL-124, SEM-224, SEM-225, experiment-core contracts, apparatus
+  context, participant visibility contracts, control-plane security,
+  diagnostics, schema authority, concept authority, or Ground Control policy.

--- a/implementations/python/packages/aces_backend_protocols/capabilities.py
+++ b/implementations/python/packages/aces_backend_protocols/capabilities.py
@@ -71,9 +71,8 @@ PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS = {
 }
 """Minimum published contract surfaces needed to make API-405 claims checkable.
 
-The table is intentionally conservative: it does not prove that every backend
-implements every action kind. It gives the conformance runner a falsifiable
-floor for standard terms, so a manifest cannot claim ACES participant support
+The table is intentionally conservative. It gives the conformance runner a
+falsifiable floor for standard terms, so a manifest cannot claim ACES participant support
 while omitting the contracts that carry the corresponding runtime evidence.
 """
 
@@ -82,6 +81,7 @@ OBSERVATION_CAPABILITY_REQUIRED_CONTRACTS = frozenset(
         "experiment-capture-spec-v1",
         "experiment-evidence-record-v1",
         "experiment-derived-measure-v1",
+        "experiment-run-v1",
     }
 )
 

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -90,6 +90,7 @@ def create_stub_manifest(
         supported_contract_versions.discard("experiment-capture-spec-v1")
         supported_contract_versions.discard("experiment-evidence-record-v1")
         supported_contract_versions.discard("experiment-derived-measure-v1")
+        supported_contract_versions.discard("experiment-run-v1")
     concept_bindings = (
         ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
         ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
@@ -232,6 +233,7 @@ def create_stub_manifest(
                             "experiment-capture-spec-v1",
                             "experiment-evidence-record-v1",
                             "experiment-derived-measure-v1",
+                            "experiment-run-v1",
                         }
                     ),
                     supported_media_types=frozenset({"application/json", "text/plain"}),

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -30,6 +30,7 @@ from aces_contracts.contracts import (
     ExperimentCaptureSpecModel,
     ExperimentDerivedMeasureModel,
     ExperimentEvidenceRecordModel,
+    ExperimentRunModel,
     OperationReceiptModel,
     OperationStatusModel,
     OrchestrationPlanModel,
@@ -79,6 +80,21 @@ from aces_sdl.parser import parse_sdl
 from pydantic import ValidationError
 
 _SEMANTIC_INVALID_DIAGNOSTIC_CODE = "conformance.semantic-invalid"
+_OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE = "conformance.observability-evidence-invalid"
+_PORTABLE_AUGMENTATION_CARRIER_KINDS = frozenset(
+    {
+        "apparatus-context",
+        "capture-spec",
+        "derived-measure",
+        "evidence-record",
+        "manifest",
+        "measurement-channel",
+        "profile",
+        "run",
+        "scenario-snapshot",
+    }
+)
+_RUN_REFINEMENT_CONCERN_KINDS = frozenset({"capture-window", "measurement-channel"})
 
 
 class BackendCapabilityProfile(str, Enum):
@@ -178,6 +194,7 @@ _MODEL_VALIDATORS = {
     "experiment-capture-spec-v1": ExperimentCaptureSpecModel.model_validate,
     "experiment-evidence-record-v1": ExperimentEvidenceRecordModel.model_validate,
     "experiment-derived-measure-v1": ExperimentDerivedMeasureModel.model_validate,
+    "experiment-run-v1": ExperimentRunModel.model_validate,
 }
 
 
@@ -808,6 +825,87 @@ def _runtime_snapshot_semantic_diagnostics(payload: Any) -> list[Diagnostic]:
     ]
 
 
+def observability_evidence_conformance_diagnostics(
+    payload: ExperimentRunModel | Mapping[str, Any],
+) -> tuple[Diagnostic, ...]:
+    """Return ASR-525 diagnostics for issue #128 observability/evidence semantics.
+
+    The individual contract models already enforce the closed-world shape and
+    SEM-225 baseline rules. This helper adds the conformance-level checks that
+    tie the existing carriers together for issue #128: augmentation reports
+    must name their portable affected carriers, and run-scoped capture
+    refinements must preserve the authored/base requirement plus evidence.
+    """
+
+    run = payload if isinstance(payload, ExperimentRunModel) else ExperimentRunModel.model_validate(payload)
+    diagnostics: list[Diagnostic] = []
+    diagnostics.extend(_augmentation_conformance_diagnostics(run))
+    diagnostics.extend(_run_refinement_conformance_diagnostics(run))
+    return tuple(diagnostics)
+
+
+def _augmentation_conformance_diagnostics(run: ExperimentRunModel) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    for disclosure in run.augmentation_disclosures:
+        address = f"experiment-run-v1.augmentation_disclosures.{disclosure.augmentation_id}"
+        if not disclosure.affected_refs:
+            diagnostics.append(
+                _diagnostic(
+                    _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE,
+                    f"{address}.affected_refs",
+                    (
+                        "augmentation disclosures must name affected_refs so added capture surfaces, apparatus, "
+                        "constraints, side effects, and comparability implications are portable"
+                    ),
+                )
+            )
+        if not any(ref.ref_kind in _PORTABLE_AUGMENTATION_CARRIER_KINDS for ref in disclosure.carrier_refs):
+            diagnostics.append(
+                _diagnostic(
+                    _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE,
+                    f"{address}.carrier_refs",
+                    "augmentation disclosures must cite at least one portable carrier_ref",
+                )
+            )
+        if disclosure.purpose in {"evidence", "evaluation", "comparability"} and not disclosure.evidence_refs:
+            diagnostics.append(
+                _diagnostic(
+                    _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE,
+                    f"{address}.evidence_refs",
+                    f"{disclosure.purpose} augmentation disclosures must preserve supporting evidence_refs",
+                )
+            )
+    return diagnostics
+
+
+def _run_refinement_conformance_diagnostics(run: ExperimentRunModel) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    for disclosure in run.realized_form_disclosures:
+        if disclosure.concern_kind not in _RUN_REFINEMENT_CONCERN_KINDS:
+            continue
+        address = f"experiment-run-v1.realized_form_disclosures.{disclosure.concern_id}"
+        if disclosure.authored_ref is None:
+            diagnostics.append(
+                _diagnostic(
+                    _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE,
+                    f"{address}.authored_ref",
+                    (
+                        "run-level evidence requirement refinements must preserve authored_ref instead of "
+                        "rewriting authored scenario meaning"
+                    ),
+                )
+            )
+        if not disclosure.evidence_refs:
+            diagnostics.append(
+                _diagnostic(
+                    _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE,
+                    f"{address}.evidence_refs",
+                    "run-level evidence requirement refinements must preserve supporting evidence_refs",
+                )
+            )
+    return diagnostics
+
+
 def _semantic_diagnostics(contract_name: str, payload: Any) -> list[Diagnostic]:
     if contract_name == "workflow-result-envelope-v1":
         return _state_semantic_diagnostics(
@@ -840,6 +938,8 @@ def _semantic_diagnostics(contract_name: str, payload: Any) -> list[Diagnostic]:
         )
     if contract_name == "participant-behavior-history-event-stream-v1":
         return _participant_behavior_stream_diagnostics(contract_name, payload)
+    if contract_name == "experiment-run-v1":
+        return list(observability_evidence_conformance_diagnostics(payload))
     if contract_name != "runtime-snapshot-v1":
         return []
     return _runtime_snapshot_semantic_diagnostics(payload)

--- a/implementations/python/packages/aces_contracts/manifest_authority.py
+++ b/implementations/python/packages/aces_contracts/manifest_authority.py
@@ -56,6 +56,7 @@ BACKEND_SUPPORTED_CONTRACT_IDS = (
     "experiment-capture-spec-v1",
     "experiment-evidence-record-v1",
     "experiment-derived-measure-v1",
+    "experiment-run-v1",
 )
 
 PARTICIPANT_IMPLEMENTATION_SUPPORTED_CONTRACT_IDS = (

--- a/implementations/python/packages/aces_reference_backend/manifest.py
+++ b/implementations/python/packages/aces_reference_backend/manifest.py
@@ -181,6 +181,7 @@ def _capabilities() -> BackendCapabilitySet:
                     "experiment-capture-spec-v1",
                     "experiment-evidence-record-v1",
                     "experiment-derived-measure-v1",
+                    "experiment-run-v1",
                 }
             ),
             supported_media_types=frozenset({"application/json", "text/plain"}),

--- a/implementations/python/tests/test_backend_manifest.py
+++ b/implementations/python/tests/test_backend_manifest.py
@@ -164,6 +164,7 @@ def test_backend_manifest_v2_declares_observation_capability_dimensions():
         "experiment-capture-spec-v1",
         "experiment-derived-measure-v1",
         "experiment-evidence-record-v1",
+        "experiment-run-v1",
     ]
     assert observation["supported_sealing_modes"] == ["digest", "immutable-store"]
     assert observation["supports_redaction"] is True
@@ -395,13 +396,29 @@ def test_participant_runtime_capability_evidence_covers_standard_vocabularies():
 def test_observation_capability_evidence_covers_standard_vocabularies():
     catalog_path = FIXTURES_ROOT / "concept-authority" / "controlled-vocabularies-v1" / "valid" / "reference.json"
     catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
-    scopes = {
-        scope for definition in catalog["vocabularies"].values() for scope in definition.get("governed_scopes", ())
+    terms_by_scope = {
+        scope: set(definition["terms"])
+        for definition in catalog["vocabularies"].values()
+        for scope in definition.get("governed_scopes", ())
+        if scope.startswith("capabilities.observation.")
     }
 
-    assert OBSERVATION_CAPABILITY_CAPTURE_KIND_SCOPE in scopes
-    assert OBSERVATION_CAPABILITY_CHANNEL_KIND_SCOPE in scopes
-    assert OBSERVATION_CAPABILITY_SEALING_MODE_SCOPE in scopes
+    assert set(terms_by_scope) == {
+        OBSERVATION_CAPABILITY_CAPTURE_KIND_SCOPE,
+        OBSERVATION_CAPABILITY_CHANNEL_KIND_SCOPE,
+        OBSERVATION_CAPABILITY_SEALING_MODE_SCOPE,
+    }
+    capability = ObservationCapabilities(
+        name="observation",
+        supported_capture_kinds=frozenset(terms_by_scope[OBSERVATION_CAPABILITY_CAPTURE_KIND_SCOPE]),
+        supported_channel_kinds=frozenset(terms_by_scope[OBSERVATION_CAPABILITY_CHANNEL_KIND_SCOPE]),
+        supported_evidence_contracts=frozenset({"experiment-evidence-record-v1"}),
+        supported_media_types=frozenset({"application/json"}),
+        supported_sealing_modes=frozenset(terms_by_scope[OBSERVATION_CAPABILITY_SEALING_MODE_SCOPE]),
+    )
+    assert capability.supported_capture_kinds == terms_by_scope[OBSERVATION_CAPABILITY_CAPTURE_KIND_SCOPE]
+    assert capability.supported_channel_kinds == terms_by_scope[OBSERVATION_CAPABILITY_CHANNEL_KIND_SCOPE]
+    assert capability.supported_sealing_modes == terms_by_scope[OBSERVATION_CAPABILITY_SEALING_MODE_SCOPE]
 
 
 def test_participant_runtime_capability_claims_require_published_contract_evidence():

--- a/implementations/python/tests/test_observability_evidence_conformance.py
+++ b/implementations/python/tests/test_observability_evidence_conformance.py
@@ -1,0 +1,132 @@
+"""ASR-525 observability/evidence conformance probes for issue #128."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aces_conformance.conformance import (
+    observability_evidence_conformance_diagnostics,
+    run_fixture_suite,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_FIXTURE = (
+    REPO_ROOT / "contracts" / "fixtures" / "experiment-core" / "experiment-run-v1" / "valid" / "reference.json"
+)
+
+
+def _reference_run() -> dict:
+    return json.loads(RUN_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _augmentation_disclosure() -> dict:
+    return {
+        "augmentation_id": "packet-capture-sidecar",
+        "purpose": "evidence",
+        "realization_layer": "backend",
+        "classifications": ["apparatus_only", "comparability_relevant"],
+        "augmented_by_ref": {
+            "ref_kind": "backend",
+            "ref_id": "stub-backend",
+            "ref_version": "0.1.0",
+        },
+        "carrier_refs": [
+            {
+                "ref_kind": "measurement-channel",
+                "ref_id": "evaluation-history-channel",
+                "ref_version": "1.0.0",
+            }
+        ],
+        "affected_refs": [
+            {
+                "ref_kind": "capture-spec",
+                "ref_id": "capture-techvault-evidence-v1",
+                "ref_version": "1.0.0",
+            }
+        ],
+        "evidence_refs": [
+            {
+                "ref_kind": "evidence-record",
+                "ref_id": "evidence-techvault-network-trace-001",
+                "ref_version": "1.0.0",
+            }
+        ],
+        "disclosure_policy": "Internal run-provenance disclosure; no raw packet content is embedded.",
+        "markings": ["internal"],
+        "observer_effect": "The sidecar observes run traffic without modifying scenario services.",
+        "comparability_effect": "Compare only with runs that declare equivalent capture support.",
+    }
+
+
+def test_observability_evidence_conformance_accepts_traced_augmentation() -> None:
+    payload = _reference_run()
+    payload["augmentation_disclosures"] = [_augmentation_disclosure()]
+
+    diagnostics = observability_evidence_conformance_diagnostics(payload)
+
+    assert diagnostics == ()
+
+
+def test_observability_evidence_conformance_requires_affected_refs() -> None:
+    payload = _reference_run()
+    disclosure = _augmentation_disclosure()
+    disclosure["affected_refs"] = []
+    payload["augmentation_disclosures"] = [disclosure]
+
+    diagnostics = observability_evidence_conformance_diagnostics(payload)
+
+    assert {diagnostic.code for diagnostic in diagnostics} == {"conformance.observability-evidence-invalid"}
+    assert any("affected_refs" in diagnostic.address for diagnostic in diagnostics)
+    assert any("must name affected_refs" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_observability_evidence_conformance_requires_authored_ref_for_run_refinement() -> None:
+    payload = _reference_run()
+    payload["realized_form_disclosures"].append(
+        {
+            "concern_id": "capture-window-tightening",
+            "concern_kind": "capture-window",
+            "basis": "processor-realized",
+            "realized_by_ref": {
+                "ref_kind": "processor",
+                "ref_id": "aces-reference-processor",
+                "ref_version": "0.1.0",
+            },
+            "realized_value_summary": "Run used a narrower post-condition capture window.",
+            "disclosure": "The processor narrowed the capture window for this run without rewriting the authored requirement.",
+            "evidence_refs": [],
+        }
+    )
+
+    diagnostics = observability_evidence_conformance_diagnostics(payload)
+
+    assert {diagnostic.code for diagnostic in diagnostics} == {"conformance.observability-evidence-invalid"}
+    assert any("authored_ref" in diagnostic.message for diagnostic in diagnostics)
+    assert any("evidence_refs" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_fixture_suite_exercises_experiment_run_observability_semantics(tmp_path: Path) -> None:
+    backend_dir = tmp_path / "backend"
+    backend_dir.mkdir()
+    (backend_dir / "observability-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "backend-profile/v1",
+                "profile": "observability-evidence",
+                "required_contracts": ["experiment-run-v1"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = run_fixture_suite(profile="observability-evidence", profiles_root=backend_dir)
+
+    assert report.passed is True
+    invalid_case = next(case for case in report.cases if case.name == "augmentation-without-affected-refs")
+    assert invalid_case.valid is False
+    assert invalid_case.passed is True
+    assert any(
+        diagnostic.code == "conformance.observability-evidence-invalid" for diagnostic in invalid_case.diagnostics
+    )

--- a/implementations/python/tests/test_runtime_contracts.py
+++ b/implementations/python/tests/test_runtime_contracts.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+from aces_conformance.conformance import observability_evidence_conformance_diagnostics
 from aces_contracts.contracts import (
     AcesSemanticInvariantEntryModel,
     AcesSemanticInvariantProfileReferenceModel,
@@ -48,6 +49,10 @@ EXPERIMENT_CORE_FIXTURE_MODELS = {
     "experiment-run-v1": ExperimentRunModel,
     "experiment-study-v1": ExperimentStudyModel,
     "experiment-task-v1": ExperimentTaskModel,
+}
+
+SEMANTIC_INVALID_EXPERIMENT_CORE_FIXTURES = {
+    ("experiment-run-v1", "augmentation-without-affected-refs.json"),
 }
 
 
@@ -611,6 +616,11 @@ def test_experiment_core_invalid_fixtures_fail_schema_and_model_validation():
         validator = Draft202012Validator(schemas[contract_id])
         for path in sorted((fixture_root / contract_id / "invalid").glob("*.json")):
             payload = json.loads(path.read_text(encoding="utf-8"))
+            if (contract_id, path.name) in SEMANTIC_INVALID_EXPERIMENT_CORE_FIXTURES:
+                assert not list(validator.iter_errors(payload)), path
+                model = model_cls.model_validate(payload)
+                assert observability_evidence_conformance_diagnostics(model)
+                continue
             assert list(validator.iter_errors(payload)), path
             with pytest.raises(ValidationError):
                 model_cls.model_validate(payload)

--- a/specs/formal/observability-evidence-plane.md
+++ b/specs/formal/observability-evidence-plane.md
@@ -6,6 +6,9 @@ This cross-domain formal design artifact supports ADR-066 and issue #127 for:
 - `SEM-225` - Realization Augmentation And Environment-Visibility Semantics
 - `DSL-123` - Scenario-Native Observability And Telemetry Systems
 - `DSL-124` - Authored Data And Evidence Requirements
+- `RUN-316` / `API-419` / `ASR-525` / `EXP-731` / `EXP-732` -
+  Operational apparatus observability and run-level augmentation/evidence
+  conformance
 
 It is design coverage. It defines the invariant set and source-to-contract-to-
 test matrix that the spawned implementation issues must realize in SDL models,
@@ -112,6 +115,7 @@ comparability needs. The classification set is additive:
 | DSL-124 | Requirements come from declared sources, scopes, windows, or comparable boundaries. | ADR-066; SDL catalog. | Qualified source/scope/window resolver. | SDL semantic validation and experiment binding. | Requirement references runtime sensor and run window. | Requirement references an unknown hidden backend object. | #337 |
 | DSL-124 | Requirements are independent of participant objectives. | ADR-066; SDL catalog. | Cross-plane validation between objectives and evidence requirements. | SDL semantic validation and compiler. | Evidence requirement exists without an objective. | Objective success criterion is treated as capture requirement by implication. | #337 |
 | DSL-124 | Requirements are distinct from scenario-native observability systems. | ADR-066; SDL catalog. | Plane classifier and source binding helper. | SDL semantic validation. | Requirement cites an observability system as source but remains a separate obligation. | Observability system declaration is treated as proof of capture. | #337 |
+| RUN-316 / API-419 / ASR-525 / EXP-731 / EXP-732 | Backend observation capability declarations and run records must make operational augmentation support and realized evidence provenance portable. | ADR-066; this spec; experiment-core run contracts. | Backend manifest authority plus experiment-run conformance diagnostics. | Backend profile fixture conformance and run archive validation. | Run augmentation names portable carrier refs, affected refs, and traced evidence refs. | Run augmentation is traced but omits affected refs. | #128 |
 
 ## Negative Probe Set
 
@@ -226,3 +230,25 @@ vocabularies instead of free-form observability bags.
 | Source refs fail closed and bare runtime ids do not first-match | `SemanticValidator._verify_evidence_requirements` over `_validate_named_ref(targetable=True)` | `test_dsl_124_source_refs_fail_closed` | yes |
 | Evidence requirements are independent of participant objectives | `evidence_requirements.` is excluded from targetable refs | `test_dsl_124_evidence_requirements_are_not_objective_targets` | yes |
 | SDL section plane ownership is carrier-based | `PLANE_BY_SDL_SECTION`, `classify_sdl_section_plane()` | `test_dsl_124_accepts_authored_evidence_requirement_independent_of_objectives` | yes |
+
+## Implementation Coverage (#128 / RUN-316, API-419, ASR-525, EXP-731, EXP-732)
+
+Issue #128 connects the already-realized observability/evidence carriers to the
+backend conformance runner. `experiment-run-v1` is now part of the governed
+backend observation evidence surface, so backend profiles can require it and
+manifest observation capability checks can detect a missing archival run
+carrier.
+
+The conformance runner registers `experiment-run-v1` and applies
+`observability_evidence_conformance_diagnostics()` after schema validation. The
+diagnostics keep the declaration/reporting split explicit: manifests declare
+support for the run/evidence carriers, while concrete runs disclose actual
+augmentation and realized-form behavior.
+
+| Invariant / matrix row | Realizing artifact | Test | New in #128? |
+| --- | --- | --- | --- |
+| RUN-316 operational apparatus observability has a portable run carrier | `BACKEND_SUPPORTED_CONTRACT_IDS`, `OBSERVATION_CAPABILITY_REQUIRED_CONTRACTS`, reference/stub observation manifests | `test_backend_manifest_v2_declares_observation_capability_dimensions`, `test_fixture_suite_exercises_experiment_run_observability_semantics` | yes |
+| API-419 augmentation reports name affected carriers | `_augmentation_conformance_diagnostics()` requires `affected_refs` and portable `carrier_refs` | `test_observability_evidence_conformance_requires_affected_refs`; fixture `augmentation-without-affected-refs.json` | yes |
+| ASR-525 conformance validates experiment-run semantics | `_MODEL_VALIDATORS["experiment-run-v1"]`, `_semantic_diagnostics()` | `test_fixture_suite_exercises_experiment_run_observability_semantics` | yes |
+| EXP-731 run-scoped capture refinements preserve authored requirements | `_run_refinement_conformance_diagnostics()` requires `authored_ref` for capture-window and measurement-channel disclosures | `test_observability_evidence_conformance_requires_authored_ref_for_run_refinement` | yes |
+| EXP-732 augmentation and refinements remain evidence-traced | experiment run model traced evidence refs plus conformance evidence-ref checks | `test_observability_evidence_conformance_accepts_traced_augmentation`, `test_observability_evidence_conformance_requires_authored_ref_for_run_refinement` | yes |


### PR DESCRIPTION
## Summary

Adds run-level observability/evidence conformance for experiment-run-v1 so backend observation declarations can require the archival run carrier and fixture conformance can reject augmentation or refinement reports that omit portable affected/authored/evidence provenance.

## Requirement UIDs

- `RUN-316`
- `API-419`
- `ASR-525`
- `EXP-731`
- `EXP-732`

## Related Issues

Closes #128

## ADR Impact

- ADR-009
- ADR-064
- ADR-065
- ADR-066

## Changes

- Registers experiment-run-v1 in backend-supported contract authority, backend profile schemas, stub/reference observation capability declarations, and published schema manifests.
- Adds experiment-run-v1 semantic conformance diagnostics for augmentation affected_refs, portable carrier_refs, evidence_refs, and capture-window/measurement-channel realized-form authored/evidence refs.
- Adds a schema-valid semantic-invalid experiment-run fixture plus focused conformance tests and runtime-contract fixture handling for semantic-invalid cases.
- Strengthens observation vocabulary coverage tests and records the RUN-316/API-419/ASR-525/EXP-731/EXP-732 formal-spec coverage and preflight evidence.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification: pre-commit run --all-files; uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify. Also ran focused conformance/backend/schema slices during development.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: RUN-316 <- implementations/python/packages/aces_backend_protocols/capabilities.py, RUN-316 <- implementations/python/packages/aces_conformance/conformance.py, API-419 <- implementations/python/packages/aces_conformance/conformance.py, API-419 <- contracts/schemas/profiles/backend-profile-v1.json, ASR-525 <- implementations/python/packages/aces_conformance/conformance.py, ASR-525 <- contracts/fixtures/experiment-core/experiment-run-v1/invalid/augmentation-without-affected-refs.json, EXP-731 <- implementations/python/packages/aces_conformance/conformance.py, EXP-732 <- implementations/python/packages/aces_conformance/conformance.py, EXP-732 <- contracts/fixtures/backend-manifest/backend-manifest-v2/valid/stub.json
- TESTS: RUN-316 <- implementations/python/tests/test_backend_manifest.py, API-419 <- implementations/python/tests/test_observability_evidence_conformance.py, ASR-525 <- implementations/python/tests/test_observability_evidence_conformance.py, EXP-731 <- implementations/python/tests/test_observability_evidence_conformance.py, EXP-732 <- implementations/python/tests/test_runtime_contracts.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/128.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
