### PR TITLE
fixed: parameterize target-conformance probe with a backend-supplied reference scenario

### DIFF
--- a/changelog.d/663.fixed.md
+++ b/changelog.d/663.fixed.md
@@ -1,0 +1,7 @@
+Target conformance no longer assumes every backend can realize an arbitrary
+reference scenario. `run_target_conformance` accepts an optional
+`reference_scenario`, so a fixed-topology emulation or bounded simulation
+backend can certify against a scenario it declares it can realize instead of
+being wrongly failed for not realizing a hard-coded `vm` node; the issue #606
+full-realization guard still applies to whichever scenario is selected.
+Temporary bridge superseded by the realizability-envelope design (#667/#668).

--- a/docs/decisions/issue-606-libvirt-conformance-preflight.md
+++ b/docs/decisions/issue-606-libvirt-conformance-preflight.md
@@ -12,6 +12,14 @@ fixture-level and target-level backend conformance. It is guidance only: it
 does not implement the conformance probe, change manifests, add schemas, or add
 live-daemon behavior.
 
+Correction for issue #663: this note's backend-neutral live provisioning probe
+guardrail applies only when the selected probe scenario is within the target's
+declared or supplied realization envelope. Backend conformance must not treat a
+fixed hard-coded VM scenario as universal proof material for scenario-scoped,
+fixed-topology, or simulation backends. See
+`docs/decisions/issue-663-target-conformance-provisioning-scope-preflight.md`
+for the contract-conformance versus scenario-realizability boundary.
+
 ## Binding Sources
 
 - `docs/explain/reference/backend-conformance.md` owns the backend conformance

--- a/docs/decisions/issue-663-target-conformance-provisioning-scope-preflight.md
+++ b/docs/decisions/issue-663-target-conformance-provisioning-scope-preflight.md
@@ -1,0 +1,200 @@
+# Issue 663 Target Conformance Provisioning Scope Preflight
+
+Date: 2026-07-04
+
+Issue: #663.
+
+Requirement: none. The GitHub issue title, body, and acceptance criteria are
+the contract.
+
+This note records architecture guardrails for correcting target conformance
+after issue #606. It is guidance only: it does not implement the probe, change
+schemas, add profiles, or certify a downstream backend.
+
+## Binding Sources
+
+- `docs/explain/reference/backend-conformance.md` owns the backend conformance
+  model: profiles and fixtures are published contract authority; target
+  conformance is implementation-side verification.
+- `docs/decisions/issue-606-libvirt-conformance-preflight.md` introduced the
+  backend-neutral live provisioning probe. This issue narrows that guardrail:
+  contract conformance and arbitrary scenario realizability are distinct.
+- `contracts/profiles/backend/*.json`, `aces_contracts.backend_profiles`, and
+  `BackendCapabilityProfile` define contract sets and known runtime surfaces.
+  They are not scenario fixture catalogs.
+- `BackendManifest`, `ProvisionerCapabilities`, `RealizationSupportDeclaration`,
+  `backend_manifest_payload()`, and `BackendManifestV2Model` are the existing
+  capability and realization declaration surfaces.
+- `run_reference_processor()`, `RuntimeControlPlane`,
+  `OperationReceipt`/`OperationStatus`, `RuntimeSnapshotEnvelope`, and
+  `ConformanceCaseResult` are the incumbent live-probe and report seams.
+- `_validate_payload()`, `_semantic_diagnostics()`,
+  `_capability_gaps()`, `_declared_contract_gaps()`,
+  `participant_runtime_capability_contract_gaps()`, and
+  `observation_capability_contract_gaps()` are the shared validation and
+  capability-claim gates that must remain active.
+
+## Architecture Decisions
+
+- Do not treat a backend profile as a promise to realize any arbitrary SDL
+  scenario. Backend profiles certify contract sets and known runtime surfaces;
+  realizability is a separate claim that must be negotiated from the manifest
+  and the selected live-probe input.
+- Keep `operation-status-v1` contract conformance separate from successful
+  realization. A backend that rejects an unsupported scenario with a well-formed
+  operation status and diagnostics may be contract-conformant; that rejection is
+  not, by itself, proof that the backend lacks the provisioning contract.
+- Keep issue #606's no-op guard for applicable live probes. When the selected
+  probe scenario is within the backend's declared/provided support envelope,
+  conformance must still require a succeeded provisioning operation,
+  non-empty changed addresses, and a snapshot that validates and carries
+  provisioning-domain state.
+- Use existing manifest surfaces first. `realization_support.support_mode`,
+  `supported_constraint_kinds`, `supported_exact_requirement_kinds`,
+  `ProvisionerCapabilities`, and manifest `constraints` are the current
+  disclosure surfaces for bounded or scenario-scoped realization. Do not add a
+  second conformance-only capability schema.
+- The reference scenario seam belongs at target-conformance invocation or
+  target construction, using existing `Scenario`/`ProvisioningPlan` data and an
+  expected snapshot/changed-address predicate. Do not put backend-specific
+  scenario fixtures in `contracts/profiles/backend`, and do not hard-code APTL,
+  libvirt, Docker, or VM assumptions in `aces_conformance`.
+- If a backend supplies a supported reference scenario, process it through
+  `parse_sdl()`/`run_reference_processor()` and the target manifest. Do not
+  bypass the reference processor, planner manifest validation, or
+  `RuntimeControlPlane`.
+- The same boundary applies to participant-runtime live probes: a full remote
+  control plane can still be required to prove RUN-311 control envelopes, but
+  the probe must not require an arbitrary participant address or topology when a
+  fixed-topology backend can only drive declared or realized participants.
+
+## Required Incumbents
+
+Reuse these before adding anything new:
+
+- Conformance runner/reporting:
+  `run_target_conformance()`, `_live_target_cases()`,
+  `_provisioning_probe_case()`, `_live_snapshot_case()`,
+  `_drive_participant_episode_probe()`, `ConformanceCaseResult`, and
+  `BackendConformanceReport`.
+- Profile and fixture authority:
+  `required_contracts()`, `_resolve_required_contracts()`,
+  `load_backend_profile_from_path()`, `fixtures_root()`, `profiles_root()`,
+  `schema_bundle()`, and the published `contracts/` corpus.
+- Manifest/capability authority:
+  `BackendManifest`, `BackendCapabilitySet`, `ProvisionerCapabilities`,
+  `RealizationSupportDeclaration`, `backend_manifest_payload()`,
+  `BackendManifestV2Model`, `validate_backend_supported_contract_versions()`,
+  and controlled-vocabulary validators.
+- Planning/runtime gates:
+  `run_reference_processor()`, planner manifest validation,
+  `RuntimeTarget` shape validation, `RuntimeControlPlane.submit_provisioning()`,
+  `_call_backend_diagnostics()`, `_call_backend_apply()`,
+  `_snapshot_contract_diagnostics()`, `OperationReceipt`, `OperationStatus`,
+  and `RuntimeSnapshot`.
+- Claim-gap checks:
+  `_capability_gaps()`, `_declared_contract_gaps()`,
+  `participant_runtime_capability_contract_gaps()`, and
+  `observation_capability_contract_gaps()`.
+- Test precedents:
+  `test_runtime_conformance.py`, `test_reference_backend_conformance.py`,
+  `test_libvirt_conformance.py`, `test_backend_conformance_cli.py`, and
+  seeded corpus tests that assert stable diagnostic codes instead of exact
+  validator prose.
+- Repository policy:
+  `.ground-control.yaml`, `.gc/plan-rules.md`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, and `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- Profile and corpus ingress: profile ids must keep flowing through
+  `aces_contracts.backend_profiles` grammar and root confinement; fixtures and
+  profile defaults must keep resolving through `aces_contracts.corpus`. The fix
+  must not fetch remote scenarios, use path separators in profile ids, or add
+  repo-root parent heuristics.
+- SDL and planning layer: any supplied reference scenario must be parsed and
+  planned by the existing parser/reference processor against the target
+  manifest. Planner diagnostics for unsupported node types, OS families,
+  content, accounts, workflow features, or realization requirements are real
+  capability evidence, not strings to reinterpret locally in conformance.
+- Contract shape layer: manifests, provisioning plans, operation receipts,
+  operation statuses, and snapshots must validate through existing Pydantic
+  contract models and closed-world schemas. Do not add local DTOs or ad hoc key
+  checks for the new branch.
+- Manifest authority layer: `supported_contract_versions`, concept bindings,
+  capability vocabulary terms, and realization support declarations must pass
+  existing validators. Do not suppress unsupported-contract or
+  unsupported-capability diagnostics to make a scenario-scoped backend pass.
+- Runtime target layer: `RuntimeTarget` component presence and callable
+  signatures must still match the manifest. A target that declares a surface it
+  does not provide must fail before probe negotiation matters.
+- Control-plane/apply layer: live probes must submit through
+  `RuntimeControlPlane`. `_call_backend_apply()` must continue to deep-copy the
+  baseline snapshot, reject malformed `ApplyResult` values, preserve baseline
+  state on failure, and validate snapshot/result contracts.
+- Error-envelope layer: report public failures as `Diagnostic` values with
+  stable codes, addresses, domains, severities, and redacted messages. Do not
+  surface raw tracebacks, native object reprs, libvirt XML, compose files,
+  stdout/stderr, host paths, connection URIs, credentials, tokens, or process
+  environment.
+- OS and secret exposure layer: target conformance must not require secrets in
+  CLI arguments or process argv, inspect `~/.secrets`, read host daemon
+  inventory, or rely on privileged libvirt/Docker/APTL state in the default
+  hermetic verification path.
+- Persistence layer: conformance remains report-oriented. Do not add a
+  conformance database, native state ledger, or scenario cache. If durable
+  report output is later required, reuse existing run-artifact writers rather
+  than inventing a writer.
+
+## Extensibility Seam
+
+The seam is a selected live-probe input plus an applicability decision, not a
+new profile family. The obvious future variation is a backend- or caller-supplied
+reference scenario for a fixed topology. Keep that parameterized as a
+`Scenario`/`ProvisioningPlan` source and expected changed-address/snapshot
+predicate so future simulation, emulation, and infrastructure backends can
+provide supported probes without editing the canonical runner for each backend.
+
+If the realization/applicability declaration must become portable across
+processes, extend `backend-manifest-v2` deliberately with schema-publication
+governance. Until then, use the existing manifest capability/realization fields
+and runner parameter seams rather than publishing a new schema or overloading
+backend profiles.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- equating `provisioning-only`, `orchestration-evaluation`, or
+  `full-remote-control-plane` with universal SDL scenario support;
+- making a fixed hard-coded `vm` scenario the only proof path for all backends;
+- deleting issue #606's mutation check for backends that can realize the
+  selected probe scenario;
+- treating an unsupported-scenario `OperationStatus(state="failed")` as a
+  conformance failure when the failure is well-formed and diagnostically
+  explains an out-of-envelope scenario;
+- allowing a backend to pass live target conformance with a success-returning
+  no-op when a supported probe was selected;
+- adding APTL-specific, libvirt-specific, Docker-specific, or simulator-specific
+  branches to `aces_conformance`;
+- adding duplicate profile maps, capability DTOs, schemas, exception
+  hierarchies, report formats, or validation helpers;
+- hiding capability under-claims or over-claims by skipping
+  `_declared_contract_gaps()` or capability-claim checks;
+- using manifest `constraints` prose as the only machine-verifiable authority
+  for a new portable claim without a later schema-governed field;
+- changing published schemas or profiles without
+  `contracts/schema-publication-manifest.json` and generated-schema parity.
+
+## Non-Goals
+
+- Implementing issue #663 in this preflight.
+- Certifying APTL, libvirt, the reference backend, or any consumer repository.
+- Redesigning backend profiles, published fixture structure, report schemas,
+  `RuntimeControlPlane`, `ProvisioningPlan`, `RuntimeSnapshot`, or the
+  reference processor.
+- Weakening manifest contract coverage, capability-gap diagnostics, target
+  shape validation, or snapshot semantic validation.
+- Publishing a new schema, controlled vocabulary, backend profile, SDL syntax,
+  or native topology fixture in this issue unless implementation proves the
+  existing manifest and runner seams cannot carry the distinction.

--- a/docs/explain/reference/backend-conformance.md
+++ b/docs/explain/reference/backend-conformance.md
@@ -184,6 +184,32 @@ the command can be wired directly into CI gates. The historic
 `python -m aces_conformance.runner` entry point is preserved as a thin
 delegate that forwards to the same Typer command.
 
+## Target Conformance Reference Scenario
+
+Target conformance drives a live provisioning/snapshot probe (issue #606) that
+proves *real* realization — a succeeded provisioning operation, non-empty
+changed addresses, and a mutated snapshot — not merely a valid manifest. The
+probe needs a scenario to realize. By default it uses a generic linux-vm
+scenario (`_DEFAULT_CONFORMANCE_SCENARIO`).
+
+A single hard-coded scenario wrongly assumes *every* backend can realize it.
+Fixed-topology emulation backends (which map ACES nodes onto a pre-built
+environment) and bounded simulation backends legitimately cannot realize an
+arbitrary scenario, yet still honor the provisioning contract. `run_target_conformance`
+therefore accepts an optional `reference_scenario` (issue #663): a backend or
+caller supplies a scenario it declares it can realize, and the probe holds it to
+**full realization of that scenario** — the #606 mutation guard is unchanged, so
+this negotiates *which* scenario is realized without weakening the requirement
+that one is.
+
+This runner parameter is a **temporary bridge**. The durable answer is a portable
+*realizability envelope* — one parameterized/typed SDL semantics with open/closed
+posture that both authored scenarios and backend manifests reference, plus a
+scenario/envelope subsumption relation the probe checks (and from which it derives
+an in-envelope witness). That design is tracked in #667, with the subsumption
+relation in #668; contract conformance and scenario realizability are distinct
+dimensions and must stay separately reportable.
+
 ## Non-Goals
 
 This preflight does not implement `ASR-502`, change requirement status, add new

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -69,14 +69,13 @@ from aces_processor.models import (
     iter_participant_behavior_history_violations,
     iter_participant_behavior_joint_action_violations,
 )
-from aces_processor.reference import run_reference_processor
+from aces_processor.reference import ScenarioInput, run_reference_processor
 from aces_runtime.control_plane import RuntimeControlPlane
 from aces_runtime.registry import RuntimeTarget
 from aces_runtime.result_contracts import (
     evaluation_result_contract_diagnostics,
     workflow_result_contract_diagnostics,
 )
-from aces_sdl.parser import parse_sdl
 from pydantic import ValidationError
 
 _SEMANTIC_INVALID_DIAGNOSTIC_CODE = "conformance.semantic-invalid"
@@ -95,6 +94,47 @@ _PORTABLE_AUGMENTATION_CARRIER_KINDS = frozenset(
     }
 )
 _RUN_REFINEMENT_CONCERN_KINDS = frozenset({"capture-window", "measurement-channel"})
+
+# Default reference scenario the target-conformance live probe drives when the
+# caller supplies none. Backend-neutral: a single generic linux vm node.
+#
+# Issue #663 makes this a *default*, not a universal assumption. A fixed-topology
+# emulation or bounded simulation backend that cannot realize this generic
+# scenario supplies one it can realize via
+# ``run_target_conformance(reference_scenario=...)``; the live probe then holds
+# it to full realization of *that* scenario. This is a temporary runner-parameter
+# bridge — superseded by the realizability-envelope design (#667) and the
+# scenario/envelope subsumption relation (#668), which will let the probe
+# negotiate an in-envelope witness instead of carrying a default at all.
+_DEFAULT_CONFORMANCE_SCENARIO = dedent(
+    """
+    name: conformance
+    nodes:
+      vm:
+        type: vm
+        os: linux
+        resources: {ram: 1 gib, cpu: 1}
+        conditions: {health: ops}
+        roles: {ops: operator}
+    conditions:
+      health: {command: /bin/true, interval: 15}
+    entities:
+      blue: {role: blue}
+    objectives:
+      validate:
+        entity: blue
+        success: {conditions: [health]}
+    workflows:
+      response:
+        start: run
+        steps:
+          run:
+            type: objective
+            objective: validate
+            on-success: finish
+          finish: {type: end}
+    """
+)
 
 
 class BackendCapabilityProfile(str, Enum):
@@ -1121,11 +1161,22 @@ def run_target_conformance(
     profile: BackendProfileSelector | None = None,
     root: Path | None = None,
     profiles_root: Path | None = None,
+    reference_scenario: ScenarioInput | None = None,
 ) -> BackendConformanceReport:
     """Run fixture conformance for a target's declared runtime surface.
 
     ``root`` overrides the fixtures tree and ``profiles_root`` overrides the
     backend profile tree; both default to the canonical published roots.
+
+    ``reference_scenario`` selects the scenario the live provisioning/snapshot
+    probes drive (issue #663). It defaults to a generic linux-vm scenario
+    (``_DEFAULT_CONFORMANCE_SCENARIO``). A fixed-topology emulation or bounded
+    simulation backend that cannot realize the generic default supplies a
+    scenario it *can* realize here, instead of being wrongly failed for not
+    realizing an arbitrary hard-coded scenario; the probe still requires full
+    realization (issue #606 mutation guard) of whichever scenario is selected.
+    This is a temporary runner-parameter bridge superseded by the
+    realizability-envelope design (#667/#668).
     """
 
     effective_profile = profile or profile_for_manifest(target.manifest)
@@ -1205,7 +1256,7 @@ def run_target_conformance(
                 + "; ".join(claim_gaps),
             )
         )
-    live_cases = _live_target_cases(target, effective_profile)
+    live_cases = _live_target_cases(target, effective_profile, reference_scenario=reference_scenario)
     cases = tuple((*fixture_report.cases, *live_cases))
     passed = passed and all(case.passed for case in live_cases)
     return BackendConformanceReport(
@@ -1483,6 +1534,8 @@ def _live_snapshot_case(control_plane: RuntimeControlPlane) -> ConformanceCaseRe
 def _live_target_cases(
     target: RuntimeTarget,
     profile: BackendProfileSelector,
+    *,
+    reference_scenario: ScenarioInput | None = None,
 ) -> tuple[ConformanceCaseResult, ...]:
     """Run live probes appropriate for known runtime surfaces only.
 
@@ -1494,6 +1547,12 @@ def _live_target_cases(
     that declare those roles. For an unknown profile id we run only the
     universally-safe manifest validation case and skip the live probes, since
     their runtime contract is not known to this implementation.
+
+    The probe drives ``reference_scenario`` when supplied, else
+    ``_DEFAULT_CONFORMANCE_SCENARIO`` (issue #663). Whichever scenario is
+    selected is held to full realization (the #606 mutation guard is
+    unchanged); the parameter only stops the probe assuming *every* backend can
+    realize one hard-coded scenario.
     """
 
     cases: list[ConformanceCaseResult] = []
@@ -1513,37 +1572,7 @@ def _live_target_cases(
     if known is None:
         return tuple(cases)
 
-    scenario = parse_sdl(
-        dedent(
-            """
-            name: conformance
-            nodes:
-              vm:
-                type: vm
-                os: linux
-                resources: {ram: 1 gib, cpu: 1}
-                conditions: {health: ops}
-                roles: {ops: operator}
-            conditions:
-              health: {command: /bin/true, interval: 15}
-            entities:
-              blue: {role: blue}
-            objectives:
-              validate:
-                entity: blue
-                success: {conditions: [health]}
-            workflows:
-              response:
-                start: run
-                steps:
-                  run:
-                    type: objective
-                    objective: validate
-                    on-success: finish
-                  finish: {type: end}
-            """
-        )
-    )
+    scenario = _DEFAULT_CONFORMANCE_SCENARIO if reference_scenario is None else reference_scenario
     execution_plan = run_reference_processor(scenario, target.manifest).execution_plan
     control_plane = RuntimeControlPlane(target)
     cases.append(_provisioning_probe_case(control_plane, execution_plan.provisioning))

--- a/implementations/python/tests/test_runtime_conformance.py
+++ b/implementations/python/tests/test_runtime_conformance.py
@@ -6,8 +6,16 @@ import json
 from pathlib import Path
 
 import pytest
-from aces_backend_protocols.capabilities import BackendManifest
+from aces_backend_protocols.capabilities import (
+    BackendCapabilitySet,
+    BackendManifest,
+    ProvisionerCapabilities,
+)
 from aces_conformance.conformance import _semantic_diagnostics
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
+from aces_contracts.planning import ChangeAction, RuntimeDomain
+from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
+from aces_contracts.vocabulary import RealizationSupportMode
 
 from aces.backends.stubs import create_stub_components, create_stub_manifest, create_stub_target
 from aces.core.runtime.conformance import (
@@ -1112,3 +1120,183 @@ def test_run_fixture_suite_load_failure_diagnostic_does_not_echo_input(tmp_path:
     assert report.passed is False
     for diag in report.diagnostics:
         assert sentinel not in diag.message, "profile-load diagnostic must not echo the rejected input value verbatim"
+
+
+# --- Issue #663: caller-supplied reference scenario for target conformance ---
+#
+# A fixed-topology emulation backend (e.g. APTL) declares generic provisioning
+# capability but only realizes nodes that map to its pre-built environment. The
+# probe must not fail it for refusing an arbitrary hard-coded scenario; it must
+# let the backend supply a scenario it can realize, held to full realization.
+# Temporary runner-parameter bridge, superseded by #667/#668.
+
+_FIXED_TOPOLOGY_PREBUILT_NODE = "prebuilt"
+
+
+def _fixed_topology_manifest() -> BackendManifest:
+    """Provisioning-only manifest declaring generic vm/linux support.
+
+    Both the default conformance scenario (node ``vm``) and a supplied scenario
+    (node ``prebuilt``) plan cleanly against it; the difference is purely at
+    realization, exercised by ``_FixedTopologyProvisioner``.
+    """
+
+    return BackendManifest(
+        name="fixed-topology",
+        version="1.0.0",
+        supported_contract_versions=frozenset(
+            {
+                "backend-manifest-v2",
+                "operation-receipt-v1",
+                "operation-status-v1",
+                "runtime-snapshot-v1",
+            }
+        ),
+        compatible_processors=frozenset({"aces-reference-processor"}),
+        concept_bindings=(
+            ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
+            ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
+        ),
+        realization_support=(
+            RealizationSupportDeclaration(
+                domain="runtime-realization",
+                support_mode=RealizationSupportMode.CONSTRAINED,
+                supported_constraint_kinds=frozenset({"node-type", "os-family"}),
+                supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
+                disclosure_kinds=frozenset({"backend-manifest-v2", "runtime-snapshot-v1", "operation-status-v1"}),
+            ),
+        ),
+        capabilities=BackendCapabilitySet(
+            provisioner=ProvisionerCapabilities(
+                name="fixed-topology-provisioner",
+                supported_node_types=frozenset({"vm"}),
+                supported_os_families=frozenset({"linux"}),
+            ),
+        ),
+    )
+
+
+class _FixedTopologyProvisioner:
+    """Realizes only the one pre-built node; fails fast on anything else.
+
+    Mirrors a fixed-topology emulation backend that maps ACES nodes onto a
+    pre-built environment and refuses nodes it has no realization for.
+    """
+
+    def validate(self, plan) -> list:
+        return []
+
+    def apply(self, plan, snapshot: RuntimeSnapshot) -> ApplyResult:
+        node_ops = [op for op in plan.operations if op.resource_type == "node" and op.action != ChangeAction.DELETE]
+        unmapped = [op for op in node_ops if op.payload.get("node_name") != _FIXED_TOPOLOGY_PREBUILT_NODE]
+        if not node_ops or unmapped:
+            return ApplyResult(
+                success=False,
+                snapshot=snapshot,
+                diagnostics=("fixed-topology backend has no realization for the requested node(s)",),
+            )
+        entries = dict(snapshot.entries)
+        changed: list[str] = []
+        for op in plan.operations:
+            entries[op.address] = SnapshotEntry(
+                address=op.address,
+                domain=RuntimeDomain.PROVISIONING,
+                resource_type=op.resource_type,
+                payload=op.payload,
+                ordering_dependencies=op.ordering_dependencies,
+                refresh_dependencies=op.refresh_dependencies,
+                status="applied",
+            )
+            changed.append(op.address)
+        return ApplyResult(success=True, snapshot=snapshot.with_entries(entries), changed_addresses=changed)
+
+
+class _NoopProvisioner(_FixedTopologyProvisioner):
+    """Accepts everything but realizes nothing (success-returning no-op)."""
+
+    def apply(self, plan, snapshot: RuntimeSnapshot) -> ApplyResult:
+        return ApplyResult(success=True, snapshot=snapshot, changed_addresses=[])
+
+
+def _reference_scenario(node_name: str, *, os_family: str = "linux") -> str:
+    return f"""
+name: conformance
+nodes:
+  {node_name}:
+    type: vm
+    os: {os_family}
+    resources: {{ram: 1 gib, cpu: 1}}
+    conditions: {{health: ops}}
+    roles: {{ops: operator}}
+conditions:
+  health: {{command: /bin/true, interval: 15}}
+entities:
+  blue: {{role: blue}}
+objectives:
+  validate: {{entity: blue, success: {{conditions: [health]}}}}
+workflows:
+  response:
+    start: run
+    steps:
+      run: {{type: objective, objective: validate, on-success: finish}}
+      finish: {{type: end}}
+"""
+
+
+def _fixed_topology_target(provisioner=None) -> RuntimeTarget:
+    return RuntimeTarget(
+        name="fixed-topology",
+        manifest=_fixed_topology_manifest(),
+        provisioner=provisioner or _FixedTopologyProvisioner(),
+    )
+
+
+def test_target_conformance_default_scenario_fails_fixed_topology_backend():
+    """Issue #663: the hard-coded default scenario is not universally realizable.
+
+    A fixed-topology backend that cannot realize the generic ``vm`` node fails
+    the default probe — the reported false negative the reference-scenario seam
+    exists to correct.
+    """
+
+    report = run_target_conformance(_fixed_topology_target())
+
+    assert report.profile == BackendCapabilityProfile.PROVISIONING_ONLY
+    assert report.passed is False
+    provisioning = next(case for case in report.cases if case.name == "live-provisioning")
+    assert provisioning.passed is False
+    assert any(diag.code == "conformance.provisioning-failed" for diag in provisioning.diagnostics)
+
+
+def test_target_conformance_accepts_supplied_reference_scenario():
+    """Issue #663: a backend-supplied scenario it can realize passes, and full
+    realization (issue #606 mutation guard) is still required and met."""
+
+    report = run_target_conformance(
+        _fixed_topology_target(),
+        reference_scenario=_reference_scenario(_FIXED_TOPOLOGY_PREBUILT_NODE),
+    )
+
+    assert report.passed is True
+    provisioning = next(case for case in report.cases if case.name == "live-provisioning")
+    assert provisioning.passed is True
+    snapshot_case = next(case for case in report.cases if case.name == "live-snapshot")
+    assert snapshot_case.passed is True
+
+
+def test_supplied_reference_scenario_still_enforces_mutation_guard():
+    """The reference-scenario seam does not weaken the realization bar: a
+    success-returning no-op provisioner still fails on a supplied scenario."""
+
+    report = run_target_conformance(
+        _fixed_topology_target(provisioner=_NoopProvisioner()),
+        reference_scenario=_reference_scenario(_FIXED_TOPOLOGY_PREBUILT_NODE),
+    )
+
+    assert report.passed is False
+    provisioning = next(case for case in report.cases if case.name == "live-provisioning")
+    snapshot_case = next(case for case in report.cases if case.name == "live-snapshot")
+    assert provisioning.passed is False
+    assert snapshot_case.passed is False
+    codes = {diag.code for case in report.cases for diag in case.diagnostics}
+    assert "conformance.snapshot-not-mutated" in codes


### PR DESCRIPTION
## Summary

The backend-neutral target-conformance live provisioning probe (issue #606) assumed every backend could realize a single hard-coded vm/linux scenario, so fixed-topology emulation backends (e.g. APTL, which maps ACES nodes onto a pre-built environment) and bounded simulation backends were wrongly reported non-conformant for refusing an arbitrary scenario. This is a temporary bridge: run_target_conformance now accepts an optional reference_scenario, so a backend supplies a scenario it declares it can realize; the issue #606 full-realization guard (succeeded op + changed addresses + mutated snapshot) still applies to whichever scenario is selected. No schema, manifest, or profile change. Superseded by the realizability-envelope design (#667) and the scenario/envelope subsumption relation (#668).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #663

## ADR Impact

- ADR-021
- ADR-063

## Changes

- conformance.py: add optional reference_scenario to run_target_conformance, threaded to _live_target_cases; extract the default scenario into _DEFAULT_CONFORMANCE_SCENARIO
- Preserve the #606 mutation guard for whichever scenario is selected (no contract-only weakening)
- tests: fixed-topology backend fails the default scenario, passes a supplied realizable scenario, and a no-op still fails (guard intact)
- docs: backend-conformance.md documents the reference-scenario seam as a temporary bridge; add issue-663 preflight design note
- changelog.d/663.fixed.md

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Requirement-free run (no ## Requirements section; bug fix to the conformance verifier). Verified locally: tests/test_runtime_conformance.py — 32 passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: target-conformance reference_scenario ← implementations/python/tests/test_runtime_conformance.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/663.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
