### PR TITLE
feat(libvirt): typed capability diagnostics for out-of-envelope plan terms

### DIFF
--- a/changelog.d/605.added.md
+++ b/changelog.d/605.added.md
@@ -1,0 +1,8 @@
+### Added
+
+- libvirt backend: emit typed, blocking capability diagnostics
+  (`libvirt-backend.realization.unsupported-{node-type,os-family,content-type,account-feature}`)
+  when a provisioning plan requires a node type, OS family, content type, or
+  account feature outside the backend's declared manifest envelope. The backend
+  now fails closed on out-of-envelope terms instead of silently or partially
+  realizing them, consistent with the processor's manifest capability checks.

--- a/docs/decisions/issue-605-libvirt-envelope-diagnostics-preflight.md
+++ b/docs/decisions/issue-605-libvirt-envelope-diagnostics-preflight.md
@@ -1,0 +1,191 @@
+# Issue 605 Libvirt Envelope Diagnostics Preflight
+
+Date: 2026-07-01
+
+Issue: #605.
+
+Requirement: none. The GitHub issue title, body, and acceptance criteria are
+the contract.
+
+This note records guardrails for surfacing typed diagnostics when a
+`ProvisioningPlan` asks the libvirt/QEMU backend to realize capability terms
+outside the selected backend manifest envelope. It is guidance only: it does
+not implement diagnostics, change manifests, add schemas, or alter runtime
+behavior.
+
+## Binding Sources
+
+- `docs/decisions/issue-602-libvirt-backend-manifest-preflight.md` owns the
+  truthful libvirt manifest boundary: realization-support kinds are not the
+  same thing as concrete capability values.
+- `docs/decisions/issue-603-libvirt-apply-realization-preflight.md` owns
+  fail-closed libvirt plan interpretation and apply behavior.
+- `docs/decisions/issue-604-libvirt-reconciliation-teardown-preflight.md` owns
+  snapshot reconciliation, teardown, and no-driver-call behavior for invalid or
+  unchanged operations.
+- `aces_backend_libvirt.manifest.create_libvirt_manifest()` is the libvirt
+  capability envelope authority.
+- `aces_backend_protocols.capabilities.BackendManifest` and
+  `ProvisionerCapabilities` are the Python manifest models.
+- `aces_contracts.contracts.BackendManifestV2Model`,
+  `contracts/schemas/backend-manifest/backend-manifest-v2.json`, and
+  `aces_contracts.controlled_vocabularies` are the manifest shape and
+  vocabulary gates.
+- `aces_processor.planner._validate_manifest()` and
+  `aces_processor.semantics.realization.realization_support_diagnostics()` are
+  the processor-side support checks the backend diagnostics must stay
+  conceptually aligned with.
+- `aces_backend_libvirt.realization.interpret_provisioning_plan()` and
+  `LibvirtProvisioner.validate()` / `apply()` are the backend-side plan gates.
+- `RuntimeManager`, `RuntimeControlPlane`, and
+  `aces_runtime.backend_calls._call_backend_apply()` are the runtime execution,
+  error-envelope, and snapshot-acceptance gates.
+
+## Architecture Decisions
+
+- Treat issue #605 as a backend plan-envelope validation task, not a manifest,
+  schema, profile, SDL, or control-plane redesign.
+- The selected `BackendManifest` must remain the single source of truth for
+  libvirt's realizable node types, OS families, content types, and account
+  features. Do not add a second hard-coded list of supported terms in the
+  provisioner or driver.
+- The libvirt provisioner/interpreter should validate plan terms against the
+  manifest selected by `create_libvirt_components(manifest=...)`. A narrow local
+  adapter that maps a plan dimension to a manifest capability surface is
+  acceptable; a parallel capability schema is not.
+- Governed extension syntax such as `x-owner:term` means "valid vocabulary
+  shape", not "this backend realizes it". A term that passes concept-authority
+  validation but is absent from `manifest.provisioner.*` must produce a blocking
+  typed `Diagnostic`.
+- Keep diagnostics typed by dimension: unsupported node type, OS family,
+  content type, account feature, and unsupported provisioning resource type
+  should be machine-distinguishable stable codes. Do not collapse them into a
+  generic libvirt failure or a native driver error.
+- Use the same validation helper from both `validate()` and `apply()`. The
+  control plane records validation diagnostics but still calls `apply()`, so
+  `apply()` must independently fail before snapshot reconciliation or driver IO
+  whenever the envelope helper reports an error.
+- Validate the same materialization surface the provisioner can persist or
+  drive. Do not inspect only `plan.resources` if `plan.operations` can still
+  create snapshot entries or request driver work from divergent payloads.
+- Do not reject in-envelope governed terms that issue #603 already realizes:
+  content types `file`, `dataset`, and `directory`, and the governed account
+  feature terms declared by the libvirt manifest.
+- Keep SEM-218 realization-support diagnostics distinct from concrete term
+  envelope diagnostics. `realization_support_diagnostics()` answers "does the
+  backend declare this requirement kind?"; #605 answers "is this concrete plan
+  term inside this backend's declared capability envelope?"
+
+## Required Incumbents
+
+Reuse these before adding anything new:
+
+- Manifest and rendering: `create_libvirt_manifest()`, `BackendManifest`,
+  `BackendCapabilitySet`, `ProvisionerCapabilities`,
+  `RealizationSupportDeclaration`, and `backend_manifest_payload()`.
+- Contract and vocabulary validation: `BackendManifestV2Model`,
+  `ProvisionerCapabilitiesModel`,
+  `validate_controlled_vocabulary_scope_values()`, and the checked-in
+  controlled-vocabulary catalog.
+- Processor-side semantics: `_validate_manifest()` for concrete provisioner
+  capability checks, `_account_features()` for the existing account-feature
+  extraction rules, and `realization_support_diagnostics()` for SEM-218
+  requirement-kind checks. If those extraction rules must be shared, extract the
+  minimal neutral helper rather than copying divergent logic.
+- Libvirt plan gates: `interpret_provisioning_plan()`, `Realization`,
+  `LibvirtProvisioner.validate()`, `LibvirtProvisioner.apply()`, and the
+  existing package-local `Diagnostic` pattern.
+- Runtime fail-closed path: `RuntimeManager._apply_precondition_failure()`,
+  `RuntimeControlPlane.submit_provisioning()`, `_call_backend_diagnostics()`,
+  `_call_backend_apply()`, `ApplyResult`, and `RuntimeSnapshot`.
+- Verification precedents: `test_runtime_planner.py`,
+  `test_libvirt_backend_manifest_publication.py`,
+  `test_libvirt_backend_realization.py`, and the control-plane/runtime-manager
+  tests that prove invalid plans do not persist snapshots or call drivers.
+
+## Cross-Cutting Layers
+
+- SDL and parser layer: no new SDL authoring fields are needed. Closed
+  Pydantic SDL models, semantic validation, instantiation, and compilation
+  remain the normal authoring path.
+- Concept-authority layer: vocabulary validators still decide whether a term is
+  governed or syntactically valid as an extension. Backend envelope validation
+  decides whether the selected backend realizes that valid term.
+- Manifest/config layer: `BackendManifest` construction and
+  `BackendManifestV2Model` validation continue to enforce non-empty capability
+  surfaces, account-support consistency, concept bindings, contract ids, and
+  realization-support shape. Do not bypass these with local JSON or dict
+  payloads.
+- Planner layer: processor planning already emits diagnostics for normal
+  compiled models that exceed a manifest. Backend envelope validation is the
+  defense for direct, mutated, or third-party `ProvisioningPlan` inputs.
+- Runtime target layer: component presence must still match the manifest via
+  `_validate_runtime_target_shape()`. Passing a manifest into libvirt
+  validation must not imply orchestrator, evaluator, observation, or
+  participant-runtime support.
+- Backend apply layer: all diagnostics are `Diagnostic` values. Any error from
+  the envelope helper must stop before `_reconcile_snapshot()`, `driver.realize()`,
+  or `driver.destroy()`, and must return the input snapshot unchanged.
+- Control-plane/API layer: `RuntimeControlPlane` must keep using operation
+  receipts/statuses, idempotency keys, request fingerprints, audit records, and
+  existing API guards. No libvirt-specific endpoint or exception path is
+  needed.
+- Error-envelope layer: messages may name ACES addresses, dimensions, and
+  capability terms. They must not echo raw plan payloads, content text,
+  cloud-init data, credentials, SSH keys, environment variables, native libvirt
+  XML, host paths, stdout/stderr, or stack traces.
+- Host/OS exposure layer: envelope validation is pure. It must not import
+  `libvirt`, inspect the daemon, run subprocesses, read host images, or place
+  secrets in argv or environment.
+- Persistence layer: rejected plans must not write `RuntimeSnapshot` entries,
+  control-plane snapshot state, `ApplyResult.details`, or metadata ledgers for
+  unsupported terms.
+
+## Extensibility Boundary
+
+The parameter for future capability variation belongs at the manifest/target
+factory boundary: `create_libvirt_manifest(**config)`,
+`create_libvirt_target(**config)`, and `create_libvirt_components(manifest=...)`.
+If a future libvirt configuration truly realizes an extension term, the manifest
+factory should declare that term for that configuration and the same envelope
+validator should accept it without code changes to the term list.
+
+If future dimensions need envelope checks, add them through one small mapping:
+plan payload extractor, manifest capability surface, realization requirement
+kind when one exists, and diagnostic code. Do not scatter per-dimension
+allowlists through the interpreter, provisioner, driver, and tests.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating governed extension syntax as backend support;
+- checking `resource.resource_type == "node"` while ignoring the payload's
+  `node_type`;
+- realizing an unsupported content type by falling through and emitting no
+  cloud-init contribution;
+- interpreting every account field as an account-feature requirement and
+  accidentally rejecting descriptive fields that `_validate_manifest()` does not
+  treat as features;
+- silently ignoring an unsupported account feature while creating the account;
+- validating only the happy-path compiler output while leaving direct
+  `ProvisioningPlan` inputs unguarded;
+- relying on `RuntimeControlPlane.submit_provisioning()` validation diagnostics
+  to prevent side effects, because `apply()` is still invoked;
+- calling the driver before all envelope diagnostics are known;
+- adding libvirt-specific schemas, profiles, DTOs, exception hierarchies, or
+  control-plane routes;
+- changing published controlled vocabularies or manifest schemas just to test
+  an out-of-envelope term.
+
+## Non-Goals
+
+- Implementing issue #605.
+- Redesigning `BackendManifest`, `ProvisioningPlan`, `RuntimeSnapshot`,
+  `RuntimeManager`, `RuntimeControlPlane`, SEM-218 realization gates, or backend
+  conformance.
+- Adding new SDL syntax, schemas, backend profiles, concept families,
+  controlled-vocabulary terms, or public libvirt DTOs.
+- Expanding libvirt beyond the issue #603 governed provisioning envelope.
+- Making default verification require a real libvirt daemon, QEMU/KVM,
+  privileged host access, host-local images, or network access.

