### PR TITLE
feat(sdl): add DSL-115 authoring specificity helper

### DIFF
--- a/docs/decisions/issue-73-dsl-115-specificity-preflight.md
+++ b/docs/decisions/issue-73-dsl-115-specificity-preflight.md
@@ -1,0 +1,153 @@
+# Issue 73 / DSL-115 Specificity Preflight
+
+Date: 2026-07-08
+
+Requirement DSL-115 asks for author-selectable specificity across scenario,
+participant, evaluation, and experiment concerns. This note is architecture
+preflight only. It does not define new SDL syntax, schemas, validators,
+runtime behavior, conformance behavior, or an implementation plan.
+
+## Architecture Decisions
+
+- Treat DSL-115 as a specificity contract over existing concern-owning
+  surfaces, not as a new global abstraction level.
+- Reuse the existing exact/constrained/open vocabulary from SEM-218
+  (`aces_sdl.explicitness`) for authored intent. If richer machine-checkable
+  domains are needed, align with ADR-070 and the realization envelope domain
+  model instead of creating a second constraint language.
+- Open or underspecified forms are allowed only where the owning SDL,
+  contract, or semantic rule explicitly admits them. Silence remains
+  fail-closed.
+- Scenario specificity belongs in the SDL scenario model, variables,
+  references, instantiation, explicitness metadata, and realization-envelope
+  semantics. Do not move scenario meaning into experiment-core records.
+- Participant specificity belongs in the participant surfaces that already own
+  it: `Agent`, participant action contracts, observation boundaries, behavior
+  specifications, and participant runtime contracts.
+- Evaluation specificity must respect ADR-073: SDL objectives express
+  observable success through `conditions`; graded scoring, reward, derived
+  measures, and evaluator outputs belong in the experiment/evaluator plane.
+- Experiment specificity belongs in experiment-core task, apparatus context,
+  run, study, capture, evidence, and derived-measure contracts. Do not add
+  tasks, runs, studies, or evaluator scoring records to SDL.
+- Constraints that affect semantics must be machine-checkable: typed
+  variables, `allowed_values`, governed references, domain descriptors, and
+  semantic invariants. Prose-only constraints are explanatory, not normative.
+- Preserve authored specificity provenance through instantiation, compilation,
+  planning, runtime disclosure, and persisted snapshots. Substituting a
+  variable must not falsely promote a constrained authored value to exact.
+- Published schema changes must follow the contract publication path:
+  `contracts/schemas/**`, `contracts/schema-publication-manifest.json`,
+  generated-schema parity, and `schema_bundle()` compatibility.
+
+## Canonical Incumbents
+
+- Authority chain: ADR-009, ADR-061, `contracts/README.md`,
+  `.gc/plan-rules.md`, `tools/check_repo_policy.py`,
+  `tools/check_schema_publication.py`, `tools/check_generated_schemas.py`, and
+  `tools/verify_all.py`.
+- SDL parsing and model shape: `aces_sdl.parser.parse_sdl`,
+  `aces_sdl.parser.parse_sdl_file`, `yaml.safe_load`, hashmap key
+  preservation, variable-key rejection, and `SDLModel(extra="forbid")`.
+- SDL semantic validation: `SemanticValidator`, `SDLParseError`,
+  `SDLValidationError`, `SDLInstantiationError`, SDL diagnostics, references,
+  variables, and instantiation specs.
+- Specificity and realization: `specs/formal/realization/explicitness-and-realization.md`,
+  ADR-070, `specs/formal/realization/envelope-semantics.md`,
+  `aces_sdl.explicitness`, `RealizationEnvelopeModel`,
+  `aces_sdl.realization_envelope`, `CompiledRealizationRequirement`,
+  `realization_support_diagnostics`, `realization_disclosure`, and
+  `RuntimeSnapshot.realization_provenance`.
+- Participant semantics: `Agent`, `ParticipantActionContract`,
+  `ParticipantObservationBoundary`, `ParticipantBehaviorSpecification`,
+  participant behavior validators, and participant runtime contracts.
+- Evaluation and experiment contracts: ADR-055, ADR-064, ADR-068, ADR-073,
+  experiment task, apparatus context, run, study, capture spec, evidence
+  record, and derived-measure contracts.
+- Runtime and API cross-cutting behavior: `Diagnostic`, `OperationStatus`,
+  `OperationReceipt`, `ControlPlaneSecurityConfig`, role authorization,
+  request-size guards, idempotency keys, request fingerprints, audit records,
+  and the redacted control-plane error handler.
+- Conformance: `run_target_conformance(reference_scenario=...)` as the
+  current #663 bridge, backend manifest validation, profile loading, and
+  `schema_bundle()`.
+
+## Cross-Cutting Layers
+
+- Parse/model gate: continue through `yaml.safe_load`, normalized SDL models,
+  closed Pydantic models, hashmap key preservation, variable-key rejection, and
+  removed scoring-section rejection.
+- Reference/semantic gate: preserve fail-closed reference resolution, collect
+  all semantic diagnostics, and report paths and concern kinds rather than raw
+  payload values.
+- Instantiation/config gate: use the existing variable declaration, type,
+  default, `allowed_values`, substitution, unresolved-token, and revalidation
+  pipeline. Do not introduce a new env-binding path for specificity.
+- Contract/schema gate: use `ContractModel`, published schemas, schema
+  manifests, generated bundles, and `x-aces-invariants` for semantic rules
+  that schemas cannot express directly.
+- Manifest/planner gate: use backend manifest realization declarations,
+  `resolve_realization_concern()`, support diagnostics, and runtime
+  disclosure. Unsupported exact or constrained requirements are diagnostics,
+  not silent approximation.
+- Runtime/control-plane gate: keep strict default auth, bearer/proxy identity
+  validation, role checks, request-size limits, idempotency, audit records, and
+  redacted FastAPI exception envelopes.
+- OS and secret-exposure gate: do not place credentials, tokens, private keys,
+  environment dumps, process argv, backend-private state, hidden truth, host
+  paths, full tracebacks, or raw logs in SDL artifacts, contracts, fixtures,
+  diagnostics, audit records, persisted snapshots, or examples.
+- Error-envelope gate: use SDL exceptions, `Diagnostic`, `OperationStatus`,
+  and redacted API errors. Diagnostics should identify address, field path,
+  domain, scope, or kind, not sensitive authored or realized values.
+- Persistence/evidence gate: store provenance, digests, references, and
+  explicit evidence records through the established contracts. Do not hide new
+  specificity state in metadata blobs, tags, or untyped log payloads.
+
+## Extensibility Boundary
+
+The required seam is per-concern specificity metadata on the owning surface,
+parameterized by concern kind, scope, domain, closure, carriage, and
+provenance. Existing anchors are `ExplicitnessRecord`, ADR-070 realization
+domains, and the planner concern-kind mapping in
+`resolve_realization_concern()`.
+
+Future variations should add governed concern kinds, domain descriptors,
+semantic invariants, or schema fields at the owning boundary. They should not
+require re-editing every backend, duplicating schemas, or introducing a
+top-level `specificity` bag.
+
+## Gotchas And Anti-Patterns
+
+- Do not add a universal `specificity:` root section or a generic
+  `open|constrained|exact` field disconnected from the owning concern.
+- Do not treat missing data as open unless the owning rule explicitly says so.
+- Do not conflate authored explicitness with backend
+  `RealizationSupportMode`, participant feature support levels, semantic
+  profiles, validation strength, backend profiles, or experiment study
+  membership.
+- Do not reintroduce SDL scoring or reward language for evaluation
+  specificity.
+- Do not encode normative domains in free-form `constraints`, notes, comments,
+  or ungoverned extension maps.
+- Do not promote variable-substituted values to exact when the authored form was
+  constrained.
+- Do not resolve ambiguous references by first match or by parser order.
+- Do not persist new runtime state in `RuntimeSnapshot.metadata`, tags, audit
+  detail blobs, or raw backend logs.
+- Do not add implementation logic under `implementations/python/src/aces/**`;
+  that tree is a compatibility surface.
+- Do not create duplicate parsers, validators, exception hierarchies, schema
+  bundles, workflow scripts, logging paths, or security gates.
+
+## Non-Goals
+
+- No implementation of DSL-115 in this preflight.
+- No new SDL syntax, schema publication, manifest version, compiler behavior,
+  planner behavior, runtime API behavior, or conformance behavior in this note.
+- No change to requirement status, coverage, or traceability records.
+- No relocation of experiment tasks, runs, studies, rewards, scoring, or
+  evaluator results into SDL.
+- No solver, backend callback language, external query language, or hidden
+  policy engine for constraints.
+- No implementation plan.

