### PR TITLE
test: add example corpus non-vacuity guard

### DIFF
--- a/implementations/python/tests/test_scenarios.py
+++ b/implementations/python/tests/test_scenarios.py
@@ -114,6 +114,11 @@ class TestFindScenarios:
         assert find_scenarios(tmp_path / "missing") == []
 
 
+def test_example_scenario_corpus_is_nonempty():
+    """A stale corpus root must fail loudly, not collect zero parametrized cases."""
+    assert EXAMPLE_SCENARIOS, f"No example SDL scenarios found under {EXAMPLES_DIR} (glob '*.sdl.yaml')"
+
+
 @pytest.mark.parametrize("path", EXAMPLE_SCENARIOS, ids=lambda path: path.name)
 def test_example_scenarios_load(path):
     """Every example SDL should load successfully from disk."""


### PR DESCRIPTION
## Summary

Adds an explicit non-vacuity guard to the SDL example scenario loading suite so a stale or relocated example-corpus root fails loudly instead of collecting zero parametrized cases.

## Requirement UIDs

- `ASR-504`

## Related Issues

Closes #7

## ADR Impact

- No ADR required

## Changes

- Added `test_example_scenario_corpus_is_nonempty` beside the example scenario parametrization in `implementations/python/tests/test_scenarios.py`.
- Kept the existing marker-discovered `EXAMPLES_DIR` and `load_scenario()` path unchanged.
- Verified the SDL testing documentation already points at `examples/scenarios/`, so no documentation edit was needed.

## Test Plan

- [x] `cd implementations/python && uv run --extra dev pytest tests/test_scenarios.py -q` (27 passed)
- [x] `ACES_REQUIREMENT_UID=ASR-504 pre-commit run --all-files`
- [x] `ACES_REQUIREMENT_UID=ASR-504 implementations/python/.venv/bin/python tools/check_repo_policy.py`
- [x] `ACES_REQUIREMENT_UID=ASR-504 implementations/python/.venv/bin/python tools/check_requirement_governance.py` (exited 0 with Ground Control unavailable skip)
- [x] `ACES_REQUIREMENT_UID=ASR-504 implementations/python/.venv/bin/python tools/verify_all.py`
- [x] `ACES_REQUIREMENT_UID=ASR-504 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`

The full verify runs passed. Their requirement-governance subcheck also exited 0 in Ground Control unavailable skip mode.

## Ground Control Checks

- [x] Latest implemented-diff GRC screening recorded `not_security_relevant`
- [x] `gc_assert_quality_gates` passed for `ASR-504`
- [x] Pre-push codex review and test-quality review completed cleanly

## Traceability

- IMPLEMENTS: ASR-504 <- implementations/python/tests/test_scenarios.py
- TESTS: ASR-504 <- implementations/python/tests/test_scenarios.py, ASR-504 <- implementations/python/tests/test_example_schema_conformance.py, ASR-504 <- implementations/python/tests/test_sdl_models.py, ASR-504 <- implementations/python/tests/test_sdl_realworld.py, ASR-504 <- implementations/python/tests/test_sdl_fuzz.py, ASR-504 <- implementations/python/tests/test_sdl_validator.py

## Checklist

- [x] Code follows project coding standards
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — test-only diff; repo plan rules forbid changelog fragments
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation update required for the test-only diff, and `docs/explain/sdl/testing.md` already documents repo-root `examples/scenarios/`.