--- a/implementations/python/packages/aces_backend_libvirt/_payload.py
+++ b/implementations/python/packages/aces_backend_libvirt/_payload.py
@@ -1,0 +1,52 @@
+"""Shared accessors over ACES provisioning-plan resource payloads.
+
+The low-level, package-internal layer both :mod:`realization` (interpretation)
+and :mod:`capability_envelope` (capability-envelope diagnostics) build on, so the
+two never duplicate — or diverge on — how a plan payload's node type, OS family,
+content type, or spec is read.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+NODE_RESOURCE_TYPE = "node"
+NETWORK_RESOURCE_TYPE = "network"
+ACCOUNT_PLACEMENT_RESOURCE_TYPE = "account-placement"
+CONTENT_PLACEMENT_RESOURCE_TYPE = "content-placement"
+FEATURE_BINDING_RESOURCE_TYPE = "feature-binding"
+PLACEMENT_RESOURCE_TYPES = frozenset(
+    {
+        ACCOUNT_PLACEMENT_RESOURCE_TYPE,
+        CONTENT_PLACEMENT_RESOURCE_TYPE,
+        FEATURE_BINDING_RESOURCE_TYPE,
+    }
+)
+SUPPORTED_RESOURCE_TYPES = frozenset({NODE_RESOURCE_TYPE, NETWORK_RESOURCE_TYPE}) | PLACEMENT_RESOURCE_TYPES
+
+
+def _spec(payload: Mapping[str, object]) -> Mapping[str, object]:
+    spec = payload.get("spec")
+    return spec if isinstance(spec, Mapping) else {}
+
+
+def _str(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _os_family(payload: Mapping[str, object]) -> str:
+    family = payload.get("os_family")
+    if isinstance(family, str) and family:
+        return family
+    node = _spec(payload).get("node")
+    node_os = node.get("os") if isinstance(node, Mapping) else None
+    return node_os if isinstance(node_os, str) else ""
+
+
+def _node_type(payload: Mapping[str, object]) -> str:
+    node_type = payload.get("node_type")
+    if isinstance(node_type, str) and node_type:
+        return node_type
+    node = _spec(payload).get("node")
+    nested = node.get("type") if isinstance(node, Mapping) else None
+    return nested if isinstance(nested, str) else ""

--- a/implementations/python/packages/aces_backend_libvirt/capability_envelope.py
+++ b/implementations/python/packages/aces_backend_libvirt/capability_envelope.py
@@ -111,22 +111,28 @@ def capability_envelope_diagnostics(
     DELETE never realizes a term, so its payload is not gated.
     """
 
