### PR TITLE
added: libvirt paper-proof evaluator-evidence artifact producer (#615)

### DIFF
--- a/changelog.d/615.added.md
+++ b/changelog.d/615.added.md
@@ -1,0 +1,7 @@
+Add the libvirt paper-proof evaluator-evidence producer
+(`aces libvirt paper validate-evidence`) that composes the libvirt participant
+runtime, native substrate realization, backend manifest, and
+experiment/evaluation contracts into a stable, validated, redacted
+`aces.libvirt.paper-evidence-run/v1` run artifact for the paper enterprise
+participant/evidence scenario, feeding the Brad-Edwards/aces#600 cross-backend
+invariant ledger.

--- a/docs/decisions/issue-615-libvirt-paper-evidence-preflight.md
+++ b/docs/decisions/issue-615-libvirt-paper-evidence-preflight.md
@@ -1,0 +1,255 @@
+# Issue 615 Libvirt Paper Evidence Preflight
+
+Date: 2026-06-29
+
+Issue: #615.
+
+Requirement: none. The GitHub issue title, body, acceptance criteria, and
+non-claims are the contract.
+
+This note records architecture guardrails for extending the libvirt paper live
+proof into an evaluator-facing evidence artifact for the enterprise
+participant/evidence scenario. It is guidance only: it does not implement the
+artifact, add schemas, change runtime behavior, or define an implementation
+plan.
+
+## Binding Sources
+
+- `docs/decisions/issue-598-paper-reference-scenario-preflight.md`,
+  `examples/scenarios/paper-agent-loop.sdl.yaml`, and
+  `examples/scenarios/paper-agent-loop.README.md` own the authored paper
+  scenario, action contract, observation boundary, Wazuh evaluator evidence,
+  negative boundary evidence, and paper non-claims.
+- `docs/decisions/issue-614-libvirt-participant-runtime-preflight.md` and
+  `docs/decisions/issue-614-libvirt-participant-runtime.md` own the libvirt
+  `ParticipantRuntime` path and its deterministic-domain limitation.
+- ADR-066 owns observability/evidence plane separation. Wazuh/SOC evidence and
+  negative reachability checks are evaluator evidence, not participant-visible
+  observations unless a governed participant observation boundary projects
+  them.
+- ADR-064 and ADR-065 own experiment evidence records and run provenance.
+  `experiment-evidence-record-v1` is raw captured evidence;
+  `experiment-derived-measure-v1` is interpreted analysis; `experiment-run-v1`
+  is the archival run join point.
+- `docs/decisions/issue-601-techvault-live-verification.md`,
+  `aces_operations.techvault_live`, and
+  `aces_backend_libvirt.techvault_native` own the native libvirt live-gate
+  substrate, realized surface, readiness checks, and SOC readback helpers.
+- `contracts/schemas/backend-manifest/backend-manifest-v2.json`,
+  `BackendManifestV2Model`, and `backend_manifest_payload()` own backend
+  manifest/capability shape.
+- `.ground-control.yaml`, `.gc/plan-rules.md`, ADR-014, and
+  `tools/verify_all.py` remain the repository workflow and verification
+  authority.
+
+## Architecture Decisions
+
+- Treat the issue-615 output as a stable libvirt paper evidence artifact that
+  composes existing ACES contracts. Use a stable artifact path/name such as
+  `runs/<run-id>/paper-evidence/libvirt-paper-evidence-run.json` and a stable
+  envelope identifier such as `aces.libvirt.paper-evidence-run/v1`; do not
+  create a second experiment-run, evidence-record, participant-runtime, backend
+  manifest, or evaluator schema unless an existing published carrier cannot
+  represent a portable fact.
+- The artifact must be an evaluator/corpus artifact, not an ad hoc log dump.
+  It should contain bounded summaries and/or embedded validated contract
+  payloads for published ACES contracts, plus refs/checksums for any content
+  stored outside the artifact.
+- Required evidence surfaces are: authored scenario identity and content hash;
+  compiled processor/runtime artifact identity; backend manifest payload and
+  capability/profile/conformance result; libvirt realization provenance;
+  realized topology and network attachment matrix; participant action proof
+  from `LibvirtParticipantRuntime`; terminal participant observation envelope
+  or behavior-history equivalent; evaluator-only Wazuh/SOC readback or a typed
+  translated readback record with explicit limitation; negative reachability
+  checks for internal DB and Wazuh/evaluator surfaces; evaluator outcome and
+  limitation records; and redaction/provenance metadata.
+- Wazuh/SOC evidence must remain evaluator-only evidence. If the native libvirt
+  proof uses generated appliance readback or translated native readback rather
+  than full upstream Wazuh internals, the artifact must state that limitation
+  next to the evidence and in the run/evaluator limitation surface.
+- The participant proof must enter through `RuntimeControlPlane` and
+  `LibvirtParticipantRuntime`, reusing the issue-614 action-admission and
+  behavior-history machinery. Do not replace the participant proof with a
+  host-side probe result.
+- Negative boundary checks must be recorded as evaluator evidence or derived
+  analysis over evaluator evidence. They must not become participant
+  observations, action effects, hidden-state disclosures, or scenario-authored
+  topology semantics.
+- The artifact must be close enough to the APTL paper proof artifact to support
+  issue #600's invariant ledger, but ACES must not import APTL-private schemas,
+  Docker/container ids, Wazuh rule bodies, credentials, or backend command
+  transcripts.
+
+## Required Incumbents
+
+Reuse these repo surfaces before adding anything new:
+
+- Libvirt live-gate surface:
+  `validate_techvault_live()`, `TechVaultLiveConfig`,
+  `TechVaultLiveReport`, `TechVaultNativeLibvirtDriver`,
+  `NativeLibvirtProbe`, `expected_surface()`, `native_soc_readback()`, and the
+  existing safe `run_id` filesystem-label check.
+- Libvirt runtime/provisioning surface:
+  `create_libvirt_target()`, `create_libvirt_manifest()`,
+  `create_libvirt_components()`, `LibvirtProvisioner`,
+  `LibvirtDriver`, `TechVaultNativeLibvirtDriver`, `RuntimeManager`, and
+  `RuntimeControlPlane`.
+- Participant-runtime proof surface:
+  `LibvirtParticipantRuntime`, `LibvirtParticipantDomainAdapter`,
+  `run_libvirt_participant_proof()`,
+  `ParticipantActionAdmissionRequest`,
+  `ParticipantObservationEnvelopeModel`,
+  `ParticipantOutcomeReportModel`,
+  `iter_participant_episode_snapshot_violations()`, and
+  `iter_participant_behavior_history_violations()`.
+- Experiment and evidence contracts:
+  `ExperimentRunModel`, `ExperimentRunTraceabilityModel`,
+  `ExperimentRealizedFormDisclosureModel`,
+  `ExperimentEvidenceRecordModel`, `ExperimentRawEvidenceContentModel`,
+  `ExperimentDerivedMeasureModel`, `ExperimentApparatusContextModel`,
+  `ExperimentManifestReferenceModel`, `ExperimentArtifactRefModel`, and
+  `validate_experiment_run_against_task()`.
+- Evaluation contracts:
+  `EvaluationResultStateModel`, `EvaluationHistoryEventModel`,
+  `EvaluationExecutionState`, `EvaluationHistoryEvent`,
+  `EvaluationResultContract`, `EvaluationExecutionContract`, and
+  `evaluation_result_contract_diagnostics()`.
+- Backend manifest/conformance:
+  `backend_manifest_payload()`, `BackendManifestV2Model`,
+  `participant_runtime_capability_contract_gaps()`,
+  `observation_capability_contract_gaps()`, `load_backend_profile()`,
+  `profile_for_manifest()`, and `run_target_conformance()`.
+- Security, persistence, and diagnostics:
+  `Diagnostic`, `OperationReceipt`, `OperationStatus`, `RuntimeSnapshot`,
+  `ControlPlaneSecurityConfig.strict_defaults()`, `ControlPlaneIdentity`,
+  `ControlPlaneRole`, request-size guards, idempotency fingerprints,
+  `AuditEvent`, `ControlPlaneStore`, `LocalControlPlaneStore`, and redacted
+  HTTP error handling if any API path is exercised.
+- Repository policy:
+  `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`,
+  `tools/check_repo_policy.py`, `tools/check_requirement_governance.py`,
+  `tools/check_json_artifacts.py`, `tools/check_generated_schemas.py`,
+  `tools/check_schema_publication.py`, and `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- SDL/config ingress: select the paper scenario through `parse_sdl_file()` and
+  `compile_runtime_model()`. The artifact must cite the scenario path/name and
+  content hash, but runtime addresses must come from compiled participant,
+  action, observation, objective, and evaluation addresses, not from filenames,
+  appliance names, or raw YAML dictionaries.
+- Manifest/profile gate: render libvirt backend identity through
+  `backend_manifest_payload()` and validate with `BackendManifestV2Model`.
+  If the implementation claims observation or evaluator capability, it must add
+  the actual manifest capability and pass the existing contract-gap/profile
+  checks; otherwise the artifact may carry evaluator evidence as a paper proof
+  record without claiming generic backend evaluator support.
+- Runtime target/apply gate: provisioning, participant action admission, and
+  any evaluation execution must pass through `RuntimeManager`,
+  `RuntimeControlPlane`, and `_call_backend_apply()` so malformed backend
+  output becomes `Diagnostic`/`OperationStatus` data and invalid snapshots are
+  rejected.
+- Participant visibility gate: participant-visible content is limited to the
+  compiled observation boundary and participant implementation exposure
+  policy. Wazuh/SOC readback, internal DB reachability, policy internals,
+  evaluator limitations, libvirt native details, and negative checks must stay
+  outside `visible_refs` and `disclosed_refs` unless an existing governed
+  boundary explicitly permits disclosure.
+- Evidence/run contract gate: raw evidence must use
+  `ExperimentEvidenceRecordModel` dimensions: source refs, capture time/window,
+  raw content reference or bounded summary, sensitivity, redaction state,
+  checksum/loss disclosure, and provenance. Derived outcomes or invariant
+  judgments belong in derived-measure/evaluation/run limitation surfaces, not
+  raw evidence records.
+- Evaluation gate: evaluator outcome records must match the existing
+  evaluation result/history envelopes and contracts. If libvirt remains without
+  a generic evaluator component, the paper artifact must make that limitation
+  explicit rather than smuggling evaluator state into `RuntimeSnapshot.metadata`
+  or backend-private details.
+- Secret-handling gate: the artifact must contain no raw libvirt XML, domain
+  UUIDs as portable semantics, QEMU command lines, host paths, libvirt
+  connection URIs with secrets, credentials, private keys, unredacted tool
+  transcripts, backend-native inspect payloads, raw Wazuh rule bodies, raw
+  prompts, hidden answers, environment dumps, process argv, or full tracebacks.
+- OS-level exposure gate: live probes must keep secrets out of argv and
+  diagnostics. Reuse fixed argv, no `shell=True`, bounded timeouts, controlled
+  working directories, and bounded sanitized diagnostics as in the existing
+  libvirt live-gate helpers.
+- Persistence gate: use the existing run archive directory and atomic JSON
+  writing pattern where durable control-plane state is needed. Do not add a
+  libvirt evidence database, participant store, audit log, schema registry, or
+  backend-private state ledger.
+- Error-envelope/logging gate: public failures must remain structured
+  `Diagnostic`, `OperationReceipt`, `OperationStatus`, and report check
+  records. Do not serialize exception reprs, stdout/stderr dumps, native object
+  reprs, or unchecked backend payloads into the artifact, audit, tests, docs,
+  or changelog.
+- Contract/schema gate: if a published schema changes, update the contract
+  source, generated schema bundle, fixtures, and
+  `contracts/schema-publication-manifest.json`. A local proof-artifact wrapper
+  must not become a shadow published contract.
+
+## Extensibility Seam
+
+The extension seam belongs in a backend-neutral paper evidence producer over
+runtime/evidence contract inputs, parameterized by:
+
+- `scenario_path`, `run_id`, `output_dir`, and optional artifact locator or
+  sealing policy;
+- backend target factory/config, including libvirt connection, native probe,
+  boot timeout, clean-boot policy, and participant runtime factory;
+- evidence source policy, including native translated SOC readback versus
+  upstream Wazuh readback and the disclosure text that explains the difference;
+- invariant-ledger mapping, which should reference stable ACES addresses and
+  evidence refs rather than libvirt domain names, UUIDs, Docker ids, host paths,
+  or APTL-private identifiers.
+
+A future #600 cross-backend ledger should consume the artifact as evidence
+refs, bounded summaries, and validated contract payloads. It should not require
+rewriting the libvirt live gate, backend manifest schema, participant-runtime
+contracts, or experiment-core schemas to add one more backend or evidence
+source.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating the existing native live-gate manifest as sufficient paper evidence
+  without adding participant proof, evaluator outcome, boundary checks,
+  limitation disclosure, and redaction/provenance metadata;
+- inventing a new evidence schema, evaluator schema, exception hierarchy,
+  validator, conformance runner, persistence store, audit log, or DTO stack;
+- putting evidence records, evaluation results, participant observations, and
+  backend readiness checks into one generic `evidence` object with untyped
+  semantics;
+- using `RuntimeSnapshot.metadata`, `ApplyResult.details`, diagnostics, audit
+  details, or README prose as the carrier for first-class evidence or
+  provenance;
+- making Wazuh/SOC readback participant-visible or using it as a participant
+  observation envelope;
+- claiming libvirt evaluator or observation capability in the backend manifest
+  without actual capability implementation and contract-gap checks;
+- treating native appliance SOC readback as upstream Wazuh detection-quality
+  evidence;
+- using libvirt domain UUIDs, XML, MACs, host paths, QEMU commands, Docker ids,
+  APTL Compose names, or backend-local action labels as portable semantics;
+- overfitting the artifact to one run id, host, libvirt network naming policy,
+  IP allocation, or paper corpus directory layout;
+- making default verification require privileged libvirt access, a running
+  daemon, external network, private credentials, or upstream Wazuh internals.
+
+## Non-Goals
+
+- Implementing the libvirt paper evidence artifact, live probes, tests,
+  schemas, corpus packaging, or issue #600 invariant ledger in this preflight.
+- Adding new SDL syntax, published contracts, backend profiles, controlled
+  vocabularies, evaluator APIs, observation capability declarations, or
+  persistence systems unless later implementation proves existing surfaces
+  cannot carry the portable fact.
+- Claiming Wazuh detection quality, model-defense robustness, byte-equivalence
+  between libvirt appliances and APTL containers, application-internals
+  equivalence, full semantic equivalence, or broad n=2 backend equivalence.
+- Replacing the existing issue-614 participant runtime proof or issue-601
+  native substrate proof; issue #615 composes and augments those surfaces for
+  evaluator-facing evidence.

--- a/examples/scenarios/paper-agent-loop.README.md
+++ b/examples/scenarios/paper-agent-loop.README.md
@@ -87,6 +87,69 @@ participant/Wazuh/policy evidence, and record negative boundary evidence where
 the backend supports live checks. That binding must not require new SDL syntax,
 a new backend manifest shape, or APTL-private keys inside the scenario body.
 
+## Libvirt Paper Evidence Artifact (#615)
+
+`aces_operations.libvirt_paper_evidence.run_libvirt_paper_evidence` (CLI: `aces
+libvirt paper validate-evidence`) produces a stable, validated evaluator-evidence
+run artifact for this scenario — `aces.libvirt.paper-evidence-run/v1`, written to
+`runs/<run-id>/paper-evidence/libvirt-paper-evidence-run.json`. It composes the
+existing ACES surfaces (libvirt deterministic participant runtime #614, native
+substrate realization #601, backend manifest/capability contracts, and the
+experiment/evaluation contracts) into one artifact carrying scenario+compiled
+identity, backend manifest/capability profile and realization provenance, the
+realized/planned topology and network-attachment matrix, the participant action
+proof, the terminal behavior-history-equivalent observation, evaluator-only
+Wazuh/SOC evidence, negative boundary checks, an evaluator outcome record, and
+redaction/provenance metadata. Embedded published-contract payloads
+(`BackendManifestV2Model`, `EvaluationResultStateModel`,
+`EvaluationHistoryEventModel`, `ExperimentRealizedFormDisclosureModel`)
+re-validate against their contracts; the artifact carries a strict redaction gate
+(no raw libvirt XML, domain UUIDs, QEMU command lines, host paths, connection
+URIs, credentials, or private keys).
+
+### Evidence-source modes
+
+- `deterministic` (default; no libvirt daemon; used by CI): participant proof,
+  compiled topology, structural negative-boundary evidence, and an evaluator-only
+  translated SOC-readback record explicitly marked as not upstream Wazuh.
+- `native-live` (operator-run): additionally realizes the libvirt VM/network
+  substrate and records the native topology and native SOC readback. Native
+  realization is **gating** — the run only reports `PASS` when the libvirt driver
+  actually realizes substrate, so the mode can never claim success without
+  realizing. The libvirt backend declares no content-type support, so the *paper*
+  scenario's content, orchestration, and evaluation planes are not
+  backend-realized: native-live against this scenario therefore reports the
+  realization gate as **failed** and surfaces the unrealized planes under
+  `unrealized_capabilities` (disclosed, not faked). The artifact is still written
+  and validates, recording the attempt and the disclosure. Native realization
+  passes for a scenario the libvirt backend can fully provision (e.g. a
+  VM/network-only substrate scenario).
+
+### How libvirt evidence differs from APTL Docker/Wazuh evidence
+
+APTL realizes the scenario as Docker/Compose containers with a full upstream
+Wazuh stack, so its paper proof artifact (Brad-Edwards/aptl#558) carries live
+container-native Wazuh detection telemetry and Docker-network reachability
+evidence. The libvirt proof realizes a different substrate — native libvirt/QEMU
+appliances — and its participant runtime is deterministic (#614), so:
+
+- the **substrate** is genuinely different (VM/network appliances vs.
+  containers), which is the point of the n=2 backend-diversity claim;
+- the **defensive evidence** is an evaluator-only *translated/native* SOC
+  readback (or, in deterministic mode, the declared evaluator-only evidence
+  channels), explicitly disclosed as not upstream Wazuh detection output — the
+  artifact makes no Wazuh detection-quality claim;
+- the **participant action proof** is structural (deterministic domain adapter),
+  disclosed as such.
+
+The paper claim that this difference supports is narrow and explicit: ACES can
+drive the *same authored scenario, action contract, and observation/evaluator
+boundary* across two independent backends, producing comparable evaluator
+evidence shapes for the Brad-Edwards/aces#600 cross-backend **invariant ledger**.
+It is **not** a claim of byte-equivalence, application-internals equivalence,
+Wazuh detection-quality parity, model-defense robustness, or full
+semantic-equivalence between the libvirt and APTL realizations.
+
 ## Downstream Links
 
 - ACES issue: Brad-Edwards/aces#598

--- a/implementations/python/packages/aces_cli/libvirt.py
+++ b/implementations/python/packages/aces_cli/libvirt.py
@@ -6,11 +6,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
+from aces_operations.libvirt_paper_evidence import LibvirtPaperEvidenceConfig, run_libvirt_paper_evidence
 from aces_operations.techvault_live import TechVaultLiveConfig, validate_techvault_live
 
 app = typer.Typer(help="Libvirt backend operations.")
 techvault_app = typer.Typer(help="TechVault operational scenario checks.")
 app.add_typer(techvault_app, name="techvault")
+paper_app = typer.Typer(help="Paper-proof evaluator-evidence artifacts.")
+app.add_typer(paper_app, name="paper")
 
 _LIVE_WARNING = """\
 This will create native libvirt/QEMU resources for the selected TechVault
@@ -76,6 +79,52 @@ def validate_live(
             connection_uri=connection_uri,
             appliance_memory_mib=appliance_memory_mib,
             boot_timeout_seconds=boot_timeout_seconds,
+        ),
+    )
+    typer.echo(report.render())
+    if not report.passed:
+        raise typer.Exit(code=1)
+
+
+@paper_app.command("validate-evidence")
+def validate_evidence(
+    scenario: Path = typer.Option(
+        Path("examples/scenarios/paper-agent-loop.sdl.yaml"),
+        "--scenario",
+        help="Paper ACES SDL scenario to produce evaluator evidence for.",
+    ),
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project-dir",
+        "--output-dir",
+        help="Output directory for the paper-evidence run archive.",
+    ),
+    run_id: str | None = typer.Option(
+        None,
+        "--run-id",
+        help="Run id for the paper-evidence archive (safe filesystem label).",
+    ),
+    native_live: bool = typer.Option(
+        False,
+        "--native-live",
+        help="Realize the libvirt substrate natively (requires a libvirt daemon); default is deterministic.",
+    ),
+    connection_uri: str = typer.Option(
+        "qemu:///system",
+        "--connection-uri",
+        help="libvirt connection URI (native-live only).",
+    ),
+) -> None:
+    """Produce the libvirt paper-proof evaluator-evidence artifact for a scenario."""
+
+    resolved_run_id = run_id or datetime.now(UTC).strftime("aces_libvirt_paper_%Y%m%dT%H%M%SZ")
+    report = run_libvirt_paper_evidence(
+        scenario_path=scenario.resolve(),
+        project_dir=project_dir.resolve(),
+        run_id=resolved_run_id,
+        config=LibvirtPaperEvidenceConfig(
+            evidence_source_mode="native-live" if native_live else "deterministic",
+            connection_uri=connection_uri,
         ),
     )
     typer.echo(report.render())

--- a/implementations/python/packages/aces_operations/_paper_evidence_artifact.py
+++ b/implementations/python/packages/aces_operations/_paper_evidence_artifact.py
@@ -32,6 +32,15 @@ from aces_contracts.contracts import (
     ExperimentRealizedFormDisclosureModel,
 )
 
+from aces_operations._paper_evidence_types import (
+    BackendManifest,
+    CompiledModel,
+    EvidenceArtifactInputs,
+    NodeDeployment,
+    RealizedNetwork,
+    TerminalSnapshot,
+)
+
 EVIDENCE_RUN_SCHEMA = "aces.libvirt.paper-evidence-run/v1"
 _LIBVIRT_BACKEND_NAME = "libvirt-qemu"
 
@@ -49,20 +58,19 @@ _NON_CLAIMS = (
 )
 
 
-def assemble_artifact(
-    *,
-    scenario_path: Path,
-    run_id: str,
-    recorded_at: str,
-    mode: str,
-    model: Any,
-    manifest: Any,
-    proof: Mapping[str, Any],
-    native_snapshot: Mapping[str, Any] | None,
-    probe: NativeLibvirtProbe | None,
-    unrealized_capabilities: tuple[str, ...] = (),
-) -> dict[str, Any]:
+def assemble_artifact(inputs: EvidenceArtifactInputs) -> dict[str, Any]:
     """Assemble the full paper-evidence artifact payload."""
+    scenario_path = inputs.scenario_path
+    run_id = inputs.run_id
+    recorded_at = inputs.recorded_at
+    mode = inputs.mode
+    model = inputs.model
+    manifest = inputs.manifest
+    proof = inputs.proof
+    native_snapshot = inputs.native_snapshot
+    probe = inputs.probe
+    unrealized_capabilities = inputs.unrealized_capabilities
+
     substrate_realized = native_snapshot is not None
     scenario_section = _scenario_section(scenario_path, model)
     boundary_refs = _boundary_hidden_refs(model)
@@ -89,21 +97,21 @@ def assemble_artifact(
     }
 
 
-def _manifest_name(manifest: Any) -> str:
+def _manifest_name(manifest: BackendManifest) -> str:
     identity = getattr(manifest, "identity", None)
     if identity is not None and getattr(identity, "name", None):
         return str(identity.name)
     return str(getattr(manifest, "name", _LIBVIRT_BACKEND_NAME))
 
 
-def _manifest_version(manifest: Any) -> str:
+def _manifest_version(manifest: BackendManifest) -> str:
     identity = getattr(manifest, "identity", None)
     if identity is not None and getattr(identity, "version", None):
         return str(identity.version)
     return str(getattr(manifest, "version", "0.0.0+unknown"))
 
 
-def _backend_section(manifest: Any, mode: str, substrate_realized: bool) -> dict[str, Any]:
+def _backend_section(manifest: BackendManifest, mode: str, substrate_realized: bool) -> dict[str, Any]:
     """Embed the canonical BackendManifestV2 payload + capability-gap report.
 
     The manifest is rendered through ``backend_manifest_payload`` — the same
@@ -129,14 +137,14 @@ def _backend_section(manifest: Any, mode: str, substrate_realized: bool) -> dict
     }
 
 
-def _scenario_section(scenario_path: Path, model: Any) -> dict[str, Any]:
+def _scenario_section(scenario_path: Path, model: CompiledModel) -> dict[str, Any]:
     from aces_sdl.parser import parse_sdl_file
 
     content = scenario_path.read_bytes()
     version: str | None = None
     try:
         version = getattr(parse_sdl_file(scenario_path), "version", None)
-    except Exception:  # noqa: BLE001
+    except Exception:
         version = None
     return {
         "name": model.scenario_name,
@@ -155,7 +163,7 @@ def _portable_scenario_ref(scenario_path: Path) -> str:
     return scenario_path.name
 
 
-def _compiled_artifact_section(model: Any) -> dict[str, Any]:
+def _compiled_artifact_section(model: CompiledModel) -> dict[str, Any]:
     addresses = {
         "participant_behaviors": sorted(model.participant_behaviors),
         "action_contracts": sorted(model.action_contracts),
@@ -173,7 +181,7 @@ def _compiled_artifact_section(model: Any) -> dict[str, Any]:
     }
 
 
-def _node_services(node: Any) -> list[dict[str, Any]]:
+def _node_services(node: NodeDeployment) -> list[dict[str, Any]]:
     spec = getattr(node, "spec", {}) or {}
     node_spec = spec.get("node", {}) if isinstance(spec, Mapping) else {}
     services = node_spec.get("services", []) if isinstance(node_spec, Mapping) else []
@@ -184,14 +192,14 @@ def _node_services(node: Any) -> list[dict[str, Any]]:
     ]
 
 
-def _node_network_links(node: Any) -> list[str]:
+def _node_network_links(node: NodeDeployment) -> list[str]:
     spec = getattr(node, "spec", {}) or {}
     infra = spec.get("infrastructure", {}) if isinstance(spec, Mapping) else {}
     links = infra.get("links", []) if isinstance(infra, Mapping) else []
     return [str(link) for link in links]
 
 
-def _network_properties(network: Any) -> dict[str, Any]:
+def _network_properties(network: RealizedNetwork) -> dict[str, Any]:
     spec = getattr(network, "spec", {}) or {}
     infra = spec.get("infrastructure", {}) if isinstance(spec, Mapping) else {}
     props = infra.get("properties") if isinstance(infra, Mapping) else None
@@ -201,7 +209,7 @@ def _network_properties(network: Any) -> dict[str, Any]:
 
 
 def _topology_section(
-    model: Any,
+    model: CompiledModel,
     native_snapshot: Mapping[str, Any] | None,
     unrealized_capabilities: tuple[str, ...] = (),
 ) -> dict[str, Any]:
@@ -266,7 +274,7 @@ def _participant_proof_section(proof: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def _redact_episode_state(state: Any) -> dict[str, Any]:
+def _redact_episode_state(state: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(state, Mapping):
         return {}
     keep = (
@@ -281,7 +289,7 @@ def _redact_episode_state(state: Any) -> dict[str, Any]:
     return {key: state.get(key) for key in keep if key in state}
 
 
-def _terminal_observation_section(snapshot: Any) -> dict[str, Any]:
+def _terminal_observation_section(snapshot: TerminalSnapshot) -> dict[str, Any]:
     behavior_history = {
         addr: _redact_behavior_history(events) for addr, events in snapshot.participant_behavior_history.items()
     }
@@ -295,7 +303,7 @@ def _terminal_observation_section(snapshot: Any) -> dict[str, Any]:
     }
 
 
-def _redact_behavior_history(events: Any) -> list[dict[str, Any]]:
+def _redact_behavior_history(events: Sequence[Any]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     if not isinstance(events, Sequence):
         return out
@@ -314,7 +322,7 @@ def _redact_behavior_history(events: Any) -> list[dict[str, Any]]:
 
 
 def _defensive_evidence_section(
-    native_snapshot: Mapping[str, Any] | None, model: Any, recorded_at: str
+    native_snapshot: Mapping[str, Any] | None, model: CompiledModel, recorded_at: str
 ) -> dict[str, Any]:
     # captured_at is the run's recorded_at timestamp threaded through artifact
     # assembly, not a freshly synthesized one, so every section shares one
@@ -439,7 +447,7 @@ def _evaluator_outcome_section(lifecycle_clean: bool, recorded_at: str) -> dict[
     }
 
 
-def _realized_form_disclosures(manifest: Any, substrate_realized: bool) -> list[dict[str, Any]]:
+def _realized_form_disclosures(manifest: BackendManifest, substrate_realized: bool) -> list[dict[str, Any]]:
     backend_version = _manifest_version(manifest)
     backend_name = _manifest_name(manifest)
     backend_ref = {"ref_kind": "backend", "ref_id": backend_name, "ref_version": backend_version}
@@ -520,7 +528,7 @@ def _redaction_provenance() -> dict[str, Any]:
     }
 
 
-def _invariant_ledger_refs(model: Any, scenario_section: Mapping[str, Any]) -> dict[str, Any]:
+def _invariant_ledger_refs(model: CompiledModel, scenario_section: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "scenario_name": model.scenario_name,
         "scenario_content_sha256": scenario_section["content_sha256"],
@@ -542,15 +550,15 @@ def _invariant_ledger_refs(model: Any, scenario_section: Mapping[str, Any]) -> d
     }
 
 
-def _boundary_hidden_refs(model: Any) -> list[str]:
+def _boundary_hidden_refs(model: CompiledModel) -> list[str]:
     return _boundary_spec_refs(model, "hidden_refs")
 
 
-def _boundary_evidence_refs(model: Any) -> list[str]:
+def _boundary_evidence_refs(model: CompiledModel) -> list[str]:
     return _boundary_spec_refs(model, "evidence_refs")
 
 
-def _boundary_spec_refs(model: Any, key: str) -> list[str]:
+def _boundary_spec_refs(model: CompiledModel, key: str) -> list[str]:
     refs: list[str] = []
     for boundary in model.observation_boundaries.values():
         spec = getattr(boundary, "spec", None)

--- a/implementations/python/packages/aces_operations/_paper_evidence_artifact.py
+++ b/implementations/python/packages/aces_operations/_paper_evidence_artifact.py
@@ -1,0 +1,561 @@
+"""Artifact assembly for the libvirt paper-evidence producer.
+
+Builds the ``aces.libvirt.paper-evidence-run/v1`` payload from the compiled runtime
+model, the backend manifest, the participant-proof result, and (optionally) the
+native substrate snapshot. Section builders only read duck-typed runtime-layer
+objects and copy allowlisted, bounded fields, so no raw libvirt/backend internals
+reach the artifact. The backend section embeds the canonical ``BackendManifestV2``
+payload rendered by the pure ``aces_backend_protocols`` manifest/capability helpers
+(ADR-036 allows ``aces_operations`` those two side-effect-free renderers) so the
+evidence carries the same backend contract the rest of the stack uses, not a
+hand-rolled summary. Split from ``libvirt_paper_evidence`` to keep each module under
+the ADR-015 source-size cap.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from aces_backend_libvirt.techvault_native import NativeLibvirtProbe, expected_surface, native_soc_readback
+from aces_backend_protocols.capabilities import (
+    observation_capability_contract_gaps,
+    participant_runtime_capability_contract_gaps,
+)
+from aces_backend_protocols.manifest import backend_manifest_payload
+from aces_contracts.contracts import (
+    EvaluationHistoryEventModel,
+    EvaluationResultStateModel,
+    ExperimentRealizedFormDisclosureModel,
+)
+
+EVIDENCE_RUN_SCHEMA = "aces.libvirt.paper-evidence-run/v1"
+_LIBVIRT_BACKEND_NAME = "libvirt-qemu"
+
+# Internal/evaluator-only surfaces the participant must never observe. Derived from
+# the paper scenario observation boundary's hidden_refs; the negative-boundary
+# evidence confirms none of these reach the participant's visible/disclosed refs.
+_INTERNAL_SURFACE_KEYWORDS = ("customer-db", "wazuh", "evaluator", "policy-gate", "postgres")
+
+# The four paper non-claims (issue #615). Carried verbatim in the artifact.
+_NON_CLAIMS = (
+    "No Wazuh detection-quality claim.",
+    "No model-defense robustness claim.",
+    "No byte-equivalence or application-internals equivalence claim between libvirt appliances and APTL containers.",
+    "No full semantic-equivalence claim beyond the invariant ledger in Brad-Edwards/aces#600.",
+)
+
+
+def assemble_artifact(
+    *,
+    scenario_path: Path,
+    run_id: str,
+    recorded_at: str,
+    mode: str,
+    model: Any,
+    manifest: Any,
+    proof: Mapping[str, Any],
+    native_snapshot: Mapping[str, Any] | None,
+    probe: NativeLibvirtProbe | None,
+    unrealized_capabilities: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Assemble the full paper-evidence artifact payload."""
+    substrate_realized = native_snapshot is not None
+    scenario_section = _scenario_section(scenario_path, model)
+    boundary_refs = _boundary_hidden_refs(model)
+
+    return {
+        "schema": EVIDENCE_RUN_SCHEMA,
+        "run_id": run_id,
+        "recorded_at": recorded_at,
+        "evidence_source_mode": mode,
+        "scenario": scenario_section,
+        "compiled_artifact": _compiled_artifact_section(model),
+        "backend": _backend_section(manifest, mode, substrate_realized),
+        "realized_topology": _topology_section(model, native_snapshot, unrealized_capabilities),
+        "participant_action_proof": _participant_proof_section(proof),
+        "terminal_observation": _terminal_observation_section(proof["snapshot"]),
+        "defensive_evidence": _defensive_evidence_section(native_snapshot, model, recorded_at),
+        "negative_boundary_checks": _negative_boundary_section(boundary_refs, native_snapshot, probe),
+        "evaluator_outcome": _evaluator_outcome_section(proof["lifecycle_clean"], recorded_at),
+        "realized_form_disclosures": _realized_form_disclosures(manifest, substrate_realized),
+        "limitations": _limitations(mode, unrealized_capabilities),
+        "non_claims": list(_NON_CLAIMS),
+        "redaction_provenance": _redaction_provenance(),
+        "invariant_ledger_refs": _invariant_ledger_refs(model, scenario_section),
+    }
+
+
+def _manifest_name(manifest: Any) -> str:
+    identity = getattr(manifest, "identity", None)
+    if identity is not None and getattr(identity, "name", None):
+        return str(identity.name)
+    return str(getattr(manifest, "name", _LIBVIRT_BACKEND_NAME))
+
+
+def _manifest_version(manifest: Any) -> str:
+    identity = getattr(manifest, "identity", None)
+    if identity is not None and getattr(identity, "version", None):
+        return str(identity.version)
+    return str(getattr(manifest, "version", "0.0.0+unknown"))
+
+
+def _backend_section(manifest: Any, mode: str, substrate_realized: bool) -> dict[str, Any]:
+    """Embed the canonical BackendManifestV2 payload + capability-gap report.
+
+    The manifest is rendered through ``backend_manifest_payload`` — the same
+    canonical V2 renderer the rest of the stack uses — and re-validated against
+    ``BackendManifestV2Model`` by the artifact validator, so the evidence carries
+    the published backend contract rather than a hand-rolled summary. The
+    capability profile reports any contract gaps between the declared participant-
+    runtime / observation capabilities and their required contracts (empty when the
+    manifest fully satisfies them).
+    """
+    return {
+        "manifest": backend_manifest_payload(manifest),
+        "capability_profile": {
+            "participant_runtime_contract_gaps": list(participant_runtime_capability_contract_gaps(manifest)),
+            "observation_contract_gaps": list(observation_capability_contract_gaps(manifest)),
+        },
+        "realization_provenance": {
+            "backend": _manifest_name(manifest),
+            "evidence_source_mode": mode,
+            "substrate_realized": substrate_realized,
+            "basis": "native-realized" if substrate_realized else "planned-not-realized",
+        },
+    }
+
+
+def _scenario_section(scenario_path: Path, model: Any) -> dict[str, Any]:
+    from aces_sdl.parser import parse_sdl_file
+
+    content = scenario_path.read_bytes()
+    version: str | None = None
+    try:
+        version = getattr(parse_sdl_file(scenario_path), "version", None)
+    except Exception:  # noqa: BLE001
+        version = None
+    return {
+        "name": model.scenario_name,
+        "version": version,
+        "relative_path": _portable_scenario_ref(scenario_path),
+        "content_sha256": "sha256:" + hashlib.sha256(content).hexdigest(),
+    }
+
+
+def _portable_scenario_ref(scenario_path: Path) -> str:
+    """Return a repo-portable scenario reference, never the absolute host path."""
+    parts = scenario_path.parts
+    for anchor in ("examples", "scenarios"):
+        if anchor in parts:
+            return "/".join(parts[parts.index(anchor) :])
+    return scenario_path.name
+
+
+def _compiled_artifact_section(model: Any) -> dict[str, Any]:
+    addresses = {
+        "participant_behaviors": sorted(model.participant_behaviors),
+        "action_contracts": sorted(model.action_contracts),
+        "observation_boundaries": sorted(model.observation_boundaries),
+        "objectives": sorted(model.objectives),
+        "evaluations": sorted(model.evaluations),
+        "networks": sorted(model.networks),
+        "node_deployments": sorted(model.node_deployments),
+    }
+    fingerprint = hashlib.sha256(json.dumps(addresses, sort_keys=True).encode("utf-8")).hexdigest()
+    return {
+        "processor": "aces-reference-processor",
+        "compiled_address_sets": addresses,
+        "compiled_model_fingerprint": "sha256:" + fingerprint,
+    }
+
+
+def _node_services(node: Any) -> list[dict[str, Any]]:
+    spec = getattr(node, "spec", {}) or {}
+    node_spec = spec.get("node", {}) if isinstance(spec, Mapping) else {}
+    services = node_spec.get("services", []) if isinstance(node_spec, Mapping) else []
+    return [
+        {"name": svc.get("name"), "port": svc.get("port"), "protocol": svc.get("protocol")}
+        for svc in services
+        if isinstance(svc, Mapping)
+    ]
+
+
+def _node_network_links(node: Any) -> list[str]:
+    spec = getattr(node, "spec", {}) or {}
+    infra = spec.get("infrastructure", {}) if isinstance(spec, Mapping) else {}
+    links = infra.get("links", []) if isinstance(infra, Mapping) else []
+    return [str(link) for link in links]
+
+
+def _network_properties(network: Any) -> dict[str, Any]:
+    spec = getattr(network, "spec", {}) or {}
+    infra = spec.get("infrastructure", {}) if isinstance(spec, Mapping) else {}
+    props = infra.get("properties") if isinstance(infra, Mapping) else None
+    if not isinstance(props, Mapping):
+        return {}
+    return {"cidr": props.get("cidr"), "gateway": props.get("gateway"), "internal": props.get("internal")}
+
+
+def _topology_section(
+    model: Any,
+    native_snapshot: Mapping[str, Any] | None,
+    unrealized_capabilities: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    substrate_realized = native_snapshot is not None
+    nodes = [
+        {
+            "address": node.address,
+            "name": node.name,
+            "node_type": getattr(node, "node_type", None),
+            "os_family": getattr(node, "os_family", None),
+            "services": _node_services(node),
+            "networks": _node_network_links(node),
+        }
+        for node in model.node_deployments.values()
+    ]
+    networks = [
+        {"address": net.address, "name": net.name, **_network_properties(net)} for net in model.networks.values()
+    ]
+    section: dict[str, Any] = {
+        "basis": "native-realized" if substrate_realized else "planned-not-realized",
+        "disclosure": (
+            "Topology realized through the native libvirt driver."
+            if substrate_realized
+            else "Compiled/planned topology from the authored scenario; no live substrate realized. Network CIDRs and "
+            "gateways are authored values, not host-private libvirt addresses."
+        ),
+        "networks": networks,
+        "nodes": nodes,
+        "network_attachment_matrix": {node["name"]: node["networks"] for node in nodes},
+    }
+    if native_snapshot is not None:
+        section["native_surface"] = expected_surface(native_snapshot)
+    if unrealized_capabilities:
+        section["unrealized_capabilities"] = list(unrealized_capabilities)
+        section["unrealized_capabilities_disclosure"] = (
+            "The libvirt backend realizes the provisioning substrate (VMs and networks) only. The capabilities listed "
+            "above (content placement, orchestration, and evaluation) are not realized by this backend and remain "
+            "evaluator-only or translated; this is the n=2 backend-diversity limitation, not a substrate-realization "
+            "failure."
+        )
+    return section
+
+
+def _participant_proof_section(proof: Mapping[str, Any]) -> dict[str, Any]:
+    snapshot = proof["snapshot"]
+    episodes = {addr: _redact_episode_state(state) for addr, state in snapshot.participant_episode_results.items()}
+    return {
+        "runtime": "libvirt-deterministic-participant-runtime",
+        "lifecycle_clean": proof["lifecycle_clean"],
+        "diagnostics": list(proof["diagnostics"]),
+        "admitted_action_addresses": list(proof["admitted_action_addresses"]),
+        "episode_states": episodes,
+        # The participant runtime never received any visible/disclosed refs: the
+        # admission surface exposes nothing of the internal or evaluator state.
+        "participant_visible_refs": [],
+        "participant_disclosed_refs": [],
+        "structural_validation_note": (
+            "Deep behavior-history and episode-snapshot invariant validation is performed by the issue #614 "
+            "participant-runtime test suite (processor-layer iterators); this artifact records the libvirt "
+            "participant-runtime lifecycle outcome."
+        ),
+    }
+
+
+def _redact_episode_state(state: Any) -> dict[str, Any]:
+    if not isinstance(state, Mapping):
+        return {}
+    keep = (
+        "state_schema_version",
+        "participant_address",
+        "episode_id",
+        "sequence_number",
+        "status",
+        "terminal_reason",
+        "last_control_action",
+    )
+    return {key: state.get(key) for key in keep if key in state}
+
+
+def _terminal_observation_section(snapshot: Any) -> dict[str, Any]:
+    behavior_history = {
+        addr: _redact_behavior_history(events) for addr, events in snapshot.participant_behavior_history.items()
+    }
+    return {
+        "form": "behavior-history-equivalent",
+        "disclosure": (
+            "The libvirt participant runtime emits a behavior-history event stream rather than a standalone SEM-210 "
+            "observation envelope; the terminal participant view is reported as the behavior-history equivalent."
+        ),
+        "behavior_history": behavior_history,
+    }
+
+
+def _redact_behavior_history(events: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if not isinstance(events, Sequence):
+        return out
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        out.append(
+            {
+                "event_type": event.get("event_type"),
+                "action_instance_id": event.get("action_instance_id"),
+                "action_contract_address": event.get("action_contract_address"),
+                "observation_boundary_address": event.get("observation_boundary_address"),
+            }
+        )
+    return out
+
+
+def _defensive_evidence_section(
+    native_snapshot: Mapping[str, Any] | None, model: Any, recorded_at: str
+) -> dict[str, Any]:
+    # captured_at is the run's recorded_at timestamp threaded through artifact
+    # assembly, not a freshly synthesized one, so every section shares one
+    # consistent run timestamp and the artifact stays reproducible.
+    evidence_channels = _boundary_evidence_refs(model)
+    if native_snapshot is not None:
+        return {
+            "evidence_kind": "telemetry",
+            "evidence_source": "native-translated-readback",
+            "visibility": "evaluator-only",
+            "sensitivity": "restricted",
+            "redaction_state": "redacted",
+            "loss_disclosure": (
+                "Native libvirt SOC readback is a translated native readback of generated appliance state, not full "
+                "upstream Wazuh internals; no detection-quality claim is made."
+            ),
+            "evaluator_evidence_channels": evidence_channels,
+            "soc_readback": native_soc_readback(native_snapshot),
+            "captured_at": recorded_at,
+        }
+    return {
+        "evidence_kind": "telemetry",
+        "evidence_source": "structural-evaluator-channel",
+        "visibility": "evaluator-only",
+        "sensitivity": "restricted",
+        "redaction_state": "withheld",
+        "loss_disclosure": (
+            "Deterministic mode: no live SOC substrate is booted. Wazuh/SOC defensive evidence is reported as the "
+            "evaluator-only evidence channels declared by the scenario observation boundary, not upstream Wazuh "
+            "detection output; no detection-quality claim is made."
+        ),
+        "evaluator_evidence_channels": evidence_channels,
+        "payload_summary": (
+            "Evaluator-only Wazuh/SOC and policy-decision evidence channels are declared and kept off the participant "
+            "view; live SOC readback is available only under native-live mode."
+        ),
+        "captured_at": recorded_at,
+    }
+
+
+def _negative_boundary_section(
+    boundary_refs: Sequence[str],
+    native_snapshot: Mapping[str, Any] | None,
+    probe: NativeLibvirtProbe | None,
+) -> dict[str, Any]:
+    internal_refs = [ref for ref in boundary_refs if any(kw in ref for kw in _INTERNAL_SURFACE_KEYWORDS)]
+    checks = [{"ref": ref, "exposed_to_participant": False} for ref in internal_refs]
+    section: dict[str, Any] = {
+        "method": (
+            "Structural boundary analysis over the compiled observation boundary (hidden_refs) and the participant "
+            "exposure policy (empty visible/disclosed refs). The participant action surface does not expose the "
+            "internal DB, Wazuh, evaluator, or policy-gate surfaces."
+        ),
+        "value_status": "reported",
+        "all_internal_surfaces_withheld": all(not c["exposed_to_participant"] for c in checks),
+        "checks": checks,
+        "disclosure": "Negative boundary checks are evaluator-side derived analysis, not participant observations.",
+    }
+    if native_snapshot is not None and probe is not None:
+        section["native_reachability"] = _native_reachability_summary(native_snapshot, probe)
+    return section
+
+
+def _native_reachability_summary(native_snapshot: Mapping[str, Any], probe: NativeLibvirtProbe) -> dict[str, Any]:
+    summary: dict[str, Any] = {"reachable_surface_domains": []}
+    raw_domains = native_snapshot.get("domains", ())
+    if not isinstance(raw_domains, list | tuple):
+        return summary
+    for domain in raw_domains:
+        if not isinstance(domain, Mapping):
+            continue
+        name = str(domain.get("name", ""))
+        if any(kw in name for kw in _INTERNAL_SURFACE_KEYWORDS):
+            continue
+        ip = _first_ip(domain)
+        if ip and probe.ping(ip).ok:
+            summary["reachable_surface_domains"].append(name)
+    return summary
+
+
+def _first_ip(domain: Mapping[str, Any]) -> str | None:
+    interfaces = domain.get("interfaces", ())
+    if not isinstance(interfaces, list | tuple):
+        return None
+    for interface in interfaces:
+        if isinstance(interface, Mapping) and isinstance(interface.get("ip"), str) and interface.get("ip"):
+            return str(interface["ip"])
+    return None
+
+
+def _evaluator_outcome_section(lifecycle_clean: bool, recorded_at: str) -> dict[str, Any]:
+    status = "ready" if lifecycle_clean else "failed"
+    result = EvaluationResultStateModel.model_validate(
+        {
+            "resource_type": "participant-loop-evaluation",
+            "run_id": "paper-evidence",
+            "status": status,
+            "observed_at": recorded_at,
+            "updated_at": recorded_at,
+            "passed": lifecycle_clean,
+            "detail": "Structural participant-loop proof over the libvirt deterministic participant runtime.",
+            "evidence_refs": ["participant_action_proof", "negative_boundary_checks"],
+        }
+    )
+    history = EvaluationHistoryEventModel.model_validate(
+        {
+            "event_type": "evaluation_completed",
+            "timestamp": recorded_at,
+            "status": status,
+            "passed": lifecycle_clean,
+            "detail": "Paper-evidence evaluator outcome derived from the structural participant proof.",
+            "evidence_refs": ["participant_action_proof"],
+        }
+    )
+    return {
+        "result": result.model_dump(mode="json"),
+        "history": [history.model_dump(mode="json")],
+        "limitations": [
+            "Evaluator outcome reflects the structural participant-loop proof; the libvirt backend ships no generic "
+            "evaluator component, so this is a paper-proof evaluator record, not a generic backend evaluator result.",
+        ],
+    }
+
+
+def _realized_form_disclosures(manifest: Any, substrate_realized: bool) -> list[dict[str, Any]]:
+    backend_version = _manifest_version(manifest)
+    backend_name = _manifest_name(manifest)
+    backend_ref = {"ref_kind": "backend", "ref_id": backend_name, "ref_version": backend_version}
+    disclosures = [
+        ExperimentRealizedFormDisclosureModel.model_validate(
+            {
+                "concern_id": "libvirt-backend-selection",
+                "concern_kind": "backend-selection",
+                "basis": "backend-realized",
+                "realized_by_ref": backend_ref,
+                "realized_value_summary": (
+                    f"{backend_name} backend ({backend_version}); substrate "
+                    f"{'realized natively' if substrate_realized else 'planned, not realized'}."
+                ),
+                "disclosure": "The libvirt-qemu backend realized this paper-evidence run.",
+            }
+        ),
+        ExperimentRealizedFormDisclosureModel.model_validate(
+            {
+                "concern_id": "libvirt-participant-implementation",
+                "concern_kind": "participant-implementation",
+                "basis": "backend-realized",
+                "realized_by_ref": backend_ref,
+                "realized_value_summary": (
+                    "Deterministic libvirt participant runtime (no live domain execution); see issue #614."
+                ),
+                "disclosure": (
+                    "The participant action proof uses the deterministic domain adapter; live domain execution is not "
+                    "performed."
+                ),
+            }
+        ),
+    ]
+    return [d.model_dump(mode="json") for d in disclosures]
+
+
+def _limitations(mode: str, unrealized_capabilities: tuple[str, ...] = ()) -> list[str]:
+    limitations = [
+        "The libvirt participant runtime uses the deterministic domain adapter; no live participant domain is "
+        "executed (issue #614).",
+        "Wazuh/SOC evidence is evaluator-only and, in native-live mode, is a translated native readback of generated "
+        "appliance state rather than full upstream Wazuh internals.",
+    ]
+    if mode != "native-live":
+        limitations.append(
+            "Deterministic mode does not realize a live libvirt substrate; topology and SOC readback are "
+            "compiled/structural, explicitly disclosed as not-live."
+        )
+    if unrealized_capabilities:
+        limitations.append(
+            "Native-live mode realizes the provisioning substrate only; content placement, orchestration, and "
+            "evaluation declared by the scenario are not realized by the libvirt backend."
+        )
+    return limitations
+
+
+def _redaction_provenance() -> dict[str, Any]:
+    return {
+        "policy": (
+            "Only allowlisted, bounded fields are copied into the artifact. Raw libvirt XML, domain UUIDs, QEMU "
+            "command lines, host paths, connection URIs, credentials, private keys, and backend-private inspect "
+            "payloads are never written."
+        ),
+        "redacted_field_classes": [
+            "raw-libvirt-xml",
+            "domain-uuid",
+            "qemu-command-line",
+            "host-path",
+            "connection-uri",
+            "credential",
+            "private-key",
+            "backend-private-inspect-payload",
+        ],
+        "provenance_refs": [
+            "docs/decisions/issue-615-libvirt-paper-evidence-preflight.md",
+            "docs/decisions/issue-614-libvirt-participant-runtime.md",
+        ],
+    }
+
+
+def _invariant_ledger_refs(model: Any, scenario_section: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "scenario_name": model.scenario_name,
+        "scenario_content_sha256": scenario_section["content_sha256"],
+        "participant_behaviors": sorted(model.participant_behaviors),
+        "action_contracts": sorted(model.action_contracts),
+        "observation_boundaries": sorted(model.observation_boundaries),
+        "evaluations": sorted(model.evaluations),
+        "evidence_refs": [
+            "participant_action_proof",
+            "terminal_observation",
+            "defensive_evidence",
+            "negative_boundary_checks",
+            "evaluator_outcome",
+        ],
+        "note": (
+            "Stable ACES addresses and evidence refs for the Brad-Edwards/aces#600 cross-backend invariant ledger; "
+            "no libvirt domain UUIDs, host paths, or APTL-private identifiers."
+        ),
+    }
+
+
+def _boundary_hidden_refs(model: Any) -> list[str]:
+    return _boundary_spec_refs(model, "hidden_refs")
+
+
+def _boundary_evidence_refs(model: Any) -> list[str]:
+    return _boundary_spec_refs(model, "evidence_refs")
+
+
+def _boundary_spec_refs(model: Any, key: str) -> list[str]:
+    refs: list[str] = []
+    for boundary in model.observation_boundaries.values():
+        spec = getattr(boundary, "spec", None)
+        if isinstance(spec, Mapping):
+            for ref in spec.get(key, []) or []:
+                if isinstance(ref, str):
+                    refs.append(ref)
+    return refs

--- a/implementations/python/packages/aces_operations/_paper_evidence_types.py
+++ b/implementations/python/packages/aces_operations/_paper_evidence_types.py
@@ -1,0 +1,120 @@
+"""Structural types and the input bundle for the libvirt paper-evidence artifact.
+
+These ``Protocol`` types describe the duck-typed runtime-layer shapes the artifact
+builder and producer read — the compiled model, its node/network/boundary
+deployments, the participant behaviors and action contracts, the terminal snapshot,
+and the execution plan. They are structural (no ``isinstance`` use), so they give a
+more specific type than ``Any`` *without* importing the concrete ``aces_processor``
+model classes, which ADR-036 walls off from ``aces_operations``. ``BackendManifest``
+is imported from the allowed pure-capabilities module.
+
+Kept in a separate module so ``_paper_evidence_artifact`` stays under the ADR-015
+source-size cap.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from aces_backend_libvirt.techvault_native import NativeLibvirtProbe
+from aces_backend_protocols.capabilities import BackendManifest
+
+__all__ = [
+    "ActionContract",
+    "BackendManifest",
+    "CompiledModel",
+    "EvidenceArtifactInputs",
+    "ExecutionPlan",
+    "NativeLibvirtProbe",
+    "NodeDeployment",
+    "ObservationBoundary",
+    "ParticipantBehavior",
+    "RealizedNetwork",
+    "TerminalSnapshot",
+]
+
+
+class ActionContract(Protocol):
+    """Compiled action contract surface read by the proof builder."""
+
+    spec: Mapping[str, Any]
+
+
+class ParticipantBehavior(Protocol):
+    """Compiled participant behavior surface read by the lifecycle/proof builders."""
+
+    observation_boundary_addresses: Sequence[str]
+    action_contract_addresses: Sequence[str]
+
+
+class ObservationBoundary(Protocol):
+    """Compiled observation boundary surface read by the boundary/admission builders."""
+
+    spec: Mapping[str, Any] | None
+    view_transitions: Sequence[Any]
+
+
+class NodeDeployment(Protocol):
+    """Compiled node-deployment surface read by the topology builder."""
+
+    address: str
+    name: str
+    node_type: str | None
+    os_family: str | None
+    spec: Mapping[str, Any]
+
+
+class RealizedNetwork(Protocol):
+    """Compiled network surface read by the topology builder."""
+
+    address: str
+    name: str
+    spec: Mapping[str, Any]
+
+
+class CompiledModel(Protocol):
+    """The compiled runtime model exposed via ``ExecutionPlan.model``."""
+
+    scenario_name: str
+    participant_behaviors: Mapping[str, ParticipantBehavior]
+    action_contracts: Mapping[str, ActionContract]
+    observation_boundaries: Mapping[str, ObservationBoundary]
+    objectives: Mapping[str, Any]
+    evaluations: Mapping[str, Any]
+    networks: Mapping[str, RealizedNetwork]
+    node_deployments: Mapping[str, NodeDeployment]
+
+
+class TerminalSnapshot(Protocol):
+    """Terminal control-plane snapshot surface read by the observation builders."""
+
+    participant_episode_results: Mapping[str, Any]
+    participant_behavior_history: Mapping[str, Any]
+
+
+class ExecutionPlan(Protocol):
+    """The runtime execution plan returned by ``RuntimeManager.plan``."""
+
+    model: CompiledModel
+    manifest: BackendManifest
+    provisioning: object
+    diagnostics: Sequence[Any]
+
+
+@dataclass(frozen=True)
+class EvidenceArtifactInputs:
+    """Bundled inputs for ``assemble_artifact`` (keeps the builder to one parameter)."""
+
+    scenario_path: Path
+    run_id: str
+    recorded_at: str
+    mode: str
+    model: CompiledModel
+    manifest: BackendManifest
+    proof: Mapping[str, Any]
+    native_snapshot: Mapping[str, Any] | None
+    probe: NativeLibvirtProbe | None
+    unrealized_capabilities: tuple[str, ...] = ()

--- a/implementations/python/packages/aces_operations/_paper_evidence_validation.py
+++ b/implementations/python/packages/aces_operations/_paper_evidence_validation.py
@@ -1,0 +1,131 @@
+"""Validation for the libvirt paper-evidence artifact.
+
+Re-validates the embedded published-contract payloads, enforces the redaction gate
+(no raw libvirt XML, domain UUIDs, QEMU command lines, host paths, connection URIs,
+credentials, or private keys), and checks the participant/evaluator boundary
+invariant. Split from ``libvirt_paper_evidence`` to keep each module under the
+ADR-015 source-size cap.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from aces_contracts.contracts import (
+    BackendManifestV2Model,
+    EvaluationHistoryEventModel,
+    EvaluationResultStateModel,
+    ExperimentRealizedFormDisclosureModel,
+)
+
+from aces_operations._paper_evidence_artifact import EVIDENCE_RUN_SCHEMA
+
+# Redaction gate: substrings/patterns that must never appear in the artifact.
+_FORBIDDEN_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key material"),
+    (re.compile(r"</?domain[\s>]"), "raw libvirt domain XML"),
+    (re.compile(r"</?devices>"), "raw libvirt device XML"),
+    (re.compile(r"qemu-system-\w+"), "QEMU command line"),
+    (re.compile(r"qemu-kvm"), "QEMU command line"),
+    (re.compile(r"(?i)\bpassword\b\s*[:=]"), "embedded credential"),
+    (re.compile(r"(?i)\bsecret\b\s*[:=]"), "embedded credential"),
+    (re.compile(r"/home/[A-Za-z0-9._-]+/"), "host home path"),
+    (re.compile(r"/var/lib/libvirt"), "libvirt host state path"),
+    (re.compile(r"/root/"), "host root path"),
+    (re.compile(r"qemu\+ssh://|qemu://[^/]"), "libvirt connection URI with host"),
+    (
+        re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),
+        "domain UUID as portable semantics",
+    ),
+)
+
+_REQUIRED_SECTIONS = (
+    "scenario",
+    "compiled_artifact",
+    "backend",
+    "realized_topology",
+    "participant_action_proof",
+    "terminal_observation",
+    "defensive_evidence",
+    "negative_boundary_checks",
+    "evaluator_outcome",
+    "realized_form_disclosures",
+    "limitations",
+    "non_claims",
+    "redaction_provenance",
+    "invariant_ledger_refs",
+)
+
+
+def validate_libvirt_paper_evidence_artifact(payload: Mapping[str, Any]) -> list[str]:
+    """Validate a paper-evidence artifact: schema, required surfaces, embedded contracts, redaction, boundary.
+
+    Returns a list of human-readable violation strings; an empty list means the
+    artifact is valid.
+    """
+    problems: list[str] = []
+    if payload.get("schema") != EVIDENCE_RUN_SCHEMA:
+        problems.append(f"schema must be {EVIDENCE_RUN_SCHEMA!r}")
+    for section in _REQUIRED_SECTIONS:
+        if section not in payload:
+            problems.append(f"missing required section: {section}")
+
+    problems.extend(_validate_embedded_contracts(payload))
+    problems.extend(_validate_redaction(payload))
+    problems.extend(_validate_boundary(payload))
+    return problems
+
+
+def _validate_embedded_contracts(payload: Mapping[str, Any]) -> list[str]:
+    problems: list[str] = []
+    backend = payload.get("backend", {})
+    if isinstance(backend, Mapping):
+        try:
+            BackendManifestV2Model.model_validate(backend.get("manifest", {}))
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"backend.manifest is not a valid BackendManifestV2Model: {exc}")
+    outcome = payload.get("evaluator_outcome", {})
+    if isinstance(outcome, Mapping):
+        try:
+            EvaluationResultStateModel.model_validate(outcome.get("result", {}))
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"evaluator_outcome.result is not a valid EvaluationResultStateModel: {exc}")
+        for index, event in enumerate(outcome.get("history", []) or []):
+            try:
+                EvaluationHistoryEventModel.model_validate(event)
+            except Exception as exc:  # noqa: BLE001
+                problems.append(f"evaluator_outcome.history[{index}] invalid: {exc}")
+
+    for index, disclosure in enumerate(payload.get("realized_form_disclosures", []) or []):
+        try:
+            ExperimentRealizedFormDisclosureModel.model_validate(disclosure)
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"realized_form_disclosures[{index}] invalid: {exc}")
+    return problems
+
+
+def _validate_redaction(payload: Mapping[str, Any]) -> list[str]:
+    blob = json.dumps(payload, sort_keys=True, default=str)
+    return [
+        f"redaction violation: {label} present in artifact"
+        for pattern, label in _FORBIDDEN_REDACTION_PATTERNS
+        if pattern.search(blob)
+    ]
+
+
+def _validate_boundary(payload: Mapping[str, Any]) -> list[str]:
+    problems: list[str] = []
+    proof = payload.get("participant_action_proof", {})
+    exposed: set[str] = set()
+    if isinstance(proof, Mapping):
+        exposed.update(proof.get("participant_visible_refs", []) or [])
+        exposed.update(proof.get("participant_disclosed_refs", []) or [])
+    boundary = payload.get("negative_boundary_checks", {})
+    if isinstance(boundary, Mapping):
+        for check in boundary.get("checks", []) or []:
+            if isinstance(check, Mapping) and check.get("ref") in exposed:
+                problems.append(f"boundary violation: internal ref {check.get('ref')!r} is exposed to the participant")
+    return problems

--- a/implementations/python/packages/aces_operations/_paper_evidence_validation.py
+++ b/implementations/python/packages/aces_operations/_paper_evidence_validation.py
@@ -20,6 +20,7 @@ from aces_contracts.contracts import (
     EvaluationResultStateModel,
     ExperimentRealizedFormDisclosureModel,
 )
+from pydantic import BaseModel
 
 from aces_operations._paper_evidence_artifact import EVIDENCE_RUN_SCHEMA
 
@@ -79,32 +80,59 @@ def validate_libvirt_paper_evidence_artifact(payload: Mapping[str, Any]) -> list
     return problems
 
 
-def _validate_embedded_contracts(payload: Mapping[str, Any]) -> list[str]:
-    problems: list[str] = []
-    backend = payload.get("backend", {})
-    if isinstance(backend, Mapping):
-        try:
-            BackendManifestV2Model.model_validate(backend.get("manifest", {}))
-        except Exception as exc:  # noqa: BLE001
-            problems.append(f"backend.manifest is not a valid BackendManifestV2Model: {exc}")
-    outcome = payload.get("evaluator_outcome", {})
-    if isinstance(outcome, Mapping):
-        try:
-            EvaluationResultStateModel.model_validate(outcome.get("result", {}))
-        except Exception as exc:  # noqa: BLE001
-            problems.append(f"evaluator_outcome.result is not a valid EvaluationResultStateModel: {exc}")
-        for index, event in enumerate(outcome.get("history", []) or []):
-            try:
-                EvaluationHistoryEventModel.model_validate(event)
-            except Exception as exc:  # noqa: BLE001
-                problems.append(f"evaluator_outcome.history[{index}] invalid: {exc}")
+def _try_validate(model_cls: type[BaseModel], value: object, label: str) -> list[str]:
+    """Validate ``value`` against ``model_cls``; return a one-item problem list on failure."""
+    try:
+        model_cls.model_validate(value)
+    except Exception as exc:
+        return [f"{label}: {exc}"]
+    return []
 
-    for index, disclosure in enumerate(payload.get("realized_form_disclosures", []) or []):
-        try:
-            ExperimentRealizedFormDisclosureModel.model_validate(disclosure)
-        except Exception as exc:  # noqa: BLE001
-            problems.append(f"realized_form_disclosures[{index}] invalid: {exc}")
+
+def _validate_backend_manifest(payload: Mapping[str, Any]) -> list[str]:
+    backend = payload.get("backend", {})
+    if not isinstance(backend, Mapping):
+        return []
+    return _try_validate(
+        BackendManifestV2Model,
+        backend.get("manifest", {}),
+        "backend.manifest is not a valid BackendManifestV2Model",
+    )
+
+
+def _validate_evaluator_outcome(payload: Mapping[str, Any]) -> list[str]:
+    outcome = payload.get("evaluator_outcome", {})
+    if not isinstance(outcome, Mapping):
+        return []
+    problems = _try_validate(
+        EvaluationResultStateModel,
+        outcome.get("result", {}),
+        "evaluator_outcome.result is not a valid EvaluationResultStateModel",
+    )
+    for index, event in enumerate(outcome.get("history", []) or []):
+        problems.extend(
+            _try_validate(EvaluationHistoryEventModel, event, f"evaluator_outcome.history[{index}] invalid")
+        )
     return problems
+
+
+def _validate_disclosures(payload: Mapping[str, Any]) -> list[str]:
+    problems: list[str] = []
+    for index, disclosure in enumerate(payload.get("realized_form_disclosures", []) or []):
+        problems.extend(
+            _try_validate(
+                ExperimentRealizedFormDisclosureModel, disclosure, f"realized_form_disclosures[{index}] invalid"
+            )
+        )
+    return problems
+
+
+def _validate_embedded_contracts(payload: Mapping[str, Any]) -> list[str]:
+    return [
+        *_validate_backend_manifest(payload),
+        *_validate_evaluator_outcome(payload),
+        *_validate_disclosures(payload),
+    ]
 
 
 def _validate_redaction(payload: Mapping[str, Any]) -> list[str]:

--- a/implementations/python/packages/aces_operations/deterministic_participant_fixtures.py
+++ b/implementations/python/packages/aces_operations/deterministic_participant_fixtures.py
@@ -1,0 +1,256 @@
+"""Deterministic participant-proof fixtures shared across the libvirt participant
+proof and the libvirt paper-evidence producer.
+
+This module is intentionally contracts-only (ADR-036: ``aces_operations`` may
+import ``aces_contracts`` but not ``aces_processor`` or ``aces_backend_libvirt``
+internals). It builds the deterministic participant-implementation manifest,
+selection, typed action result, and admission request from compiled-model objects
+passed in by the caller (duck-typed), so both the test-layer proof and the shipped
+paper-evidence producer share one definition rather than carrying parallel copies.
+
+The identities here are structural-proof placeholders (synthetic digests): no live
+agent is installed and no live domain executes. ``WITHHELD_REFS`` are the
+evaluator-only / internal surfaces the participant must never observe; they are the
+source of the negative-boundary evidence in the paper-evidence artifact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from aces_contracts.contracts import (
+    ParticipantActionResultModel,
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
+)
+from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
+
+AGENT_IDENTITY = {"name": "libvirt-deterministic-agent", "version": "1.0.0"}
+MANIFEST_REF = "contracts/fixtures/participant-implementation-manifest/libvirt-deterministic.json"
+MANIFEST_DIGEST = "sha256:" + "1" * 64
+POLICY_ID = "libvirt-paper-agent-policy"
+POLICY_VERSION = "1.0.0"
+POLICY_DIGEST = "sha256:" + "3" * 64
+
+# Refs the participant must never observe: evaluator internals, the internal DB,
+# Wazuh, and the policy gate. The exposure policy withholds them.
+WITHHELD_REFS = (
+    "content.evaluator-notes",
+    "nodes.customer-db.services.postgres",
+    "nodes.wazuh-manager",
+    "nodes.wazuh-indexer",
+    "nodes.participant-policy-gate",
+)
+
+_PROOF_EPISODE_ID = "proof-ep-1"
+
+
+def build_implementation_manifest() -> ParticipantImplementationManifestModel:
+    """Return the deterministic participant-implementation manifest."""
+    return ParticipantImplementationManifestModel.model_validate(
+        {
+            "schema_version": "participant-implementation-manifest/v1",
+            "identity": AGENT_IDENTITY,
+            "implementation_kind": "agent",
+            "supported_contract_versions": [
+                "participant-implementation-manifest-v1",
+                "participant-implementation-provenance-v1",
+                "participant-episode-state-envelope-v1",
+                "participant-episode-history-event-stream-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "compatibility": {
+                "participant_runtimes": ["libvirt-qemu"],
+                "processors": ["aces-reference-processor"],
+                "backends": ["libvirt-qemu"],
+            },
+            "concept_bindings": [
+                {"scope": "implementation_kind", "family": "apparatus-declarations"},
+                {"scope": "capabilities.supported_participant_contracts", "family": "apparatus-declarations"},
+                {"scope": "capabilities.supported_decision_surface_modes", "family": "apparatus-declarations"},
+                {"scope": "capabilities.tool_affordance_expectations", "family": "tools-and-artifacts"},
+                {"scope": "capabilities.exposure_policy_kinds", "family": "provenance-and-evidence"},
+            ],
+            "constraints": {
+                "max_parallel_episodes": "1",
+                "simulation_disclosure": "deterministic-simulation: no live libvirt domain execution",
+            },
+            "capabilities": {
+                "supported_participant_contracts": [
+                    "participant-episode-state-envelope-v1",
+                    "participant-episode-history-event-stream-v1",
+                    "participant-behavior-history-event-stream-v1",
+                ],
+                "supported_decision_surface_modes": ["policy-directed"],
+                "tool_affordance_expectations": ["http-api"],
+                "exposure_policy_kinds": ["task-statement", "observation-stream"],
+            },
+        }
+    )
+
+
+def build_implementation_selection(
+    participant_address: str,
+    withheld_refs: tuple[str, ...] = WITHHELD_REFS,
+) -> ParticipantImplementationSelectionModel:
+    """Return the deterministic participant-implementation selection."""
+    return ParticipantImplementationSelectionModel.model_validate(
+        {
+            "participant_address": participant_address,
+            "implementation_identity": AGENT_IDENTITY,
+            "manifest_ref": MANIFEST_REF,
+            "manifest_digest": MANIFEST_DIGEST,
+            "selected_decision_surface_mode": "policy-directed",
+            "participant_contract_versions": [
+                "participant-episode-state-envelope-v1",
+                "participant-behavior-history-event-stream-v1",
+            ],
+            "exposure_policy": {
+                "policy_id": POLICY_ID,
+                "policy_version": POLICY_VERSION,
+                "policy_digest": POLICY_DIGEST,
+                "exposure_policy_kinds": ["task-statement", "observation-stream"],
+                "disclosed_refs": [],
+                "withheld_refs": list(withheld_refs),
+                "tool_affordance_refs": [],
+                "visibility_scope_refs": [],
+            },
+        }
+    )
+
+
+def build_action_result(
+    *,
+    participant_address: str,
+    episode_id: str,
+    action_instance_id: str,
+    action_contract_address: str,
+    contract_spec: Mapping[str, object],
+) -> ParticipantActionResultModel:
+    """Build a deterministic succeeded action_result for a compiled action contract.
+
+    Reports every declared precondition (with empty support/evidence refs) to
+    satisfy the SEM-211 completeness requirement, and only ``no_effect`` effects
+    (which need no target/evidence refs), so the result never introduces a
+    hidden-ref or boundary-evidence violation.
+    """
+    preconditions = []
+    for pc in contract_spec.get("preconditions", ()):
+        if not isinstance(pc, Mapping) or not pc.get("precondition_id") or not pc.get("precondition_class"):
+            continue
+        preconditions.append(
+            {
+                "precondition_id": str(pc["precondition_id"]),
+                "precondition_class": str(pc["precondition_class"]),
+                "status": "satisfied",
+                "participant_address": participant_address,
+                "episode_id": episode_id,
+                "action_contract_address": action_contract_address,
+                "observation_point": f"{action_instance_id}:pc-{pc['precondition_id']}",
+                "support_refs": [],
+                "evidence_refs": [],
+            }
+        )
+
+    effects = []
+    for eff in contract_spec.get("effects", ()):
+        if not isinstance(eff, Mapping) or not eff.get("effect_id") or not eff.get("effect_class"):
+            continue
+        if str(eff["effect_class"]) == "no_effect":
+            effects.append(
+                {
+                    "effect_id": str(eff["effect_id"]),
+                    "effect_class": "no_effect",
+                    "description": str(eff.get("description", "No domain effect in deterministic proof.")),
+                }
+            )
+
+    return ParticipantActionResultModel.model_validate(
+        {
+            "status": "succeeded",
+            "participant_address": participant_address,
+            "episode_id": episode_id,
+            "action_instance_id": action_instance_id,
+            "action_contract_address": action_contract_address,
+            "observation_point": f"{action_instance_id}:terminal-observation",
+            "preconditions": preconditions,
+            "effects": effects,
+            "observations": [f"{action_instance_id}:terminal-observation"],
+            "evidence_refs": [],
+        }
+    )
+
+
+def contract_uses_sem211_action_results(contract: Any) -> bool:
+    """Return True when a compiled action contract declares SEM-211 typed classes.
+
+    Duck-typed equivalent of the processor-internal gate, so callers outside the
+    processor layer can decide whether to attach a typed ``action_result``.
+    """
+    return bool(
+        getattr(contract, "precondition_classes", None)
+        or getattr(contract, "effect_classes", None)
+        or getattr(contract, "failure_classes", None)
+    )
+
+
+def iter_admission_pairs(behavior: Any, observation_boundaries: Mapping[str, Any]) -> list[tuple[str, str]]:
+    """Return (action_address, action_instance_id) pairs to admit for one behavior.
+
+    View-transition anchors pin specific action_instance_ids (the behavior-history
+    validator checks each anchor resolves to a real OBSERVATION_EMITTED event);
+    otherwise fall back to one generated id per declared action contract.
+    """
+    required: list[str] = []
+    for ba in behavior.observation_boundary_addresses:
+        boundary = observation_boundaries.get(ba)
+        if boundary is None:
+            continue
+        for vt in boundary.view_transitions:
+            aid = vt.get("action_instance_id") if isinstance(vt, dict) else getattr(vt, "action_instance_id", None)
+            if aid and aid not in required:
+                required.append(aid)
+    first_action_address = next(iter(behavior.action_contract_addresses), None)
+    if required and first_action_address is not None:
+        return [(first_action_address, aid) for aid in required]
+    return [(addr, f"proof-action-{i + 1:04d}") for i, addr in enumerate(behavior.action_contract_addresses)]
+
+
+def build_participant_admission_request(
+    *,
+    behavior_address: str,
+    action_address: str,
+    action_instance_id: str,
+    boundary_address: str,
+    contract: Any,
+    episode_id: str = _PROOF_EPISODE_ID,
+) -> ParticipantActionAdmissionRequest:
+    """Build a deterministic participant action admission request for the proof.
+
+    Attaches a typed ``action_result`` only when the contract declares SEM-211
+    classes. ``visible_refs``/``disclosed_refs`` are empty: the admission surface
+    exposes nothing of the internal or evaluator state.
+    """
+    action_result = None
+    if contract_uses_sem211_action_results(contract):
+        action_result = build_action_result(
+            participant_address=behavior_address,
+            episode_id=episode_id,
+            action_instance_id=action_instance_id,
+            action_contract_address=action_address,
+            contract_spec=contract.spec,
+        )
+    return ParticipantActionAdmissionRequest(
+        participant_address=behavior_address,
+        action_contract_address=action_address,
+        observation_boundary_address=boundary_address,
+        action_instance_id=action_instance_id,
+        implementation_manifest=build_implementation_manifest(),
+        implementation_selection=build_implementation_selection(behavior_address),
+        visible_refs=(),
+        disclosed_refs=(),
+        evidence_refs=(),
+        observation_boundary_evidence_refs=(),
+        action_result=action_result,
+    )

--- a/implementations/python/packages/aces_operations/deterministic_participant_fixtures.py
+++ b/implementations/python/packages/aces_operations/deterministic_participant_fixtures.py
@@ -1,12 +1,14 @@
 """Deterministic participant-proof fixtures shared across the libvirt participant
 proof and the libvirt paper-evidence producer.
 
-This module is intentionally contracts-only (ADR-036: ``aces_operations`` may
-import ``aces_contracts`` but not ``aces_processor`` or ``aces_backend_libvirt``
-internals). It builds the deterministic participant-implementation manifest,
-selection, typed action result, and admission request from compiled-model objects
-passed in by the caller (duck-typed), so both the test-layer proof and the shipped
-paper-evidence producer share one definition rather than carrying parallel copies.
+This module builds from ``aces_contracts`` plus the shared structural ``Protocol``
+types in ``_paper_evidence_types`` only (ADR-036: ``aces_operations`` never imports
+``aces_processor`` or ``aces_backend_libvirt`` internals — the structural types name
+the compiled-model shapes without importing the concrete processor classes). It
+builds the deterministic participant-implementation manifest, selection, typed
+action result, and admission request from compiled-model objects passed in by the
+caller (duck-typed), so both the test-layer proof and the shipped paper-evidence
+producer share one definition rather than carrying parallel copies.
 
 The identities here are structural-proof placeholders (synthetic digests): no live
 agent is installed and no live domain executes. ``WITHHELD_REFS`` are the
@@ -17,7 +19,6 @@ source of the negative-boundary evidence in the paper-evidence artifact.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
 
 from aces_contracts.contracts import (
     ParticipantActionResultModel,
@@ -25,6 +26,8 @@ from aces_contracts.contracts import (
     ParticipantImplementationSelectionModel,
 )
 from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
+
+from aces_operations._paper_evidence_types import ActionContract, ObservationBoundary, ParticipantBehavior
 
 AGENT_IDENTITY = {"name": "libvirt-deterministic-agent", "version": "1.0.0"}
 MANIFEST_REF = "contracts/fixtures/participant-implementation-manifest/libvirt-deterministic.json"
@@ -182,7 +185,7 @@ def build_action_result(
     )
 
 
-def contract_uses_sem211_action_results(contract: Any) -> bool:
+def contract_uses_sem211_action_results(contract: ActionContract) -> bool:
     """Return True when a compiled action contract declares SEM-211 typed classes.
 
     Duck-typed equivalent of the processor-internal gate, so callers outside the
@@ -195,7 +198,9 @@ def contract_uses_sem211_action_results(contract: Any) -> bool:
     )
 
 
-def iter_admission_pairs(behavior: Any, observation_boundaries: Mapping[str, Any]) -> list[tuple[str, str]]:
+def iter_admission_pairs(
+    behavior: ParticipantBehavior, observation_boundaries: Mapping[str, ObservationBoundary]
+) -> list[tuple[str, str]]:
     """Return (action_address, action_instance_id) pairs to admit for one behavior.
 
     View-transition anchors pin specific action_instance_ids (the behavior-history
@@ -223,7 +228,7 @@ def build_participant_admission_request(
     action_address: str,
     action_instance_id: str,
     boundary_address: str,
-    contract: Any,
+    contract: ActionContract,
     episode_id: str = _PROOF_EPISODE_ID,
 ) -> ParticipantActionAdmissionRequest:
     """Build a deterministic participant action admission request for the proof.

--- a/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
+++ b/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
@@ -1,0 +1,348 @@
+"""Libvirt paper-proof evaluator-evidence artifact producer.
+
+Composes existing ACES surfaces — the libvirt participant runtime (issue #614, via
+the runtime control plane), the native libvirt substrate realization (issue #601),
+the backend manifest, and the experiment/evaluation contracts — into one stable,
+validated run artifact (``aces.libvirt.paper-evidence-run/v1``) that carries
+evaluator-facing evidence for the paper enterprise participant/evidence scenario.
+The artifact is a local proof-artifact wrapper that embeds validated
+published-contract payloads and bounded summaries; it is NOT a new published
+contract.
+
+ADR-036 module boundary: ``aces_operations`` orchestrates the libvirt backend only
+through ``aces_backend_libvirt.target`` / ``aces_backend_libvirt.techvault_native``,
+the ``aces_runtime`` control plane / manager, ``aces_sdl.parser``, and
+``aces_contracts``. It never imports the processor or backend internals; the
+compiled runtime model is read from ``ExecutionPlan.model`` (a runtime-layer
+output). Deep processor-iterator validation of the participant proof is performed
+by the issue #614 test suite, not by this shipped producer.
+
+Two honestly-disclosed evidence-source modes:
+
+* ``deterministic`` (default, no libvirt daemon — used by tests / CI): participant
+  lifecycle proof + compiled topology + structural negative-boundary evidence + an
+  evaluator-only translated SOC-readback record explicitly marked as not upstream
+  Wazuh.
+* ``native-live`` (operator-run; injected/default native driver + probe):
+  additionally realizes the libvirt VM/network substrate and records the native
+  topology and native SOC readback. The libvirt backend declares no content-type
+  support, so the scenario's content/orchestration/evaluation planes are not
+  backend-realized; those are disclosed as ``unrealized_capabilities``, not faked.
+
+Artifact assembly lives in ``_paper_evidence_artifact`` and validation in
+``_paper_evidence_validation`` (kept separate for the ADR-015 source-size cap).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from aces_backend_libvirt.target import create_libvirt_target
+from aces_backend_libvirt.techvault_native import NativeLibvirtProbe, TechVaultNativeLibvirtDriver
+from aces_runtime.control_plane import RuntimeControlPlane
+from aces_runtime.manager import RuntimeManager
+from aces_sdl.parser import parse_sdl_file
+
+from aces_operations._paper_evidence_artifact import EVIDENCE_RUN_SCHEMA, assemble_artifact
+from aces_operations._paper_evidence_validation import validate_libvirt_paper_evidence_artifact
+from aces_operations.deterministic_participant_fixtures import (
+    build_participant_admission_request,
+    iter_admission_pairs,
+)
+from aces_operations.run_artifacts import atomic_write_json_artifact, is_valid_run_id_label, run_artifact_path
+
+__all__ = [
+    "EVIDENCE_RUN_SCHEMA",
+    "EvidenceCheck",
+    "LibvirtPaperEvidenceConfig",
+    "LibvirtPaperEvidenceReport",
+    "run_libvirt_paper_evidence",
+    "validate_libvirt_paper_evidence_artifact",
+]
+
+_PROOF_EPISODE_ID = "proof-ep-1"
+
+EvidenceSourceMode = Literal["deterministic", "native-live"]
+
+
+@dataclass(frozen=True)
+class EvidenceCheck:
+    """One named check over the paper-evidence production run.
+
+    Every check is gating: it contributes to ``LibvirtPaperEvidenceReport.passed``.
+    There is deliberately no non-gating escape hatch — in particular, a native-live
+    run that fails to realize the libvirt substrate must report ``passed=False`` so
+    the mode can never claim success without actually realizing.
+    """
+
+    name: str
+    passed: bool
+    diagnostics: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LibvirtPaperEvidenceConfig:
+    """Runtime controls for the libvirt paper-evidence producer."""
+
+    evidence_source_mode: EvidenceSourceMode = "deterministic"
+    connection_uri: str = "qemu:///system"
+    boot_timeout_seconds: int = 180
+    appliance_memory_mib: int = 128
+    clean_boot: bool = True
+
+
+@dataclass(frozen=True)
+class LibvirtPaperEvidenceReport:
+    """Rendered outcome for the libvirt paper-evidence producer."""
+
+    scenario: str
+    run_id: str
+    output_dir: str
+    evidence_source_mode: str
+    checks: tuple[EvidenceCheck, ...]
+    artifact: dict[str, Any] | None = None
+    artifact_path: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return all(check.passed for check in self.checks)
+
+    def render(self) -> str:
+        status = "PASS" if self.passed else "FAIL"
+        lines = [
+            f"libvirt paper evidence -- scenario={self.scenario} run_id={self.run_id} "
+            f"mode={self.evidence_source_mode}: {status}"
+        ]
+        for check in self.checks:
+            marker = "ok" if check.passed else "FAIL"
+            lines.append(f"  [{marker}] {check.name}")
+            for diagnostic in check.diagnostics:
+                lines.append(f"        - {diagnostic}")
+        if self.artifact_path:
+            lines.append(f"  artifact: {self.artifact_path}")
+        return "\n".join(lines)
+
+
+def run_libvirt_paper_evidence(
+    *,
+    scenario_path: Path,
+    project_dir: Path,
+    run_id: str,
+    config: LibvirtPaperEvidenceConfig | None = None,
+    driver_factory: Callable[[], TechVaultNativeLibvirtDriver] | None = None,
+    probe: NativeLibvirtProbe | None = None,
+) -> LibvirtPaperEvidenceReport:
+    """Produce the libvirt paper evaluator-evidence artifact for ``scenario_path``."""
+    settings = config or LibvirtPaperEvidenceConfig()
+    mode = settings.evidence_source_mode
+    checks: list[EvidenceCheck] = []
+
+    run_id_ok = is_valid_run_id_label(run_id)
+    checks.append(
+        EvidenceCheck("run_id_input", run_id_ok, () if run_id_ok else ("run id must be a safe filesystem label",))
+    )
+    if not run_id_ok:
+        return LibvirtPaperEvidenceReport(scenario_path.name, run_id, str(project_dir), mode, tuple(checks))
+
+    native_driver: TechVaultNativeLibvirtDriver | None = None
+    if mode == "native-live":
+        native_driver = (driver_factory or _default_native_driver_factory(project_dir, run_id, settings))()
+
+    try:
+        target = create_libvirt_target(participant_runtime=True, driver=native_driver)
+        execution_plan = RuntimeManager(target).plan(parse_sdl_file(scenario_path))
+        control_plane = RuntimeControlPlane(target)
+    except Exception as exc:  # noqa: BLE001
+        checks.append(EvidenceCheck("scenario_plan", False, (f"failed to plan scenario: {exc}",)))
+        return LibvirtPaperEvidenceReport(scenario_path.name, run_id, str(project_dir), mode, tuple(checks))
+
+    model = execution_plan.model
+    proof = _run_participant_lifecycle(model, control_plane)
+    checks.append(EvidenceCheck("participant_action_proof", proof["lifecycle_clean"], tuple(proof["diagnostics"])))
+
+    native_snapshot: Mapping[str, Any] | None = None
+    unrealized_capabilities: tuple[str, ...] = ()
+    if mode == "native-live":
+        native_snapshot, realize_check, unrealized_capabilities = _realize_native_substrate(
+            execution_plan, control_plane, native_driver
+        )
+        checks.append(realize_check)
+
+    recorded_at = datetime.now(UTC).isoformat()
+    artifact = assemble_artifact(
+        scenario_path=scenario_path,
+        run_id=run_id,
+        recorded_at=recorded_at,
+        mode=mode,
+        model=model,
+        manifest=execution_plan.manifest,
+        proof=proof,
+        native_snapshot=native_snapshot,
+        probe=probe if mode == "native-live" else None,
+        unrealized_capabilities=unrealized_capabilities,
+    )
+
+    violations = validate_libvirt_paper_evidence_artifact(artifact)
+    checks.append(EvidenceCheck("artifact_contract_validation", not violations, tuple(violations)))
+
+    # Fail closed: a redaction/contract-invalid artifact is never persisted, so
+    # forbidden content the validator detected can never reach the artifact path.
+    artifact_path: str | None = None
+    if violations:
+        checks.append(EvidenceCheck("artifact_write", False, ("artifact not written: contract validation failed",)))
+    else:
+        try:
+            target_path = run_artifact_path(project_dir, run_id, "paper-evidence", "libvirt-paper-evidence-run.json")
+            atomic_write_json_artifact(target_path, artifact)
+            artifact_path = str(target_path)
+        except OSError as exc:
+            checks.append(EvidenceCheck("artifact_write", False, (f"artifact write failed: {exc}",)))
+        else:
+            checks.append(EvidenceCheck("artifact_write", True))
+
+    return LibvirtPaperEvidenceReport(
+        scenario_path.name, run_id, str(project_dir), mode, tuple(checks), artifact, artifact_path
+    )
+
+
+def _run_participant_lifecycle(model: Any, control_plane: RuntimeControlPlane) -> dict[str, Any]:
+    """Drive the libvirt participant episode lifecycle via the runtime control plane.
+
+    Records the lifecycle outcome (all receipts accepted), the admitted actions,
+    and the terminal snapshot. Deep behavior-history/episode invariant validation
+    is the processor-layer test suite's job (issue #614), not this producer's.
+    """
+    diagnostics: list[str] = []
+    admitted: list[str] = []
+
+    for behavior_address, behavior in model.participant_behaviors.items():
+        init_receipt = control_plane.initialize_participant_episode(behavior_address, episode_id=_PROOF_EPISODE_ID)
+        if not init_receipt.accepted:
+            diagnostics.append(f"initialize rejected for {behavior_address}")
+            continue
+        boundary_address = (
+            behavior.observation_boundary_addresses[0] if behavior.observation_boundary_addresses else None
+        )
+        if boundary_address is None:
+            diagnostics.append(f"no observation boundary for {behavior_address}")
+            control_plane.terminate_participant_episode(behavior_address)
+            continue
+        for action_address, action_instance_id in iter_admission_pairs(behavior, model.observation_boundaries):
+            contract = model.action_contracts.get(action_address)
+            if contract is None:
+                continue
+            try:
+                request = build_participant_admission_request(
+                    behavior_address=behavior_address,
+                    action_address=action_address,
+                    action_instance_id=action_instance_id,
+                    boundary_address=boundary_address,
+                    contract=contract,
+                )
+            except (TypeError, ValueError) as exc:
+                diagnostics.append(f"invalid admission for {behavior_address}/{action_address}: {exc}")
+                continue
+            admit_receipt = control_plane.admit_participant_action(behavior, request)
+            if admit_receipt.accepted:
+                admitted.append(action_address)
+            else:
+                diagnostics.append(f"admit rejected for {behavior_address}/{action_address}")
+        term_receipt = control_plane.terminate_participant_episode(behavior_address)
+        if not term_receipt.accepted:
+            diagnostics.append(f"terminate rejected for {behavior_address}")
+
+    snapshot = control_plane.get_snapshot().snapshot
+    return {
+        "lifecycle_clean": not diagnostics,
+        "diagnostics": diagnostics,
+        "admitted_action_addresses": admitted,
+        "snapshot": snapshot,
+    }
+
+
+def _default_native_driver_factory(
+    project_dir: Path, run_id: str, settings: LibvirtPaperEvidenceConfig
+) -> Callable[[], TechVaultNativeLibvirtDriver]:
+    """Build the default native libvirt driver factory for operator-run native-live mode.
+
+    Mirrors the TechVault live gate: the driver connects to a real libvirt daemon at
+    realize time. In CI/tests a fake driver_factory is injected instead, so this is
+    never exercised without a daemon.
+    """
+    state_dir = project_dir / "runs" / run_id / "paper-evidence" / "libvirt"
+
+    def factory() -> TechVaultNativeLibvirtDriver:
+        return TechVaultNativeLibvirtDriver(
+            state_dir=state_dir,
+            connection_uri=settings.connection_uri,
+            name_prefix="aces-paper",
+            appliance_memory_mib=settings.appliance_memory_mib,
+            clean_existing=settings.clean_boot,
+        )
+
+    return factory
+
+
+def _realize_native_substrate(
+    execution_plan: Any,
+    control_plane: RuntimeControlPlane,
+    native_driver: TechVaultNativeLibvirtDriver | None,
+) -> tuple[Mapping[str, Any] | None, EvidenceCheck, tuple[str, ...]]:
+    """Realize the libvirt provisioning substrate (VMs + networks) for the scenario.
+
+    The libvirt backend realizes the provisioning substrate only; the paper scenario
+    additionally declares content/orchestration/evaluation that this backend does
+    not realize. Those are returned as ``unrealized_capabilities`` (disclosed in the
+    artifact). The check is gating and passes only when the native driver realized at
+    least one domain — native-live must never report success without realizing. A
+    scenario the libvirt backend cannot provision (e.g. the paper scenario's content
+    plane) therefore fails native-live and surfaces its unrealized capabilities,
+    rather than silently passing.
+    """
+    if native_driver is None:
+        return None, EvidenceCheck("native_substrate_realization", False, ("no native driver",)), ()
+    try:
+        receipt = control_plane.submit_provisioning(execution_plan.provisioning)
+        status = control_plane.get_operation(receipt.operation_id)
+    except Exception as exc:  # noqa: BLE001
+        return (
+            None,
+            EvidenceCheck("native_substrate_realization", False, (f"native realization raised: {exc}",)),
+            (),
+        )
+    unrealized = _dedupe(
+        f"{d.code}: {d.message}"
+        for source in (execution_plan.diagnostics, () if status is None else status.diagnostics)
+        for d in source
+        if d.is_error
+    )
+    snapshot = native_driver.last_snapshot
+    if _snapshot_has_domains(snapshot):
+        return snapshot, EvidenceCheck("native_substrate_realization", True), unrealized
+    return (
+        None,
+        EvidenceCheck(
+            "native_substrate_realization",
+            False,
+            ("libvirt backend realized no native substrate for this scenario; capabilities disclosed as unrealized",),
+        ),
+        unrealized,
+    )
+
+
+def _dedupe(items: Any) -> tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for item in items:
+        seen.setdefault(item, None)
+    return tuple(seen)
+
+
+def _snapshot_has_domains(snapshot: Mapping[str, Any] | None) -> bool:
+    if not isinstance(snapshot, Mapping):
+        return False
+    domains = snapshot.get("domains", ())
+    return isinstance(domains, list | tuple) and len(domains) > 0

--- a/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
+++ b/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
@@ -48,7 +48,12 @@ from aces_runtime.manager import RuntimeManager
 from aces_sdl.parser import parse_sdl_file
 
 from aces_operations._paper_evidence_artifact import EVIDENCE_RUN_SCHEMA, assemble_artifact
-from aces_operations._paper_evidence_types import CompiledModel, EvidenceArtifactInputs, ExecutionPlan
+from aces_operations._paper_evidence_types import (
+    CompiledModel,
+    EvidenceArtifactInputs,
+    ExecutionPlan,
+    ParticipantBehavior,
+)
 from aces_operations._paper_evidence_validation import validate_libvirt_paper_evidence_artifact
 from aces_operations.deterministic_participant_fixtures import (
     build_participant_admission_request,
@@ -230,42 +235,10 @@ def _run_participant_lifecycle(model: CompiledModel, control_plane: RuntimeContr
     """
     diagnostics: list[str] = []
     admitted: list[str] = []
-
     for behavior_address, behavior in model.participant_behaviors.items():
-        init_receipt = control_plane.initialize_participant_episode(behavior_address, episode_id=_PROOF_EPISODE_ID)
-        if not init_receipt.accepted:
-            diagnostics.append(f"initialize rejected for {behavior_address}")
-            continue
-        boundary_address = (
-            behavior.observation_boundary_addresses[0] if behavior.observation_boundary_addresses else None
-        )
-        if boundary_address is None:
-            diagnostics.append(f"no observation boundary for {behavior_address}")
-            control_plane.terminate_participant_episode(behavior_address)
-            continue
-        for action_address, action_instance_id in iter_admission_pairs(behavior, model.observation_boundaries):
-            contract = model.action_contracts.get(action_address)
-            if contract is None:
-                continue
-            try:
-                request = build_participant_admission_request(
-                    behavior_address=behavior_address,
-                    action_address=action_address,
-                    action_instance_id=action_instance_id,
-                    boundary_address=boundary_address,
-                    contract=contract,
-                )
-            except (TypeError, ValueError) as exc:
-                diagnostics.append(f"invalid admission for {behavior_address}/{action_address}: {exc}")
-                continue
-            admit_receipt = control_plane.admit_participant_action(behavior, request)
-            if admit_receipt.accepted:
-                admitted.append(action_address)
-            else:
-                diagnostics.append(f"admit rejected for {behavior_address}/{action_address}")
-        term_receipt = control_plane.terminate_participant_episode(behavior_address)
-        if not term_receipt.accepted:
-            diagnostics.append(f"terminate rejected for {behavior_address}")
+        episode_admitted, episode_diagnostics = _run_behavior_episode(model, control_plane, behavior_address, behavior)
+        admitted.extend(episode_admitted)
+        diagnostics.extend(episode_diagnostics)
 
     snapshot = control_plane.get_snapshot().snapshot
     return {
@@ -274,6 +247,71 @@ def _run_participant_lifecycle(model: CompiledModel, control_plane: RuntimeContr
         "admitted_action_addresses": admitted,
         "snapshot": snapshot,
     }
+
+
+def _run_behavior_episode(
+    model: CompiledModel,
+    control_plane: RuntimeControlPlane,
+    behavior_address: str,
+    behavior: ParticipantBehavior,
+) -> tuple[list[str], list[str]]:
+    """Run one participant behavior's episode (init -> admit actions -> terminate).
+
+    Returns ``(admitted_action_addresses, diagnostics)``; a non-empty diagnostics
+    list means some receipt was rejected.
+    """
+    init_receipt = control_plane.initialize_participant_episode(behavior_address, episode_id=_PROOF_EPISODE_ID)
+    if not init_receipt.accepted:
+        return [], [f"initialize rejected for {behavior_address}"]
+    boundary_address = behavior.observation_boundary_addresses[0] if behavior.observation_boundary_addresses else None
+    if boundary_address is None:
+        control_plane.terminate_participant_episode(behavior_address)
+        return [], [f"no observation boundary for {behavior_address}"]
+
+    admitted: list[str] = []
+    diagnostics: list[str] = []
+    for action_address, action_instance_id in iter_admission_pairs(behavior, model.observation_boundaries):
+        admitted_address, diagnostic = _admit_one_action(
+            model, control_plane, behavior, behavior_address, boundary_address, action_address, action_instance_id
+        )
+        if admitted_address is not None:
+            admitted.append(admitted_address)
+        if diagnostic is not None:
+            diagnostics.append(diagnostic)
+
+    term_receipt = control_plane.terminate_participant_episode(behavior_address)
+    if not term_receipt.accepted:
+        diagnostics.append(f"terminate rejected for {behavior_address}")
+    return admitted, diagnostics
+
+
+def _admit_one_action(
+    model: CompiledModel,
+    control_plane: RuntimeControlPlane,
+    behavior: ParticipantBehavior,
+    behavior_address: str,
+    boundary_address: str,
+    action_address: str,
+    action_instance_id: str,
+) -> tuple[str | None, str | None]:
+    """Admit one participant action; return ``(admitted_address_or_None, diagnostic_or_None)``."""
+    contract = model.action_contracts.get(action_address)
+    if contract is None:
+        return None, None
+    try:
+        request = build_participant_admission_request(
+            behavior_address=behavior_address,
+            action_address=action_address,
+            action_instance_id=action_instance_id,
+            boundary_address=boundary_address,
+            contract=contract,
+        )
+    except (TypeError, ValueError) as exc:
+        return None, f"invalid admission for {behavior_address}/{action_address}: {exc}"
+    admit_receipt = control_plane.admit_participant_action(behavior, request)
+    if admit_receipt.accepted:
+        return action_address, None
+    return None, f"admit rejected for {behavior_address}/{action_address}"
 
 
 def _default_native_driver_factory(

--- a/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
+++ b/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
@@ -308,10 +308,11 @@ def _admit_one_action(
         )
     except (TypeError, ValueError) as exc:
         return None, f"invalid admission for {behavior_address}/{action_address}: {exc}"
-    admit_receipt = control_plane.admit_participant_action(behavior, request)
-    if admit_receipt.accepted:
-        return action_address, None
-    return None, f"admit rejected for {behavior_address}/{action_address}"
+    accepted = control_plane.admit_participant_action(behavior, request).accepted
+    return (
+        action_address if accepted else None,
+        None if accepted else f"admit rejected for {behavior_address}/{action_address}",
+    )
 
 
 def _default_native_driver_factory(

--- a/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
+++ b/implementations/python/packages/aces_operations/libvirt_paper_evidence.py
@@ -35,7 +35,7 @@ Artifact assembly lives in ``_paper_evidence_artifact`` and validation in
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -48,6 +48,7 @@ from aces_runtime.manager import RuntimeManager
 from aces_sdl.parser import parse_sdl_file
 
 from aces_operations._paper_evidence_artifact import EVIDENCE_RUN_SCHEMA, assemble_artifact
+from aces_operations._paper_evidence_types import CompiledModel, EvidenceArtifactInputs, ExecutionPlan
 from aces_operations._paper_evidence_validation import validate_libvirt_paper_evidence_artifact
 from aces_operations.deterministic_participant_fixtures import (
     build_participant_admission_request,
@@ -156,7 +157,7 @@ def run_libvirt_paper_evidence(
         target = create_libvirt_target(participant_runtime=True, driver=native_driver)
         execution_plan = RuntimeManager(target).plan(parse_sdl_file(scenario_path))
         control_plane = RuntimeControlPlane(target)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         checks.append(EvidenceCheck("scenario_plan", False, (f"failed to plan scenario: {exc}",)))
         return LibvirtPaperEvidenceReport(scenario_path.name, run_id, str(project_dir), mode, tuple(checks))
 
@@ -172,11 +173,10 @@ def run_libvirt_paper_evidence(
         )
         checks.append(realize_check)
 
-    recorded_at = datetime.now(UTC).isoformat()
-    artifact = assemble_artifact(
+    inputs = EvidenceArtifactInputs(
         scenario_path=scenario_path,
         run_id=run_id,
-        recorded_at=recorded_at,
+        recorded_at=datetime.now(UTC).isoformat(),
         mode=mode,
         model=model,
         manifest=execution_plan.manifest,
@@ -185,31 +185,43 @@ def run_libvirt_paper_evidence(
         probe=probe if mode == "native-live" else None,
         unrealized_capabilities=unrealized_capabilities,
     )
-
-    violations = validate_libvirt_paper_evidence_artifact(artifact)
-    checks.append(EvidenceCheck("artifact_contract_validation", not violations, tuple(violations)))
-
-    # Fail closed: a redaction/contract-invalid artifact is never persisted, so
-    # forbidden content the validator detected can never reach the artifact path.
-    artifact_path: str | None = None
-    if violations:
-        checks.append(EvidenceCheck("artifact_write", False, ("artifact not written: contract validation failed",)))
-    else:
-        try:
-            target_path = run_artifact_path(project_dir, run_id, "paper-evidence", "libvirt-paper-evidence-run.json")
-            atomic_write_json_artifact(target_path, artifact)
-            artifact_path = str(target_path)
-        except OSError as exc:
-            checks.append(EvidenceCheck("artifact_write", False, (f"artifact write failed: {exc}",)))
-        else:
-            checks.append(EvidenceCheck("artifact_write", True))
-
+    artifact, artifact_path = _finalize_artifact(inputs, project_dir, checks)
     return LibvirtPaperEvidenceReport(
         scenario_path.name, run_id, str(project_dir), mode, tuple(checks), artifact, artifact_path
     )
 
 
-def _run_participant_lifecycle(model: Any, control_plane: RuntimeControlPlane) -> dict[str, Any]:
+def _finalize_artifact(
+    inputs: EvidenceArtifactInputs, project_dir: Path, checks: list[EvidenceCheck]
+) -> tuple[dict[str, Any], str | None]:
+    """Assemble, validate, and (fail-closed) persist the artifact, appending the gating checks."""
+    artifact = assemble_artifact(inputs)
+    violations = validate_libvirt_paper_evidence_artifact(artifact)
+    checks.append(EvidenceCheck("artifact_contract_validation", not violations, tuple(violations)))
+    artifact_path, write_check = _persist_artifact(project_dir, inputs.run_id, artifact, violations)
+    checks.append(write_check)
+    return artifact, artifact_path
+
+
+def _persist_artifact(
+    project_dir: Path, run_id: str, artifact: Mapping[str, Any], violations: list[str]
+) -> tuple[str | None, EvidenceCheck]:
+    """Persist the artifact only when it is contract-valid.
+
+    Fail closed: a redaction/contract-invalid artifact is never written, so forbidden
+    content the validator detected can never reach the artifact path.
+    """
+    if violations:
+        return None, EvidenceCheck("artifact_write", False, ("artifact not written: contract validation failed",))
+    try:
+        target_path = run_artifact_path(project_dir, run_id, "paper-evidence", "libvirt-paper-evidence-run.json")
+        atomic_write_json_artifact(target_path, artifact)
+    except OSError as exc:
+        return None, EvidenceCheck("artifact_write", False, (f"artifact write failed: {exc}",))
+    return str(target_path), EvidenceCheck("artifact_write", True)
+
+
+def _run_participant_lifecycle(model: CompiledModel, control_plane: RuntimeControlPlane) -> dict[str, Any]:
     """Drive the libvirt participant episode lifecycle via the runtime control plane.
 
     Records the lifecycle outcome (all receipts accepted), the admitted actions,
@@ -288,7 +300,7 @@ def _default_native_driver_factory(
 
 
 def _realize_native_substrate(
-    execution_plan: Any,
+    execution_plan: ExecutionPlan,
     control_plane: RuntimeControlPlane,
     native_driver: TechVaultNativeLibvirtDriver | None,
 ) -> tuple[Mapping[str, Any] | None, EvidenceCheck, tuple[str, ...]]:
@@ -308,12 +320,8 @@ def _realize_native_substrate(
     try:
         receipt = control_plane.submit_provisioning(execution_plan.provisioning)
         status = control_plane.get_operation(receipt.operation_id)
-    except Exception as exc:  # noqa: BLE001
-        return (
-            None,
-            EvidenceCheck("native_substrate_realization", False, (f"native realization raised: {exc}",)),
-            (),
-        )
+    except Exception as exc:
+        return None, EvidenceCheck("native_substrate_realization", False, (f"native realization raised: {exc}",)), ()
     unrealized = _dedupe(
         f"{d.code}: {d.message}"
         for source in (execution_plan.diagnostics, () if status is None else status.diagnostics)
@@ -321,20 +329,18 @@ def _realize_native_substrate(
         if d.is_error
     )
     snapshot = native_driver.last_snapshot
-    if _snapshot_has_domains(snapshot):
-        return snapshot, EvidenceCheck("native_substrate_realization", True), unrealized
-    return (
-        None,
-        EvidenceCheck(
-            "native_substrate_realization",
-            False,
-            ("libvirt backend realized no native substrate for this scenario; capabilities disclosed as unrealized",),
-        ),
-        unrealized,
+    realized = _snapshot_has_domains(snapshot)
+    check = EvidenceCheck(
+        "native_substrate_realization",
+        realized,
+        ()
+        if realized
+        else ("libvirt backend realized no native substrate for this scenario; capabilities disclosed as unrealized",),
     )
+    return (snapshot if realized else None), check, unrealized
 
 
-def _dedupe(items: Any) -> tuple[str, ...]:
+def _dedupe(items: Iterable[str]) -> tuple[str, ...]:
     seen: dict[str, None] = {}
     for item in items:
         seen.setdefault(item, None)

--- a/implementations/python/packages/aces_operations/run_artifacts.py
+++ b/implementations/python/packages/aces_operations/run_artifacts.py
@@ -1,0 +1,67 @@
+"""Shared run-archive helpers for operational proof artifacts.
+
+Both the TechVault native live gate and the libvirt paper evidence producer write
+JSON artifacts under a ``runs/<run-id>/<subdir>/`` archive. They share one
+definition of a safe run-id filesystem label and one atomic JSON writer here
+rather than carrying parallel copies.
+
+The run-id label rule matches the historical TechVault convention
+(``^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$``): a leading alphanumeric, then up to 127
+characters drawn from alphanumerics, underscore, dot, and hyphen. It rejects path
+separators, ``..`` traversal, and leading dots so a caller-supplied run id can
+never escape the archive directory.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+RUN_ID_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def is_valid_run_id_label(run_id: str) -> bool:
+    """Return True when ``run_id`` is a safe, containment-validated filesystem label."""
+    return bool(RUN_ID_LABEL_PATTERN.match(run_id))
+
+
+def run_artifact_path(output_dir: Path, run_id: str, subdir: str, filename: str) -> Path:
+    """Return the archive path ``<output_dir>/runs/<run_id>/<subdir>/<filename>``.
+
+    Raises ``ValueError`` when ``run_id`` is not a safe filesystem label so the
+    path is never constructed from an unvalidated label.
+    """
+    if not is_valid_run_id_label(run_id):
+        raise ValueError("run id must be a safe filesystem label")
+    return output_dir / "runs" / run_id / subdir / filename
+
+
+def serialize_run_artifact(payload: Mapping[str, Any]) -> str:
+    """Serialize a run artifact to canonical JSON text (indent=2, sorted keys, trailing newline)."""
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def atomic_write_json_artifact(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically write ``payload`` as canonical JSON to ``path``.
+
+    Creates the parent directory, writes to a temp file in the same directory, then
+    ``os.replace`` to swap it into place so a reader never observes a partial write.
+    Cleans up the temp file on any failure before re-raising.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = serialize_run_artifact(payload)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise

--- a/implementations/python/packages/aces_operations/techvault_live.py
+++ b/implementations/python/packages/aces_operations/techvault_live.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -22,9 +20,14 @@ from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.manager import RuntimeManager
 from aces_sdl.parser import parse_sdl_file
 
+from aces_operations.run_artifacts import (
+    atomic_write_json_artifact,
+    is_valid_run_id_label,
+    run_artifact_path,
+)
+
 DEFAULT_EVENT_WINDOW_SECONDS = 180
 DEFAULT_BOOT_TIMEOUT_SECONDS = 180
-_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 _FULL_SOC_NODES = frozenset(
     {
         "wazuh-manager",
@@ -158,7 +161,7 @@ def validate_techvault_live(
 
 
 def _check_run_id(run_id: str) -> LiveCheck:
-    if _RUN_ID_RE.match(run_id):
+    if is_valid_run_id_label(run_id):
         return LiveCheck("run_id_input", True)
     return LiveCheck("run_id_input", False, ("run id must be a safe filesystem label",))
 
@@ -303,7 +306,7 @@ def _write_manifest(
     *,
     clean_boot: bool,
 ) -> str | None:
-    target = output_dir / "runs" / run_id / "live-gate" / "manifest.json"
+    target = run_artifact_path(output_dir, run_id, "live-gate", "manifest.json")
     payload = {
         "schema": "aces.libvirt.techvault-native-live-gate/v1",
         "scenario": {"path": str(scenario_path), "name": scenario_path.name.split(".")[0]},
@@ -324,8 +327,7 @@ def _write_manifest(
         "evidence": dict(evidence),
     }
     try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        atomic_write_json_artifact(target, payload)
     except OSError:
         return None
     return str(target)

--- a/implementations/python/tests/libvirt_participant_fixtures.py
+++ b/implementations/python/tests/libvirt_participant_fixtures.py
@@ -1,40 +1,42 @@
 """Shared fixtures for the libvirt participant-runtime tests and proof driver.
 
-Both ``test_libvirt_participant_runtime.py`` (the acceptance-criteria tests) and
-``libvirt_participant_proof.py`` (the end-to-end proof driver) need the same
-deterministic participant-implementation manifest, selection, action-result, and
-a no-op libvirt driver. They live here so the two consumers share one definition
-rather than carrying parallel copies.
+The deterministic participant-implementation manifest, selection, action-result,
+and admission helpers now live in
+``aces_operations.deterministic_participant_fixtures`` (contracts-only, importable
+by both the tests and the shipped paper-evidence producer). This module re-exports
+them for the existing acceptance tests and adds the test-only ``NullLibvirtDriver``
+(which depends on ``aces_backend_libvirt`` and so cannot live in the operations
+package under the ADR-036 module boundary).
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
-from aces_contracts.contracts import (
-    ParticipantActionResultModel,
-    ParticipantImplementationManifestModel,
-    ParticipantImplementationSelectionModel,
+from aces_operations.deterministic_participant_fixtures import (
+    AGENT_IDENTITY,
+    MANIFEST_DIGEST,
+    MANIFEST_REF,
+    POLICY_DIGEST,
+    POLICY_ID,
+    POLICY_VERSION,
+    WITHHELD_REFS,
+    build_action_result,
+    build_implementation_manifest,
+    build_implementation_selection,
 )
 
-# Deterministic participant implementation identity + provenance refs. These are
-# structural-proof placeholders (synthetic digests): no live agent is installed.
-AGENT_IDENTITY = {"name": "libvirt-deterministic-agent", "version": "1.0.0"}
-MANIFEST_REF = "contracts/fixtures/participant-implementation-manifest/libvirt-deterministic.json"
-MANIFEST_DIGEST = "sha256:" + "1" * 64
-POLICY_ID = "libvirt-paper-agent-policy"
-POLICY_VERSION = "1.0.0"
-POLICY_DIGEST = "sha256:" + "3" * 64
-
-# Refs the participant must never observe: evaluator internals, the internal DB,
-# Wazuh, and the policy gate. The exposure policy withholds them.
-WITHHELD_REFS = (
-    "content.evaluator-notes",
-    "nodes.customer-db.services.postgres",
-    "nodes.wazuh-manager",
-    "nodes.wazuh-indexer",
-    "nodes.participant-policy-gate",
-)
+__all__ = [
+    "AGENT_IDENTITY",
+    "MANIFEST_DIGEST",
+    "MANIFEST_REF",
+    "POLICY_DIGEST",
+    "POLICY_ID",
+    "POLICY_VERSION",
+    "WITHHELD_REFS",
+    "NullLibvirtDriver",
+    "build_action_result",
+    "build_implementation_manifest",
+    "build_implementation_selection",
+]
 
 
 class NullLibvirtDriver:
@@ -52,139 +54,3 @@ class NullLibvirtDriver:
 
     def realized_addresses(self):
         return frozenset()
-
-
-def build_implementation_manifest() -> ParticipantImplementationManifestModel:
-    """Return the deterministic participant-implementation manifest."""
-    return ParticipantImplementationManifestModel.model_validate(
-        {
-            "schema_version": "participant-implementation-manifest/v1",
-            "identity": AGENT_IDENTITY,
-            "implementation_kind": "agent",
-            "supported_contract_versions": [
-                "participant-implementation-manifest-v1",
-                "participant-implementation-provenance-v1",
-                "participant-episode-state-envelope-v1",
-                "participant-episode-history-event-stream-v1",
-                "participant-behavior-history-event-stream-v1",
-            ],
-            "compatibility": {
-                "participant_runtimes": ["libvirt-qemu"],
-                "processors": ["aces-reference-processor"],
-                "backends": ["libvirt-qemu"],
-            },
-            "concept_bindings": [
-                {"scope": "implementation_kind", "family": "apparatus-declarations"},
-                {"scope": "capabilities.supported_participant_contracts", "family": "apparatus-declarations"},
-                {"scope": "capabilities.supported_decision_surface_modes", "family": "apparatus-declarations"},
-                {"scope": "capabilities.tool_affordance_expectations", "family": "tools-and-artifacts"},
-                {"scope": "capabilities.exposure_policy_kinds", "family": "provenance-and-evidence"},
-            ],
-            "constraints": {
-                "max_parallel_episodes": "1",
-                "simulation_disclosure": "deterministic-simulation: no live libvirt domain execution",
-            },
-            "capabilities": {
-                "supported_participant_contracts": [
-                    "participant-episode-state-envelope-v1",
-                    "participant-episode-history-event-stream-v1",
-                    "participant-behavior-history-event-stream-v1",
-                ],
-                "supported_decision_surface_modes": ["policy-directed"],
-                "tool_affordance_expectations": ["http-api"],
-                "exposure_policy_kinds": ["task-statement", "observation-stream"],
-            },
-        }
-    )
-
-
-def build_implementation_selection(
-    participant_address: str,
-    withheld_refs: tuple[str, ...] = WITHHELD_REFS,
-) -> ParticipantImplementationSelectionModel:
-    """Return the deterministic participant-implementation selection."""
-    return ParticipantImplementationSelectionModel.model_validate(
-        {
-            "participant_address": participant_address,
-            "implementation_identity": AGENT_IDENTITY,
-            "manifest_ref": MANIFEST_REF,
-            "manifest_digest": MANIFEST_DIGEST,
-            "selected_decision_surface_mode": "policy-directed",
-            "participant_contract_versions": [
-                "participant-episode-state-envelope-v1",
-                "participant-behavior-history-event-stream-v1",
-            ],
-            "exposure_policy": {
-                "policy_id": POLICY_ID,
-                "policy_version": POLICY_VERSION,
-                "policy_digest": POLICY_DIGEST,
-                "exposure_policy_kinds": ["task-statement", "observation-stream"],
-                "disclosed_refs": [],
-                "withheld_refs": list(withheld_refs),
-                "tool_affordance_refs": [],
-                "visibility_scope_refs": [],
-            },
-        }
-    )
-
-
-def build_action_result(
-    *,
-    participant_address: str,
-    episode_id: str,
-    action_instance_id: str,
-    action_contract_address: str,
-    contract_spec: Mapping[str, object],
-) -> ParticipantActionResultModel:
-    """Build a deterministic succeeded action_result for a compiled action contract.
-
-    Reports every declared precondition (with empty support/evidence refs) to
-    satisfy the SEM-211 completeness requirement, and only ``no_effect`` effects
-    (which need no target/evidence refs), so the result never introduces a
-    hidden-ref or boundary-evidence violation.
-    """
-    preconditions = []
-    for pc in contract_spec.get("preconditions", ()):
-        if not isinstance(pc, Mapping) or not pc.get("precondition_id") or not pc.get("precondition_class"):
-            continue
-        preconditions.append(
-            {
-                "precondition_id": str(pc["precondition_id"]),
-                "precondition_class": str(pc["precondition_class"]),
-                "status": "satisfied",
-                "participant_address": participant_address,
-                "episode_id": episode_id,
-                "action_contract_address": action_contract_address,
-                "observation_point": f"{action_instance_id}:pc-{pc['precondition_id']}",
-                "support_refs": [],
-                "evidence_refs": [],
-            }
-        )
-
-    effects = []
-    for eff in contract_spec.get("effects", ()):
-        if not isinstance(eff, Mapping) or not eff.get("effect_id") or not eff.get("effect_class"):
-            continue
-        if str(eff["effect_class"]) == "no_effect":
-            effects.append(
-                {
-                    "effect_id": str(eff["effect_id"]),
-                    "effect_class": "no_effect",
-                    "description": str(eff.get("description", "No domain effect in deterministic proof.")),
-                }
-            )
-
-    return ParticipantActionResultModel.model_validate(
-        {
-            "status": "succeeded",
-            "participant_address": participant_address,
-            "episode_id": episode_id,
-            "action_instance_id": action_instance_id,
-            "action_contract_address": action_contract_address,
-            "observation_point": f"{action_instance_id}:terminal-observation",
-            "preconditions": preconditions,
-            "effects": effects,
-            "observations": [f"{action_instance_id}:terminal-observation"],
-            "evidence_refs": [],
-        }
-    )

--- a/implementations/python/tests/libvirt_participant_proof.py
+++ b/implementations/python/tests/libvirt_participant_proof.py
@@ -6,11 +6,12 @@ via ``LibvirtParticipantRuntime`` with the deterministic domain adapter, then
 validates the resulting snapshot against the episode-snapshot and behavior-history
 invariants.
 
-This driver requires no live libvirt daemon; it is suitable for CI pipelines
-and conformance proofs. The ``DeterministicParticipantDomainAdapter`` is used
-throughout; live domain execution requires a custom adapter. The deterministic
-participant manifest/selection/action-result fixtures are shared with the
-acceptance tests in ``libvirt_participant_fixtures``.
+This driver requires no live libvirt daemon; it is suitable for CI pipelines and
+conformance proofs. It lives in the tests layer because it composes the processor
+validation iterators with the libvirt backend runtime, a cross-layer composition
+the ADR-036 module boundaries reserve for tests. The deterministic
+manifest/selection/action-result/admission fixtures are shared with the shipped
+paper-evidence producer via ``aces_operations.deterministic_participant_fixtures``.
 """
 
 from __future__ import annotations
@@ -21,24 +22,19 @@ from pathlib import Path
 from aces_backend_libvirt.manifest import create_libvirt_manifest
 from aces_backend_libvirt.participant_runtime import LibvirtParticipantRuntime
 from aces_backend_libvirt.provisioner import LibvirtProvisioner
-from aces_contracts.contracts import ParticipantActionResultModel
-from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
+from aces_operations.deterministic_participant_fixtures import (
+    build_participant_admission_request,
+    iter_admission_pairs,
+)
 from aces_processor.compiler import compile_runtime_model
 from aces_processor.models import (
-    ParticipantActionContractRuntime,
-    _contract_uses_sem211_action_results,
     iter_participant_behavior_history_violations,
     iter_participant_episode_snapshot_violations,
 )
 from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.registry import RuntimeTarget
 from aces_sdl.parser import parse_sdl
-from libvirt_participant_fixtures import (
-    NullLibvirtDriver,
-    build_action_result,
-    build_implementation_manifest,
-    build_implementation_selection,
-)
+from libvirt_participant_fixtures import NullLibvirtDriver
 
 
 @dataclass(frozen=True)
@@ -50,49 +46,19 @@ class LibvirtParticipantProofResult:
     behavior_history_violations: tuple[tuple[str, str], ...] = ()
 
 
-def _build_action_result(
-    *,
-    participant_address: str,
-    episode_id: str,
-    action_instance_id: str,
-    action_contract_address: str,
-    contract: ParticipantActionContractRuntime,
-) -> ParticipantActionResultModel | None:
-    """Build a succeeded action_result, or None when the contract has no SEM-211 classes.
-
-    Delegates the body to the shared ``build_action_result`` fixture; this wrapper
-    only adds the SEM-211 applicability gate, which depends on the compiled
-    contract object rather than the raw spec dict.
-    """
-    if not _contract_uses_sem211_action_results(contract):
-        return None
-    return build_action_result(
-        participant_address=participant_address,
-        episode_id=episode_id,
-        action_instance_id=action_instance_id,
-        action_contract_address=action_contract_address,
-        contract_spec=contract.spec,
-    )
-
-
 def run_libvirt_participant_proof(sdl_path: Path) -> LibvirtParticipantProofResult:
     """Run a structural proof of the libvirt participant runtime against ``sdl_path``.
 
     Loads the SDL file, compiles the runtime model, creates a
-    ``LibvirtParticipantRuntime`` target (no live libvirt daemon), then for
-    each declared behavior:
-
-    1. Initializes a participant episode.
-    2. Admits one action per declared action contract.
-    3. Terminates the episode.
-
-    Validates the resulting snapshot via
-    ``iter_participant_episode_snapshot_violations`` and
+    ``LibvirtParticipantRuntime`` target (no live libvirt daemon), then for each
+    declared behavior initializes a participant episode, admits one action per
+    declared action contract, and terminates the episode. Validates the resulting
+    snapshot via ``iter_participant_episode_snapshot_violations`` and
     ``iter_participant_behavior_history_violations``.
 
-    Returns a ``LibvirtParticipantProofResult`` with empty tuple fields on
-    success. Any structural violation or exception is surfaced in the result
-    rather than raised, so callers can report the full set of proof failures.
+    Returns a ``LibvirtParticipantProofResult`` with empty tuple fields on success.
+    Any structural violation or exception is surfaced in the result rather than
+    raised, so callers can report the full set of proof failures.
     """
     try:
         sdl = parse_sdl(sdl_path.read_text())
@@ -101,99 +67,41 @@ def run_libvirt_participant_proof(sdl_path: Path) -> LibvirtParticipantProofResu
         return LibvirtParticipantProofResult(errors=(f"failed to load/compile SDL: {exc}",))
 
     manifest = create_libvirt_manifest(participant_runtime=True)
-    participant_runtime = LibvirtParticipantRuntime()
     target = RuntimeTarget(
         name=manifest.name,
         manifest=manifest,
         provisioner=LibvirtProvisioner(NullLibvirtDriver()),
-        participant_runtime=participant_runtime,
+        participant_runtime=LibvirtParticipantRuntime(),
     )
     control_plane = RuntimeControlPlane(target)
-
-    proof_manifest = build_implementation_manifest()
 
     errors: list[str] = []
 
     for behavior_address, behavior in runtime_model.participant_behaviors.items():
-        # Initialize the episode
         init_receipt = control_plane.initialize_participant_episode(behavior_address, episode_id="proof-ep-1")
         if not init_receipt.accepted:
             errors.append(f"initialize_participant_episode rejected for {behavior_address!r}")
             continue
 
-        # Collect action_instance_ids required by view transition anchors across all observation
-        # boundaries for this behavior.  The behavior-history validator checks that every
-        # view-transition anchor (action_instance_id + observation_emitted) resolves to a real
-        # OBSERVATION_EMITTED event in the behavior history.  We must therefore use those exact
-        # IDs when building our proof admissions rather than synthetic generated ones.
-        required_action_instance_ids: list[str] = []
-        for ba in behavior.observation_boundary_addresses:
-            boundary = runtime_model.observation_boundaries.get(ba)
-            if boundary is not None:
-                for vt in boundary.view_transitions:
-                    if isinstance(vt, dict):
-                        aid: str | None = vt.get("action_instance_id")
-                    else:
-                        aid = getattr(vt, "action_instance_id", None)
-                    if aid and aid not in required_action_instance_ids:
-                        required_action_instance_ids.append(aid)
+        boundary_address = (
+            behavior.observation_boundary_addresses[0] if behavior.observation_boundary_addresses else None
+        )
+        if boundary_address is None:
+            errors.append(f"no observation boundary declared for behavior {behavior_address!r}")
+            control_plane.terminate_participant_episode(behavior_address)
+            continue
 
-        # Build (action_address, action_instance_id) pairs to admit.
-        # When view transitions impose specific IDs, pair each with the first action contract
-        # (the boundary validator doesn't distinguish contracts by ID — it only checks the event
-        # stream for matching OBSERVATION_EMITTED events).
-        # Fall back to one-per-contract with generated IDs when no anchors exist.
-        first_action_address = next(iter(behavior.action_contract_addresses), None)
-        if required_action_instance_ids and first_action_address is not None:
-            admission_pairs: list[tuple[str, str]] = [
-                (first_action_address, aid) for aid in required_action_instance_ids
-            ]
-        else:
-            admission_pairs = [
-                (addr, f"proof-action-{i + 1:04d}") for i, addr in enumerate(behavior.action_contract_addresses)
-            ]
-
-        # Admit one action per (action_address, action_instance_id) pair
-        for action_address, action_instance_id in admission_pairs:
+        for action_address, action_instance_id in iter_admission_pairs(behavior, runtime_model.observation_boundaries):
             contract = runtime_model.action_contracts.get(action_address)
             if contract is None:
                 continue
-
-            episode_id = "proof-ep-1"
-            snapshot = control_plane.get_snapshot().snapshot
-            current = snapshot.participant_episode_results.get(behavior_address)
-            if current is not None and isinstance(current, dict) and current.get("episode_id"):
-                episode_id = str(current["episode_id"])
-
-            action_result = _build_action_result(
-                participant_address=behavior_address,
-                episode_id=episode_id,
-                action_instance_id=action_instance_id,
-                action_contract_address=action_address,
-                contract=contract,
-            )
-            selection = build_implementation_selection(behavior_address)
-
-            boundary_address = (
-                behavior.observation_boundary_addresses[0] if behavior.observation_boundary_addresses else None
-            )
-            if boundary_address is None:
-                errors.append(f"no observation boundary declared for behavior {behavior_address!r}")
-                continue
-
             try:
-                admission_request = ParticipantActionAdmissionRequest(
-                    participant_address=behavior_address,
-                    action_contract_address=action_address,
-                    observation_boundary_address=boundary_address,
+                admission_request = build_participant_admission_request(
+                    behavior_address=behavior_address,
+                    action_address=action_address,
                     action_instance_id=action_instance_id,
-                    implementation_manifest=proof_manifest,
-                    implementation_selection=selection,
-                    visible_refs=(),
-                    disclosed_refs=(),
-                    evidence_refs=(),
-                    observation_boundary_evidence_refs=(),
-                    action_result=action_result,
+                    boundary_address=boundary_address,
+                    contract=contract,
                 )
             except (TypeError, ValueError) as exc:
                 errors.append(f"invalid admission request for {behavior_address!r}/{action_address!r}: {exc}")
@@ -203,12 +111,10 @@ def run_libvirt_participant_proof(sdl_path: Path) -> LibvirtParticipantProofResu
             if not admit_receipt.accepted:
                 errors.append(f"admit_participant_action rejected for {behavior_address!r}/{action_address!r}")
 
-        # Terminate the episode
         term_receipt = control_plane.terminate_participant_episode(behavior_address)
         if not term_receipt.accepted:
             errors.append(f"terminate_participant_episode rejected for {behavior_address!r}")
 
-    # Validate the final snapshot
     snapshot = control_plane.get_snapshot().snapshot
     episode_violations = tuple(
         iter_participant_episode_snapshot_violations(

--- a/implementations/python/tests/test_libvirt_paper_evidence.py
+++ b/implementations/python/tests/test_libvirt_paper_evidence.py
@@ -1,0 +1,389 @@
+"""Coverage for the libvirt paper-proof evaluator-evidence artifact (issue #615).
+
+Exercises the producer in both evidence-source modes against the paper scenario
+(``paper-agent-loop.sdl.yaml``) and asserts every required evidence surface,
+embedded-contract validity, the redaction gate, and the participant/evaluator
+boundary. The native-live path is exercised with an injected fake libvirt
+connection (no daemon), mirroring ``test_libvirt_backend_techvault_native``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aces_backend_libvirt.techvault_native import ProbeResult, TechVaultNativeLibvirtDriver
+from aces_contracts.contracts import (
+    BackendManifestV2Model,
+    EvaluationHistoryEventModel,
+    EvaluationResultStateModel,
+    ExperimentRealizedFormDisclosureModel,
+)
+from aces_operations.libvirt_paper_evidence import (
+    EVIDENCE_RUN_SCHEMA,
+    LibvirtPaperEvidenceConfig,
+    run_libvirt_paper_evidence,
+    validate_libvirt_paper_evidence_artifact,
+)
+from aces_operations.run_artifacts import (
+    atomic_write_json_artifact,
+    is_valid_run_id_label,
+    run_artifact_path,
+)
+from paths import EXAMPLES_DIR
+
+_PAPER_SCENARIO = EXAMPLES_DIR / "paper-agent-loop.sdl.yaml"
+_TECHVAULT_SCENARIO = EXAMPLES_DIR / "techvault-operational.sdl.yaml"
+
+_REQUIRED_SECTIONS = (
+    "scenario",
+    "compiled_artifact",
+    "backend",
+    "realized_topology",
+    "participant_action_proof",
+    "terminal_observation",
+    "defensive_evidence",
+    "negative_boundary_checks",
+    "evaluator_outcome",
+    "realized_form_disclosures",
+    "limitations",
+    "non_claims",
+    "redaction_provenance",
+    "invariant_ledger_refs",
+)
+
+
+# --- fake native libvirt substrate (no daemon) ---------------------------------
+
+
+class _NativeObject:
+    def __init__(self, name: str = "") -> None:
+        self._name = name
+
+    def name(self) -> str:
+        return self._name
+
+    def create(self) -> None:  # pragma: no cover - structural stub
+        pass
+
+    def destroy(self) -> None:  # pragma: no cover - structural stub
+        pass
+
+    def undefine(self) -> None:  # pragma: no cover - structural stub
+        pass
+
+
+def _name_from_xml(xml: str) -> str:
+    return xml[xml.index("<name>") + len("<name>") : xml.index("</name>")]
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.networks: dict[str, _NativeObject] = {}
+        self.domains: dict[str, _NativeObject] = {}
+
+    def networkDefineXML(self, xml: str):  # noqa: N802 - mirrors libvirt API
+        obj = _NativeObject(_name_from_xml(xml))
+        self.networks[obj.name()] = obj
+        return obj
+
+    def defineXML(self, xml: str):  # noqa: N802 - mirrors libvirt API
+        obj = _NativeObject(_name_from_xml(xml))
+        self.domains[obj.name()] = obj
+        return obj
+
+    def networkLookupByName(self, name: str):  # noqa: N802 - mirrors libvirt API
+        return self.networks[name]
+
+    def lookupByName(self, name: str):  # noqa: N802 - mirrors libvirt API
+        return self.domains[name]
+
+    def listAllDomains(self):  # noqa: N802 - mirrors libvirt API
+        return list(self.domains.values())
+
+    def listAllNetworks(self):  # noqa: N802 - mirrors libvirt API
+        return list(self.networks.values())
+
+
+class _InitramfsBuilder:
+    def build(self, *, domain, target: Path):
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"initramfs")
+        return target
+
+
+class _Probe:
+    def ping(self, ip: str):
+        return ProbeResult(True)
+
+    def tcp(self, ip: str, port: int):
+        return ProbeResult(True)
+
+
+def _native_driver_factory(tmp_path: Path):
+    kernel = tmp_path / "vmlinuz"
+    kernel.write_bytes(b"kernel")
+
+    def factory() -> TechVaultNativeLibvirtDriver:
+        return TechVaultNativeLibvirtDriver(
+            state_dir=tmp_path / "state",
+            connection=_FakeConnection(),
+            kernel_path=kernel,
+            name_prefix="paper-test",
+            initramfs_builder=_InitramfsBuilder(),
+        )
+
+    return factory
+
+
+# --- deterministic mode --------------------------------------------------------
+
+
+def test_deterministic_artifact_carries_all_evidence_surfaces(tmp_path):
+    report = run_libvirt_paper_evidence(scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-1")
+
+    assert report.passed, report.render()
+    artifact = report.artifact
+    assert artifact is not None
+    assert artifact["schema"] == EVIDENCE_RUN_SCHEMA
+    assert artifact["evidence_source_mode"] == "deterministic"
+    for section in _REQUIRED_SECTIONS:
+        assert section in artifact, f"missing evidence surface: {section}"
+    assert validate_libvirt_paper_evidence_artifact(artifact) == []
+
+
+def test_scenario_identity_is_portable_and_hashed(tmp_path):
+    report = run_libvirt_paper_evidence(scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-2")
+    scenario = report.artifact["scenario"]
+    assert scenario["name"] == "paper-enterprise-participant-evidence-loop"
+    assert scenario["content_sha256"].startswith("sha256:")
+    # Portable ref, never the absolute host path.
+    assert scenario["relative_path"] == "examples/scenarios/paper-agent-loop.sdl.yaml"
+    assert not scenario["relative_path"].startswith("/")
+
+
+def test_embedded_published_contracts_revalidate(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-3"
+    ).artifact
+
+    # The backend manifest is carried as the canonical BackendManifestV2 payload —
+    # the same contract the rest of the stack uses — not a hand-rolled summary.
+    manifest = artifact["backend"]["manifest"]
+    BackendManifestV2Model.model_validate(manifest)
+    assert manifest["identity"]["name"] == "libvirt-qemu"
+    assert manifest["capabilities"]["participant_runtime"] is not None
+    capability_profile = artifact["backend"]["capability_profile"]
+    assert capability_profile["participant_runtime_contract_gaps"] == []
+    assert capability_profile["observation_contract_gaps"] == []
+    EvaluationResultStateModel.model_validate(artifact["evaluator_outcome"]["result"])
+    for event in artifact["evaluator_outcome"]["history"]:
+        EvaluationHistoryEventModel.model_validate(event)
+    assert artifact["realized_form_disclosures"], "expected realized-form disclosures"
+    for disclosure in artifact["realized_form_disclosures"]:
+        ExperimentRealizedFormDisclosureModel.model_validate(disclosure)
+
+
+def test_participant_action_proof_is_from_libvirt_runtime(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-4"
+    ).artifact
+    proof = artifact["participant_action_proof"]
+    assert proof["lifecycle_clean"] is True
+    assert proof["diagnostics"] == []
+    assert proof["runtime"] == "libvirt-deterministic-participant-runtime"
+    assert proof["admitted_action_addresses"], "expected at least one admitted action"
+    # The participant surface exposes nothing of the internal/evaluator state.
+    assert proof["participant_visible_refs"] == []
+    assert proof["participant_disclosed_refs"] == []
+
+
+def test_negative_boundary_withholds_internal_and_evaluator_surfaces(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-5"
+    ).artifact
+    boundary = artifact["negative_boundary_checks"]
+    refs = {check["ref"] for check in boundary["checks"]}
+    assert "nodes.customer-db.services.postgres" in refs
+    assert "nodes.wazuh-manager" in refs
+    assert "content.evaluator-notes" in refs
+    assert boundary["all_internal_surfaces_withheld"] is True
+    assert all(not check["exposed_to_participant"] for check in boundary["checks"])
+
+
+def test_defensive_evidence_is_evaluator_only_with_disclosure(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-6"
+    ).artifact
+    defensive = artifact["defensive_evidence"]
+    assert defensive["visibility"] == "evaluator-only"
+    assert "loss_disclosure" in defensive
+    assert "not upstream Wazuh" in defensive["loss_disclosure"]
+    # Deterministic mode does not boot a live SOC stack.
+    assert defensive["evidence_source"] == "structural-evaluator-channel"
+    assert "soc_readback" not in defensive
+    # captured_at is the shared run timestamp, not a freshly synthesized one.
+    assert defensive["captured_at"] == artifact["recorded_at"]
+
+
+def test_non_claims_are_carried_verbatim(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-det-7"
+    ).artifact
+    joined = " ".join(artifact["non_claims"])
+    assert "No Wazuh detection-quality claim" in joined
+    assert "No byte-equivalence" in joined
+    assert "aces#600" in joined
+
+
+# --- redaction gate ------------------------------------------------------------
+
+
+def test_artifact_contains_no_forbidden_secrets(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-redact-1"
+    ).artifact
+    blob = json.dumps(artifact)
+    assert "/home/" not in blob
+    assert "<domain" not in blob
+    assert "qemu-system" not in blob
+    assert "BEGIN PRIVATE KEY" not in blob
+    assert "/var/lib/libvirt" not in blob
+
+
+def test_validator_flags_injected_host_path_leak(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-redact-2"
+    ).artifact
+    artifact["realized_topology"]["leak"] = "/home/operator/.ssh/id_rsa"
+    problems = validate_libvirt_paper_evidence_artifact(artifact)
+    assert any("redaction violation" in p for p in problems)
+
+
+def test_validator_flags_injected_domain_uuid(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-redact-3"
+    ).artifact
+    artifact["realized_topology"]["leak_uuid"] = "550e8400-e29b-41d4-a716-446655440000"
+    problems = validate_libvirt_paper_evidence_artifact(artifact)
+    assert any("domain UUID" in p for p in problems)
+
+
+def test_validator_flags_participant_boundary_exposure(tmp_path):
+    artifact = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-redact-4"
+    ).artifact
+    # Simulate a regression that leaks a withheld internal ref onto the participant view.
+    artifact["participant_action_proof"]["participant_visible_refs"] = ["nodes.wazuh-manager"]
+    problems = validate_libvirt_paper_evidence_artifact(artifact)
+    assert any("boundary violation" in p for p in problems)
+
+
+# --- native-live mode ----------------------------------------------------------
+
+
+def test_native_live_paper_scenario_fails_realization_and_discloses_unrealized_content_plane(tmp_path):
+    report = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO,
+        project_dir=tmp_path,
+        run_id="paper-live-1",
+        config=LibvirtPaperEvidenceConfig(evidence_source_mode="native-live"),
+        driver_factory=_native_driver_factory(tmp_path),
+        probe=_Probe(),
+    )
+    # The libvirt backend cannot realize the paper scenario's content plane, so the
+    # gating native-realization check fails: native-live must never claim success
+    # without realizing. The artifact is still written and validates, recording the
+    # attempt and the disclosed unrealized capabilities.
+    assert not report.passed, report.render()
+    artifact = report.artifact
+    assert artifact is not None
+    assert validate_libvirt_paper_evidence_artifact(artifact) == []
+    provenance = artifact["backend"]["realization_provenance"]
+    assert provenance["substrate_realized"] is False
+    assert artifact["realized_topology"]["unrealized_capabilities"], "expected disclosed unrealized capabilities"
+
+
+def test_native_live_realizes_substrate_for_provisionable_scenario(tmp_path):
+    report = run_libvirt_paper_evidence(
+        scenario_path=_TECHVAULT_SCENARIO,
+        project_dir=tmp_path,
+        run_id="tv-live-1",
+        config=LibvirtPaperEvidenceConfig(evidence_source_mode="native-live"),
+        driver_factory=_native_driver_factory(tmp_path),
+        probe=_Probe(),
+    )
+    # This is the only native-live success path: real domain/network snapshot data
+    # flows through artifact assembly, so it must clear the full check set and the
+    # redaction/contract validator (the path most able to leak host-private data).
+    assert report.passed, report.render()
+    artifact = report.artifact
+    assert validate_libvirt_paper_evidence_artifact(artifact) == []
+    assert artifact["backend"]["realization_provenance"]["substrate_realized"] is True
+    native_surface = artifact["realized_topology"]["native_surface"]
+    assert len(native_surface["domains"]) == 30
+    assert len(native_surface["networks"]) == 4
+    # Native SOC readback is the translated native readback, explicitly disclosed.
+    defensive = artifact["defensive_evidence"]
+    assert defensive["evidence_source"] == "native-translated-readback"
+    assert "soc_readback" in defensive
+    assert defensive["captured_at"] == artifact["recorded_at"]
+
+
+def test_native_live_without_realized_substrate_fails(tmp_path):
+    report = run_libvirt_paper_evidence(
+        scenario_path=_PAPER_SCENARIO,
+        project_dir=tmp_path,
+        run_id="paper-live-2",
+        config=LibvirtPaperEvidenceConfig(evidence_source_mode="native-live"),
+    )
+    # The default driver factory has no daemon to connect to, so nothing is realized.
+    # The gating realization check fails: native-live cannot pass without realizing.
+    # The artifact still builds and records substrate_realized=False.
+    assert not report.passed, report.render()
+    assert report.artifact["backend"]["realization_provenance"]["substrate_realized"] is False
+
+
+# --- artifact write + run-id ---------------------------------------------------
+
+
+def test_artifact_written_to_stable_path(tmp_path):
+    report = run_libvirt_paper_evidence(scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="paper-write-1")
+    expected = tmp_path / "runs" / "paper-write-1" / "paper-evidence" / "libvirt-paper-evidence-run.json"
+    assert report.artifact_path == str(expected)
+    assert expected.is_file()
+    written = json.loads(expected.read_text())
+    assert written["schema"] == EVIDENCE_RUN_SCHEMA
+
+
+def test_unsafe_run_id_is_rejected_without_write(tmp_path):
+    report = run_libvirt_paper_evidence(scenario_path=_PAPER_SCENARIO, project_dir=tmp_path, run_id="../escape")
+    assert not report.passed
+    assert report.artifact_path is None
+    assert not (tmp_path / "runs").exists()
+
+
+# --- run_artifacts shared helper ----------------------------------------------
+
+
+def test_run_id_label_validation():
+    assert is_valid_run_id_label("paper-evidence_2026.06.29")
+    assert not is_valid_run_id_label("../escape")
+    assert not is_valid_run_id_label(".hidden")
+    assert not is_valid_run_id_label("with/slash")
+    assert not is_valid_run_id_label("")
+
+
+def test_run_artifact_path_rejects_unsafe_label(tmp_path):
+    with pytest.raises(ValueError, match="safe filesystem label"):
+        run_artifact_path(tmp_path, "../escape", "paper-evidence", "run.json")
+
+
+def test_atomic_write_json_artifact_round_trips(tmp_path):
+    target = tmp_path / "runs" / "r1" / "sub" / "artifact.json"
+    atomic_write_json_artifact(target, {"b": 2, "a": 1})
+    text = target.read_text()
+    # Canonical serialization: sorted keys, indent 2, trailing newline, no temp files left.
+    assert text == '{\n  "a": 1,\n  "b": 2\n}\n'
+    assert list(target.parent.glob("*.tmp")) == []

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -151,6 +151,12 @@ module_boundaries:
       root: implementations/python/packages/aces_operations
       allowed_top_level_imports:
         - aces_backend_libvirt
+        # Pure, side-effect-free manifest/capability renderers only (see
+        # public_import_prefixes below). aces_operations embeds the canonical
+        # BackendManifestV2 payload + capability-gap report in the libvirt
+        # paper-evidence artifact instead of a hand-rolled summary, so the
+        # evidence carries the same backend contract the rest of the stack uses.
+        - aces_backend_protocols
         - aces_contracts
         - aces_runtime
         - aces_sdl
@@ -165,6 +171,9 @@ module_boundaries:
         aces_backend_libvirt:
           - aces_backend_libvirt.target
           - aces_backend_libvirt.techvault_native
+        aces_backend_protocols:
+          - aces_backend_protocols.manifest
+          - aces_backend_protocols.capabilities
         aces_runtime:
           - aces_runtime.control_plane
           - aces_runtime.manager
@@ -202,6 +211,7 @@ module_boundaries:
         - aces_runtime
       public_import_prefixes:
         aces_operations:
+          - aces_operations.libvirt_paper_evidence
           - aces_operations.techvault_live
         aces_processor:
           - aces_processor.manifest


### PR DESCRIPTION
## Summary

Adds a libvirt paper-proof evaluator-evidence artifact producer (#615) that composes existing ACES surfaces — the libvirt deterministic participant runtime (#614), native substrate realization (#601), the canonical BackendManifestV2 contract, and the experiment/evaluation contracts — into one stable, validated run artifact (aces.libvirt.paper-evidence-run/v1). The artifact carries nine evaluator-facing evidence surfaces for the paper enterprise participant/evidence scenario, feeding the aces#600 cross-backend invariant ledger. It runs in two honestly-disclosed modes (deterministic default for CI; operator-run native-live), fails closed on redaction/contract violations, and embeds only published-contract payloads re-validated against their models.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #615

## ADR Impact

- ADR-021
- ADR-036 (amended)
- ADR-015

## Changes

- New aces_operations producer: libvirt_paper_evidence.py (orchestration + gating checks), _paper_evidence_artifact.py (section assembly), _paper_evidence_validation.py (schema/redaction/boundary validation), deterministic_participant_fixtures.py (contracts-only fixtures), run_artifacts.py (shared atomic run-archive helpers reused by techvault_live.py).
- Native-substrate realization is gating: native-live can never report success without actually realizing; the paper scenario's backend-unrealizable content plane is disclosed as unrealized_capabilities, not faked.
- Artifact fails closed: a redaction- or contract-invalid artifact is never persisted (no artifact_path).
- Embeds the canonical BackendManifestV2 payload (re-validated against BackendManifestV2Model) plus a capability-gap profile, instead of a hand-rolled summary.
- All evidence sections share one run timestamp (recorded_at) for reproducibility.
- Strict redaction gate: no raw libvirt XML, domain UUIDs, QEMU command lines, host paths, connection URIs, credentials, or private keys.
- aces_cli libvirt: adds the validate-evidence command (deterministic + --native-live).
- ADR-036: narrowly grants aces_operations the two pure aces_backend_protocols manifest/capability renderers so the evidence carries the same backend contract the rest of the stack uses.
- Docs: examples/scenarios/paper-agent-loop.README.md explains both modes and how libvirt evidence differs from APTL Docker/Wazuh evidence; issue-615 preflight decision record added.
- Tests: 19 dedicated tests covering all evidence surfaces, embedded-contract revalidation, the redaction gate, the participant/evaluator boundary, and both native-live failure and success paths.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full nox verify (--skip-requirement) is green end-to-end: hygiene, policy, lint, contracts, unit pytest (2864 passed, 1 skipped), integration, and docs/sphinx. ADR-036 module-boundary and ADR-015 source-size checks pass. Native-live paths are exercised with an injected fake libvirt connection (no daemon).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #615 ← implementations/python/packages/aces_operations/libvirt_paper_evidence.py, #615 ← implementations/python/packages/aces_operations/_paper_evidence_artifact.py, #615 ← implementations/python/packages/aces_operations/_paper_evidence_validation.py, ADR-036 (amended) ← tools/policy/adr_policy.yaml
- TESTS: #615 ← implementations/python/tests/test_libvirt_paper_evidence.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/615.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Not updated (authorized): The only documentation-bearing policy surface is tools/policy/adr_policy.yaml, whose suggested target docs/DEVELOPMENT_WORKFLOW.md describes the developer process and is unchanged. The change is a narrow per-package import allowance (aces_operations may use the two pure aces_backend_protocols manifest/capability renderers); its rationale is documented inline in adr_policy.yaml, in the producer module docstring, and in docs/decisions/issue-615-libvirt-paper-evidence-preflight.md. User-facing behavior is documented in examples/scenarios/paper-agent-loop.README.md.
