### PR TITLE
docs: add CAGE-2 replication architecture

### DIFF
--- a/changelog.d/635.added.md
+++ b/changelog.d/635.added.md
@@ -1,0 +1,2 @@
+Added the accepted CAGE-2 replication architecture ADR and companion design
+record for REP-001.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -113,6 +113,7 @@ adr-065-experiment-run-provenance-contract-boundary
 adr-066-observability-evidence-plane-separation
 adr-067-participant-behavior-model
 adr-068-experiment-trials-replication-and-replay-claims
+adr-069-cage-2-replication-architecture
 ```
 
 | ADR | Title | Status | Date |
@@ -186,3 +187,4 @@ adr-068-experiment-trials-replication-and-replay-claims
 | [066](adr-066-observability-evidence-plane-separation.md) | Observability and Evidence Plane Separation | accepted | 2026-06-23 |
 | [067](adr-067-participant-behavior-model.md) | Participant Behavior Model | proposed | 2026-06-23 |
 | [068](adr-068-experiment-trials-replication-and-replay-claims.md) | Experiment Trials, Replication, and Replay Claims | accepted | 2026-06-25 |
+| [069](adr-069-cage-2-replication-architecture.md) | CAGE-2 Replication Architecture | accepted | 2026-07-01 |

--- a/docs/decisions/adrs/adr-069-cage-2-replication-architecture.md
+++ b/docs/decisions/adrs/adr-069-cage-2-replication-architecture.md
@@ -1,0 +1,288 @@
+# ADR-069: CAGE-2 Replication Architecture
+
+## Status
+
+accepted
+
+## Date
+
+2026-07-01
+
+## Classification
+
+Classification: FM2
+Required artifacts: ADR, design record, preflight guardrails, changelog
+fragment
+Waivers: No schema, fixture, profile, contract-source, implementation, or
+runtime artifact is introduced by this issue. REP-001 is a design decision for
+an adapter-driven replication program; downstream issues must author the SDL
+scenario, create the adapter repository, implement the CybORG backend, add
+conformance probes, and publish evidence artifacts.
+
+## Context
+
+REP-001 asks ACES to define how the TTCP CAGE Challenge 2 scenario is driven
+through ACES into a conformant simulator backend. The design must cover the
+CAGE-2 to ACES SDL mapping, a CybORG simulator adapter against the ACES backend
+protocols, a shared simulator adapter base, the future `aces-adapters`
+monorepo, replication/equivalence criteria, and the cross-repo workflow. It
+explicitly excludes realizing CAGE-2 on an emulation backend.
+
+ACES already has most of the load-bearing architecture:
+
+- ADR-001, ADR-002, ADR-004, ADR-008, ADR-020, ADR-022, ADR-054, ADR-060,
+  ADR-066, and ADR-067 define SDL, runtime, participant, observation, and
+  outcome semantics.
+- ADR-009, ADR-012, ADR-019, ADR-061, and ADR-062 define normative artifact
+  authority, schema publication, concept authority, controlled vocabularies,
+  and governed extension discipline.
+- ADR-036 keeps processor, runtime, contract, and backend protocol packages
+  separated.
+- ADR-063 defines the reference emulation backend as one concrete backend
+  pattern, not as a superclass for simulators.
+- ADR-064, ADR-065, ADR-066, and ADR-068 define experiment evidence, run
+  provenance, plane separation, replication, and replay-claim boundaries.
+
+The missing decision is how to make CAGE-2 a portable ACES replication target
+without creating CAGE-specific SDL syntax, a second backend protocol family, a
+parallel conformance harness, or an informal cross-repo status process.
+
+The upstream sources that downstream mapping work must pin include:
+
+- `https://github.com/cage-challenge/cage-challenge-2`, observed at
+  `26ce1c1253fa9e2e73f25e6a7f2da32860c11257` during this design, especially
+  `README.md`, `CybORG/CybORG/Shared/Scenarios/Scenario2.yaml`,
+  `CybORG/CybORG/Evaluation/evaluation.py`, reward calculators, wrappers, and
+  red/blue/green agent implementations.
+- `https://github.com/cage-challenge/CybORG`, observed at
+  `2742b5e0ce4330c9b14006b38acd3b5ebe00d6fd` during this design, especially
+  `CybORG/Simulator/Scenarios/scenario_files/Scenario2.yaml`,
+  `CybORG/Evaluation/evaluation.py`, wrappers, reward calculators, and action
+  implementations.
+- The CAGE Challenge 2 paper, `https://arxiv.org/abs/2309.07388`, for
+  challenge description, red-agent variants, action/reward/evaluation
+  semantics, and evaluation protocol context.
+
+These observed pins are not an executable dependency. The downstream mapping
+issue must re-pin the exact commits or releases it consumes and record source
+paths and digests in its mapping ledger.
+
+## Decision
+
+### 1. ACES remains the semantic authority
+
+CAGE-2 is an authored ACES scenario plus backend-specific realization evidence.
+The scenario mapping must use existing SDL, runtime, participant, objective,
+observation, evidence, and experiment surfaces. It must not add
+CAGE-specific SDL sections, schemas, profiles, vocabularies, manifest blocks,
+exceptions, stores, or policy gates to make the mapping convenient.
+
+Native CAGE/CybORG names, gym spaces, action ids, reward arrays, simulator
+objects, and leaderboard scores are source facts. They become portable ACES
+facts only when the mapping ledger binds them to existing ACES concepts,
+contracts, evidence records, derived measures, or disclosed limitations.
+
+### 2. The CAGE-2 mapping is a pinned ledger
+
+The CAGE-2 to ACES SDL mapping must be a ledger over pinned upstream sources.
+For each source fact, the ledger records the upstream repository, commit or
+release, file path, source selector, optional digest, mapped ACES artifact or
+field, mapping rationale, and loss disclosure.
+
+The ledger must account for at least:
+
+- network topology, subnets, hosts, services, accounts, credentials, roles, and
+  privileges;
+- blue, red, green, backend, evaluator, and participant identities;
+- initial knowledge, visibility, observation surfaces, and hidden truth;
+- blue defensive actions, red reconnaissance/exploitation/effect actions,
+  green/user behavior, sleep/no-op behavior, and action admissibility;
+- turn order, fixed step counts, episode termination, red-agent variants,
+  randomization, seeds, and stochastic controls;
+- reward components, cumulative score, objectives, outcomes, evidence, and
+  derived measures.
+
+Every source fact is mapped, explicitly declared out of scope, or
+loss-disclosed. A disclosed gap weakens the replication claim; it is not filled
+by raw CybORG logs, fixture-local assertions, or prose-only evidence.
+
+### 3. CybORG is a conformant simulator backend
+
+The future CybORG adapter is a simulator backend behind the existing ACES
+backend protocol surface:
+
+- `Provisioner` loads and validates target configuration, source pins,
+  simulator package/version, mapping-ledger refs, seed policy, and initial
+  simulator construction inputs. It returns ACES diagnostics and plans, not
+  native simulator objects.
+- `Orchestrator` steps the simulator through compiled ACES orchestration and
+  action contracts. It reports runtime snapshots, participant histories, and
+  operation receipts through ACES contracts.
+- `Evaluator` projects reward, objective, terminal-condition, and scoring facts
+  into ACES evaluation results, evidence records, and derived measures with
+  declared margins and limitations.
+- `ParticipantRuntime` mediates blue/red/green participant episodes through
+  participant lifecycle, action admission, observation envelopes, behavior
+  histories, and context/outcome views.
+
+The adapter must publish a `backend-manifest-v2` through
+`backend_manifest_payload()`, declare only evidence-backed capabilities, and
+pass `_validate_runtime_target_shape()` before runtime use. Native CybORG
+state, gym/PettingZoo tuples, reward vectors, action ids, and simulator object
+representations stay adapter-private.
+
+### 4. `sim_adapter_base` is shared adapter plumbing, not authority
+
+The future `sim_adapter_base` package belongs in the adapter monorepo as a
+convenience library for simulator drivers. It may factor target factories,
+clock/seed controls, action translators, observation projectors, reward
+projectors, manifest helpers, redaction helpers, and conformance harness
+utilities.
+
+It must consume ACES contracts and published artifacts. It must not define a
+new semantic model, schema registry, backend protocol, diagnostic envelope,
+exception hierarchy, conformance profile table, fixture corpus, concept
+catalog, or policy gate.
+
+### 5. `aces-adapters` isolates adapter projects
+
+The future `aces-adapters` repository is a co-located monorepo of independent
+adapter projects. Each adapter owns its own dependency lockfile, virtual
+environment, package metadata, tests, and simulator pins. Shared packages are
+versioned and consumed like ordinary dependencies.
+
+The root repository may provide orchestration, shared documentation, and a CI
+matrix, but it must not impose one resolved dependency graph across all
+adapters. The CI matrix must include adapter path, lockfile, Python version,
+optional simulator extras, conformance profile, and seed suite so a CybORG pin
+cannot constrain unrelated adapters.
+
+### 6. Backend conformance composes existing ACES gates
+
+The CybORG adapter conformance harness must invoke or wrap the existing ACES
+conformance runner and published backend profile/fixture corpus. It may add
+simulator-specific probes, seeded equivalence checks, and mapping-ledger
+coverage checks, but those probes produce ACES diagnostics and evidence. They
+do not replace `contracts/profiles/backend/**`, `contracts/fixtures/**`,
+`BackendManifestV2Model`, or `run_target_conformance()`.
+
+### 7. Equivalence is tiered evidence
+
+CAGE-2 replication is not bit-for-bit backend identity. It is a tiered evidence
+claim over canonical artifacts:
+
+- authored-source equivalence: one ACES SDL scenario and a complete pinned
+  CAGE-2 mapping ledger;
+- contract equivalence: each backend manifest validates and declares only
+  evidence-backed support;
+- execution-control equivalence: matched trial length, red-agent variant, seed
+  or stochastic-control disclosure, logical step count, turn order, episode
+  termination, and participant selection;
+- state/observation equivalence: mapped topology, services, privileges,
+  visibility, action admissibility, observations, and shared-state transitions
+  satisfy declared ACES semantics;
+- outcome/evaluation equivalence: reward components, objective results,
+  cumulative score, evidence, derived measures, margins, and confidence
+  criteria satisfy the declared claim.
+
+If a backend cannot expose a required fact, the result is a weaker disclosed
+claim or a failed equivalence check.
+
+### 8. Cross-repo workflow is issue-driven from ACES
+
+ACES issues, requirements, ADRs, and design records are the authority for this
+replication program. Downstream `aces-adapters` issues and PRs must reference
+the ACES issue, `REP-001`, this ADR, the design record, and the relevant
+acceptance evidence. Adapter status must be read from linked downstream issues,
+PRs, conformance reports, and evidence artifacts, not from comments or stale
+docs in this repository.
+
+### 9. Emulation is out of scope
+
+This decision does not design or reserve a hidden emulation path for CAGE-2.
+The first replication target is simulator-only. A future emulation realization
+requires a separate requirement, threat/risk review, ADR or amendment, and
+evidence plan.
+
+## Implementation Mapping
+
+Issue #635 is satisfied by this ADR, the companion design record
+`docs/decisions/cage-2-replication-design.md`, and the preflight note
+`docs/decisions/issue-635-rep-001-cage-2-replication-preflight.md`.
+
+Downstream implementation issues must use the design record as their checklist:
+
+- REP-002 stands up the adapter repository and CI isolation.
+- REP-003 authors the CAGE-2 ACES SDL scenario and mapping ledger.
+- REP-004 implements the CybORG simulator backend and shared adapter base.
+- REP-005 drives and validates replicated runs through equivalence evidence.
+
+## Alternatives Considered
+
+### Add CAGE-specific SDL syntax or schemas
+
+Rejected. ACES already has SDL, runtime, participant, evidence, and experiment
+surfaces that can carry the required facts. A CAGE-specific fork would make the
+first replication target a special case instead of a portability proof.
+
+### Treat CybORG as a direct ACES runtime dependency
+
+Rejected. CybORG is a backend dependency of the adapter, not a core ACES
+dependency. ACES core packages must continue to work from published contracts,
+manifests, fixtures, and profiles without importing concrete simulator
+packages.
+
+### Make `sim_adapter_base` a new protocol authority
+
+Rejected. Shared driver plumbing is useful, but protocol authority already
+lives in `aces_backend_protocols`, `aces_contracts`, published schemas,
+fixtures, profiles, and conformance runners.
+
+### Use one global adapter lockfile
+
+Rejected. Simulator packages have different dependency and version constraints.
+One lockfile would couple unrelated adapters and make the monorepo a hidden
+dependency policy authority.
+
+### Define equivalence as one score or CI result
+
+Rejected. Scores and CI runs are evidence inputs. They are not enough to prove
+that authored source, contracts, execution controls, observations, state
+transitions, outcomes, and limitations align across backends.
+
+### Include emulation realization now
+
+Rejected. The issue explicitly excludes emulation. Mixing simulator and
+emulation design here would blur the claim boundary and delay the first
+adapter-driven replication.
+
+## Consequences
+
+### Positive
+
+- CAGE-2 becomes a disciplined replication target without changing ACES core
+  semantics.
+- Downstream adapter work has a concrete boundary, file layout, and evidence
+  plan.
+- The design preserves independent backend conformance instead of treating
+  CybORG as a privileged implementation.
+- The equivalence claim is falsifiable because every tier names artifacts and
+  disclosures.
+
+### Negative / Costs
+
+- Downstream work must maintain a detailed source mapping ledger before it can
+  claim replication.
+- The adapter monorepo needs more CI ceremony than a single shared package.
+- Some CAGE facts may become disclosed losses rather than exact ACES facts.
+
+### Risks
+
+- Authors may overstate equivalence by treating score similarity as semantic
+  replication. Reviews must require the tiered evidence checklist.
+- Adapter authors may leak simulator-private state into portable artifacts for
+  convenience. Conformance and design review must reject native object reprs,
+  raw logs, hidden truth, argv/env dumps, tokens, and full tracebacks.
+- Cross-repo work may drift if downstream issues do not link back to ACES
+  requirements and design records. The workflow requires linked issues, PRs,
+  and evidence readback.

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -275,3 +275,6 @@ adrs:
   - id: ADR-068
     path: docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
     pin: 2cd46b67fb86a8d5d5c089e2b2f492a94e6141470706f33a2bb14d7268c49d02