-    diagnostics: list[Diagnostic] = []
-    seen: set[tuple[str, str, str]] = set()
+    deduped: dict[tuple[str, str, str], Diagnostic] = {}
     for address, resource_type, payload in _materialized_payloads(plan):
-        for dimension in _ENVELOPE_DIMENSIONS:
-            if resource_type not in dimension.resource_types:
-                continue
-            supported = dimension.supported(capabilities)
-            for term in dimension.extract(payload):
-                if not term or term in supported:
-                    continue
-                key = (dimension.code, address, term)
-                if key in seen:
-                    continue
-                seen.add(key)
-                diagnostics.append(_envelope_diagnostic(dimension, address, term))
-    return diagnostics
+        for key, diagnostic in _out_of_envelope_terms(address, resource_type, payload, capabilities):
+            deduped.setdefault(key, diagnostic)
+    return list(deduped.values())
+
+
+def _out_of_envelope_terms(
+    address: str,
+    resource_type: str,
+    payload: Mapping[str, object],
+    capabilities: ProvisionerCapabilities,
+) -> Iterator[tuple[tuple[str, str, str], Diagnostic]]:
+    """Yield ``((code, address, term), diagnostic)`` for each unsupported term of a payload."""
+
+    for dimension in _ENVELOPE_DIMENSIONS:
+        if resource_type not in dimension.resource_types:
+            continue
+        supported = dimension.supported(capabilities)
+        for term in dimension.extract(payload):
+            if term and term not in supported:
+                yield (dimension.code, address, term), _envelope_diagnostic(dimension, address, term)
 
 
 def _materialized_payloads(plan: ProvisioningPlan) -> Iterator[tuple[str, str, Mapping[str, object]]]:

--- a/implementations/python/packages/aces_backend_libvirt/capability_envelope.py
+++ b/implementations/python/packages/aces_backend_libvirt/capability_envelope.py
@@ -1,0 +1,157 @@
+"""Typed capability-envelope diagnostics for the libvirt backend (issue #605).
+
+A provisioning plan may ask the backend to realize a node type, OS family,
+content type, or account feature outside the selected manifest's declared
+:class:`ProvisionerCapabilities` envelope (an ungoverned/extension term the
+backend does not realize). This module surfaces those as blocking, typed
+``Diagnostic`` values so the backend fails closed instead of silently or
+partially realizing them — the backend-side sibling of the processor's
+``planner._validate_manifest`` concrete-capability checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+
+from aces_backend_protocols.account_features import provisioner_account_features
+from aces_backend_protocols.capabilities import ProvisionerCapabilities
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.planning import ChangeAction, ProvisioningPlan, RuntimeDomain
+
+from ._payload import (
+    ACCOUNT_PLACEMENT_RESOURCE_TYPE,
+    CONTENT_PLACEMENT_RESOURCE_TYPE,
+    NETWORK_RESOURCE_TYPE,
+    NODE_RESOURCE_TYPE,
+    _node_type,
+    _os_family,
+    _spec,
+    _str,
+)
+
+_DOMAIN = "runtime"
+
+# A network resource is realized as a libvirt switch, so its node-type envelope
+# term is fixed.
+_SWITCH_NODE_TYPE = "switch"
+
+_CODE_UNSUPPORTED_NODE_TYPE = "libvirt-backend.realization.unsupported-node-type"
+_CODE_UNSUPPORTED_OS_FAMILY = "libvirt-backend.realization.unsupported-os-family"
+_CODE_UNSUPPORTED_CONTENT_TYPE = "libvirt-backend.realization.unsupported-content-type"
+_CODE_UNSUPPORTED_ACCOUNT_FEATURE = "libvirt-backend.realization.unsupported-account-feature"
+
+
+@dataclass(frozen=True)
+class _EnvelopeDimension:
+    """One capability dimension checked against the manifest envelope.
+
+    ``extract`` yields the concrete term(s) a payload declares for this dimension
+    (empty terms are ignored); ``supported`` selects the manifest's declared set
+    for the dimension. Adding a future dimension is one row here, not a new
+    allowlist scattered across the interpreter and provisioner.
+    """
+
+    resource_types: frozenset[str]
+    code: str
+    noun: str
+    extract: Callable[[Mapping[str, object]], tuple[str, ...]]
+    supported: Callable[[ProvisionerCapabilities], frozenset[str]]
+
+
+_ENVELOPE_DIMENSIONS: tuple[_EnvelopeDimension, ...] = (
+    _EnvelopeDimension(
+        resource_types=frozenset({NODE_RESOURCE_TYPE}),
+        code=_CODE_UNSUPPORTED_NODE_TYPE,
+        noun="node type",
+        extract=lambda payload: (_node_type(payload),),
+        supported=lambda caps: caps.supported_node_types,
+    ),
+    _EnvelopeDimension(
+        resource_types=frozenset({NODE_RESOURCE_TYPE}),
+        code=_CODE_UNSUPPORTED_OS_FAMILY,
+        noun="OS family",
+        extract=lambda payload: (_os_family(payload),),
+        supported=lambda caps: caps.supported_os_families,
+    ),
+    _EnvelopeDimension(
+        resource_types=frozenset({NETWORK_RESOURCE_TYPE}),
+        code=_CODE_UNSUPPORTED_NODE_TYPE,
+        noun="node type",
+        extract=lambda payload: (_SWITCH_NODE_TYPE,),
+        supported=lambda caps: caps.supported_node_types,
+    ),
+    _EnvelopeDimension(
+        resource_types=frozenset({CONTENT_PLACEMENT_RESOURCE_TYPE}),
+        code=_CODE_UNSUPPORTED_CONTENT_TYPE,
+        noun="content type",
+        extract=lambda payload: (_str(_spec(payload).get("type")),),
+        supported=lambda caps: caps.supported_content_types,
+    ),
+    _EnvelopeDimension(
+        resource_types=frozenset({ACCOUNT_PLACEMENT_RESOURCE_TYPE}),
+        code=_CODE_UNSUPPORTED_ACCOUNT_FEATURE,
+        noun="account feature",
+        extract=lambda payload: tuple(sorted(provisioner_account_features(_spec(payload)))),
+        supported=lambda caps: caps.supported_account_features,
+    ),
+)
+
+
+def capability_envelope_diagnostics(
+    plan: ProvisioningPlan,
+    capabilities: ProvisionerCapabilities,
+) -> list[Diagnostic]:
+    """Blocking diagnostics for plan terms outside the backend capability envelope.
+
+    Covers the full materialization surface — plan resources *and* non-DELETE
+    operations, since either can persist a snapshot entry or request driver work
+    from a divergent payload — deduplicated by ``(code, address, term)`` so a
+    resource and its matching operation do not double-report the same term. A
+    DELETE never realizes a term, so its payload is not gated.
+    """
+
+    diagnostics: list[Diagnostic] = []
+    seen: set[tuple[str, str, str]] = set()
+    for address, resource_type, payload in _materialized_payloads(plan):
+        for dimension in _ENVELOPE_DIMENSIONS:
+            if resource_type not in dimension.resource_types:
+                continue
+            supported = dimension.supported(capabilities)
+            for term in dimension.extract(payload):
+                if not term or term in supported:
+                    continue
+                key = (dimension.code, address, term)
+                if key in seen:
+                    continue
+                seen.add(key)
+                diagnostics.append(_envelope_diagnostic(dimension, address, term))
+    return diagnostics
+
+
+def _materialized_payloads(plan: ProvisioningPlan) -> Iterator[tuple[str, str, Mapping[str, object]]]:
+    """Yield ``(address, resource_type, payload)`` for every gated provisioning surface."""
+
+    for resource in plan.resources.values():
+        if resource.domain != RuntimeDomain.PROVISIONING:
+            continue
+        if isinstance(resource.payload, Mapping):
+            yield resource.address, resource.resource_type, resource.payload
+    for op in plan.operations:
+        if op.action is ChangeAction.DELETE:
+            continue
+        if isinstance(op.payload, Mapping):
+            yield op.address, op.resource_type, op.payload
+
+
+def _envelope_diagnostic(dimension: _EnvelopeDimension, address: str, term: str) -> Diagnostic:
+    return Diagnostic(
+        code=dimension.code,
+        domain=_DOMAIN,
+        address=address,
+        message=(
+            f"Libvirt backend does not realize {dimension.noun} '{term}' for '{address}': "
+            "it is outside the declared manifest capability envelope."
+        ),
+        severity=Severity.ERROR,
+    )

--- a/implementations/python/packages/aces_backend_libvirt/manifest.py
+++ b/implementations/python/packages/aces_backend_libvirt/manifest.py
@@ -17,6 +17,21 @@ from aces_contracts.vocabulary import ParticipantFeatureSupportLevel, Realizatio
 
 LIBVIRT_BACKEND_NAME = "libvirt-qemu"
 
+# The libvirt provisioning capability envelope: the maximum governed provisioning
+# vocabulary the driver realizes through cloud-init. Single source of truth for
+# both the rendered manifest and the backend's capability-envelope diagnostics
+# (issue #605), so the declared envelope and the enforced envelope cannot drift.
+LIBVIRT_PROVISIONER_CAPABILITIES = ProvisionerCapabilities(
+    name="libvirt-provisioner",
+    supported_node_types=frozenset({"switch", "vm"}),
+    supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
+    supported_content_types=frozenset({"file", "dataset", "directory"}),
+    supported_account_features=frozenset({"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}),
+    max_total_nodes=None,
+    supports_acls=True,
+    supports_accounts=True,
+)
+
 _LIBVIRT_BASE_CONTRACT_VERSIONS = frozenset(
     {
         "backend-manifest-v2",
@@ -152,18 +167,7 @@ def create_libvirt_manifest(**config: object) -> BackendManifest:
             ),
         ),
         capabilities=BackendCapabilitySet(
-            provisioner=ProvisionerCapabilities(
-                name="libvirt-provisioner",
-                supported_node_types=frozenset({"switch", "vm"}),
-                supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
-                supported_content_types=frozenset({"file", "dataset", "directory"}),
-                supported_account_features=frozenset(
-                    {"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}
-                ),
-                max_total_nodes=None,
-                supports_acls=True,
-                supports_accounts=True,
-            ),
+            provisioner=LIBVIRT_PROVISIONER_CAPABILITIES,
             participant_runtime=participant_runtime_cap,
         ),
     )

--- a/implementations/python/packages/aces_backend_libvirt/provisioner.py
+++ b/implementations/python/packages/aces_backend_libvirt/provisioner.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from aces_backend_protocols.capabilities import ProvisionerCapabilities
 from aces_contracts.diagnostics import Diagnostic, Severity
 from aces_contracts.planning import ChangeAction, ProvisioningPlan, ProvisionOp, RuntimeDomain
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
 
+from ._payload import NETWORK_RESOURCE_TYPE, NODE_RESOURCE_TYPE
 from .driver import DriverResult, LibvirtDriver
-from .realization import NETWORK_RESOURCE_TYPE, NODE_RESOURCE_TYPE, Realization, interpret_provisioning_plan
+from .manifest import LIBVIRT_PROVISIONER_CAPABILITIES
+from .realization import Realization, interpret_provisioning_plan
 
 _DOMAIN = "runtime"
 INVALID_PLAN_CODE = "libvirt-backend.invalid-plan"
@@ -28,14 +31,22 @@ class _SnapshotReconciliation:
 class LibvirtProvisioner:
     """Provisioning-only backend that realizes plans through a libvirt driver."""
 
-    def __init__(self, driver: LibvirtDriver | None = None) -> None:
+    def __init__(
+        self,
+        driver: LibvirtDriver | None = None,
+        *,
+        provisioner_capabilities: ProvisionerCapabilities | None = None,
+    ) -> None:
         self._driver = driver if driver is not None else _default_driver()
+        # The capability envelope every plan term is validated against; defaults to
+        # the libvirt manifest envelope but tracks the manifest the target was built
+        # with when create_libvirt_components passes it in (issue #605).
+        self._provisioner_capabilities = provisioner_capabilities or LIBVIRT_PROVISIONER_CAPABILITIES
 
-    @staticmethod
-    def validate(plan: ProvisioningPlan) -> list[Diagnostic]:
+    def validate(self, plan: ProvisioningPlan) -> list[Diagnostic]:
         if not isinstance(plan, ProvisioningPlan):
             return [_invalid_plan_diagnostic()]
-        realization = interpret_provisioning_plan(plan)
+        realization = interpret_provisioning_plan(plan, provisioner_capabilities=self._provisioner_capabilities)
         return list(realization.diagnostics)
 
     def apply(self, plan: ProvisioningPlan, snapshot: RuntimeSnapshot) -> ApplyResult:
@@ -46,7 +57,7 @@ class LibvirtProvisioner:
         return result
 
     def _apply_provisioning_plan(self, plan: ProvisioningPlan, snapshot: RuntimeSnapshot) -> ApplyResult:
-        realization = interpret_provisioning_plan(plan)
+        realization = interpret_provisioning_plan(plan, provisioner_capabilities=self._provisioner_capabilities)
         diagnostics: list[Diagnostic] = list(realization.diagnostics)
         if _has_error(diagnostics):
             return ApplyResult(success=False, snapshot=snapshot, diagnostics=diagnostics)

--- a/implementations/python/packages/aces_backend_libvirt/realization.py
+++ b/implementations/python/packages/aces_backend_libvirt/realization.py
@@ -22,28 +22,28 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
+from aces_backend_protocols.capabilities import ProvisionerCapabilities
 from aces_contracts.diagnostics import Diagnostic, Severity
 from aces_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
 
+from ._payload import (
+    ACCOUNT_PLACEMENT_RESOURCE_TYPE,
+    CONTENT_PLACEMENT_RESOURCE_TYPE,
+    NETWORK_RESOURCE_TYPE,
+    NODE_RESOURCE_TYPE,
+    SUPPORTED_RESOURCE_TYPES,
+    _os_family,
+    _spec,
+    _str,
+)
 from .acls import realize_node_acls
+from .capability_envelope import capability_envelope_diagnostics
 from .cloudinit import CloudInitFile, CloudInitSpec, CloudInitUser, safe_path_component
 from .dialects import GuestDialect, GuestEmit, dialect_for
 from .driver import DomainSpec, NetworkAcl, NetworkSpec, ServiceSpec
+from .manifest import LIBVIRT_PROVISIONER_CAPABILITIES
 
 _DOMAIN = "runtime"
-NODE_RESOURCE_TYPE = "node"
-NETWORK_RESOURCE_TYPE = "network"
-ACCOUNT_PLACEMENT_RESOURCE_TYPE = "account-placement"
-CONTENT_PLACEMENT_RESOURCE_TYPE = "content-placement"
-FEATURE_BINDING_RESOURCE_TYPE = "feature-binding"
-PLACEMENT_RESOURCE_TYPES = frozenset(
-    {
-        ACCOUNT_PLACEMENT_RESOURCE_TYPE,
-        CONTENT_PLACEMENT_RESOURCE_TYPE,
-        FEATURE_BINDING_RESOURCE_TYPE,
-    }
-)
-SUPPORTED_RESOURCE_TYPES = frozenset({NODE_RESOURCE_TYPE, NETWORK_RESOURCE_TYPE}) | PLACEMENT_RESOURCE_TYPES
 
 
 @dataclass(frozen=True)
@@ -78,10 +78,23 @@ class _CloudInitAccumulator:
         )
 
 
-def interpret_provisioning_plan(plan: ProvisioningPlan) -> Realization:
-    """Interpret an ACES provisioning plan as portable libvirt intent."""
+def interpret_provisioning_plan(
+    plan: ProvisioningPlan,
+    *,
+    provisioner_capabilities: ProvisionerCapabilities | None = None,
+) -> Realization:
+    """Interpret an ACES provisioning plan as portable libvirt intent.
 
