### PR TITLE
docs: document realization envelope semantics

### DIFF
--- a/changelog.d/667.added.md
+++ b/changelog.d/667.added.md
@@ -1,0 +1,2 @@
+Documented the proposed realization-envelope semantics, including prior art,
+manifest carriage, subsumption, witness generation, and negative conformance.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -114,6 +114,7 @@ adr-066-observability-evidence-plane-separation
 adr-067-participant-behavior-model
 adr-068-experiment-trials-replication-and-replay-claims
 adr-069-cage-2-replication-architecture
+adr-070-realization-envelope-semantics
 ```
 
 | ADR | Title | Status | Date |
@@ -188,3 +189,4 @@ adr-069-cage-2-replication-architecture
 | [067](adr-067-participant-behavior-model.md) | Participant Behavior Model | proposed | 2026-06-23 |
 | [068](adr-068-experiment-trials-replication-and-replay-claims.md) | Experiment Trials, Replication, and Replay Claims | accepted | 2026-06-25 |
 | [069](adr-069-cage-2-replication-architecture.md) | CAGE-2 Replication Architecture | accepted | 2026-07-01 |
+| [070](adr-070-realization-envelope-semantics.md) | Realization Envelope Semantics | proposed | 2026-07-04 |

--- a/docs/decisions/adrs/adr-070-realization-envelope-semantics.md
+++ b/docs/decisions/adrs/adr-070-realization-envelope-semantics.md
@@ -1,0 +1,228 @@
+# ADR-070: Realization Envelope Semantics
+
+## Status
+
+proposed
+
+## Date
+
+2026-07-04
+
+## Classification
+
+Classification: FM2
+Required artifacts: ADR, prior-art/design-criteria note, formal invariant list,
+changelog fragment
+Waivers: No schema, fixture, contract-source, implementation, runtime behavior,
+or conformance-runner artifact is introduced by issue #667. The executable
+membership/subsumption helper, backend-manifest schema evolution, witness-based
+conformance probes, and replacement of the #663 `reference_scenario` bridge are
+downstream implementation work tracked by the blocked subsumption/conformance
+issues, including #668.
+
+## Context
+
+ACES currently has two related but incomplete surfaces.
+
+- SEM-218, defined in
+  `specs/formal/realization/explicitness-and-realization.md`,
+  classifies authored realization concerns as exact, constrained, or open and
+  requires backend manifests to disclose coarse `realization_support`.
+- Target conformance accepts `run_target_conformance(reference_scenario=...)`
+  as an issue #663 bridge so fixed-topology or simulation backends are not
+  failed solely because they cannot realize one hard-coded generic Linux VM
+  scenario.
+
+What ACES lacks is the set expression both sides need:
+
+- an author can say "run this over this family of acceptable scenario
+  instances";
+- a backend can say "this is the family of scenario instances I can realize";
+- conformance can ask whether the request is inside the backend's family and
+  can derive an in-envelope witness without carrying a global default
+  scenario.
+
+The prior-art note
+[`docs/research/realization-envelope/prior-art-and-design-criteria.md`](../../research/realization-envelope/prior-art-and-design-criteria.md)
+reviews CUE, Dhall, JSON Schema closure, CEL/Rego admission patterns,
+FMI/OGC capability declarations, and decidable SMT fragments. The common lesson
+is that ACES needs a small, typed, bounded, portable expression language with a
+known set relation. It should not become a second manifest language, an
+arbitrary policy callback, or a solver-dependent DSL.
+
+## Decision
+
+Adopt a **realization envelope** as a versioned SDL semantic expression that
+describes a set of scenario instances. The same expression model is used in both
+directions:
+
+- authored SDL uses it to describe acceptable variation in a scenario family;
+- backend declarations use it to describe realizability.
+
+The normative formal boundary is
+`specs/formal/realization/envelope-semantics.md`.
+
+### 1. The envelope is one SDL semantics extension
+
+The envelope expression extends SDL semantics. It is not a new backend-manifest
+capability language and not a new experiment-run-set model.
+
+An envelope has:
+
+- a versioned expression identity;
+- typed domain descriptors based on the SDL variable model;
+- scoped posture overlays for field, node, topology, app, and scenario scopes;
+- closure rules that say whether unspecified values or children are allowed;
+- provenance and optional digest fields when carried by or referenced from a
+  manifest.
+
+Existing surfaces remain distinct:
+
+- `realization_support` is a coarse capability/disclosure floor;
+- backend profiles remain conformance profile selectors;
+- semantic profiles remain concept-binding authorities;
+- experiment-core run sets record what was executed, not what could be
+  realized.
+
+### 2. Membership, subsumption, and witness generation are one relation
+
+The implementation seam is a pure semantic helper over the versioned envelope
+contract:
+
+- `member(instance, envelope)` decides whether one concrete scenario instance is
+  inside the envelope.
+- `subsumes(offered, requested)` decides whether every scenario in the requested
+  envelope is in the backend-offered envelope. Equivalently, the requested set
+  is a subset of the offered set.
+- `witness(envelope, policy, seed)` deterministically derives one concrete
+  in-envelope scenario instance and then runs normal SDL structural and semantic
+  validation on it.
+
+Witness generation is not evidence of subsumption by itself. It is only the
+concrete instance conformance can execute after the set relation has passed.
+
+### 3. The admitted fragment is intentionally small
+
+The portable fragment admits:
+
+- exact singleton values;
+- finite enum/value sets;
+- booleans;
+- bounded numeric intervals with inclusive/exclusive endpoints;
+- governed references to controlled vocabularies or scenario registries;
+- acyclic record/product structure;
+- scoped closed-world extra-key rejection.
+
+The fragment excludes arbitrary Python predicates, backend callbacks, external
+queries, unbounded regex or SMT fragments, recursion, unbounded quantification,
+non-linear arithmetic, and expressions that depend on hidden backend state.
+
+This keeps membership and subsumption reducible to local domain subset checks
+plus structural closure checks, and keeps witness generation deterministic.
+
+### 4. Scope and closure are explicit
+
+Posture applies at one of five scopes: field, node, topology, app, or scenario.
+Most-specific-wins selects the effective posture for a concrete field or child
+scope, but a more-specific posture may not silently widen a closed enclosing
+scope. Equal-specificity conflicts are diagnostics, not merge order.
+
+Open means the expression leaves the value to a downstream realizer at a point
+the SDL semantics declares realizable. Constrained means the value must fall
+inside a typed domain. Exact means the domain is a singleton. Closed-world
+scope means no unspecified realizable dimensions under that scope are portable
+members of the set.
+
+### 5. Backend manifest carriage is a schema-evolution question
+
+Current `backend-manifest-v2` can disclose coarse support through
+`realization_support`. It cannot express value-level sets, scoped closure, or a
+portable subsumption relation.
+
+The selected carriage direction is a future manifest evolution that can either:
+
+- embed a small envelope expression directly; or
+- reference a published envelope artifact by contract id, digest, and version.
+
+Both modes use the same expression contract. Neither overloads the current
+`constraints: dict[str, str]` prose map as the final semantics.
+
+### 6. Closed envelopes require negative conformance
+
+For a closed envelope, conformance must not stop after one in-envelope witness.
+It must also derive out-of-envelope probes for closed dimensions that can be
+varied safely and require the backend to refuse them through the ordinary
+`OperationStatus` / `Diagnostic` envelope without mutating state.
+
+Negative conformance is the falsification surface for honesty: a backend that
+declares "only this set" must prove refusal for requests outside that set, not
+merely accept one allowed instance.
+
+### 7. Sensitive values stay out of public artifacts
+
+Envelope ids, refs, digests, domain kinds, scope paths, and bounded summaries
+may appear in manifests, diagnostics, witnesses, fixtures, and conformance
+reports. Credentials, bearer tokens, private keys, process argv, host paths,
+backend-native ids, raw backend object representations, hidden truth, scoring
+state, and full tracebacks must not.
+
+## Alternatives Considered
+
+### A separate backend-manifest capability language
+
+Rejected. It would require authors and backends to reason in two languages and
+would make conformance a translation problem instead of a set-relation problem.
+It also risks forking validators, schemas, and diagnostics away from the SDL
+semantic authority.
+
+### Reuse only existing `realization_support` fields
+
+Rejected. The existing fields declare support modes and kind strings. They do
+not carry value domains, scope closure, typed variables, membership,
+subsumption, or witness generation.
+
+### Arbitrary policy predicates
+
+Rejected. CEL/Rego-style admission languages are useful precedent, but ACES
+needs a portable structural set expression, not a backend callback or
+user-authored program. Arbitrary predicates would make decidability, witness
+generation, negative conformance, and safe diagnostics harder to guarantee.
+
+### Keep the #663 `reference_scenario` bridge
+
+Rejected as the final design. The parameter is a useful temporary bridge, but it
+requires a caller to supply the witness and does not prove the requested set is
+within the backend's realizable set.
+
+## Consequences
+
+### Positive
+
+- Authors and backend implementers share one semantic model for scenario sets.
+- Target conformance has a principled replacement for the hard-coded/default
+  reference scenario path.
+- Closed-world backend claims become falsifiable through generated negative
+  probes.
+- Future schema and implementation work has a clear seam: versioned envelope
+  expression plus pure relation helper.
+
+### Negative
+
+- Backend manifest evolution is required before the design can replace #663 in
+  executable conformance.
+- The admitted fragment is deliberately conservative; some expressive
+  constraints will need governed domain extensions rather than arbitrary
+  predicates.
+- Implementers must keep experiment-run variation separate from realizability
+  variation, which is an additional documentation and validation burden.
+
+### Risks
+
+- If later work widens the expression language without preserving decidability,
+  subsumption and witness generation may stop being reliable CI gates.
+- If negative probes echo concrete sensitive values, conformance could leak
+  backend-private or author-private data. The formal spec requires diagnostics
+  to name paths, refs, and kinds rather than raw values.
+- If manifest carriage embeds large envelopes directly, manifests could become
+  noisy and hard to review. The reference-by-contract-id/digest mode exists to
+  keep large envelopes governed as separate published artifacts.

--- a/docs/decisions/issue-667-realization-envelope-preflight.md
+++ b/docs/decisions/issue-667-realization-envelope-preflight.md
@@ -1,0 +1,193 @@
+# Issue 667 Realization Envelope Preflight
+
+Date: 2026-07-04
+
+Issue: #667.
+
+Requirement: none. The GitHub issue title, body, and acceptance criteria are
+the contract.
+
+This note records architecture guardrails for the realization-envelope design
+work. It is guidance only: it does not publish the prior-art pass, formal
+semantics, ADR, schema, conformance relation, or implementation.
+
+## Architecture Decisions
+
+- Treat the realization envelope as one SDL semantics extension, not as a
+  second manifest capability language. Authored scenario families and backend
+  realizability declarations must reference the same typed envelope expression
+  model.
+- Keep an envelope distinct from a concrete scenario, experiment run set,
+  backend profile, semantic profile, `ProvisionerCapabilities`,
+  `ParticipantRuntimeCapabilities.feature_support`, and today's
+  `realization_support` declarations. Those surfaces may carry or consume an
+  envelope, but none is the envelope semantics authority.
+- Build the typed-variable substrate by extending the existing SDL variable and
+  instantiation model. Do not create a parallel parameter system inside backend
+  manifests, conformance, or `constraints` strings.
+- Model open, constrained, and exact posture as a scope overlay from field to
+  node, topology, app, and scenario. The design must define most-specific-wins
+  override behavior and explicit closed-world "and nothing else" semantics.
+  Absence of a bound is not universal realizability.
+- Membership, subsumption, and witness generation are semantic services over
+  the typed envelope expression. They must be decidable in the admitted fragment
+  and shared by validation, planning, runtime/conformance checks, and tests.
+  Avoid backend-local implementations of the relation.
+- The manifest carriage decision should be made as a `backend-manifest` schema
+  evolution question: embed an envelope expression or reference one by governed
+  contract id/digest. Reusing today's coarse capability fields alone is not
+  sufficient because they have no values, no scoped closed-world posture, and
+  no set relation.
+- Closed envelopes require negative conformance. A backend that declares "only
+  this set" must be shown to refuse out-of-envelope requests, not merely accept
+  one generated witness inside the envelope.
+
+## Required Incumbents
+
+Reuse these repo surfaces before adding anything new:
+
+- SDL language and instantiation: ADR-001, ADR-003,
+  `specs/sdl/variables-and-instantiation.md`, `aces_sdl.variables`,
+  `instantiate_scenario()`, `SDLInstantiationError`, closed SDL models,
+  variable-key rejection, and post-instantiation semantic revalidation.
+- Shared semantic lifecycle: ADR-007, ADR-016,
+  `docs/explain/reference/shared-semantic-integrity.md`, `SemanticValidator`,
+  `SDLValidationError`, `compile_runtime_model()`, `plan()`, and shared
+  `aces_sdl.semantics.*` / `aces_processor.semantics.*` helpers.
+- Existing realization seam: `specs/formal/realization/explicitness-and-realization.md`,
+  `docs/explain/reference/explicitness-realization-semantics.md`,
+  `RealizationSupportMode`, `RealizationSupportDeclaration`,
+  `CompiledRealizationRequirement`, `realization_support_diagnostics()`,
+  `realization_disclosure()`, and `RuntimeSnapshot.realization_provenance`.
+- Contract authority: ADR-009, ADR-019, ADR-061, `ContractModel`,
+  `schema_bundle()`, `contracts/schema-publication-manifest.json`,
+  `tools/generate_contract_schemas.py`, `tools/check_generated_schemas.py`,
+  `tools/check_schema_publication.py`, and `x-aces-invariants` annotations for
+  semantic rules JSON Schema cannot express.
+- Concept authority: ADR-012, ADR-062,
+  `contracts/concept-authority/concept-families-v1.json`,
+  `contracts/concept-authority/controlled-vocabularies-v1.json`,
+  `contracts/concept-authority/reference-models-v1.json`,
+  `validate_controlled_vocabulary_scope_values()`, and canonical
+  `concept_bindings`. The `realization-and-disclosure` concept family governs
+  realization semantics, not the cyber objects being realized.
+- Backend declarations: `BackendManifest`, `BackendManifestV2Model`,
+  `BackendCapabilitySet`, `ProvisionerCapabilities`,
+  `ParticipantRuntimeCapabilities`, `backend_manifest_payload()`,
+  `BACKEND_SUPPORTED_CONTRACT_IDS`, and existing capability-gap helpers.
+- Conformance: `run_target_conformance()`, `run_fixture_suite()`,
+  backend profile loading from `contracts/profiles/backend/`,
+  `_validate_payload()`, semantic diagnostics, and `ConformanceCaseResult`.
+  The #663 `reference_scenario` parameter is a temporary bridge to replace with
+  envelope witness generation.
+- Runtime and API security: `RuntimeControlPlane`, `ControlPlaneStore`,
+  `ControlPlaneSecurityConfig`, `ControlPlaneIdentity`, `ControlPlaneRole`,
+  request-size guard, idempotency fingerprints, audit events, redacted FastAPI
+  error handling, `Diagnostic`, `OperationReceipt`, and `OperationStatus`.
+- Experiment/evidence boundaries: ADR-055, ADR-066, ADR-068 and the
+  experiment-core contracts. A realizable set is not an executed run set,
+  replication study, raw evidence record, or replay claim.
+- Repository policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `tools/policy/adr_policy.yaml`, module-boundary rules, schema-publication
+  checks, concept-authority gates, and `tools/verify_all.py`.
+
+## Cross-Cutting Layers
+
+- SDL parser/model layer: envelope syntax must be structured model data, not
+  raw strings embedded in `constraints`. Variables may parameterize values but
+  must not create symbol keys or rename identities.
+- Semantic validation layer: validate variable scope, domain type, domain
+  boundedness, closure posture, most-specific override conflicts, and
+  reference ambiguity through existing validation errors that collect all
+  defects.
+- Instantiation layer: parameter binding must type-check, domain-check, remove
+  unresolved placeholders, preserve explicitness/envelope provenance, and rerun
+  semantic validation on the concrete scenario.
+- Contract/schema layer: public envelope payloads must be closed
+  `ContractModel` shapes with generated schemas, fixtures, publication-manifest
+  entries, and semantic-invariant annotations where relation checks are outside
+  JSON Schema.
+- Manifest layer: backend carriage must render through
+  `backend_manifest_payload()` and validate with the manifest model. Do not add
+  a second manifest renderer, schema registry, or profile map.
+- Planner/runtime layer: admission failures and backend dishonesty must remain
+  `Diagnostic` values on the existing plan/apply path. Diagnostics may name
+  field paths, relation kinds, and envelope ids; they must not echo sensitive
+  concrete values.
+- Conformance layer: generated witnesses must still pass the live mutation
+  guard, snapshot validation, and semantic diagnostics. Closed-envelope
+  negative probes must expect refusal through the same `OperationStatus` /
+  diagnostic envelope, not backend-native exceptions.
+- HTTP/control-plane layer: any envelope admission or witness API must reuse
+  authentication, role authorization, request-size limits, idempotency, audit,
+  published response models, and redacted internal-error responses.
+- Persistence/evidence layer: store envelope refs, digests, provenance,
+  declarations, and bounded summaries. Do not persist credentials, bearer
+  tokens, private keys, raw environment dumps, process argv, backend-native
+  object representations, or full tracebacks in envelopes, snapshots,
+  diagnostics, fixtures, audit details, or evidence records.
+- Host/OS exposure layer: witness generation or external tooling must not put
+  secrets, tokens, or sensitive realized values in command argv, logs, or
+  diagnostics. If a later solver/tool is introduced, call it through a bounded,
+  fixed-argv adapter and keep inputs secret-free.
+- Module-boundary layer: put SDL syntax and variable typing in `aces_sdl`,
+  neutral contract DTOs in `aces_contracts`, backend dataclasses/rendering in
+  `aces_backend_protocols`, planning relation consumers in `aces_processor`,
+  runtime admission at `aces_runtime`, and probes in `aces_conformance`.
+  Respect the existing import DAG.
+
+## Extensibility Boundary
+
+The primary seam is a versioned envelope expression contract plus a pure
+membership/subsumption/witness helper over that contract. The helper should be
+parameterized by:
+
+- governed scope/kind identifiers, so new SDL fields or runtime families add
+  terms rather than editing every backend;
+- domain descriptors, so finite sets, enums, numeric intervals, and future
+  bounded domain kinds slot into the decidable fragment deliberately;
+- carriage mode, so a backend manifest can embed a small envelope or reference
+  a larger published envelope by contract id and digest; and
+- witness selection policy/seed, so conformance can generate reproducible
+  in-envelope scenarios without hard-coding one global reference scenario.
+
+Adding a future domain kind, scope level, posture value, or carrier should
+require changes to the formal spec, contract model/schema, fixtures, semantic
+helper, and tests. It should not require per-backend relation logic or edits to
+unrelated runtime/control-plane paths.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- preserving the current universal-realizability assumption in conformance;
+- treating the #663 `reference_scenario` parameter as the final design;
+- treating one successful witness as proof of subsumption or closed-world
+  refusal;
+- conflating exact singleton envelopes with exact realized values in SEM-218;
+- merging envelope posture with `realization_support` support modes,
+  participant feature support levels, backend profiles, semantic profiles, or
+  experiment study membership;
+- encoding domains or closure policy as prose in `constraints`;
+- accepting arbitrary Python predicates, unbounded regex/SMT fragments, or
+  backend-specific callbacks in portable envelopes;
+- adding duplicate schemas, validators, exception hierarchies, audit logs,
+  persistence stores, manifest renderers, vocabulary tables, or profile loaders;
+- leaking backend-private topology, native IDs, host paths, credentials,
+  process argv, hidden truth, scoring state, or sensitive concrete values
+  through diagnostics, witnesses, manifests, snapshots, fixtures, or docs;
+- letting most-specific-wins silently mask conflicting closures without an
+  explicit diagnostic.
+
+## Non-Goals
+
+- Implementing the issue, publishing the formal envelope spec, publishing a new
+  ADR, or changing checked-in schemas.
+- Completing the issue's prior-art pass. Put that follow-on research under a
+  dedicated `docs/research/realization-envelope/` note before the ADR/schema
+  work lands.
+- Changing runtime behavior, conformance behavior, backend manifests, or the
+  #663 bridge in this preflight.
+- Adding a new SDL dialect, new backend capability language, new experiment
+  run-set model, solver dependency, HTTP API, persistence service, or backend
+  adapter.

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,6 +169,11 @@ decisions/adrs/adr-062-concept-authority-catalog-governance-gate
 decisions/adrs/adr-063-reference-emulation-backend
 decisions/adrs/adr-064-experiment-evidence-and-measure-contract-boundary
 decisions/adrs/adr-065-experiment-run-provenance-contract-boundary
+decisions/adrs/adr-066-observability-evidence-plane-separation
+decisions/adrs/adr-067-participant-behavior-model
+decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims
+decisions/adrs/adr-069-cage-2-replication-architecture
+decisions/adrs/adr-070-realization-envelope-semantics
 decisions/issue-248-sem-216-boundary-semantics-preflight
 decisions/sem-213-temporal-participant-preflight
 decisions/issue-508-related-work-comparison-preflight
@@ -209,6 +214,7 @@ specs/formal
 lessons/README
 migration/README
 research/experiment-core/index
+research/realization-envelope/index
 research/primary/index
 research/related-work-comparison/index
 ```