+  - id: ADR-069
+    path: docs/decisions/adrs/adr-069-cage-2-replication-architecture.md
+    pin: 305334e5558fb88d1f84317209f0e64d182714ba8e99cdeb5f6781bf3ee384f5

--- a/docs/decisions/cage-2-replication-design.md
+++ b/docs/decisions/cage-2-replication-design.md
@@ -1,0 +1,342 @@
+# CAGE-2 Replication Design
+
+Date: 2026-07-01
+
+Issue: #635.
+
+Requirement: REP-001.
+
+Status: accepted by ADR-069.
+
+## Purpose
+
+This design record turns ADR-069 into an implementation checklist for the
+CAGE-2 replication program. It does not author the CAGE-2 ACES SDL scenario,
+create `aces-adapters`, implement a CybORG backend, add `sim_adapter_base`,
+publish fixtures, or claim equivalence. It defines what those downstream
+artifacts must prove.
+
+## Source Pins and Evidence
+
+Downstream mapping work must pin immutable upstream source identifiers and
+record file paths and digests for every consumed source fact. During REP-001,
+the following floating heads were inspected only to shape the design:
+
+| Source | Observed commit | Source paths to ledger |
+|---|---|---|
+| `https://github.com/cage-challenge/cage-challenge-2` | `26ce1c1253fa9e2e73f25e6a7f2da32860c11257` | `README.md`; `CybORG/CybORG/Shared/Scenarios/Scenario2.yaml`; `CybORG/CybORG/Evaluation/evaluation.py`; `CybORG/CybORG/Shared/*RewardCalculator.py`; wrappers; simple agents; action implementations |
+| `https://github.com/cage-challenge/CybORG` | `2742b5e0ce4330c9b14006b38acd3b5ebe00d6fd` | `CybORG/Simulator/Scenarios/scenario_files/Scenario2.yaml`; `CybORG/Evaluation/evaluation.py`; wrappers; reward calculators; `CybORG/Simulator/Actions/**`; test scenario fixtures |
+| `https://arxiv.org/abs/2309.07388` | arXiv paper version available during REP-001 | Challenge narrative, red-agent variants, action/reward/evaluation semantics, evaluation protocol context |
+
+The downstream ledger may choose a different upstream commit or release. It
+must state the exact identifier it uses and why.
+
+## CAGE-2 to ACES Mapping Ledger
+
+The mapping ledger is the primary bridge from upstream CAGE facts to ACES
+portable artifacts. Each row has this shape:
+
+| Field | Meaning |
+|---|---|
+| `source_id` | Stable row id, unique within the ledger |
+| `source_repo` | Upstream repository or paper URL |
+| `source_version` | Commit, release, tag, or paper version |
+| `source_path` | File path, section, figure, or table |
+| `source_selector` | YAML path, Python symbol, line range, or prose selector |
+| `source_digest` | Optional content digest when practical |
+| `cage_fact_type` | Host, subnet, service, account, role, action, observation, reward, terminal condition, turn order, red-agent policy, seed, or evaluation fact |
+| `aces_target` | ACES artifact, contract, field, concept binding, or evidence record that carries the fact |
+| `mapping_rule` | Transformation from source fact to ACES value |
+| `loss_disclosure` | Required when ACES cannot carry the exact source fact |
+| `verification` | Structural check, conformance probe, evidence ref, or manual review note |
+
+The ledger must cover at least the following source categories.
+
+### Topology and Assets
+
+- subnets and subnet roles;
+- hosts, servers, operational hosts, defender host, and user hosts;
+- operating-system families and versions where available;
+- services, ports, decoy-compatible services, and vulnerable services;
+- accounts, sessions, credentials, privilege levels, and initial foothold;
+- network access controls and reachability.
+
+ACES targets include SDL infrastructure, nodes, services, accounts,
+authorization surfaces, runtime inventory families, concept bindings, and
+evidence requirements. Source facts that cannot be encoded must be disclosed
+rather than stored in `metadata` as hidden semantics.
+
+### Participants and Identities
+
+The design keeps these identities separate:
+
+- backend identity: the CybORG simulator backend target;
+- evaluator identity: the component projecting reward and score into ACES;
+- blue participant implementation identity;
+- red policy identity, including B-line, Meander, and Sleep variants;
+- green/user behavior identity;
+- control-plane caller identity.
+
+Participant identities map to participant implementation manifests,
+participant runtime episode records, behavior histories, provenance, and
+experiment apparatus context. Backend or evaluator identity must not stand in
+for participant implementation identity.
+
+### Actions, Observations, and Hidden Truth
+
+CAGE actions are source facts, not ACES semantics. The ledger maps them into
+compiled ACES action contracts, action-admission requests, observed effects,
+participant-visible observations, hidden truth disclosures, evidence records,
+and derived measures.
+
+Blue actions such as monitor, analyse, restore, remove, and decoys must declare
+their ACES action category, target grammar, observation boundary, admissibility
+rule, and effect reporting. Red actions such as discovery, service discovery,
+exploitation, privilege escalation, and impact must declare whether they are
+participant behavior, backend state transition, evaluator fact, or hidden
+truth. Green/user behavior maps to participant or background-workload
+semantics with disclosed limits.
+
+Native action ids, gym spaces, simulator observations, reward arrays, and
+object reprs must not appear as portable ACES payloads.
+
+### Timing, Turn Order, and Stochastic Controls
+
+The ledger must state:
+
+- trial lengths and logical step counts;
+- ordering among red, blue, green, backend, and evaluator operations;
+- episode start and terminal conditions;
+- red-agent variant selection;
+- random seeds and stochastic policy, including any uncontrolled source of
+  randomness;
+- simulator package and scenario source version.
+
+These facts map to experiment task/run/study parameters, apparatus context,
+condition assignments, run allocation, stochastic controls, and realized-form
+disclosures.
+
+### Reward, Objectives, and Evaluation
+
+CAGE reward and score facts map to ACES objectives, evaluator results,
+evidence records, derived measures, and study analysis plans. The design keeps
+these concepts distinct:
+
+- participant-local outcome;
+- workflow success;
+- backend conformance;
+- reward component;
+- cumulative score;
+- objective satisfaction;
+- derived measure;
+- replication/equivalence claim.
+
+A high CAGE score is evidence for an analysis claim. It is not by itself
+semantic equivalence, conformance, or scenario correctness.
+
+## CybORG Backend Protocol Mapping
+
+The CybORG adapter is a target registered through the ACES backend registry.
+It provides a `BackendManifest`, components, and protocol implementations that
+consume neutral DTOs from `aces_contracts`.
+
+### Provisioner
+
+The provisioner owns target construction and source validation:
+
+- validates selected CAGE source pins and mapping-ledger refs;
+- validates simulator package/version and target config;
+- constructs the simulator driver leaf;
+- publishes capability declarations and realization-support disclosures;
+- returns `Diagnostic`, `ProvisioningPlan`, `ApplyResult`, and operation
+  receipts through ACES contracts.
+
+It does not return native simulator state or mutate SDL.
+
+### Orchestrator
+
+The orchestrator owns step execution against compiled ACES plans:
+
+- translates compiled action contracts into driver calls;
+- applies turn-order and clock policy;
+- records runtime snapshots and shared-state transitions;
+- rejects invalid native outputs before they cross the adapter boundary;
+- reports all failures as ACES diagnostics.
+
+The orchestrator must not bypass `RuntimeTarget`,
+`_validate_runtime_target_shape()`, `_call_backend_apply()`, or runtime
+snapshot validation.
+
+### Evaluator
+
+The evaluator projects CAGE reward and terminal facts into ACES evaluation
+records:
+
+- maps reward components and score;
+- records terminal conditions;
+- creates evidence records and derived measures;
+- discloses unsupported or lossy mappings;
+- binds metrics to experiment study analysis plans.
+
+It must not treat reward arrays as participant-local outcomes or workflow
+success without an explicit mapping.
+
+### ParticipantRuntime
+
+The participant runtime mediates blue/red/green episodes:
+
+- initializes, resets, and terminates episodes through the participant
+  lifecycle;
+- admits actions through `ParticipantActionAdmissionRequest`;
+- emits observation envelopes and participant histories;
+- records implementation provenance and exposure policy;
+- keeps red policy, blue implementation, green behavior, backend, evaluator,
+  and caller identities separate.
+
+## `sim_adapter_base`
+
+The future `sim_adapter_base` package may include:
+
+- simulator target factory helpers;
+- clock/step and seed controls;
+- source-pin and source-ledger utilities;
+- action translator base classes;
+- observation projector base classes;
+- reward/evaluator projector base classes;
+- redaction helpers for diagnostics and evidence;
+- conformance probe helpers that wrap ACES conformance APIs.
+
+It must not include:
+
+- SDL syntax, schema, profile, fixture, or concept-authority definitions;
+- backend protocol definitions;
+- capability evidence rules;
+- conformance profile authority;
+- exception or diagnostic envelope authority;
+- persistent stores or audit logs used as portable truth.
+
+## `aces-adapters` Monorepo Layout
+
+The future repository should use this shape:
+
+```text
+aces-adapters/
+  README.md
+  pyproject.toml                 # workspace/tooling only, not one lock for all adapters
+  packages/
+    sim_adapter_base/
+      pyproject.toml
+      uv.lock
+      src/sim_adapter_base/
+      tests/
+    cyborg_adapter/
+      pyproject.toml
+      uv.lock
+      src/aces_adapter_cyborg/
+      tests/
+      mapping/
+        cage2-source-ledger.jsonl
+        cage2-loss-disclosures.md
+      profiles/
+        conformance-overrides/
+    <future-adapter>/
+      pyproject.toml
+      uv.lock
+      src/
+      tests/
+  .github/workflows/
+    ci.yml
+```
+
+The root workflow fans out by matrix:
+
+- adapter project path;
+- adapter lockfile;
+- Python version;
+- optional simulator extras;
+- conformance profile id;
+- seed suite;
+- source-ledger id.
+
+An adapter may depend on `sim_adapter_base` by version or workspace reference,
+but it does not share one global simulator dependency resolution with other
+adapters.
+
+## Backend Conformance Harness
+
+The adapter harness composes existing ACES conformance:
+
+1. Load the adapter manifest via `backend_manifest_payload()`.
+2. Validate as `backend-manifest-v2`.
+3. Select a published backend profile from `contracts/profiles/backend/**`.
+4. Load canonical fixtures from `contracts/fixtures/**`.
+5. Run `run_target_conformance()` against a fully constructed `RuntimeTarget`.
+6. Run simulator-specific probes for source-ledger coverage, seed controls,
+   action/observation projection, and reward/evaluator projection.
+7. Emit structured `Diagnostic` values, evidence records, and derived measures.
+
+Simulator probes are additive. They must not become a second profile table,
+fixture corpus, schema registry, or manifest renderer.
+
+## Replication and Equivalence Criteria
+
+Replication success requires all tiers below. A tier can fail, pass, or pass
+with disclosed weakness.
+
+| Tier | Required evidence |
+|---|---|
+| Authored source | One ACES SDL scenario; no backend-specific SDL branches; complete pinned mapping ledger |
+| Contract | Valid backend manifests; supported contracts declared; applicable backend conformance profile passes |
+| Execution control | Same trial length, red-agent variant, seed/stochastic-control declaration, turn order, terminal rule, participant selection |
+| State and observation | Topology, services, privileges, visibility, observations, action admissibility, and shared-state transitions satisfy declared ACES semantics |
+| Outcome and evaluation | Reward components, objective results, evidence records, derived measures, cumulative score, margins, and confidence criteria satisfy the study plan |
+| Disclosure | Every unsupported fact has a loss disclosure and weakens or fails the claim explicitly |
+
+No claim may be based only on CI success, notebook output, native simulator log
+similarity, or a single cumulative score.
+
+## Cross-Repo Workflow
+
+ACES remains the authority repository for requirements, decisions, and
+portable contracts.
+
+The workflow is:
+
+1. ACES issue #635 and `REP-001` own this architecture.
+2. Downstream `aces-adapters` issues reference issue #635, `REP-001`, ADR-069,
+   and this design record.
+3. Adapter PRs include the mapped ACES requirement UID, the source-ledger id,
+   source pins, conformance profile id, seed suite, and evidence outputs.
+4. ACES follow-on issues read downstream evidence before advancing
+   requirement status or replication claims.
+5. Cross-repo status is inferred only from linked issues, PRs, conformance
+   reports, evidence artifacts, and requirement traceability.
+
+Informal comments, branch names, and docs-only status tables are not
+implementation evidence.
+
+## Non-Goals
+
+- Authoring the CAGE-2 ACES SDL scenario.
+- Creating `aces-adapters`.
+- Implementing `sim_adapter_base`.
+- Implementing a CybORG backend.
+- Adding ACES schemas, profiles, fixtures, concept vocabularies, or policy
+  gates.
+- Running CAGE-2 through a backend.
+- Claiming replication/equivalence.
+- Designing an emulation backend.
+
+## Clause Checklist
+
+| REP-001 clause | Design location |
+|---|---|
+| Accepted ADR | `docs/decisions/adrs/adr-069-cage-2-replication-architecture.md` |
+| CAGE-2 to ACES SDL mapping | `CAGE-2 to ACES Mapping Ledger` |
+| CybORG adapter against four protocols | `CybORG Backend Protocol Mapping` |
+| Shared `sim_adapter_base` package | `` `sim_adapter_base` `` |
+| Backend conformance harness | `Backend Conformance Harness` |
+| `aces-adapters` independent monorepo layout | `` `aces-adapters` Monorepo Layout `` |
+| Replication/equivalence success criteria | `Replication and Equivalence Criteria` |
+| Cross-repo issue-driven workflow | `Cross-Repo Workflow` |
+| Emulation out of scope | `Non-Goals` |