-    diagnostics: list[Diagnostic] = []
+    ``provisioner_capabilities`` is the backend capability envelope every plan
+    term is validated against; it defaults to the libvirt manifest's declared
+    envelope so a term outside it (an ungoverned/extension node type, OS family,
+    content type, or account feature the backend does not realize) yields a
+    blocking typed diagnostic instead of a silent or partial realization
+    (issue #605).
+    """
+
+    capabilities = provisioner_capabilities or LIBVIRT_PROVISIONER_CAPABILITIES
+    diagnostics: list[Diagnostic] = list(capability_envelope_diagnostics(plan, capabilities))
     network_resources: list[tuple[PlannedResource, Mapping[str, object]]] = []
     node_resources: list[tuple[PlannedResource, Mapping[str, object]]] = []
     placement_resources: list[tuple[PlannedResource, Mapping[str, object]]] = []
@@ -362,15 +375,6 @@ def _domain_spec(
     )
 
 
-def _os_family(payload: Mapping[str, object]) -> str:
-    family = payload.get("os_family")
-    if isinstance(family, str) and family:
-        return family
-    node = _spec(payload).get("node")
-    node_os = node.get("os") if isinstance(node, Mapping) else None
-    return node_os if isinstance(node_os, str) else ""
-
-
 def _network_cidr_lookup(networks: list[NetworkSpec]) -> dict[str, str]:
     lookup: dict[str, str] = {}
     for spec in networks:
@@ -467,15 +471,6 @@ def _image_ref(payload: Mapping[str, object]) -> str | None:
         if isinstance(name, str) and name:
             return name
     return None
-
-
-def _spec(payload: Mapping[str, object]) -> Mapping[str, object]:
-    spec = payload.get("spec")
-    return spec if isinstance(spec, Mapping) else {}
-
-
-def _str(value: object) -> str:
-    return value if isinstance(value, str) else ""
 
 
 def _ssh_authorized_keys(spec: Mapping[str, object]) -> tuple[str, ...]:

--- a/implementations/python/packages/aces_backend_libvirt/target.py
+++ b/implementations/python/packages/aces_backend_libvirt/target.py
@@ -27,7 +27,7 @@ def create_libvirt_components(
         raise ValueError("libvirt backend does not support orchestrator or evaluator.")
     participant_runtime = LibvirtParticipantRuntime() if manifest.has_participant_runtime else None
     return RuntimeTargetComponents(
-        provisioner=LibvirtProvisioner(deployment_driver),
+        provisioner=LibvirtProvisioner(deployment_driver, provisioner_capabilities=manifest.provisioner),
         participant_runtime=participant_runtime,
     )
 

--- a/implementations/python/packages/aces_backend_protocols/account_features.py
+++ b/implementations/python/packages/aces_backend_protocols/account_features.py
@@ -1,0 +1,40 @@
+"""Canonical account-feature extraction for the provisioner capability boundary.
+
+``provisioner_account_features`` is the single spec->feature-term mapping shared
+by the processor planner gate (``aces_processor.planner._validate_manifest``) and
+the libvirt backend's capability-envelope diagnostics (issue #605), so the two
+never diverge. It is kept out of ``capabilities`` (which declares *what a backend
+supports*) because it reads *what a plan's account spec uses* — a plan-payload
+semantics concern, not a capability declaration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def provisioner_account_features(account_spec: Mapping[str, object]) -> frozenset[str]:
+    """Return the governed account-feature terms an account-placement spec exercises.
+
+    Checked against ``ProvisionerCapabilities.supported_account_features``. Only
+    opt-in, non-default values count: a bare username, an enabled account
+    (``disabled`` falsy), and a plain password login (``auth_method`` unset or
+    ``"password"``) are descriptive defaults, not features.
+    """
+
+    features: set[str] = set()
+    if account_spec.get("groups"):
+        features.add("groups")
+    if account_spec.get("mail"):
+        features.add("mail")
+    if account_spec.get("spn"):
+        features.add("spn")
+    if account_spec.get("shell"):
+        features.add("shell")
+    if account_spec.get("home"):
+        features.add("home")
+    if account_spec.get("disabled") not in (False, None, ""):
+        features.add("disabled")
+    if account_spec.get("auth_method") not in ("", None, "password"):
+        features.add("auth_method")
+    return frozenset(features)

--- a/implementations/python/packages/aces_processor/planner.py
+++ b/implementations/python/packages/aces_processor/planner.py
@@ -1,5 +1,6 @@
 """Planner for compiled SDL runtime models."""
 
+from aces_backend_protocols.account_features import provisioner_account_features
 from aces_backend_protocols.capabilities import BackendManifest
 from aces_sdl.infrastructure import MINIMUM_NODE_COUNT
 from aces_sdl.nodes import OSFamily
@@ -511,24 +512,9 @@ def _resource_count_upper_bound(
 
 
 def _account_features(account_spec: dict[str, object]) -> set[str]:
-    features: set[str] = set()
-    if account_spec.get("groups"):
-        features.add("groups")
-    if account_spec.get("mail"):
-        features.add("mail")
-    if account_spec.get("spn"):
-        features.add("spn")
-    if account_spec.get("shell"):
-        features.add("shell")
-    if account_spec.get("home"):
-        features.add("home")
-    disabled = account_spec.get("disabled")
-    if disabled not in (False, None, ""):
-        features.add("disabled")
-    auth_method = account_spec.get("auth_method")
-    if auth_method not in ("", None, "password"):
-        features.add("auth_method")
-    return features
+    # Delegates to the shared canonical extractor so the planner gate and the
+    # libvirt backend's capability-envelope diagnostics never diverge (issue #605).
+    return set(provisioner_account_features(account_spec))
 
 
 def _validate_manifest(model: RuntimeModel, manifest: BackendManifest) -> list[Diagnostic]:

--- a/implementations/python/tests/test_backend_protocols_account_features.py
+++ b/implementations/python/tests/test_backend_protocols_account_features.py
@@ -1,0 +1,43 @@
+"""Issue #605: shared provisioner account-feature extraction.
+
+``provisioner_account_features`` is the single spec->feature-term mapping shared
+by the processor planner gate (``_validate_manifest``) and the libvirt backend's
+capability-envelope diagnostics, so the two never diverge.
+"""
+
+from __future__ import annotations
+
+from aces_backend_protocols.account_features import provisioner_account_features
+
+
+def test_empty_spec_uses_no_features():
+    assert provisioner_account_features({}) == frozenset()
+
+
+def test_full_spec_exercises_every_governed_feature():
+    spec = {
+        "username": "administrator",
+        "groups": ["sudo"],
+        "mail": "admin@example.test",
+        "spn": "HTTP/host",
+        "shell": "/bin/bash",
+        "home": "/home/administrator",
+        "disabled": True,
+        "auth_method": "ssh-key",
+    }
+
+    assert provisioner_account_features(spec) == frozenset(
+        {"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}
+    )
+
+
+def test_descriptive_defaults_are_not_features():
+    # A username alone, an enabled account, and a plain password login are not
+    # account "features"; only opt-in, non-default values count.
+    spec = {"username": "alice", "disabled": False, "auth_method": "password"}
+
+    assert provisioner_account_features(spec) == frozenset()
+
+
+def test_empty_collection_values_are_not_features():
+    assert provisioner_account_features({"groups": [], "shell": "", "home": ""}) == frozenset()

--- a/implementations/python/tests/test_libvirt_backend_provisioner.py
+++ b/implementations/python/tests/test_libvirt_backend_provisioner.py
@@ -284,6 +284,65 @@ def test_apply_delete_of_already_absent_entry_is_idempotent_success():
     assert driver.destroy_calls == [{"networks": (), "domains": ("provision.node.web",)}]
 
 
+def _out_of_envelope_node(address: str = "provision.node.gw") -> PlannedResource:
+    return PlannedResource(
+        address=address,
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload={
+            "name": "gw",
+            "node_name": "gw",
+            "node_type": "router",
+            "os_family": "linux",
+            "spec": {"node": {"type": "router"}, "infrastructure": {}},
+        },
+    )
+
+
+def test_apply_fails_closed_on_out_of_envelope_node_type():
+    driver = _RecordingDriver()
+    snapshot = RuntimeSnapshot()
+
+    result = LibvirtProvisioner(driver).apply(_plan(_out_of_envelope_node()), snapshot)
+
+    assert result.success is False
+    assert result.snapshot is snapshot
+    assert driver.realize_calls == []  # no partial/silent realization on error
+    assert [diag.code for diag in result.diagnostics] == ["libvirt-backend.realization.unsupported-node-type"]
+
+
+def test_validate_reports_out_of_envelope_node_type():
+    diagnostics = LibvirtProvisioner(_RecordingDriver()).validate(_plan(_out_of_envelope_node()))
+
+    assert [diag.code for diag in diagnostics] == ["libvirt-backend.realization.unsupported-node-type"]
+
+
+def test_apply_validates_operation_payloads_not_only_resources():
+    # An out-of-envelope term carried by a CREATE operation whose address is absent
+    # from plan.resources must still fail closed before any snapshot is persisted:
+    # operations, not just resources, materialize snapshot entries and driver work.
+    driver = _RecordingDriver()
+    snapshot = RuntimeSnapshot()
+    plan = ProvisioningPlan(
+        resources={},
+        operations=[
+            ProvisionOp(
+                action=ChangeAction.CREATE,
+                address="provision.node.gw",
+                resource_type="node",
+                payload={"name": "gw", "node_type": "router", "os_family": "linux", "spec": {}},
+            )
+        ],
+    )
+
+    result = LibvirtProvisioner(driver).apply(plan, snapshot)
+
+    assert result.success is False
+    assert driver.realize_calls == []
+    assert "provision.node.gw" not in result.snapshot.entries
+    assert [diag.code for diag in result.diagnostics] == ["libvirt-backend.realization.unsupported-node-type"]
+
+
 def test_apply_fails_closed_when_driver_omits_realization_confirmation():
     class _SilentRealizeDriver(_RecordingDriver):
         def realize(self, *, networks, domains):

--- a/implementations/python/tests/test_libvirt_backend_realization.py
+++ b/implementations/python/tests/test_libvirt_backend_realization.py
@@ -3,9 +3,31 @@
 from __future__ import annotations
 
 from aces_backend_libvirt.realization import interpret_provisioning_plan
+from aces_backend_protocols.capabilities import ProvisionerCapabilities
 from aces_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
 
 NODE_ADDRESS = "provision.node.web"
+
+
+def _narrowed_capabilities(**overrides) -> ProvisionerCapabilities:
+    """A libvirt-shaped provisioner envelope narrowed for out-of-envelope tests.
+
+    Libvirt's real manifest declares every governed account feature and both node
+    types, so an out-of-envelope account-feature or switch term is only reachable
+    against a deliberately narrower envelope injected via ``provisioner_capabilities``.
+    """
+
+    base: dict = {
+        "name": "narrowed-provisioner",
+        "supported_node_types": frozenset({"vm", "switch"}),
+        "supported_os_families": frozenset({"linux"}),
+        "supported_content_types": frozenset({"file"}),
+        "supported_account_features": frozenset({"groups", "shell"}),
+        "supports_acls": True,
+        "supports_accounts": True,
+    }
+    base.update(overrides)
+    return ProvisionerCapabilities(**base)
 
 
 def _resource(resource_type: str, address: str, payload: dict) -> PlannedResource:
@@ -404,3 +426,130 @@ def test_placement_without_target_reference_fails_closed_with_diagnostic():
     realization = interpret_provisioning_plan(_plan(_node(), untargeted))
 
     assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unbound-placement"]
+
+
+# --- issue #605: typed capability-envelope diagnostics --------------------------
+
+
+def test_out_of_envelope_node_type_fails_closed():
+    # A node type outside the declared manifest envelope (an ungoverned/extension
+    # term the backend does not realize) must block rather than realize a domain.
+    node = _resource(
+        "node",
+        NODE_ADDRESS,
+        {
+            "name": "gw",
+            "node_name": "gw",
+            "node_type": "router",
+            "os_family": "linux",
+            "spec": {"node": {"type": "router"}, "infrastructure": {}},
+        },
+    )
+
+    realization = interpret_provisioning_plan(_plan(node))
+
+    assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unsupported-node-type"]
+    assert realization.diagnostics[0].severity.name == "ERROR"
+    assert realization.diagnostics[0].address == NODE_ADDRESS
+    assert "router" in realization.diagnostics[0].message
+
+
+def test_out_of_envelope_os_family_fails_closed():
+    realization = interpret_provisioning_plan(_plan(_node_os("solaris")))
+
+    assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unsupported-os-family"]
+    assert "solaris" in realization.diagnostics[0].message
+
+
+def test_out_of_envelope_content_type_fails_closed():
+    # An unsupported content type must NOT fall through to a silent no-op cloud-init
+    # contribution: it yields a blocking diagnostic.
+    content = _resource(
+        "content-placement",
+        "provision.content.disk",
+        {"name": "disk", "target_address": NODE_ADDRESS, "spec": {"type": "raw-disk"}},
+    )
+
+    realization = interpret_provisioning_plan(_plan(_node(), content))
+
+    assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unsupported-content-type"]
+    assert "raw-disk" in realization.diagnostics[0].message
+    # The unsupported content contributed nothing to the domain's cloud-init.
+    assert _domain(realization).cloud_init.write_files == ()
+
+
+def test_governed_vocabulary_realizes_without_envelope_error():
+    # The full issue #603 governed vocabulary (all content types + account features)
+    # is in-envelope and must realize without any capability-envelope diagnostic.
+    account = _resource(
+        "account-placement",
+        "provision.account.admin",
+        {
+            "name": "admin",
+            "target_address": NODE_ADDRESS,
+            "spec": {
+                "username": "administrator",
+                "groups": ["sudo"],
+                "shell": "/bin/bash",
+                "home": "/home/administrator",
+                "disabled": True,
+                "auth_method": "ssh-key",
+                "mail": "admin@example.test",
+                "spn": "HTTP/web.example.test",
+            },
+        },
+    )
+    file_content = _resource(
+        "content-placement",
+        "provision.content.f",
+        {"name": "f", "target_address": NODE_ADDRESS, "spec": {"type": "file", "path": "/srv/f", "text": "x\n"}},
+    )
+    dir_content = _resource(
+        "content-placement",
+        "provision.content.d",
+        {"name": "d", "target_address": NODE_ADDRESS, "spec": {"type": "directory", "destination": "/opt/d"}},
+    )
+    dataset_content = _resource(
+        "content-placement",
+        "provision.content.ds",
+        {"name": "ds", "target_address": NODE_ADDRESS, "spec": {"type": "dataset"}},
+    )
+
+    realization = interpret_provisioning_plan(_plan(_node(), account, file_content, dir_content, dataset_content))
+
+    envelope_codes = [d.code for d in realization.diagnostics if "unsupported-" in d.code]
+    assert envelope_codes == []
+
+
+def test_account_feature_outside_narrowed_envelope_fails_closed():
+    caps = _narrowed_capabilities(supported_account_features=frozenset({"groups"}))
+    account = _resource(
+        "account-placement",
+        "provision.account.admin",
+        {
+            "name": "admin",
+            "target_address": NODE_ADDRESS,
+            "spec": {"username": "administrator", "groups": ["sudo"], "shell": "/bin/bash"},
+        },
+    )
+
+    realization = interpret_provisioning_plan(_plan(_node(), account), provisioner_capabilities=caps)
+
+    # 'groups' is in the narrowed envelope; 'shell' is not.
+    assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unsupported-account-feature"]
+    assert "shell" in realization.diagnostics[0].message
+    assert realization.diagnostics[0].address == "provision.account.admin"
+
+
+def test_switch_node_type_outside_narrowed_envelope_fails_closed():
+    caps = _narrowed_capabilities(supported_node_types=frozenset({"vm"}))
+    network = _resource(
+        "network",
+        "provision.network.lan",
+        {"name": "lan", "spec": {"infrastructure": {"properties": {}}}},
+    )
+
+    realization = interpret_provisioning_plan(_plan(network), provisioner_capabilities=caps)
+
+    assert [d.code for d in realization.diagnostics] == ["libvirt-backend.realization.unsupported-node-type"]
+    assert "switch" in realization.diagnostics[0].message


### PR DESCRIPTION
## Summary

Requirement-free enhancement (#605). The libvirt backend now emits blocking, typed diagnostics when a provisioning plan requires a node type, OS family, content type, or account feature outside its declared manifest envelope, failing closed instead of silently or partially realizing an ungoverned/extension term. This is the backend-side sibling of the processor's manifest capability checks (planner._validate_manifest), enforced independently because plans can be applied directly to the libvirt provisioner without the processor. The envelope is validated over the full materialization surface (plan resources and non-DELETE operations), and the selected manifest is the single source of truth for the declared envelope.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #605

## ADR Impact

- ADR-021

## Changes

- capability_envelope.py: table-driven per-dimension envelope diagnostics (libvirt-backend.realization.unsupported-{node-type,os-family,content-type,account-feature}, ERROR) over plan resources + non-DELETE operations, deduped by (code, address, term)
- account_features.py: shared account-spec->feature extractor used by both aces_processor.planner and the libvirt backend so the two never diverge; aces_processor.planner._account_features now delegates to it
- _payload.py: shared payload accessors (_spec/_str/_os_family/_node_type) + resource-type vocabulary, split out so realization and capability_envelope share one implementation and both stay under the 600-line cap
- manifest.py: LIBVIRT_PROVISIONER_CAPABILITIES module constant is the single source of truth for the declared envelope; create_libvirt_manifest reuses it
- provisioner.py: LibvirtProvisioner accepts provisioner_capabilities (defaults to the libvirt envelope); target.create_libvirt_components threads the selected manifest's provisioner in so the envelope tracks the manifest the target was built with
- Fail-closed guarantee unchanged: apply() returns before snapshot reconciliation / driver IO when any diagnostic is an error, so no partial or silent realization occurs

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Full nox -s verify passed with --skip-requirement (requirement-free run). Pre-push codex review and test-quality review both returned clean (0 findings).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #605 ← implementations/python/packages/aces_backend_libvirt/capability_envelope.py, #605 ← implementations/python/packages/aces_backend_protocols/account_features.py
- TESTS: #605 ← implementations/python/tests/test_libvirt_backend_realization.py (out-of-envelope node-type/os-family/content-type + governed-vocab regression + narrowed-envelope account-feature/switch), #605 ← implementations/python/tests/test_libvirt_backend_provisioner.py (fail-closed apply + operations-surface validation), #605 ← implementations/python/tests/test_backend_protocols_account_features.py (shared extractor contract)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/605.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
