### PR TITLE
docs(security): record 2026-07-01 commit authorship anomaly

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,42 @@ documented workflows.
 
 Please avoid publishing exploit details until there has been reasonable time to
 triage and prepare a fix or mitigation.
+
+## Commit Authorship and Signing
+
+Commits are signed with the maintainer's SSH key (ED25519,
+`SHA256:fdBpsrHmMxkK9DikzdhtWINNcTLkhmdsYrHK5cIMa/o`) under the identity
+`Brad Edwards <j.bradley.edwards@gmail.com>`.
+
+### Authorship anomaly, 2026-07-01 to 2026-07-05
+
+36 commits in this window were authored as the placeholder identity
+`Test <t@example.com>` and appear as **Unverified** on GitHub. They are not
+unsigned or forged: each is signed by the maintainer's SSH key above and
+verifies locally — `git log --show-signature` reports a good signature for
+`j.bradley.edwards@gmail.com`. GitHub withholds the Verified badge only
+because `t@example.com` is not a verified email on the account.
+
+**Cause.** A repository-local `[user]` override
+(`user.email=t@example.com`, `user.name=Test`) was written into the shared
+`.git/config` during a pre-push recovery on 2026-07-01 ~20:15 (recovery
+branch `local/prepush-base-damage-20260701-201555`). A history replay in
+that recovery re-created ~13 commits in one second at 20:15:53 under the
+placeholder identity; the override then shadowed the correct global identity
+for subsequent local commits until it was found.
+
+**Scope.** Limited to the author/committer identity fields. No other local
+configuration was altered — no `url.*.insteadOf` push redirection, no local
+`core.hooksPath`, no `core.sshCommand`, no `credential.helper`.
+
+**Affected commits.** Author `Test <t@example.com>`, from `cf4cdaa`
+(2026-07-01 20:15:53) through `a1fb96e` (2026-07-05 06:33:42). Enumerate
+with `git log --all --author='t@example.com' --format='%H %cI'`. Merge
+commits created by GitHub in this window are separately signed by GitHub's
+web-flow key and are Verified; they are not part of this set.
+
+**Remediation.** The local override was removed on 2026-07-05
+(`git config --local --remove-section user`); identity now resolves to the
+correct global values. History was not rewritten: the affected commits are
+merged into shared branches, so the placeholder author remains as the
+historical record and this note is the durable explanation.


### PR DESCRIPTION
## What

Adds a **Commit Authorship and Signing** section to `SECURITY.md` documenting an authorship anomaly so the git history is legible to anyone auditing the repo.

## Why

36 commits between 2026-07-01 and 2026-07-05 were authored as the placeholder identity `Test <t@example.com>` and appear **Unverified** on GitHub. They are not unsigned or forged — each is signed by the maintainer's SSH key and verifies locally (`git log --show-signature` → good signature for `j.bradley.edwards@gmail.com`). GitHub withholds the Verified badge only because `t@example.com` is not a verified account email.

Root cause: a repo-local `[user]` override written into the shared `.git/config` during a pre-push recovery on 2026-07-01 (branch `local/prepush-base-damage-20260701-201555`), which shadowed the correct global identity. Scope was limited to the identity fields — no `url.*.insteadOf`, no local `core.hooksPath`, no `core.sshCommand`, no `credential.helper`.

Remediation (already applied): the local override was removed on 2026-07-05; identity now resolves to the correct global values. History was not rewritten because the affected commits are merged into shared branches, so this note is the durable explanation.

## Scope

Docs-only change to `SECURITY.md`. No requirement UID; no code, contract, or schema impact.