### PR TITLE
docs: add proposed ADR-073 on scoring/reward language scope

### DIFF
--- a/changelog.d/671.added.md
+++ b/changelog.d/671.added.md
@@ -1,0 +1,7 @@
+Add ADR-073 (proposed) examining whether OCR-inherited SDL scoring
+(`metrics`/`evaluations`/`tlos`/`goals`) and the CybORG `agents.reward_calculator`
+label belong in ACES, with scoring-scope research notes
+(`docs/research/scoring-scope/`) and a SEM-206 assessment-semantics compatibility
+guardrail. The ADR recommends treating these surfaces as vestigial against the
+experiment-vs-data-use boundary (ADR-055/064/069) and defers the decision to
+review.

--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -117,6 +117,7 @@ adr-069-cage-2-replication-architecture
 adr-070-realization-envelope-semantics
 adr-071-reusable-asset-trust-and-integrity-policy
 adr-072-validation-and-admission-profiles
+adr-073-scoring-reward-language-scope
 ```
 
 | ADR | Title | Status | Date |
@@ -194,3 +195,4 @@ adr-072-validation-and-admission-profiles
 | [070](adr-070-realization-envelope-semantics.md) | Realization Envelope Semantics | proposed | 2026-07-04 |
 | [071](adr-071-reusable-asset-trust-and-integrity-policy.md) | Reusable Asset Trust and Integrity Policy | accepted | 2026-07-05 |
 | [072](adr-072-validation-and-admission-profiles.md) | Validation and Admission Profiles | proposed | 2026-07-05 |
+| [073](adr-073-scoring-reward-language-scope.md) | Scoring and Reward Language Scope in the SDL | proposed | 2026-07-05 |

--- a/docs/decisions/adrs/adr-073-scoring-reward-language-scope.md
+++ b/docs/decisions/adrs/adr-073-scoring-reward-language-scope.md
@@ -1,0 +1,263 @@
+# ADR-073: Scoring and Reward Language Scope in the SDL
+
+## Status
+
+proposed
+
+## Date
+
+2026-07-05
+
+## Classification
+
+Classification: FM2
+Required artifacts: ADR, prior-art/design-criteria note, scoring-surface
+inventory, changelog fragment
+Waivers: No schema, fixture, contract-source, implementation, runtime behavior,
+or conformance-runner artifact is introduced by issue #671. This ADR is a
+proposed boundary decision. The schema deprecation/removal, reference-model
+changes, scenario migration, documentation edits, and the amendment to ADR-002's
+objective-success clause are downstream implementation work spawned on
+acceptance.
+
+## Context
+
+Issue #671 asks whether ACES should carry **scoring / grading language** at all:
+the Open-Cyber-Range (OCR) scoring pipeline
+(`conditions -> metrics -> evaluations -> TLOs -> goals`) and the
+CybORG-inherited `agents.reward_calculator` field. The issue frames this as an
+open design question, not a decision, and asks for an ADR. It explicitly does
+not decide the answer.
+
+### The inherited surfaces and how they entered
+
+[ADR-001](adr-001-scenario-description-language.md) grounded the SDL in the OCR
+SDL. [ADR-002](adr-002-declarative-sdl-objectives.md) then recorded that "the
+repository preserved OCR's scoring pipeline
+(`conditions -> metrics -> evaluations -> TLOs -> goals`) in the SDL" and added
+a first-class `objectives` section whose `success` criteria may reference
+declared `conditions`, `metrics`, `evaluations`, `tlos`, or `goals`. CybORG's
+`agents.reward_calculator` was carried in as a label;
+[ADR-020](adr-020-declarative-participant-framing-boundaries.md) recorded it only
+as an inherited "reward-calculator label" and deferred "verifier/reward assets"
+to future work. None of these surfaces were re-examined against a later,
+deliberate experiment boundary because that boundary did not exist yet.
+
+### The discriminator
+
+Issue #671 proposes a single test: a signal is in scope for the authored ACES
+experiment only if it is **used within the experiment by the participants** — a
+signal a participant reads and acts on during the run, within its horizon. ACES
+"specifies the experiment ... it does not specify what a researcher does with
+the output of a run." RL reward-for-training, leaderboard ranking, and
+downstream statistical analysis are consumers of a run's data, not part of the
+experiment.
+
+This is not a new boundary. It is the experiment-vs-data-use boundary the
+project has already drawn three times:
+
+- [ADR-055](adr-055-experiment-core-contract-boundary.md) put tasks, runs,
+  studies, and metric definitions in the experiment-core contract family, not
+  the SDL, and its guardrails state: "Do not treat SDL `objectives` as EXP-701
+  task records; they remain scenario-local objective declarations."
+- [ADR-064](adr-064-experiment-evidence-and-measure-contract-boundary.md)
+  published `experiment-evidence-record-v1` (raw evidence) and
+  `experiment-derived-measure-v1` ("a derived measure or evaluation output").
+- [ADR-069](adr-069-cage-2-replication-architecture.md) §3 makes the backend
+  **Evaluator** the component that "projects reward, objective,
+  terminal-condition, and scoring facts into ACES evaluation results, evidence
+  records, and derived measures," and §1 treats native reward arrays and
+  leaderboard scores as *source facts* portable only when bound to existing ACES
+  evidence/measure concepts. §7 rejects defining "equivalence as one score."
+
+### What the surfaces actually are
+
+The five surfaces form one coupled OCR grading chain plus one CybORG label. The
+concrete map — schema locations, models, validators, and per-surface usage — is
+recorded in the research note
+[`scoring-surface-inventory`](../../research/scoring-scope/scoring-surface-inventory.md);
+the literature grounding (reward hypothesis, specification gaming,
+experiment-database separation) is in
+[`prior-art-and-design-criteria`](../../research/scoring-scope/prior-art-and-design-criteria.md).
+The load-bearing findings:
+
+- `metrics`, `evaluations`, `tlos`, `goals` are graded values, thresholds, and
+  training-exercise objective/goal trees. They are read by a grader, not by a
+  participant in-horizon. (`tlos` is literally "Training Learning Objective" in
+  the model.)
+- `agents.reward_calculator` is a bare free-text string with **no
+  cross-reference validator** anywhere in `aces_sdl/validator/`. It names a
+  CybORG reward class that runs outside participant perception and binds to
+  nothing in ACES. It is the weakest surface in the language.
+- `conditions` are observable state facts and `objectives` are participant
+  intent; both are read within the horizon and pass the discriminator.
+- The one leak between the two sides is `objectives.success`, which today can be
+  satisfied by the scoring pipeline instead of by observable state.
+
+Usage is narrow: only four "study-style" example scenarios use the pipeline
+(`enterprise-participant-evidence-loop`, `satcom-release-poisoning`,
+`hospital-ransomware-surgery-day`, `port-authority-surge-response`); the six
+`techvault-*` scenarios use none. The governing requirement is
+**SEM-206 (Assessment Semantics)**. A downstream consumer,
+`Brad-Edwards/aptl#606`, is blocked pending this decision.
+
+## Decision
+
+This ADR is **proposed**. It recommends a direction and defers acceptance to
+human review.
+
+### 1. The SDL scoring/reward surfaces are vestigial and should be removed
+
+`metrics`, `evaluations`, `tlos`, `goals`, and `agents.reward_calculator` fail
+the in-horizon discriminator: none is a signal a participant reads and acts on
+during the run. Each expresses grading, ranking, or training machinery — a
+data-use concern over the run's output. Every concern they express already has a
+deliberately-scoped home in the experiment plane (ADR-055/064) or the backend
+Evaluator (ADR-069). Keeping them in the SDL is not additive; it is a second,
+weaker, authoring-time copy of a boundary the project already owns, and it
+reconstructs inside the language the exact data-use concern the experiment
+boundary was created to separate out.
+
+The recommendation is therefore to **deprecate and remove** these five surfaces
+from the SDL authoring language, its published schemas, the reference model, and
+the example corpus.
+
+### 2. `objectives` and `conditions` stay in the horizon
+
+`conditions` (observable state) and `objectives` (participant intent) are
+authored scenario meaning and remain first-class SDL surfaces. Removing the
+grading pipeline must not weaken what a scenario can assert about its own
+observable state (ADR-020's reproducibility warning).
+
+### 3. Objective success references observable state, not a score
+
+`objectives.success` is narrowed to reference `conditions` (observable state),
+not `metrics` / `evaluations` / `tlos` / `goals`. This directly answers issue
+#671 question 2: success criteria should be expressed against observable state,
+which is in-horizon, rather than a score-shaped grading pipeline, which is not.
+On acceptance this narrows the success clause established by ADR-002 §Decision,
+and the implementing issue records an ADR-002 amendment.
+
+### 4. Graded scoring and reward live only in the experiment/evaluator plane
+
+When a scenario genuinely needs a graded score, cumulative reward, pass/fail
+evaluation, or a leaderboard value, that concern is expressed through the
+experiment-core contracts (`experiment-task-v1` metric definitions,
+`experiment-study-v1` analysis plans, `experiment-derived-measure-v1`,
+`experiment-evidence-record-v1`) and produced by the backend **Evaluator**
+(ADR-069 §3) — never as an authored SDL environment fact. This answers issue
+#671 question 3: scoring/reward belongs to the experiment/evaluator contract
+boundary, and it enters the SDL only if and when a participant consumes such a
+signal *in-run* (which none of the removed surfaces does).
+
+### 5. Migration and deprecation path
+
+Removal is staged, not abrupt (answering issue #671 question 4):
+
+- **Deprecate first.** Mark the five surfaces deprecated in the schema and the
+  SDL sections documentation with a pointer to the experiment/evaluator plane
+  and to `conditions`-based objective success. Emit a deprecation diagnostic
+  when a scenario uses them.
+- **Migrate the four study-style scenarios.** For each, re-express objective
+  success against `conditions`; move any genuinely-graded evaluation into an
+  `experiment-*` artifact where the study intends scientific comparison; drop
+  `reward_calculator` (it binds to nothing). The six `techvault-*` scenarios
+  need no change.
+- **Migrate the library artifacts.** `examples/library/patterns/study-scoring-chain.yaml`
+  and `examples/library/templates/study/scored-study-protocol.yaml` are re-homed
+  onto the experiment plane or retired.
+- **Remove after a deprecation window.** Delete the surfaces from the language,
+  schemas, and reference model; record the published-schema change per ADR-061
+  and the schema-publication manifest; amend ADR-002.
+- **Record the downstream dependency.** SEM-206's assessment semantics are
+  updated to reflect that scoring/evaluation is an experiment-plane concern.
+  `Brad-Edwards/aptl#606` follows by narrowing (not completing) its declared
+  evaluator/scoring surface, per the dependency Brad recorded on issue #671.
+
+### 6. Answers to the issue's four questions
+
+1. **Do the scoring sections and `reward_calculator` belong in ACES?** Not in
+   the SDL. They are vestigial given the experiment-vs-data-use boundary; their
+   concerns belong to the experiment/evaluator plane.
+2. **Should objective success reference conditions rather than a score?** Yes —
+   objective success references observable state (`conditions`).
+3. **If scoring belongs somewhere, is it the SDL or an experiment/evaluator
+   contract?** The experiment/evaluator contract boundary (ADR-055/064/069), and
+   only in the SDL when a participant consumes the signal in-run.
+4. **What is the migration path?** Deprecate, migrate the four study scenarios
+   and the two library artifacts, then remove after a deprecation window, with an
+   ADR-002 amendment and a published-schema change record.
+
+### 7. Scope of this decision
+
+This ADR schedules and directs the examination's outcome; it introduces no
+schema, model, or scenario change itself. Acceptance is a human decision at
+review. On acceptance, downstream implementation issues execute sections 1, 3,
+4, and 5.
+
+## Alternatives Considered
+
+### Keep the SDL scoring pipeline and only document the boundary
+
+Rejected. This preserves two authorities for grading — the SDL pipeline and the
+experiment-core contracts — and leaves `objectives.success` able to bypass
+observable state. Documentation cannot repair a duplicated authority; it only
+describes it. The experiment boundary (ADR-055/064/069) already owns these
+concerns.
+
+### Remove only `reward_calculator`, keep `metrics`/`evaluations`/`tlos`/`goals`
+
+Rejected as the final position, though it is the correct *first* increment.
+`reward_calculator` is the clearest case (unbound label, no validator, pure
+training machinery), but the OCR grading chain fails the same discriminator for
+the same reason. Stopping there would leave the coupled pipeline and the
+`objectives.success` leak in place and would not resolve the SEM-206 or APTL
+dependency. The staged migration in §5 removes `reward_calculator` first while
+committing to the full removal.
+
+### Move the scoring pipeline into the SDL runtime layer instead of removing it
+
+Rejected. The concern is not which SDL layer owns grading; it is that grading is
+a data-use concern that already has a non-SDL home. Relocating it within the SDL
+would repeat the ADR-055 anti-pattern of reconstructing experiment concepts one
+layer too low.
+
+### Author the ADR as accepted with the removal in the same change
+
+Rejected. Issue #671 explicitly does not decide the answer, and the removal
+touches published schemas, the reference model, four scenarios, two library
+artifacts, and an ADR-002 amendment — well beyond one change and requiring human
+ratification. The ADR is proposed; implementation is spawned on acceptance.
+
+## Consequences
+
+### Positive
+
+- One authority for scoring/evaluation/reward: the experiment/evaluator plane.
+  The SDL stops carrying a duplicate, weaker copy.
+- `objectives.success` becomes reproducible and in-horizon (observable state
+  only), closing the leak between authored meaning and grading.
+- The language shrinks by five surfaces, one of which (`reward_calculator`) was
+  unvalidated and unbound.
+- SEM-206 and `Brad-Edwards/aptl#606` get a decision to follow instead of a
+  duplicated surface to implement more completely.
+
+### Negative / costs
+
+- Four study-style scenarios and two library artifacts must be migrated.
+- Removing published schema surfaces is a schema-evolution event (ADR-061) with
+  a manifest change and a deprecation window.
+- ADR-002's objective-success clause must be amended, and downstream consumers
+  (APTL) must narrow their surfaces.
+
+### Risks
+
+- If "graded scoring lives in the experiment plane" is read as "graded scoring
+  is gone," authors may lose a legitimate scientific capability. The migration
+  must show the experiment/evaluator path for genuinely-graded studies, not just
+  delete the SDL surfaces.
+- If the deprecation window is skipped, existing scenarios break abruptly.
+  Section 5 requires deprecate-then-remove.
+- If only `reward_calculator` is removed and the follow-through lapses, the
+  duplicated grading pipeline persists. The decision commits to the full removal
+  via staged migration, and SEM-206 tracks completion.

--- a/docs/explain/reference/assessment-semantics.md
+++ b/docs/explain/reference/assessment-semantics.md
@@ -7,7 +7,7 @@ implementation plan.
 
 `SEM-206` covers the assessment pipeline semantics for SDL conditions, metrics,
 evaluations, TLOs, goals, and their relationship to declarative objectives. The
-pipeline is:
+current incumbent pipeline is:
 
 ```text
 condition bindings -> metrics -> evaluations -> TLOs -> goals -> objectives
@@ -18,6 +18,16 @@ processor layer owns compiled evaluation resources, dependency semantics,
 capability checks, and runtime result contracts. The backend/evaluator boundary
 owns only portable evaluator result envelopes and history streams, not
 backend-native scoring state.
+
+Issue #671 reopens whether OCR-style scoring and CybORG-style reward labels
+belong in authored SDL at all. Until an ADR resolves that question, treat the
+existing pipeline as the compatibility surface to preserve, not as permission to
+expand scoring language. A reward, score, return, leaderboard value, or training
+signal is SDL meaning only when it changes the experiment within its horizon or
+is consumed by a participant in-run. Researcher-only scoring, model-training
+reward, leaderboard ranking, and downstream statistical analysis belong in
+experiment/evidence/derived-measure contracts or adapter-private evidence, not
+in a new SDL assessment shortcut.
 
 ## Incumbents To Reuse
 
@@ -37,6 +47,13 @@ backend-native scoring state.
   `validate_evaluation_result()`, and
   `RuntimeManager`'s evaluation result contract diagnostics are the shared
   enforcement path for evaluator payloads.
+- Participant outcome boundary: `ParticipantOutcomeReport` carriers and
+  SEM-215 interpretation rules remain relationship/provenance records. They do
+  not carry score, reward, or objective-success fields.
+- Experiment/evidence boundary: ADR-055 experiment tasks/runs/studies and
+  ADR-064 capture/evidence/derived-measure contracts own researcher-facing
+  metrics, analysis plans, evidence records, and derived measures outside live
+  SDL scenario meaning.
 - Contracts: `aces_contracts.contracts.ContractModel`, `schema_bundle()`, and
   generated `contracts/schemas/control-plane/evaluation-*-v1.json` remain the
   external shape authority.
@@ -53,6 +70,12 @@ backend-native scoring state.
 - Keep scoring resources distinct from objectives. Metrics, evaluations, TLOs,
   and goals define assessment structure; objectives bind actors, targets,
   success criteria, dependencies, and optional windows.
+- Keep participant reward/return signals distinct from SDL scoring resources.
+  `agents.reward_calculator` is an inherited source label, not a semantic
+  authority for objective success or evaluator aggregation. If a future ADR
+  retains it, the implementation must bind it through governed participant
+  runtime or experiment/evaluator contracts instead of interpreting the string
+  locally.
 - Keep ordering dependencies and refresh dependencies separate. Assessment
   aggregation uses ordering edges from prerequisite assessment resources;
   objective windows and condition-driven changes create refresh edges where
@@ -63,15 +86,18 @@ backend-native scoring state.
   resolves the reference.
 - Preserve the existing evaluator payload contract: `metric` reports score
   fields, while `condition-binding`, `evaluation`, `tlo`, `goal`, and
-  `objective` report `passed`. Any additional portable aggregation rule must compile into
-  the contract or a governed contract version, not into backend-private
-  convention.
+  `objective` report `passed`. Any additional portable aggregation rule must
+  compile into the contract or a governed contract version, not into
+  backend-private convention.
 - Treat `detail`, `details`, and `evidence_refs` as observation metadata, not
   as hidden scoring authority. They must not contain secrets, tokens, raw
   credentials, backend-private object dumps, or full tracebacks.
 - Extend controlled vocabulary, semantic profile, or contract authority only
   when portable comparison requires it. A local evaluator implementation detail
   does not belong in those surfaces.
+- Migrate or deprecate existing scenario scoring sections only under an
+  ADR-backed compatibility rule. Do not rewrite `metrics` / `evaluations` /
+  `tlos` / `goals` fixture by fixture to settle the design question locally.
 
 ## Required Gates
 
@@ -121,6 +147,8 @@ compare them. They should not be hard-coded as evaluator-specific strings.
 - Recomputing aggregation semantics independently in validator, compiler,
   planner, manager, and backend stubs.
 - Letting backend-native evaluator payloads become the observation contract.
+- Treating `agents.reward_calculator`, reward arrays, cumulative return, or
+  leaderboard score as a shortcut for SDL objective success.
 - Treating objectives as just another aggregation node, or treating goals/TLOs
   as actor-bound objectives.
 - Editing generated schemas under `contracts/schemas/` directly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,6 +217,7 @@ lessons/README
 migration/README
 research/experiment-core/index
 research/realization-envelope/index
+research/scoring-scope/index
 research/validation-admission-profiles/index
 research/primary/index
 research/related-work-comparison/index

--- a/docs/research/scoring-scope/index.md
+++ b/docs/research/scoring-scope/index.md
@@ -1,0 +1,19 @@
+# Scoring/Reward Scope Research Notes
+
+These notes support issue #671, which asks whether ACES should carry
+scoring/reward language — the OCR-inherited SDL scoring pipeline
+(`conditions -> metrics -> evaluations -> TLOs -> goals`) and the CybORG
+`agents.reward_calculator` field — given the experiment-vs-data-use boundary.
+They are research and design evidence; they are not contract authority by
+themselves.
+
+The normative decision is the proposed ADR at
+[`ADR-073`](../../decisions/adrs/adr-073-scoring-reward-language-scope.md). The
+governing requirement is SEM-206 (Assessment Semantics).
+
+```{toctree}
+:maxdepth: 1
+
+prior-art-and-design-criteria
+scoring-surface-inventory
+```

--- a/docs/research/scoring-scope/prior-art-and-design-criteria.md
+++ b/docs/research/scoring-scope/prior-art-and-design-criteria.md
@@ -1,0 +1,174 @@
+# Prior Art and Design Criteria for Scoring/Reward Scope
+
+These notes support issue #671, which asks whether ACES should carry
+scoring/reward language at all. They are research and design evidence for the
+proposed decision recorded in
+[`ADR-073`](../../decisions/adrs/adr-073-scoring-reward-language-scope.md); they
+are not contract authority by themselves. The concrete surface map that this
+analysis reasons over is in
+[`scoring-surface-inventory`](scoring-surface-inventory.md).
+
+## The question in one line
+
+The Open-Cyber-Range (OCR) scoring pipeline
+(`conditions -> metrics -> evaluations -> TLOs -> goals`) and the CybORG
+`agents.reward_calculator` field were inherited into the SDL early (ADR-002) and
+preserved without re-litigating whether authored *scenario meaning* is the right
+home for *grading and reward*. The experiment-core work has since built a
+separate, deliberately-scoped home for measurement and evaluation. This note
+assembles the prior art that decides which home is correct.
+
+## The reward hypothesis places reward inside the agent-environment loop, not the scenario text
+
+In reinforcement learning, reward is the scalar signal an agent maximizes; the
+reward hypothesis holds that goals and purposes can be framed as the
+maximization of expected cumulative reward (Sutton and Barto,
+*Reinforcement Learning: An Introduction*, 2nd ed., MIT Press, 2018; Silver,
+Singh, Precup, and Sutton, "Reward is enough," *Artificial Intelligence* 299,
+2021). Two consequences matter for ACES:
+
+1. Reward is a property of the **agent-environment interface and the training
+   objective**, not of the environment's authored description. The same
+   environment can be trained against many reward functions; the reward function
+   belongs to the experiment/agent, not to the scenario.
+2. A reward function is a *measurement extracted from the run and consumed by
+   training or ranking*. In the CAGE-2 evaluation protocol a fixed policy is run
+   and cumulative reward is accumulated as the researcher's score
+   (TTCP CAGE Challenge 2, arXiv:2309.07388, pinned in ADR-069). That is the
+   textbook case of a data-use signal: it is read by the *evaluator*, not by a
+   participant acting within the horizon.
+
+This is the same conclusion the issue's discriminator reaches from first
+principles, and it is why `agents.reward_calculator` — a bare label naming a
+CybORG reward class — is the weakest of the surfaces: it selects training
+machinery that no ACES participant perceives.
+
+## Specification gaming shows reward is unsafe to freeze as authored fact
+
+The AI-safety literature on reward misspecification and specification gaming
+(Amodei, Olah, Steinhardt, Christiano, Schulman, and Mané, "Concrete Problems
+in AI Safety," arXiv:1606.06565, 2016; and the subsequent
+specification-gaming/reward-hacking literature) shows that reward functions are
+frequently revised as flaws are found, and that a reward is only meaningful
+relative to the agent and training regime it scores. Baking a specific
+reward-calculator selection into the authored, versioned scenario couples
+scenario meaning to a mutable, agent-specific training artifact — exactly the
+coupling the experiment-core boundary was created to avoid.
+
+## Experiment-database practice separates scenario, task, run, and evaluation
+
+The experiment-database and reproducibility literature already relied on for the
+experiment-core design (see
+[`../experiment-core/ml-experiment-rigor`](../experiment-core/ml-experiment-rigor.md))
+consistently separates the *data/scenario-like input* from the *task*, the
+*run*, and the *evaluation/metrics* (Vanschoren, van Rijn, Bischl, and Torgo,
+"OpenML: networked science in machine learning," *SIGKDD Explorations* 15(2),
+2014; and the REFORMS/DOME reproducibility work cited there). Metrics are task-
+and study-level analysis concepts, not properties of the scenario input. ACES
+adopted this separation in ADR-055: `experiment-task-v1` binds a scenario to an
+evaluation protocol and metric definitions, and ADR-055's guardrails explicitly
+say **"Do not treat SDL `objectives` as EXP-701 task records; they remain
+scenario-local objective declarations."** The SDL scoring pipeline predates that
+separation and now reconstructs it one layer too low.
+
+## ACES has already drawn this boundary — three times
+
+The decisive prior art is internal and verifiable:
+
+- **ADR-055 (Experiment Core Contract Boundary)** established that tasks,
+  runs, studies, and metric definitions live in the experiment-core contract
+  family, not the SDL, and warned that reusing SDL objectives as task records
+  blurs scientific claims.
+- **ADR-064 (Experiment Evidence and Measure Contract Boundary)** published
+  `experiment-evidence-record-v1` (raw evidence) and
+  `experiment-derived-measure-v1` ("a derived measure or evaluation output").
+  Evaluation outputs and derived measures are, by this decision, experiment
+  artifacts.
+- **ADR-069 (CAGE-2 Replication Architecture) §3** makes the backend
+  **Evaluator** the component that "projects reward, objective,
+  terminal-condition, and scoring facts into ACES evaluation results, evidence
+  records, and derived measures," and §1 treats native "reward arrays" and
+  "leaderboard scores" as *source facts* that become portable only when bound to
+  existing ACES evidence/measure concepts. ADR-069 §7 also rejects defining
+  "equivalence as one score."
+
+Under these three decisions there is already a correct home for every
+score-shaped concern the SDL pipeline expresses. Keeping the SDL pipeline is not
+additive; it is a second, weaker, authoring-time copy of a boundary the project
+already owns.
+
+## What legitimately stays in the horizon
+
+The same corpus is equally clear about what belongs in authored scenario
+meaning:
+
+- **`conditions`** are observable state facts (ADR-002; assessment-semantics
+  reference), and ADR-020 anchors participant "starting conditions" to them.
+  They are read within the horizon.
+- **`objectives`** are scenario-local participant intent (ADR-002). ADR-055
+  affirms they stay scenario-local and must not become task records.
+
+The only defect on the in-horizon side is the **success bridge**:
+`objectives.success` can currently be expressed as a score
+(`metrics`/`evaluations`/`tlos`/`goals`) instead of as observable state
+(`conditions`). Issue #671 question 2 asks precisely this, and the boundary
+answers it: objective success should be expressed against observable state, not
+a grading pipeline.
+
+## Design criteria for ADR-073
+
+A sound decision on scoring scope must satisfy:
+
+1. **Discriminator consistency.** Keep a surface in the SDL only if a
+   participant reads and acts on it within the horizon. Score-shaped surfaces
+   fail this; observable-state surfaces pass it.
+2. **No duplicate authority.** Do not keep an SDL surface whose concern is
+   already owned by the experiment-core contracts (ADR-055/064) or the backend
+   evaluator (ADR-069). Grading and reward are already owned there.
+3. **Preserve reproducibility.** Objective success and observable outcomes must
+   remain expressible against `conditions`, so removing the grading pipeline
+   does not weaken what a scenario can assert about its own state (ADR-020's
+   reproducibility warning).
+4. **Honest migration, not silent breakage.** Existing study-style scenarios
+   that use the pipeline must have a stated path — either to `conditions`-based
+   objective success, or to the experiment/evaluator plane for genuine graded
+   scoring — with deprecation rather than abrupt removal.
+5. **Falsifiable claim.** Per ADR-021, the decision must name the artifacts it
+   changes and the downstream consumers it affects (SEM-206 assessment
+   semantics; APTL evaluator/scoring surface, Brad-Edwards/aptl#606), so the
+   claim can be checked.
+6. **Decision deferral.** Issue #671 explicitly does not decide the answer; the
+   ADR is authored **proposed** so acceptance is a human decision at review.
+
+## Sources
+
+Internal (authoritative, in-repo):
+
+- ADR-002 Declarative Experiment Objectives in the SDL (records the OCR pipeline
+  inheritance).
+- ADR-020 Declarative Participant Framing Boundaries (reward assets deferred;
+  conditions as starting state; reproducibility warning).
+- ADR-055 Experiment Core Contract Boundary.
+- ADR-064 Experiment Evidence and Measure Contract Boundary.
+- ADR-065 Experiment Run Provenance Contract Boundary.
+- ADR-068 Experiment Trials, Replication, and Replay Claims.
+- ADR-069 CAGE-2 Replication Architecture.
+- ADR-021 Falsification-First Claim Evidence Gate.
+- Requirement SEM-206 Assessment Semantics.
+
+External:
+
+- Sutton and Barto, *Reinforcement Learning: An Introduction*, 2nd ed., MIT
+  Press, 2018.
+- Silver, Singh, Precup, and Sutton, "Reward is enough," *Artificial
+  Intelligence* 299, 2021.
+- Amodei, Olah, Steinhardt, Christiano, Schulman, and Mané, "Concrete Problems
+  in AI Safety," arXiv:1606.06565, 2016.
+- Vanschoren, van Rijn, Bischl, and Torgo, "OpenML: networked science in machine
+  learning," *SIGKDD Explorations* 15(2), 2014.
+
+Upstream (pinned by ADR-069):
+
+- TTCP CAGE Challenge 2, arXiv:2309.07388, and the `cage-challenge-2` / `CybORG`
+  repositories at the commits pinned in ADR-069 (reward calculators and
+  `Evaluation/evaluation.py`).

--- a/docs/research/scoring-scope/scoring-surface-inventory.md
+++ b/docs/research/scoring-scope/scoring-surface-inventory.md
@@ -1,0 +1,165 @@
+# Scoring/Reward Surface Inventory
+
+This note is the falsifiable evidence base for the scoring-scope examination
+(issue #671). It records, per surface, where the surface is defined, how it is
+validated, where it is used, and how it fares under the in-horizon
+discriminator. It is research evidence, not contract authority.
+
+## The discriminator
+
+Issue #671 proposes a single test for whether a signal belongs in the authored
+ACES **experiment** rather than in downstream **data use**:
+
+> A signal is in scope only if it is **used within the experiment by the
+> participants** — a signal a participant reads and acts on during the run,
+> within its horizon.
+
+This is the same experiment-vs-data-use boundary already drawn by the
+experiment-core decisions (ADR-055, ADR-064, ADR-065, ADR-068) and applied to a
+concrete replication target by ADR-069. Scoring, reward, measures, and
+evaluation are consumers of a run's output; they are not, by themselves, signals
+a participant perceives and acts on inside the horizon.
+
+## The coupled OCR scoring pipeline
+
+The five surfaces under examination are not independent. They form one coupled
+Open-Cyber-Range (OCR) inheritance chain, preserved verbatim by ADR-002:
+
+```
+conditions -> metrics -> evaluations -> TLOs -> goals
+```
+
+`agents.reward_calculator` is a separate CybORG inheritance, not part of that
+chain.
+
+### 1. `metrics`
+
+- **Schema**: `contracts/schemas/sdl/sdl-authoring-input-v1.json`
+  (`$defs.Metric`, `$defs.MetricType` = `manual` | `conditional`,
+  `$defs.MinScore`), mirrored in `instantiated-scenario-v1.json`.
+- **Model**: `implementations/python/packages/aces_sdl/scoring.py` (`Metric`),
+  container `aces_sdl/scenario.py`. Cross-field validator forbids `condition`
+  on manual metrics and requires it on conditional metrics.
+- **Meaning**: a scored quantity — `max_score`, plus either a human-graded
+  `artifact` (manual) or a `condition` reference (conditional). A metric is a
+  *graded value assigned to a run*, not a state a participant reads.
+
+### 2. `evaluations`
+
+- **Schema**: `$defs.Evaluation` in `sdl-authoring-input-v1.json`
+  (`metrics` list, `min_score`).
+- **Model**: `aces_sdl/scoring.py` (`Evaluation`, `MinScore` with exclusive
+  `absolute` / `percentage`).
+- **Meaning**: a pass/fail threshold over a group of metrics. This is a
+  grading rule applied to accumulated scores.
+
+### 3. `tlos`
+
+- **Schema**: `$defs.TLO` in `sdl-authoring-input-v1.json`
+  (`evaluation` reference, required).
+- **Model**: `aces_sdl/scoring.py` (`TLO`); docstring defines TLO as
+  "Training Learning Objective." (Note: the term is *training* learning
+  objective, an exercise-grading construct, not "terminal" learning objective.)
+- **Meaning**: a training-exercise learning objective linked to one
+  evaluation. Pure exercise-scoring vocabulary.
+
+### 4. `goals`
+
+- **Schema**: `$defs.Goal` in `sdl-authoring-input-v1.json` (`tlos` list).
+- **Model**: `aces_sdl/scoring.py` (`Goal`).
+- **Meaning**: a high-level exercise goal composed of TLOs. The top of the
+  grading tree.
+
+### 5. `agents.reward_calculator`
+
+- **Schema**: `$defs.Agent.reward_calculator` — a plain string with default
+  `""`, no `$ref`.
+- **Model**: `aces_sdl/agents.py` (`Agent.reward_calculator: str = ""`). This
+  is the **only** occurrence, and there is **no cross-reference validator** for
+  it anywhere under `aces_sdl/validator/` — unlike every other surface in this
+  inventory, it is an unresolved free-text label.
+- **Meaning**: names a CybORG reward-calculator class
+  (e.g. `HybridImpactPwn`, `SupplyChainImpact`). It selects training/scoring
+  machinery that runs *outside* the participant's perception, and it binds to
+  nothing inside ACES. ADR-020 already deferred "verifier/reward assets" to
+  future work and only recorded the field as an inherited label, not a modeled
+  concept.
+
+### The bridge: `objectives.success`
+
+`objectives` is an in-horizon surface (ADR-002), but its success model
+(`$defs.ObjectiveSuccess`, `aces_sdl/objectives.py`) currently lets an objective
+succeed on **either** observable state (`conditions`) **or** the score-shaped
+surfaces (`metrics` / `evaluations` / `tlos` / `goals`). This is the seam where
+the scoring pipeline reaches into the participant-facing surface. The validator
+requires at least one referenced condition/metric/evaluation/TLO/goal, so today
+a scenario can express objective success purely in grading terms.
+
+### In-horizon contrast: `conditions`
+
+- **Schema**: `$defs.Condition` in `sdl-authoring-input-v1.json` (command +
+  interval form, or `source` form).
+- **Model**: `aces_sdl/conditions.py` (`Condition`).
+- **Meaning**: an observable state fact about the run ("web-alive",
+  "OTService available"). This is exactly the class of signal the discriminator
+  keeps in scope: it describes the state of the environment that participants
+  and objectives can reference within the horizon.
+
+## Usage across the corpus
+
+Usage is narrow and concentrated in "study-style" scenarios:
+
+| Scenario | metrics/eval/tlos/goals | reward_calculator |
+|---|---|---|
+| `examples/scenarios/enterprise-participant-evidence-loop.sdl.yaml` | yes | no |
+| `examples/scenarios/satcom-release-poisoning.sdl.yaml` | yes | yes |
+| `examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml` | yes | yes |
+| `examples/scenarios/port-authority-surge-response.sdl.yaml` | yes | yes |
+| `examples/scenarios/techvault*.sdl.yaml` (all six) | none | none |
+| `examples/library/patterns/study-scoring-chain.yaml` | yes (pattern) | no |
+| `examples/library/templates/study/scored-study-protocol.yaml` | yes (template) | no |
+
+The six `techvault-*` runtime-parity scenarios use none of these surfaces. The
+`paper-agent-loop` scenario named in issue #671 does not exist in the tree yet
+(it is referenced only in preflight notes for other issues). Governing
+requirement for the assessment pipeline is **SEM-206 "Assessment Semantics."**
+
+## Where scoring/evaluation already lives (the experiment plane)
+
+The experiment-core contract family already owns the concepts the SDL pipeline
+duplicates:
+
+- `contracts/schemas/experiment-core/experiment-study-v1.json` carries an
+  analysis plan with its own `metrics` / `primary_metric` (statistical
+  experiment metrics, distinct from SDL grading).
+- `contracts/schemas/experiment-core/experiment-derived-measure-v1.json`
+  (ADR-064) is "a derived measure or evaluation output" bound to source
+  evidence records.
+- `contracts/schemas/experiment-core/experiment-evidence-record-v1.json`
+  (ADR-064) is raw captured evidence.
+- The compiled runtime evaluation contract
+  (`implementations/python/packages/aces_contracts/evaluation.py`) is the
+  processor/backend evaluation result surface.
+- ADR-069 §3 makes the backend **Evaluator** the component that "projects
+  reward, objective, terminal-condition, and scoring facts into ACES evaluation
+  results, evidence records, and derived measures."
+
+So a scenario that needs a graded score already has a home for it — outside the
+SDL, in the experiment/evaluator plane, where the score is treated as an output
+of the run rather than an authored environment fact.
+
+## Discriminator verdict per surface
+
+| Surface | Read by a participant in-horizon? | Verdict |
+|---|---|---|
+| `conditions` | yes — observable state | in scope (keep) |
+| `objectives` | yes — participant intent | in scope (keep); narrow success to observable state |
+| `metrics` | no — graded value over a run | data-use; vestigial in SDL |
+| `evaluations` | no — pass/fail grading rule | data-use; vestigial in SDL |
+| `tlos` | no — exercise grading construct | data-use; vestigial in SDL |
+| `goals` | no — exercise grading tree | data-use; vestigial in SDL |
+| `agents.reward_calculator` | no — training machinery, unbound label | data-use; vestigial in SDL |
+
+Every score-shaped surface fails the discriminator; every observable-state
+surface passes it. This is the evidence the proposed ADR (ADR-073) reasons
+over.


### PR DESCRIPTION
## Summary

Adds proposed ADR-073 examining whether the OCR-inherited SDL scoring pipeline (metrics/evaluations/tlos/goals) and the CybORG agents.reward_calculator label belong in ACES, plus scoring-scope research notes and a SEM-206 assessment-semantics compatibility guardrail. Doc-only; the decision is deferred to review (status proposed). Recommends treating these surfaces as vestigial against the experiment-vs-data-use boundary already drawn by ADR-055/064/069 and routing graded scoring to the experiment/evaluator plane, keeping objectives+conditions and narrowing objective success to observable state. Closes #671.

## Requirement UIDs

- `SEM-206`

## Related Issues

Closes #671

## ADR Impact

- ADR-073

## Changes

- docs/decisions/adrs/adr-073-scoring-reward-language-scope.md: proposed ADR with full-removal recommendation, migration path, and answers to the issue's four questions
- docs/research/scoring-scope/: prior-art-and-design-criteria and scoring-surface-inventory research notes (registered in docs/index.md)
- docs/explain/reference/assessment-semantics.md: SEM-206 compatibility guardrail (do not expand SDL scoring/reward language while the boundary is open)
- docs/decisions/adrs/README.md: ADR-073 toctree + table row
- changelog.d/671.added.md: changelog fragment

## Test Plan

- Documentation-only change. `nox -s verify` passes locally (Sphinx docs build, ADR acceptance-content pin, schema publication manifest + generated-schema drift, ruff, full pytest + integration suite).
- Pre-push codex review and test-quality review: clean.

## Ground Control Checks

- [x] GRC screening: not_security_relevant (docs-only; 0 gaps/impacts/stale).
- [x] `nox -s verify` green.
- [x] Pre-push codex + test-quality reviews clean; findings recorded on the issue thread.

## Traceability

- IMPLEMENTS: (none — proposed design ADR; no implementation surface)
- TESTS: (none — documentation-only)
- DOCUMENTS: ADR-073 → SEM-206 (Assessment Semantics)

## Checklist

- [x] Proposed ADR is not pinned in adr-index.yaml (correct for `proposed` status).
- [x] Research notes registered in docs/index.md toctree.
- [x] Decision deferred to review (status: proposed); no schema/model/scenario edits in this PR.
