### PR TITLE
chore: scope pr-title-lint to PRs targeting dev

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -7,11 +7,16 @@ name: PR Title Lint
 #
 # The PR title is untrusted event data, so it is read from $GITHUB_EVENT_PATH
 # by the checker (never shell-interpolated), the token is read-only, and this
-# uses `pull_request` (never `pull_request_target`). There is no exemption for
-# PRs targeting `dev`.
+# uses `pull_request` (never `pull_request_target`).
+#
+# Scoped to PRs targeting `dev` (feature PRs). On a squash-merged feature PR the
+# conventional title becomes the commit release-please reads, so it is enforced
+# there. `dev`->`main` promotion PRs are not squashed and their title never
+# becomes a release commit, so linting them is noise (#684).
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    branches: [dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
`pr-title-lint` now runs only on PRs whose base is `dev` (feature PRs), where the squashed conventional title becomes the commit release-please reads. `dev`->`main` promotion PRs are not squashed, so linting their title is noise — this stops the spurious failure on promotions (#684).

Tradeoff: the agent-branding ban (#567) no longer runs on PRs targeting `main` (promotions / direct-to-main). Those are typically human-initiated, low risk. If you want the branding ban kept everywhere while only dropping the conventional-shape requirement for `main`, say so and I'll make `check_pr_title.py` base-aware instead.