--- a/docs/decisions/issue-635-rep-001-cage-2-replication-preflight.md
+++ b/docs/decisions/issue-635-rep-001-cage-2-replication-preflight.md
@@ -1,0 +1,295 @@
+# Issue 635 REP-001 CAGE-2 Replication Architecture Preflight
+
+Date: 2026-07-01
+
+Issue: #635.
+
+Requirement: REP-001.
+
+This note records architecture guardrails for the REP-001 design work. It is
+guidance only: it does not publish the accepted ADR or design record, author the
+CAGE-2 SDL scenario, create `aces-adapters`, implement a CybORG adapter, add a
+backend harness, or claim replication equivalence.
+
+## Binding Sources
+
+- ADR-001, ADR-002, ADR-004, ADR-008, ADR-020, ADR-022, ADR-054, ADR-060,
+  ADR-066, and ADR-067 own SDL, runtime, participant, observation, and outcome
+  semantics. CAGE-2 terms must map into those surfaces; they must not redefine
+  them.
+- ADR-009, ADR-012, ADR-019, ADR-061, and ADR-062 own normative artifact
+  authority, schema publication, concept authority, controlled vocabularies, and
+  governed extension discipline.
+- ADR-036 owns Python package boundaries. Backends and adapters consume
+  `aces_backend_protocols`, `aces_contracts`, `aces_runtime` public seams, and
+  `aces_conformance`; core packages must not import concrete adapter packages.
+- ADR-063 and the issue #197, #601, and #614 preflight notes define the
+  concrete-backend portable-fact boundary: realization is a backend side effect;
+  portable outputs are manifests, plans, snapshots, diagnostics, participant
+  histories, evidence, and experiment records.
+- ADR-064, ADR-065, ADR-066, and ADR-068 own experiment evidence, run
+  provenance, plane separation, replication, and replay-claim boundaries.
+- The upstream CAGE Challenge 2 repository and paper are source evidence for
+  scenario facts, fixed-step episodes, red-agent variants, reward/scoring,
+  turn order, and evaluation protocol. The REP-001 ADR must pin exact upstream
+  repository commits or releases and cite the source paths it maps.
+- `.ground-control.yaml`, `.gc/plan-rules.md`, ADR-014, `noxfile.py`, and
+  `tools/verify_all.py` remain the repository workflow and verification
+  authority.
+
+## Architecture Decisions
+
+- REP-001 should produce an accepted ADR plus a design record, not code. The
+  ADR decides architecture and boundaries; the design record carries the
+  source-to-ACES mapping evidence, adapter protocol mapping, monorepo layout,
+  equivalence criteria, and cross-repo workflow.
+- The CAGE-2 to ACES SDL mapping must be a mapping ledger over pinned upstream
+  facts. Each host, subnet, service, account, role, action, observation,
+  turn-order rule, terminal condition, reward component, red-agent variant,
+  randomization control, and score/evaluation fact must be mapped, explicitly
+  declared out of scope, or loss-disclosed. Do not introduce CAGE-specific SDL
+  syntax to make the mapping convenient.
+- The CybORG adapter is a conformant simulation backend. It implements the
+  existing `Provisioner`, `Orchestrator`, `Evaluator`, and `ParticipantRuntime`
+  protocols through ACES contracts and manifests. It must not expose CybORG
+  gym/PettingZoo tuples, native action ids, reward arrays, simulator objects, or
+  backend-private state as portable ACES payloads.
+- `sim_adapter_base` is an adapter-monorepo convenience package, not a new ACES
+  semantic authority. It can factor simulator-driver plumbing, seed/clock
+  controls, action/observation projection helpers, manifest helpers, and
+  conformance harness utilities, but it must consume ACES contracts rather than
+  fork protocols, schemas, diagnostics, fixtures, or conformance profiles.
+- `aces-adapters` should be a co-located set of independent adapter projects.
+  Each adapter owns its own dependency lockfile and virtual environment; the
+  root may orchestrate CI but must not make adapters share one resolved
+  dependency graph. Shared packages must be versioned and consumed like ordinary
+  dependencies so a CybORG pin cannot constrain an unrelated adapter.
+- The backend conformance harness in `aces-adapters` should invoke or wrap the
+  existing ACES conformance runner and published backend profiles. It may add
+  simulator-specific probes and seeded equivalence checks, but it must not
+  maintain a second profile table, schema registry, fixture corpus, manifest
+  renderer, exception hierarchy, or result envelope.
+- Replication/equivalence is evidence over canonical artifacts: the same
+  authored ACES SDL scenario must parse, validate, compile, plan, and execute
+  through independent conformant backends with declared manifests and bounded
+  stochastic controls. Success criteria belong in `experiment-study-v1`,
+  `experiment-run-v1`, evidence records, derived measures, backend manifests,
+  runtime snapshots, participant histories, and conformance reports, not in
+  ad hoc notebook output or CI logs.
+- Cross-repo work is issue-driven from ACES. The ACES REP-001 issue owns the
+  requirement and ADR/design authority; downstream `aces-adapters` issues and
+  PRs reference the ACES issue, REP UID, pinned design record, and acceptance
+  evidence. Adapter implementation status must not be inferred from ACES docs
+  alone.
+- Emulation realization of CAGE-2 is explicitly out of scope. Do not design
+  hidden hooks for an emulation backend, libvirt realization path, or mixed
+  sim/emulation equivalence claim in REP-001.
+
+## Required Incumbents
+
+Reuse these repo surfaces before adding anything new:
+
+- SDL ingress and semantics: `parse_sdl()`, `parse_sdl_file()`,
+  `SDLModel(extra="forbid")`, `SemanticValidator`, `compile_runtime_model()`,
+  `compile_scenario_runtime_model()`, planner semantics, participant behavior
+  analysis, action contracts, observation boundaries, outcome interpretation,
+  scoring, objectives, workflows, and evidence requirement validators.
+- Backend protocols and manifests:
+  `aces_backend_protocols.protocols.Provisioner`, `Orchestrator`, `Evaluator`,
+  `ParticipantRuntime`, `BackendManifest`, `BackendCapabilitySet`,
+  `ProvisionerCapabilities`, `OrchestratorCapabilities`,
+  `EvaluatorCapabilities`, `ParticipantRuntimeCapabilities`,
+  `ObservationCapabilities`, `RealizationSupportDeclaration`,
+  `backend_manifest_payload()`, and capability-gap helpers.
+- Neutral runtime contracts: `ProvisioningPlan`, `OrchestrationPlan`,
+  `EvaluationPlan`, `RuntimeSnapshot`, `SnapshotEntry`, `ApplyResult`,
+  `Diagnostic`, `Severity`, `OperationReceipt`, `OperationStatus`,
+  participant episode requests, `ParticipantActionAdmissionRequest`, participant
+  behavior events, shared-state records, and time-management contexts.
+- Runtime and control-plane gates: `BackendRegistry`, `RuntimeTarget`,
+  `RuntimeTargetComponents`, `_validate_runtime_target_shape()`,
+  `RuntimeManager`, `RuntimeControlPlane`, `_call_backend_diagnostics()`,
+  `_call_backend_apply()`, `ControlPlaneStore`, `LocalControlPlaneStore`,
+  request fingerprints, idempotency keys, audit records, and redacted HTTP
+  error handling.
+- Participant runtime base: `BaseParticipantRuntime` for ACES participant
+  episode lifecycle. Simulator stepping, agent order, reward bookkeeping, and
+  CybORG driver state belong behind adapter-owned driver leaves, not in the base
+  class.
+- Conformance and contract authority: `run_target_conformance()`,
+  `contracts/profiles/backend/*.json`, `contracts/fixtures/**`,
+  `BackendManifestV2Model`, `schema_bundle()`,
+  `contracts/schema-publication-manifest.json`,
+  `tools/check_schema_publication.py`, `tools/check_generated_schemas.py`, and
+  `tools/check_json_artifacts.py`.
+- Concept and vocabulary authority:
+  `contracts/concept-authority/controlled-vocabularies-v1.json`,
+  `contracts/concept-authority/concept-families-v1.json`,
+  `validate_controlled_vocabulary_scope_values()`, concept-binding validators,
+  and the governed `x-<owner>:<term>` extension syntax.
+- Experiment and replication artifacts: `ExperimentTaskModel`,
+  `ExperimentRunModel`, `ExperimentStudyModel`,
+  `ExperimentRunAllocationPlanModel`, `ExperimentApparatusContextModel`,
+  `ExperimentCaptureSpecModel`, `ExperimentEvidenceRecordModel`,
+  `ExperimentDerivedMeasureModel`, and their cross-artifact validators.
+- Existing backend patterns: `aces_backend_stubs` only as a non-normative test
+  oracle; `aces_reference_backend` and `aces_backend_libvirt` only for registry,
+  manifest, driver-boundary, and portable-fact patterns, not as superclasses or
+  hidden authorities.
+- Workflow and policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `noxfile.py`, `implementations/python/pyproject.toml`,
+  `tools/policy/adr_policy.yaml`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, and `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- SDL/config ingress: scenario artifacts must pass safe YAML loading, closed
+  SDL models, semantic validation, compilation, planning, and advisory checks.
+  Do not build plans from raw CAGE YAML/Python objects or bypass parser and
+  validator gates.
+- Upstream-source evidence: CAGE-2 inputs must be pinned by repository URL,
+  commit or release, file path, and content digest where practical. Runtime
+  code must not fetch remote CAGE assets during verification or conformance.
+- Manifest/config layer: adapter support claims must validate through
+  `BackendManifest`, `BackendManifestV2Model`, supported-contract allowlists,
+  controlled vocabularies, concept bindings, realization-support declarations,
+  and published backend profiles. Adapter config is target factory config, not
+  hidden SDL fields or ambient environment.
+- Runtime target layer: component presence must match manifest claims, and
+  protocol methods must pass `_validate_runtime_target_shape()`. A CybORG
+  backend that declares all four protocols must provide all four components;
+  partial work must declare only evidence-backed capabilities.
+- Backend apply layer: every backend call must return `Diagnostic` or
+  `ApplyResult` values accepted by `_call_backend_diagnostics()` and
+  `_call_backend_apply()`. The apply gate deep-copies snapshots, wraps
+  unexpected exceptions, validates snapshot and history contracts, and rejects
+  invalid output through `runtime.backend-contract-invalid`.
+- Participant and observation layer: action admission must flow through
+  `ParticipantActionAdmissionRequest`, compiled action-contract addresses,
+  compiled observation-boundary addresses, implementation provenance, exposure
+  policy, and participant history validators. Red/blue/green CybORG agents,
+  backend identity, evaluator identity, participant implementation identity,
+  and control-plane caller identity are distinct.
+- Evaluation and reward layer: CAGE reward vectors and final score must map to
+  ACES evaluation/objective/derived-measure surfaces with declared limitations.
+  Reward is not participant-local outcome, workflow success, objective success,
+  or conformance by itself.
+- Experiment/replication layer: repeated runs and equivalence evidence must use
+  `experiment-run-v1` plus `experiment-study-v1` membership/allocation,
+  factors, condition assignments, stochastic controls, evidence records, and
+  derived measures. Do not infer replication from repeated simulator calls or
+  operation ids.
+- Conformance layer: contract/profile/fixture loading must use the published
+  ACES corpus and path-confined overrides. Report failures as structured
+  `Diagnostic` values; do not execute fixture content, fetch remote fixtures,
+  or echo malformed payload bodies in diagnostics.
+- Control-plane security layer: any HTTP or service harness must reuse
+  `ControlPlaneSecurityConfig.strict_defaults()`, explicit identities or bearer
+  tokens, role checks, request-size limits, idempotency fingerprints, audit
+  events, and redacted internal-error envelopes. Tokens must not be passed in
+  process argv or printed in logs.
+- Secret and OS-exposure layer: CybORG configs, dependency pins, seed values,
+  local paths, credentials, bearer tokens, private keys, hidden scenario truth,
+  process argv, environment dumps, native simulator object reprs, stdout/stderr,
+  and full tracebacks must not enter SDL, snapshots, diagnostics, audit records,
+  fixtures, evidence records, docs, or changelog text. If a subprocess leaf is
+  unavoidable, use fixed argv, no `shell=True`, bounded timeouts, controlled
+  working directories, and redacted diagnostics.
+- Persistence layer: live state uses `RuntimeSnapshot` and `ControlPlaneStore`;
+  archival evidence uses experiment/evidence/provenance contracts. Do not add
+  adapter-specific stores, audit logs, or result databases as portable
+  authority.
+- Workflow/policy layer: ACES changes still pass repo policy, requirement
+  governance, generated-schema parity, schema publication, JSON artifact, docs,
+  and full nox verification gates. `aces-adapters` should define an analogous
+  per-adapter CI matrix, but it should not weaken ACES gates or mirror their
+  code blindly.
+
+## Equivalence Guardrail
+
+The REP-001 design should define equivalence as tiered evidence, not a single
+boolean:
+
+- authored-source equivalence: one ACES SDL scenario, no backend-specific SDL
+  branches, and a complete pinned CAGE-2 mapping ledger;
+- contract equivalence: each backend manifest validates, declares only
+  evidence-backed support, and passes the applicable backend conformance
+  profile plus participant/evaluation/runtime contract checks;
+- execution-control equivalence: same trial length, red-agent variant, seed or
+  stochastic-control declaration, logical step count, agent turn order,
+  episode termination rule, and participant implementation selection;
+- state/observation equivalence: mapped topology, services, privileges,
+  visibility, observations, action admissibility, and shared-state transitions
+  match the declared ACES semantics, with every mismatch either failing or
+  carrying a mapping-loss disclosure;
+- outcome/evaluation equivalence: reward components, objective results,
+  evidence, derived measures, and cumulative score match the declared
+  equivalence margins and confidence/evidence criteria.
+
+If a backend cannot expose a fact needed for one tier, the result is a disclosed
+weaker claim or a failed equivalence check. It is not acceptable to fill the gap
+with fixture-local assertions, simulator-native logs, or prose-only evidence.
+
+## Extensibility Boundary
+
+The seam for future variation is:
+
+- a source-mapping ledger parameterized by upstream source version, scenario id,
+  red-agent policy, trial length, seed/stochastic-control policy, and declared
+  loss disclosures;
+- the backend registry descriptor/config seam for target construction and
+  injected simulator drivers;
+- a `sim_adapter_base` driver/projection layer parameterized by simulator
+  package/version, clock/step policy, action translator, observation projector,
+  reward/evaluator projector, and conformance probe set;
+- published backend profile ids and contract ids loaded from ACES artifacts,
+  not hard-coded enum branches in adapter CI;
+- a per-adapter CI matrix axis for adapter project path, lockfile, Python
+  version, optional simulator extras, conformance profile, and seed suite.
+
+A future simulator backend, CybORG version, CAGE scenario, red-agent variant,
+or seed suite should add a mapping-ledger row, target config value, driver
+implementation, adapter project, or CI matrix entry. It should not require
+changing ACES core contracts, SDL syntax, runtime manager, control plane,
+schema registry, conformance profile authority, or experiment artifact
+identity.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating CAGE-2 narrative names, CybORG class names, gym spaces, action ids,
+  reward vectors, or leaderboard scores as ACES semantics without an explicit
+  mapping and loss disclosure;
+- adding CAGE/CybORG-specific SDL sections, schemas, vocabularies, manifest
+  blocks, backend profiles, exception hierarchies, persistence stores, audit
+  logs, or conformance runners when existing ACES surfaces carry the fact;
+- subclassing `aces_backend_stubs` or copying stub capability claims into the
+  CybORG adapter;
+- declaring `ParticipantRuntime`, evaluator, observation, or feature-support
+  capabilities before the adapter emits the required contracts and evidence;
+- using `RuntimeSnapshot.metadata`, `ApplyResult.details`, notebook outputs,
+  raw simulator logs, or CI stdout as portable scenario, participant, reward,
+  or equivalence authority;
+- merging backend identity, participant implementation identity, simulator
+  policy identity, evaluator identity, and HTTP caller identity;
+- claiming bit-for-bit state identity when the design only proves declared
+  semantic equivalence with margins and disclosures;
+- making default verification depend on network fetches, external simulator
+  state, privileged host access, private credentials, or one global dependency
+  lock shared by all adapters;
+- routing cross-repo implementation status through informal comments instead of
+  linked issues, PRs, requirement UID references, and readback evidence.
+
+## Non-Goals
+
+- Implementing the REP-001 ADR/design record in this preflight note.
+- Authoring the CAGE-2 SDL scenario, mapping ledger, examples, tests,
+  conformance probes, experiment artifacts, or evidence bundles.
+- Creating `aces-adapters`, `sim_adapter_base`, a CybORG backend package,
+  dependency lockfiles, CI workflows, or cross-repo issues.
+- Adding or changing ACES SDL syntax, published schemas, backend profiles,
+  concept vocabularies, control-plane APIs, runtime stores, conformance
+  authority, exception hierarchies, or logging/audit infrastructure.
+- Realizing CAGE-2 on an emulation backend or designing a hidden path for that
+  deferred work.


### PR DESCRIPTION
## Summary

Defines the accepted REP-001 architecture for driving CAGE-2 through ACES into a conformant simulator backend, plus the companion design checklist for downstream adapter work.

## Requirement UIDs

- `REP-001`

## Related Issues

Closes #635

## ADR Impact

- ADR-069

## Changes

- Added ADR-069 for the CAGE-2 replication architecture and accepted scope boundaries.
- Added the CAGE-2 replication design record covering source pins, mapping-ledger shape, CybORG protocol mapping, sim_adapter_base boundaries, aces-adapters layout, conformance harness, equivalence criteria, and cross-repo workflow.
- Updated ADR README/index metadata with the ADR-069 toctree entry and acceptance pin.
- Kept the architecture preflight note and added a changelog fragment for the user-visible design record.

## Test Plan

- [x] `pre-commit run --all-files`
- [x] `ACES_REQUIREMENT_UID=REP-001 implementations/python/.venv/bin/python tools/check_repo_policy.py`
- [x] `ACES_REQUIREMENT_UID=REP-001 implementations/python/.venv/bin/python tools/check_requirement_governance.py` (exited cleanly after built-in Ground Control timeout skip)
- [x] `ACES_REQUIREMENT_UID=REP-001 implementations/python/.venv/bin/python tools/verify_all.py` (ran configured nox verify: policy, ADR pinning, schema checks, 2954 pytest tests, 25 integration tests, and Sphinx)
- [x] Ground Control quality gates returned ok with no enabled gates
- [x] Codex and test-quality pre-push review cycles both returned clean

## Ground Control Checks

- [x] Repository policy and requirement-governance checks ran with REP-001 context
- [x] `gc_assert_quality_gates` passed for REP-001
- [x] Pre-push Codex and test-quality review records posted clean decisions

## Traceability

- IMPLEMENTS: REP-001 <- docs/decisions/adrs/adr-069-cage-2-replication-architecture.md, REP-001 <- docs/decisions/cage-2-replication-design.md
- TESTS: (none - documentation/configuration/structural-invariant run)

## Checklist

- [x] ADR index and acceptance pin updated
- [x] Documentation-only carve-out revalidated against tracked, staged, and untracked paths
- [x] Changelog fragment added for user-visible design work