--- a/docs/explain/reference/explicitness-realization-semantics.md
+++ b/docs/explain/reference/explicitness-realization-semantics.md
@@ -123,6 +123,20 @@ additional exact requirement kinds for other artifact families; that should
 require adding governed terms and shared semantic checks, not rewriting planner
 or conformance call sites.
 
+## Authoring Specificity
+
+`classify_authoring_specificity()` is the DSL-115 helper for reviewing
+specificity across existing owned surfaces. It reuses the SEM-218 classifier
+for exact and constrained authored values, and it records open or
+underspecified concerns only when the owning caller supplies the explicit path
+in `admitted_open_paths`.
+
+Do not treat a missing field as open by default. The helper's admitted-open
+paths are authoring metadata for surfaces whose SDL, contract, or semantic rule
+already allows an underspecified form; they are not backend-realization
+permission and do not replace manifest `realization_support`, realization
+envelopes, or experiment-core contracts.
+
 ## Part 2 Implementation Boundary
 
 The typed compiler emission and planner gate must preserve the classifier output

--- a/implementations/python/packages/aces_sdl/explicitness.py
+++ b/implementations/python/packages/aces_sdl/explicitness.py
@@ -316,22 +316,47 @@ def _resolve_path_token(
     *,
     allow_unset_model_field: bool,
 ) -> tuple[bool, object]:
+    resolved: tuple[bool, object] = (False, None)
     if isinstance(token, int):
-        if _is_sequence(current) and 0 <= token < len(current):
-            return True, current[token]
-        return False, None
-    if isinstance(current, BaseModel):
-        if token not in type(current).model_fields:
-            return False, None
+        resolved = _resolve_sequence_path_token(current, token)
+    elif isinstance(current, BaseModel):
+        resolved = _resolve_model_path_token(
+            current,
+            token,
+            allow_unset_model_field=allow_unset_model_field,
+        )
+    elif isinstance(current, Mapping):
+        resolved = _resolve_mapping_path_token(current, token)
+    return resolved
+
+
+def _resolve_sequence_path_token(current: object, token: int) -> tuple[bool, object]:
+    resolved: tuple[bool, object] = (False, None)
+    if _is_sequence(current) and 0 <= token < len(current):
+        resolved = (True, current[token])
+    return resolved
+
+
+def _resolve_model_path_token(
+    current: BaseModel,
+    token: str,
+    *,
+    allow_unset_model_field: bool,
+) -> tuple[bool, object]:
+    resolved: tuple[bool, object] = (False, None)
+    if token in type(current).model_fields:
         value = getattr(current, token)
-        if value is None and token not in current.model_fields_set and not allow_unset_model_field:
-            return False, None
-        return True, value
-    if isinstance(current, Mapping):
-        if token in current:
-            return True, current[token]
-        return False, None
-    return False, None
+        missing_unset_optional = value is None and token not in current.model_fields_set
+        if not missing_unset_optional or allow_unset_model_field:
+            resolved = (True, value)
+    return resolved
+
+
+def _resolve_mapping_path_token(current: Mapping[object, object], token: str) -> tuple[bool, object]:
+    resolved: tuple[bool, object] = (False, None)
+    if token in current:
+        resolved = (True, current[token])
+    return resolved
 
 
 def _is_sequence(value: object) -> bool:

--- a/implementations/python/packages/aces_sdl/explicitness.py
+++ b/implementations/python/packages/aces_sdl/explicitness.py
@@ -332,7 +332,7 @@ def _resolve_path_token(
 
 def _resolve_sequence_path_token(current: object, token: int) -> tuple[bool, object]:
     resolved: tuple[bool, object] = (False, None)
-    if _is_sequence(current) and 0 <= token < len(current):
+    if isinstance(current, Sequence) and not isinstance(current, (str, bytes, bytearray)) and 0 <= token < len(current):
         resolved = (True, current[token])
     return resolved
 
@@ -357,10 +357,6 @@ def _resolve_mapping_path_token(current: Mapping[object, object], token: str) ->
     if token in current:
         resolved = (True, current[token])
     return resolved
-
-
-def _is_sequence(value: object) -> bool:
-    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
 
 
 class _AuthoredPathCollector:

--- a/implementations/python/packages/aces_sdl/explicitness.py
+++ b/implementations/python/packages/aces_sdl/explicitness.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import re
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 
@@ -16,12 +17,15 @@ __all__ = [
     "ExplicitnessProvenance",
     "ExplicitnessRecord",
     "ExplicitnessResult",
+    "classify_authoring_specificity",
+    "classify_model_explicitness",
     "classify_scenario_explicitness",
     "derive_instantiated_explicitness",
 ]
 
 _OPEN_ENUM_SENTINELS = frozenset({"unknown", "other"})
 _EXPLICITNESS_ORDER: dict[ExplicitnessClass, int] = {}
+_PATH_TOKEN_RE = re.compile(r"[^.\[\]]+|\[\d+\]")
 
 
 class ExplicitnessClass(str, Enum):
@@ -71,10 +75,58 @@ class ExplicitnessResult:
 def classify_scenario_explicitness(scenario: BaseModel) -> ExplicitnessResult:
     """Classify authored SDL declarations on ``scenario``."""
 
-    variables = getattr(scenario, "variables", {})
+    return classify_model_explicitness(scenario)
+
+
+def classify_model_explicitness(
+    model: BaseModel,
+    *,
+    variables: dict[str, Variable] | None = None,
+) -> ExplicitnessResult:
+    """Classify authored declarations on any closed ACES Pydantic model."""
+
+    variables = variables if variables is not None else getattr(model, "variables", {})
     classifier = _ExplicitnessClassifier(variables)
-    classifier.visit(scenario, "")
+    classifier.visit(model, "")
     return ExplicitnessResult(records=dict(classifier.records), errors=tuple(classifier.errors))
+
+
+def classify_authoring_specificity(
+    model: BaseModel,
+    *,
+    admitted_open_paths: Iterable[str] = (),
+    variables: dict[str, Variable] | None = None,
+) -> ExplicitnessResult:
+    """Classify DSL-115 specificity with opt-in open/underspecified paths.
+
+    Missing fields are not open by default. A caller must supply the exact
+    owning-surface path for any concern whose owning rule explicitly admits an
+    open or underspecified form. This records authoring review metadata only;
+    it is not backend-realization permission.
+    """
+
+    result = classify_model_explicitness(model, variables=variables)
+    records = dict(result.records)
+    errors = list(result.errors)
+    for path in admitted_open_paths:
+        normalized_path = path.strip() if isinstance(path, str) else ""
+        if not normalized_path:
+            errors.append("Cannot classify open specificity for an empty path")
+            continue
+        if not _path_addresses_model_surface(model, normalized_path):
+            errors.append(
+                f"Cannot classify open specificity for '{normalized_path}': path does not resolve to a model surface"
+            )
+            continue
+        records.setdefault(
+            normalized_path,
+            ExplicitnessRecord(
+                path=normalized_path,
+                classification=ExplicitnessClass.OPEN,
+                reason="explicitly admitted open/underspecified concern; not backend-realization permission",
+            ),
+        )
+    return ExplicitnessResult(records=records, errors=tuple(errors))
 
 
 def derive_instantiated_explicitness(
@@ -235,6 +287,55 @@ def _authored_paths(value: object) -> set[str]:
     collector = _AuthoredPathCollector()
     collector.visit(value, "")
     return collector.paths
+
+
+def _path_addresses_model_surface(root: object, path: str) -> bool:
+    tokens = _path_tokens(path)
+    if not tokens:
+        return False
+
+    current = root
+    for index, token in enumerate(tokens):
+        is_final = index == len(tokens) - 1
+        found, current = _resolve_path_token(current, token, allow_unset_model_field=is_final)
+        if not found:
+            return False
+    return True
+
+
+def _path_tokens(path: str) -> tuple[str | int, ...]:
+    tokens: list[str | int] = []
+    for raw in _PATH_TOKEN_RE.findall(path):
+        tokens.append(int(raw[1:-1]) if raw.startswith("[") else raw)
+    return tuple(tokens)
+
+
+def _resolve_path_token(
+    current: object,
+    token: str | int,
+    *,
+    allow_unset_model_field: bool,
+) -> tuple[bool, object]:
+    if isinstance(token, int):
+        if _is_sequence(current) and 0 <= token < len(current):
+            return True, current[token]
+        return False, None
+    if isinstance(current, BaseModel):
+        if token not in type(current).model_fields:
+            return False, None
+        value = getattr(current, token)
+        if value is None and token not in current.model_fields_set and not allow_unset_model_field:
+            return False, None
+        return True, value
+    if isinstance(current, Mapping):
+        if token in current:
+            return True, current[token]
+        return False, None
+    return False, None
+
+
+def _is_sequence(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
 
 
 class _AuthoredPathCollector:

--- a/implementations/python/tests/test_dsl_115_authoring_specificity.py
+++ b/implementations/python/tests/test_dsl_115_authoring_specificity.py
@@ -1,0 +1,100 @@
+"""DSL-115 author-selectable specificity over owned concern surfaces."""
+
+from __future__ import annotations
+
+import textwrap
+
+from aces_contracts.contracts import ExperimentReferenceModel
+from aces_sdl import parse_sdl
+from aces_sdl.explicitness import ExplicitnessClass, classify_authoring_specificity
+
+
+def _scenario_with_specificity_levels():
+    return parse_sdl(
+        textwrap.dedent("""
+        name: dsl-115-specificity
+        version: ${scenario_version}
+        variables:
+          scenario_version:
+            type: string
+            default: 1.0.0
+            allowed_values: [1.0.0, 1.1.0]
+          participant_label:
+            type: string
+            default: red operator
+            allowed_values: [red operator, autonomous red team]
+        entities:
+          red:
+            role: red
+        agents:
+          red-agent:
+            entity: red
+            description: ${participant_label}
+        conditions:
+          objective-complete:
+            command: /bin/true
+            interval: 5
+        objectives:
+          assess:
+            agent: red-agent
+            success:
+              conditions: [objective-complete]
+        """)
+    )
+
+
+def test_specificity_does_not_treat_missing_fields_as_open_by_default():
+    result = classify_authoring_specificity(_scenario_with_specificity_levels())
+
+    assert "agents.red-agent.initial_knowledge" not in result.records
+    assert "objectives.assess.window" not in result.records
+
+
+def test_specificity_classifies_scenario_participant_and_evaluation_concerns():
+    result = classify_authoring_specificity(
+        _scenario_with_specificity_levels(),
+        admitted_open_paths=(
+            "version",
+            "objectives.assess.success.conditions[0]",
+            "agents.red-agent.initial_knowledge",
+            "objectives.assess.window",
+        ),
+    )
+
+    assert result.records["version"].classification is ExplicitnessClass.CONSTRAINED
+    assert result.records["agents.red-agent.description"].classification is ExplicitnessClass.CONSTRAINED
+    assert result.records["objectives.assess.success.conditions[0]"].classification is ExplicitnessClass.EXACT
+    assert result.records["agents.red-agent.initial_knowledge"].classification is ExplicitnessClass.OPEN
+    assert result.records["objectives.assess.window"].classification is ExplicitnessClass.OPEN
+
+
+def test_specificity_rejects_admitted_open_paths_outside_model_surface():
+    result = classify_authoring_specificity(
+        _scenario_with_specificity_levels(),
+        admitted_open_paths=(
+            "agents.red-agent.initialKnowlege",
+            "agents.ghost.initial_knowledge",
+            "objectives.assess.window",
+        ),
+    )
+
+    assert "agents.red-agent.initialKnowlege" not in result.records
+    assert "agents.ghost.initial_knowledge" not in result.records
+    assert result.records["objectives.assess.window"].classification is ExplicitnessClass.OPEN
+    assert result.errors == (
+        "Cannot classify open specificity for 'agents.red-agent.initialKnowlege': "
+        "path does not resolve to a model surface",
+        "Cannot classify open specificity for 'agents.ghost.initial_knowledge': "
+        "path does not resolve to a model surface",
+    )
+
+
+def test_specificity_classifies_experiment_contract_concerns_without_new_sdl_syntax():
+    reference = ExperimentReferenceModel(ref_kind="scenario", ref_id="benchmark-a")
+
+    result = classify_authoring_specificity(reference, admitted_open_paths=("ref_version",))
+
+    assert result.records["ref_kind"].classification is ExplicitnessClass.EXACT
+    assert result.records["ref_id"].classification is ExplicitnessClass.EXACT
+    assert result.records["ref_version"].classification is ExplicitnessClass.OPEN
+    assert "ref_digest" not in result.records


### PR DESCRIPTION
## Summary

Adds DSL-115 authoring specificity classification on top of the existing SEM-218 explicitness metadata so scenario, participant, evaluation, and experiment concerns can be reviewed as exact, constrained, or explicitly admitted open without creating a new DSL syntax.

## Requirement UIDs

- `DSL-115`

## Related Issues

Closes #73

## ADR Impact

- ADR-070
- ADR-073

## Changes

- Add generic model explicitness classification and a DSL-115 helper that only records admitted-open paths when they resolve to an existing model surface.
- Preserve already-authored exact and constrained classifications when a caller also lists the same path as admitted open.
- Cover scenario, participant, evaluation, and experiment specificity behavior with regression tests, including fail-closed path validation.
- Document the authoring-specificity boundary and include the architecture preflight decision note.

## Test Plan

- [x] Focused DSL-115 tests pass: `implementations/python/.venv/bin/python -m pytest implementations/python/tests/test_dsl_115_authoring_specificity.py -q`
- [x] Full verifier passes: `ACES_REQUIREMENT_UID=DSL-115 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`
- [x] Requirement governance used the repo's configured Ground Control-unavailable skip path during local verification.

## Ground Control Checks

- [x] `tools/check_repo_policy.py` passes through the verifier
- [x] `gc_assert_quality_gates` passes
- [x] Architecture preflight, GRC screening, Codex review, and test-quality review completed; cap-1 findings were fixed, with no over-cap review cycle.

## Traceability

- IMPLEMENTS: DSL-115 ← implementations/python/packages/aces_sdl/explicitness.py, DSL-115 ← docs/explain/reference/explicitness-realization-semantics.md
- TESTS: DSL-115 ← implementations/python/tests/test_dsl_115_authoring_specificity.py

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment intentionally absent: `.gc/plan-rules.md` uses release-please and forbids `changelog.d/` fragments
- [x] Documentation updated

## Documentation

Updated: see diff.
