### PR TITLE
ci: auto-open a back-merge PR to dev after each release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,3 +99,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "${TAG}" dist/* --clobber
+
+  # After a release is cut, the version bump + CHANGELOG land on `main`, so `dev`
+  # falls one release commit behind. Open a back-merge PR so `dev` is resynced.
+  # `main` is ahead of `dev` only by the release commit (a fast-forward). This
+  # job cannot auto-merge it: `dev` requires status checks that a bot-opened PR
+  # does not trigger, and repo auto-merge is off — merge it yourself (admin
+  # override; enforce_admins is false).
+  sync-dev:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Open the back-merge PR (main -> dev)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          existing="$(gh pr list --repo "${GITHUB_REPOSITORY}" --base dev --head main --state open --json number --jq '.[].number')"
+          if [ -n "${existing}" ]; then
+            echo "back-merge PR main->dev already open (#${existing}); nothing to do"
+            exit 0
+          fi
+          gh pr create --repo "${GITHUB_REPOSITORY}" --base dev --head main \
+            --title "chore: back-merge ${TAG} into dev" \
+            --body "Automated back-merge of the ${TAG} release commit (version bump + CHANGELOG) from \`main\` into \`dev\`, so \`dev\` stays in sync. \`main\` is ahead of \`dev\` only by the release commit (fast-forward). \`dev\`'s required checks do not run on this bot-opened PR — merge it directly (admin)."


### PR DESCRIPTION
Adds a `sync-dev` job to `release-please.yml`: whenever release-please cuts a release (release_created=true), it opens a `main`->`dev` back-merge PR so `dev` doesn't fall behind by the version-bump/CHANGELOG release commit.

It **opens** the PR only — it can't auto-merge: `dev` has required status checks (verify/sonar/etc.) that a bot-opened PR won't trigger, and repo auto-merge is off. Since `enforce_admins` is false and `main` is only ever a fast-forward ahead of `dev` post-release, you admin-merge the back-merge PR in one click.

Takes effect once this reaches `main` (next promotion).