--- a/docs/research/realization-envelope/index.md
+++ b/docs/research/realization-envelope/index.md
@@ -1,0 +1,14 @@
+# Realization Envelope Research Notes
+
+These notes support issue #667. They are research and design evidence for the
+realization-envelope semantics; they are not contract authority by themselves.
+
+The normative decision is the proposed ADR at
+[`ADR-070`](../../decisions/adrs/adr-070-realization-envelope-semantics.md).
+The formal semantic boundary is `specs/formal/realization/envelope-semantics.md`.
+
+```{toctree}
+:maxdepth: 1
+
+prior-art-and-design-criteria
+```

--- a/docs/research/realization-envelope/prior-art-and-design-criteria.md
+++ b/docs/research/realization-envelope/prior-art-and-design-criteria.md
@@ -1,0 +1,166 @@
+# Prior Art And Design Criteria For Realization Envelopes
+
+Issue #667 asks ACES to describe a *set* of scenarios in one portable semantic
+model. Authors need to request a family of acceptable scenarios; backends need
+to declare the family they can actually realize. The same expression must
+support membership, subsumption, witness generation, and closed-envelope refusal
+without becoming a second backend-manifest capability language.
+
+## Design Question
+
+The design must answer four questions.
+
+1. What typed expression describes the set of scenario instances under
+   discussion?
+2. How does openness or closure apply from a field up to a whole scenario?
+3. When does one expression subsume another, so a backend can honestly claim it
+   realizes a requested family?
+4. How can conformance derive both an in-envelope witness and an
+   out-of-envelope negative probe without a hard-coded reference scenario?
+
+The answer must coordinate with the existing ACES incumbents:
+
+- SDL variables and instantiation:
+  `specs/sdl/variables-and-instantiation.md`.
+- SEM-218 explicitness and realization:
+  `specs/formal/realization/explicitness-and-realization.md`.
+- The temporary target-conformance bridge:
+  `run_target_conformance(reference_scenario=...)`, documented in issue #663
+  as superseded by this issue and the scenario/envelope subsumption relation.
+
+## Prior Art
+
+### CUE: constraints as values
+
+[CUE](https://cuelang.org/docs/reference/spec/) is the closest config-language
+precedent. Its type/value lattice makes constraints, concrete data, and
+subsumption part of one language rather than separate schema and data layers.
+That is the right direction for ACES: an authored family and a backend
+realizability declaration should be comparable as expressions in one type
+system.
+
+ACES should not adopt CUE wholesale. The envelope fragment needs only the
+portable parts ACES can validate, publish, and test: typed variables, finite
+sets, bounded intervals, governed references, structural closure, and a clear
+subset relation. Arbitrary CUE expressions would make backend portability and
+schema publication harder to reason about.
+
+### Dhall: total typed configuration
+
+[Dhall](https://dhall-lang.org/) shows a different useful boundary: a
+configuration language can be typed, normalized, and deliberately non-general
+purpose. The ACES lesson is that envelope expressions should normalize to a
+stable portable form before they enter manifests, conformance reports, or
+diagnostics. The language must not depend on backend callbacks, host state, or
+side effects.
+
+### JSON Schema: closed records and schema composition
+
+[JSON Schema object validation](https://json-schema.org/understanding-json-schema/reference/object)
+shows why closure is not just "reject unknown properties." `additionalProperties`
+and `unevaluatedProperties` demonstrate that closure interacts with composition:
+a schema can close one record while still composing with a base shape.
+
+ACES needs the same discipline at semantic scope. A field, node, topology, app,
+or whole scenario may be closed without making every enclosing layer a closed
+singleton. The closure decision must be explicit and scoped; silence is not
+universal realizability.
+
+### Admission policy languages: CEL and Rego
+
+Kubernetes
+[ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)
+uses CEL to make admission checks declarative and scoped to API resources. The
+Kubernetes
+[CEL resource-constraint guidance](https://kubernetes.io/docs/reference/using-api/cel/)
+also makes the operational point ACES needs: production admission expressions
+need bounded execution and complexity controls. [OPA/Rego](https://openpolicyagent.org/docs/policy-language)
+is a broader declarative policy language for deciding over nested documents.
+
+The ACES lesson is negative. Envelope semantics are an admission relation, but
+they must not become an arbitrary policy callback. The portable fragment should
+be a structural set expression with known domain kinds and deterministic
+membership/subsumption, not a user-authored program that can query backend state
+or depend on evaluation order.
+
+### Capability and conformance declarations
+
+The [FMI 3.0 specification](https://fmi-standard.org/docs/3.0/) publishes FMU
+capability flags in `modelDescription.xml`; [OGC API Common](https://docs.ogc.org/is/19-072/19-072.html)
+advertises conformance classes through a `/conformance` resource and ties them
+to requirements classes and tests. These systems establish the pattern ACES
+already follows in backend manifests: declarations are portable claims, and
+conformance must be able to falsify them.
+
+The limit is coarseness. A boolean capability or conformance-class URI does not
+say which scenario family a backend realizes, which values are closed, or which
+out-of-envelope request it must refuse. ACES should keep coarse capability
+claims as discovery and compatibility data, but realization envelopes are the
+value-level set relation those claims cannot express.
+
+### Decidable constraint fragments
+
+[SMT-LIB logics](https://smt-lib.org/logics.shtml) and the
+[Z3 arithmetic guide](https://microsoft.github.io/z3guide/docs/theories/Arithmetic/)
+show the benefit of naming fragments such as linear integer or real arithmetic.
+They also show why ACES should be conservative: once a portable language admits
+unbounded quantification, non-linear arithmetic, recursive structures, or
+backend-defined predicates, subsumption and witness generation stop being a
+simple repo-owned semantic service.
+
+ACES does not need a solver dependency for issue #667. The initial fragment can
+be deliberately smaller: finite sets, enum subsets, exact values, bounded
+numeric intervals, governed references, acyclic record/product structure, and
+closed-scope extra-key rejection. That fragment supports useful envelopes while
+keeping membership, subsumption, and witness generation mechanically checkable.
+
+## Design Criteria
+
+The ADR and formal spec must satisfy these criteria.
+
+1. **One SDL semantic model.** Authored scenario families and backend
+   realizability declarations use the same envelope expression. A backend
+   manifest may carry or reference an expression, but it does not define a
+   second language.
+2. **Typed domains first.** Envelope variables build on the SDL variable model:
+   type, optional default, optional closed value set, and fail-closed binding.
+   New domain kinds are governed extensions.
+3. **Scoped closure.** Open, constrained, and exact posture is evaluated at a
+   declared scope: field, node, topology, app, or scenario. Most-specific-wins
+   applies only when the more specific posture is compatible with the enclosing
+   closure.
+4. **Decidable relation.** Membership and subsumption reduce to per-domain
+   checks and structural key-set checks in the admitted fragment. No arbitrary
+   Python predicates, unbounded regex/SMT fragments, backend callbacks, or
+   external service calls belong in portable envelopes.
+5. **Witnesses are evidence, not proof.** A generated in-envelope witness proves
+   only that the expression is satisfiable and executable for that concrete
+   instance. It does not prove subsumption or closed-world honesty by itself.
+6. **Negative conformance is first class.** A closed envelope must be tested by
+   refusal of at least one generated out-of-envelope request for every closed
+   dimension that can be varied safely.
+7. **Manifest carriage is versioned.** Backend manifests should embed small
+   envelopes or reference published envelope artifacts by contract id and
+   digest. Current `realization_support.constraints` prose is not sufficient.
+8. **Experiment run sets stay separate.** Experiment-core replications, cohorts,
+   and comparisons describe what was executed and how it varied. A realization
+   envelope describes what could be realized before execution.
+9. **No sensitive witness leakage.** Generated witnesses, diagnostics,
+   fixtures, manifests, and conformance reports must not expose credentials,
+   backend-native ids, host paths, process argv, raw backend errors, or hidden
+   truth.
+
+## Decision Sketch Carried Into The ADR
+
+- Add a proposed ADR selecting a versioned realization-envelope expression as
+  the shared SDL semantics for authored families and backend declarations.
+- Add a formal semantics note under `specs/formal/realization/` defining:
+  scope order, posture, closure, domain descriptors, effective constraint
+  lookup, membership, subsumption, witness generation, and negative
+  conformance.
+- Treat `backend-manifest-v2` as the current coarse carrier and reserve the
+  envelope expression for a manifest schema evolution that embeds or references
+  the versioned expression. Do not overload the current `constraints` string
+  map as the final design.
+- Leave runtime implementation, schema publication, conformance runner changes,
+  and replacement of the #663 bridge to downstream issues.

--- a/docs/specs/formal.md
+++ b/docs/specs/formal.md
@@ -24,6 +24,10 @@ formal artifacts are warranted.
   apparatus-context, study/collection, capture specification, raw evidence,
   derived measure, backend observation capability, and archival provenance
   contracts
+- **Realization** (`specs/formal/realization/`) -- Exact/constrained/open
+  realization boundaries, backend realization support, and proposed
+  realization-envelope membership, subsumption, witness, and negative
+  conformance semantics
 
 ## FM Classification
 

--- a/specs/formal/realization/README.md
+++ b/specs/formal/realization/README.md
@@ -23,6 +23,10 @@ backend manifests carry `realization_support`.
   those kinds may be realized — processor manifests carry no
   `realization_support` because the processor layer does not realize
   underspecified concerns
+- the proposed realization-envelope semantics for issue #667: a
+  versioned expression that denotes a set of scenario instances and
+  supports membership, subsumption, witness generation, scoped
+  closed-world posture, and negative conformance
 
 ## Out Of Scope
 
@@ -100,6 +104,10 @@ work the SEM-218 row tracks.
   `SEM-218`. It is the citable source for "is this declaration binding?",
   "when may a realizer pick a value?", and "must this unsupported exact
   requirement be rejected?".
+- `envelope-semantics.md` is the design authority for issue #667. It is not
+  executable yet; it defines the future formal seam that replaces the #663
+  `reference_scenario` bridge once the schema, relation helper, and
+  conformance probes land.
 - The non-normative companion at
   `docs/explain/reference/explicitness-realization-semantics.md` records
   the architecture guardrails for the implementation that realizes the

--- a/specs/formal/realization/envelope-semantics.md
+++ b/specs/formal/realization/envelope-semantics.md
@@ -1,0 +1,315 @@
+# Realization Envelope Semantics
+
+This note defines the formal design boundary for issue #667. It extends the
+SEM-218 realization model with a portable expression for a set of scenario
+instances.
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY**
+in this note are to be interpreted as described in RFC 2119.
+
+## Scope
+
+This note governs:
+
+- envelope expressions authored in SDL or declared by a backend;
+- scoped open/constrained/exact posture;
+- closed-world semantics from field scope to scenario scope;
+- instance membership;
+- envelope subsumption;
+- deterministic witness generation;
+- negative conformance for closed envelopes;
+- backend-manifest carriage constraints for future schema evolution.
+
+Out of scope:
+
+- publishing a concrete JSON schema for envelope expressions;
+- replacing `run_target_conformance(reference_scenario=...)`;
+- adding implementation helpers, CLI commands, APIs, persistence, or runtime
+  behavior;
+- defining experiment-core run-set semantics;
+- defining new SDL variable syntax beyond the existing variable catalog.
+
+## Realization Status
+
+This spec is design authority. It is not yet executable. The relation helper,
+schema carrier, fixtures, property tests, target-conformance integration, and
+manifest evolution are downstream implementation work.
+
+Until that work lands:
+
+- SEM-218 remains the active exact/constrained/open realization authority;
+- `backend-manifest-v2.realization_support` remains the coarse capability and
+  disclosure surface;
+- `run_target_conformance(reference_scenario=...)` remains the temporary #663
+  bridge for fixed-topology and simulation backends.
+
+## Canonical Inputs
+
+Implementations of this spec MUST build on these authority surfaces:
+
+- SDL variables and instantiation:
+  [`specs/sdl/variables-and-instantiation.md`](../../sdl/variables-and-instantiation.md).
+- SEM-218 explicitness and realization:
+  [`explicitness-and-realization.md`](explicitness-and-realization.md).
+- Backend manifest declarations:
+  `BackendManifest`, `BackendManifestV2Model`, `backend_manifest_payload()`,
+  and `RealizationSupportDeclaration`.
+- Contract authority:
+  `ContractModel`, `schema_bundle()`,
+  `contracts/schema-publication-manifest.json`, and generated schema checks.
+- Conformance/runtime diagnostics:
+  `run_target_conformance()`, `OperationStatus`, and `Diagnostic`.
+
+## Terms
+
+**Scenario instance.** A fully instantiated, structurally valid, semantically
+valid SDL scenario with no unresolved variables.
+
+**Envelope expression.** A versioned expression denoting a set of scenario
+instances.
+
+**Domain descriptor.** A typed value set for one variable or field. The initial
+portable domain kinds are `exact`, `enum`, `boolean`, `numeric-interval`,
+`governed-reference`, and `record`.
+
+**Scope.** The semantic extent where a posture applies. Scopes are ordered from
+most local to broadest:
+
+1. field
+2. node
+3. topology
+4. app
+5. scenario
+
+`topology` and `app` are sibling aggregate scopes under `scenario`; neither is
+more specific than the other for a field outside its aggregate.
+
+**Posture.**
+
+- `open`: the value or child scope is left to realization at a point the SDL
+  semantics designates as realizable.
+- `constrained`: the value or child scope MUST satisfy a typed domain.
+- `exact`: the value or child scope MUST equal a singleton domain.
+
+**Closure.**
+
+- `open-world`: unspecified realizable dimensions under the scope may still be
+  admitted when the owning SDL semantics allows them.
+- `closed-world`: unspecified realizable dimensions under the scope are outside
+  the envelope.
+
+Closure is orthogonal to posture. A constrained field can live under an
+open-world node, and an exact node can live under a closed-world scenario.
+
+## Envelope Shape
+
+An envelope expression consists of:
+
+- `schema_version`: the envelope expression contract version;
+- `id`: a stable local or published identifier;
+- `scope`: the top-level scope the expression constrains;
+- `domains`: named domain descriptors;
+- `bindings`: scoped bindings from SDL paths or governed scope refs to domain
+  descriptors and posture;
+- `closure`: scoped open-world or closed-world overlays;
+- optional `witness_policy`: deterministic default selection policy;
+- optional `source_ref`, `contract_id`, and `digest` when the expression is
+  referenced from another artifact.
+
+The shape above is semantic, not yet a published JSON schema.
+
+## Required Semantics
+
+### R1 - Envelopes denote sets
+
+Every envelope expression denotes a set of scenario instances. A concrete
+scenario instance `s` is a member of envelope `E` exactly when:
+
+1. `s` is structurally and semantically valid under the ordinary SDL rules;
+2. every effective binding in `E` is satisfied by the corresponding value or
+   child scope in `s`;
+3. every closed-world scope in `E` has no unspecified realizable dimension in
+   `s`;
+4. every governed reference in `E` resolves under the applicable concept or SDL
+   authority.
+
+Invalid SDL is never a member, even if it satisfies the envelope domains.
+
+### R2 - Effective bindings use most-specific-wins
+
+For a concrete SDL path, the effective binding is the most specific binding
+whose scope contains that path.
+
+If two bindings have equal specificity and incompatible domains or posture, the
+envelope is invalid. If a more-specific binding widens a value that an enclosing
+closed-world scope made exact or excluded, the envelope is invalid unless the
+enclosing binding explicitly marks that child as overrideable.
+
+Most-specific-wins is therefore deterministic; it is not merge-order dependent.
+
+### R3 - Domain membership is structural
+
+Domain descriptors admit only mechanically checkable sets:
+
+- `exact(v)`: values equal to `v`;
+- `enum({v1, ... vn})`: values equal to one listed member;
+- `boolean`: `true` or `false`, optionally restricted to an exact boolean;
+- `numeric-interval(type, lower, upper, lower_closed, upper_closed)`: numbers
+  of the declared numeric type inside the bounded interval;
+- `governed-reference(authority, allowed_refs)`: references in a finite
+  governed set;
+- `record(fields, extra)`: product structure whose field domains must be
+  satisfied and whose `extra` flag controls undeclared fields.
+
+Portable envelopes MUST NOT use arbitrary Python predicates, backend callbacks,
+external queries, recursion, unbounded regex or SMT fragments, non-linear
+arithmetic, or quantification over unbounded collections.
+
+### R4 - Subsumption is set inclusion
+
+`subsumes(offered, requested)` is true exactly when every scenario instance in
+`requested` is also in `offered`.
+
+The relation is evaluated without enumerating all instances. In the admitted
+fragment it reduces to:
+
+- domain subset checks for each effective binding;
+- record/product field subset checks;
+- closed-scope key-set checks;
+- governed-reference subset checks;
+- compatibility of posture and closure overlays.
+
+When a backend declares `offered` and an author requests `requested`,
+conformance may proceed only if `subsumes(offered, requested)` is true.
+
+### R5 - Witness generation is deterministic and validated
+
+`witness(E, policy, seed)` returns one concrete scenario instance in `E`, or a
+diagnostic proving no witness can be generated in the admitted fragment.
+
+The default policy is deterministic:
+
+- exact domains choose their value;
+- enums choose the lexicographically first canonical value unless a seed policy
+  selects another member;
+- bounded numeric intervals choose the lower closed endpoint when available,
+  otherwise the smallest representable value inside the interval under the
+  declared numeric type;
+- governed references choose the first canonical ref unless a seed policy
+  selects another allowed ref;
+- records generate all required fields and no extra fields when closed.
+
+The generated witness MUST be parsed, instantiated if needed, and semantically
+validated through the normal SDL pipeline. A witness is executable evidence for
+one instance. It is not a proof of subsumption or backend honesty.
+
+### R6 - Closed envelopes require negative conformance
+
+When a backend declares a closed-world envelope, conformance MUST generate
+negative probes for closed dimensions that can be varied without introducing
+secrets or unsafe side effects.
+
+A negative probe is a request that differs from a valid witness by one
+out-of-envelope variation:
+
+- an enum value outside the offered set but inside the governing vocabulary;
+- a numeric value outside the offered interval but inside the governing type;
+- an extra field or child under a closed record/scope;
+- an omitted required exact field;
+- a governed reference outside the offered ref set.
+
+The backend MUST refuse the negative probe through the ordinary
+`OperationStatus` / `Diagnostic` surface and MUST NOT mutate runtime state. A
+backend that accepts or silently approximates the probe fails closed-envelope
+conformance.
+
+### R7 - Manifest carriage is expression identity plus digest
+
+A backend manifest that carries envelope semantics MUST either embed a small
+envelope expression or reference a published envelope artifact by:
+
+- contract id;
+- expression id;
+- version;
+- digest;
+- optional human-readable summary.
+
+Both carriage modes use the same expression contract. The manifest carrier MUST
+render through `backend_manifest_payload()` and validate through the manifest
+contract model once schema evolution lands.
+
+Current `realization_support.constraints` strings are not the envelope carrier.
+They may remain compatibility hints, but they do not define membership,
+subsumption, witness generation, or closure.
+
+### R8 - Diagnostics identify paths, not sensitive values
+
+Envelope diagnostics MAY name:
+
+- envelope ids and refs;
+- SDL paths;
+- domain kind;
+- relation kind (`membership`, `subsumption`, `witness`, `negative-probe`);
+- non-sensitive governed identifiers;
+- digest and contract ids.
+
+Diagnostics MUST NOT echo credentials, bearer tokens, private keys, process
+argv, host paths, backend-native ids, raw backend object representations,
+hidden truth, scoring state, or full tracebacks.
+
+## Invariants
+
+**I1 - One semantic language.** Authored scenario families and backend
+realizability declarations are compared as envelope expressions in the same SDL
+semantic model.
+
+**I2 - Closed-world is scoped.** Closure applies only at declared scopes and
+does not implicitly close unrelated sibling scopes.
+
+**I3 - Silence is not universal realizability.** An omitted bound is open only
+when the owning SDL semantics designates that point as realizable.
+
+**I4 - Subsumption precedes execution.** A backend-declared offered envelope
+must subsume the requested envelope before conformance executes a witness.
+
+**I5 - Witnesses are validated.** Generated witnesses pass the ordinary SDL
+structural and semantic validation pipeline before runtime use.
+
+**I6 - Negative probes are refusal tests.** Closed-world declarations require at
+least one generated refusal test for each safely variable closed dimension.
+
+**I7 - Public artifacts are secret-free.** Envelopes, manifests, witnesses,
+fixtures, diagnostics, and conformance reports carry ids, refs, digests, and
+bounded summaries, not sensitive concrete values.
+
+## Implementation Mapping
+
+This section names the intended future seams. It is not a claim that the code
+exists today.
+
+| Concern | Future owner | Existing incumbent |
+| --- | --- | --- |
+| Envelope contract DTO | `aces_contracts` | `ContractModel`, generated schema bundle |
+| SDL envelope syntax and validation | `aces_sdl` | variables, instantiation, semantic validation |
+| Relation helper | `aces_sdl` or shared semantics helper | SEM-218 explicitness helper pattern |
+| Backend manifest carriage | `aces_backend_protocols` / `aces_contracts` | `BackendManifest`, `backend_manifest_payload()` |
+| Planning admission | `aces_processor` | `realization_support_diagnostics()` |
+| Target conformance witness and negative probes | `aces_conformance` | `run_target_conformance(reference_scenario=...)` |
+| Runtime refusal evidence | `aces_runtime` / control plane | `OperationStatus`, `Diagnostic` |
+
+## Non-Goals
+
+- No runtime behavior changes.
+- No contract schema publication.
+- No backend manifest v3 publication.
+- No replacement of the #663 bridge in this issue.
+- No solver dependency.
+- No new manifest capability language.
+- No experiment-core run-set semantics.
+
+## References
+
+- [ADR-070: Realization Envelope Semantics](../../../docs/decisions/adrs/adr-070-realization-envelope-semantics.md)
+- [Realization-envelope prior art and design criteria](../../../docs/research/realization-envelope/prior-art-and-design-criteria.md)
+- [Explicitness And Realization Semantics](explicitness-and-realization.md)
+- [Variable and Instantiation Catalog](../../sdl/variables-and-instantiation.md)


### PR DESCRIPTION
## Summary

Documents the realization envelope semantics required before executable SDL manifest/schema work proceeds, including the prior-art rationale, formal membership/subsumption/witness model, manifest carriage decision, and negative conformance behavior.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #667

## ADR Impact

- ADR-070
- ADR-021

## Changes

- Add a realization-envelope prior-art review and design-criteria synthesis for the SDL semantics decision.
- Add proposed ADR-070 describing the envelope semantics, manifest carriage model, negative conformance expectations, and rollout guardrails.
- Add the formal realization envelope semantics spec and link it from the formal specs and documentation indexes.
- Record the architecture preflight evidence and add the changelog fragment for issue 667.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Local gates: pre-commit run --all-files passed with ACES_REQUIREMENT_UID=SEM-218; tools/verify_all.py passed with 3004 pytest tests passed, 1 skipped, 33 deselected, and integration tests 25 passed. Requirement governance reached its built-in Ground Control unavailable skip path because local GC HTTP was unavailable.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.