### PR TITLE
docs: define ecosystem evolution governance policy

### DIFF
--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -119,6 +119,7 @@ adr-071-reusable-asset-trust-and-integrity-policy
 adr-072-validation-and-admission-profiles
 adr-073-scoring-reward-language-scope
 adr-074-experiment-authoring-input-contract-boundary
+adr-075-ecosystem-versioning-deprecation-and-migration-governance
 ```
 
 | ADR | Title | Status | Date |
@@ -198,3 +199,4 @@ adr-074-experiment-authoring-input-contract-boundary
 | [072](adr-072-validation-and-admission-profiles.md) | Validation and Admission Profiles | proposed | 2026-07-05 |
 | [073](adr-073-scoring-reward-language-scope.md) | Scoring and Reward Language Scope in the SDL | accepted | 2026-07-05 |
 | [074](adr-074-experiment-authoring-input-contract-boundary.md) | Experiment Authoring-Input Contract Boundary | accepted | 2026-07-08 |
+| [075](adr-075-ecosystem-versioning-deprecation-and-migration-governance.md) | Ecosystem Versioning, Deprecation, and Migration Governance | proposed | 2026-07-11 |

--- a/docs/decisions/adrs/adr-075-ecosystem-versioning-deprecation-and-migration-governance.md
+++ b/docs/decisions/adrs/adr-075-ecosystem-versioning-deprecation-and-migration-governance.md
@@ -1,0 +1,129 @@
+# ADR-075: Ecosystem Versioning, Deprecation, and Migration Governance
+
+## Status
+
+proposed
+
+## Date
+
+2026-07-11
+
+## Classification
+
+Classification: FM2
+Required artifacts: ADR, normative specification, repository-policy and docs verification
+Waivers: none
+
+## Context
+
+ACES now has several independently versioned surfaces:
+
+- the Python distribution and Git tags;
+- published JSON Schema contract lineages;
+- wire discriminators in closed contract DTOs;
+- SDL scenarios and reusable modules;
+- processor, backend, participant, and apparatus declarations;
+- experiment tasks, runs, studies, and evidence artifacts; and
+- ADR and Ground Control workflow statuses.
+
+These surfaces use similar words, such as version, compatibility,
+deprecation, stability, migration, and lifecycle, but they do not all carry the
+same semantics. ADR-061 already governs published JSON Schema evolution, while
+ADR-010 governs compatibility-only Python import wrappers. Those decisions are
+necessary but not sufficient for GOV-901, GOV-902, and GOV-903 because the
+ecosystem needs one cross-surface policy that explains how versioning,
+deprecation, and migration claims are made without collapsing every surface
+into a single package-version model.
+
+The current repository also has a practical tension: release-please owns the
+package release process, the package is still pre-1.0, and all checked-in JSON
+Schemas are currently `draft` even when their filenames carry `v1` or `v2`
+lineage suffixes. A reader can otherwise infer stronger compatibility
+guarantees than the repository can honestly provide.
+
+## Decision
+
+Adopt a two-part governance structure:
+
+1. This ADR records the architectural decision and rationale.
+2. `specs/evolution/versioning-deprecation-and-migration.md` is the normative
+   operational policy for versioning, compatibility, deprecation, removal, and
+   migration across ecosystem surfaces.
+
+The policy has these core rules.
+
+Version identifiers are surface-local. Package SemVer, Git tags, contract
+lineage suffixes, wire discriminators, module versions, apparatus versions,
+domain artifact versions, ADR status, and requirement status must not be
+treated as interchangeable.
+
+Compatibility claims must name their direction, producer, consumer, surface,
+and dimension. The recognized directions are backward, forward, and full
+compatibility. The recognized dimensions are structural acceptance, semantic
+equivalence, behavioral compatibility, and operational interoperability.
+
+Stability, deprecation, and removal are separate lifecycle concepts. ADR-061
+`draft` or `stable` classification governs how a schema may evolve; it does
+not say whether a surface is deprecated or removed. ADR status and Ground
+Control requirement status remain governance workflow state, not artifact
+lifecycle records.
+
+Published JSON Schemas continue to follow ADR-061. This decision narrows the
+meaning of "additive" at the ecosystem boundary: an optional schema property or
+enum value can be structurally additive to the schema lineage, but it is not an
+end-to-end compatibility guarantee unless the relevant installed readers are
+shown to accept it or the policy explicitly scopes the claim to schema
+structure only.
+
+Deprecations must be explicit records. A deprecation record identifies the
+exact surface, first release or contract lineage carrying the notice,
+replacement, migration reference, expected notice window or removal eligibility
+rule, verification evidence, and any security exception.
+
+Migrations are surface-specific. Human migration notes belong under the
+existing documentation boundary. Automated migrations are added only when the
+transformation is deterministic, idempotent, preserves source data, reports
+ambiguous or lossy cases, and fails closed.
+
+Adapters stay at their owning boundary. The policy does not create a universal
+version registry, migration service, runtime endpoint, persistence layer, or
+cross-package exception hierarchy.
+
+## Alternatives Considered
+
+Extend ADR-061 to govern every ecosystem surface. Rejected: ADR-061 is the
+right authority for published JSON Schemas, but package releases, SDL modules,
+apparatus manifests, and experiment artifacts have different authorities and
+compatibility relations.
+
+Use Python package SemVer as the single ecosystem version. Rejected: the
+package is a release vehicle, not the identity of each contract lineage,
+scenario module, processor/backend declaration, or experiment artifact.
+
+Create a central runtime versioning or migration service. Rejected: the current
+need is repository governance, and each executable surface already has an
+owning validator, registry, checker, or adapter boundary. A central service
+would blur ownership and invite best-effort coercion.
+
+Treat deprecation as a generic warning. Rejected: lifecycle notice must remain
+separate from semantic validity. Deprecated-but-supported use is non-fatal;
+removed or unsupported input fails through the owning surface's existing error
+envelope.
+
+## Consequences
+
+The ecosystem gets one vocabulary for versioning, compatibility, deprecation,
+and migration without weakening existing authorities such as ADR-061,
+release-please, the schema publication manifest, or module registry checks.
+
+Future surface families have a clear extension seam: add a row to the
+normative surface-class matrix and update that surface's owning checker or
+documentation rather than adding a universal runtime abstraction.
+
+Some existing documentation remains more informal than the new policy. Follow-up
+work may need to align release, migration, SDL, API, and conformance prose with
+the normative spec.
+
+Because this ADR is proposed, teams can still refine the surface matrix before
+acceptance. Accepted amendments to already accepted ADRs remain governed by
+ADR-059; this ADR does not silently edit ADR-061 or any earlier decision.

--- a/docs/decisions/issue-90-gov-901-903-versioning-governance-preflight.md
+++ b/docs/decisions/issue-90-gov-901-903-versioning-governance-preflight.md
@@ -1,0 +1,362 @@
+# Issue 90 GOV-901/902/903 Versioning Governance Preflight
+
+Date: 2026-07-11
+
+Issue: #90. Spawned implementation issues: #240 (GOV-901), #241 (GOV-902),
+and #242 (GOV-903). Branch anchor: GOV-901.
+
+Requirement: none. The joint design issue is the authoritative contract.
+
+This note records architecture guardrails for the joint versioning,
+deprecation, and migration policy. It is implementation guidance only: it does
+not create the policy ADR, normative governance specification, lifecycle
+records, migrations, compatibility adapters, validators, release changes, or
+published contract changes.
+
+## Binding Sources
+
+- ADR-009, ADR-019, and `specs/authority/authority-boundary.yaml` make prose
+  under `specs/` normative and keep implementation code non-normative. The
+  governance rules belong in a normative spec; an ADR should record the
+  decision and rationale without duplicating the full rule set.
+- ADR-061 and `contracts/schema-publication-manifest.json` already own
+  published JSON Schema lineage, `draft`/`stable` classification, canonical
+  hashes, change descriptions, removal tombstones, and the conservative
+  stable-schema compatibility gate. The joint policy must compose with this
+  authority rather than create a second schema registry or classifier.
+- ADR-010 and `tools/policy/adr_policy.yaml` own the one-way `aces.*`
+  compatibility layer and package ownership boundaries. Import compatibility
+  is one governed surface, not the definition of ecosystem compatibility.
+- ADR-053 and `aces_sdl.module_registry` own scenario/module version matching,
+  lock identities, digest and signature checks, and import trust. Module
+  versions are not package versions or contract lineage identifiers.
+- ADR-014, `.ground-control.yaml`, `.gc/plan-rules.md`, and `noxfile.py` make
+  `nox -s verify` the canonical verification graph.
+- ADR-059, `docs/decisions/adrs/adr-index.yaml`, and
+  `tools/check_adr_immutability.py` govern accepted ADR evolution. ADR-061 must
+  not be silently edited to absorb the new policy.
+- `docs/explain/releasing.md`, `.github/workflows/release-please.yml`,
+  `release-please-config.json`, `.release-please-manifest.json`, and
+  `implementations/python/pyproject.toml` are the current package-release
+  workflow. Release-please, Conventional Commit PR titles, and the static
+  project version are the canonical incumbents.
+- `specs/sdl/diagnostics.md` defines the SDL error/advisory boundary.
+  `SDLParseError`, `SDLValidationError`, `SDLInstantiationError`, shared
+  `Diagnostic`, Typer errors, and bounded control-plane `HTTPException`
+  responses are existing delivery envelopes; lifecycle policy must not create
+  a universal exception hierarchy.
+
+## Version Domains Must Stay Distinct
+
+The joint policy must classify the existing version domains before it defines
+compatibility. A common spelling does not give two fields common semantics.
+
+| Surface | Canonical incumbent | Meaning and guardrail |
+|---|---|---|
+| Python distribution and Git tag | `pyproject.toml`, release-please manifest/config/workflow | One `X.Y.Z` package release and matching `vX.Y.Z` tag. Release-please owns bumps and `CHANGELOG.md`; feature work must not hand-edit either. |
+| Published contract lineage | `contracts/schema-publication-manifest.json`, ADR-061, `contracts/schemas/` | Exact contract ids such as `backend-manifest-v2` and payload discriminators such as `backend-manifest/v2`. The major suffix identifies a lineage; it is not a package version or a stability promise. |
+| State/envelope schema identity | `aces_contracts.versions` and closed contract models | Exact wire discriminator such as `workflow-step-state/v1`. It selects payload shape; it is not an apparatus or package release. |
+| Processor/backend support declaration | `aces_contracts.manifest_authority` and manifest models | Despite the legacy field name `supported_contract_versions`, values are exact governed contract ids, not SemVer ranges. Do not reinterpret the field in place. |
+| Apparatus identity | `ApparatusIdentity`, processor/backend/participant manifests | Product/component identity version. Current contracts require only a non-empty value and compatibility blocks name counterpart implementations; they do not establish version-range negotiation. |
+| SDL scenario and module | `Scenario.version`, `ModuleDescriptor.version`, `ImportDecl.version`, module registry | Author/module release identity. Import matching uses `packaging` specifiers for parseable versions and exact-string fallback otherwise. `*` means unpinned. It does not select an SDL schema version. |
+| Domain artifact versions | experiment task/run/study fields, behavior `semantic_version`, external vocabulary source versions | Version the owning domain assigns to the artifact or source. It remains governed by that domain and must not inherit package or schema bump rules accidentally. |
+| Decision and requirement status | ADR status/pin gate and Ground Control requirement status | Governance workflow state, not consumer-facing artifact lifecycle. `deprecated` ADR status must not be reused as a contract deprecation record. |
+
+The normative governance spec should carry one surface-class matrix that names
+the identifier syntax, authority, compatibility relation, lifecycle evidence,
+and migration evidence for each class. This is a documentation seam, not a new
+runtime registry or universal `Version` model.
+
+## Architecture Decisions And Guardrails
+
+- Use one umbrella ADR for the cross-surface decisions and one normative
+  governance specification under `specs/`. Keep rationale and rejected
+  alternatives in the ADR; keep operational rules, terms, and the surface
+  matrix in the spec. Explanatory release or migration docs may point to the
+  spec but must not restate a competing policy.
+- Treat versioning, deprecation, and migration as related but separate
+  concepts. A version identifies an artifact or lineage; compatibility is a
+  directional relation between a producer and consumer; deprecation is a
+  lifecycle notice while a surface still works; migration is the documented or
+  executable transition. None is a synonym for another.
+- Define compatibility direction explicitly: backward (new reader accepts old
+  producer output), forward (old reader accepts new producer output), and full
+  compatibility where both hold. Name the producer, consumer, and compared
+  surface. A bare claim that a change is "compatible" is insufficient.
+- Separate structural acceptance, semantic equivalence, behavioral
+  compatibility, and operational interoperability. Passing JSON Schema does
+  not prove that meaning or runtime behavior is preserved; sharing a package
+  version does not prove that two apparatus manifests interoperate.
+- Keep stability and lifecycle orthogonal. ADR-061 `draft`/`stable` says how a
+  schema may evolve; active/deprecated/removed says whether consumers should
+  adopt it. Do not overload `stability`, JSON Schema's `deprecated` annotation,
+  ADR status, or requirement status to carry all lifecycle meanings.
+- Resolve ADR-061's additive-change assumption explicitly. The reference
+  `ContractModel` and `SDLModel` are closed (`extra="forbid"`), and many enum
+  fields are literals. An optional property or enum addition that is additive
+  to a schema can still be rejected by an older installed reader. The joint
+  policy must either state the compatible-reader assumption and its evidence or
+  supersede/narrow the earlier claim; it must not silently call structural
+  schema growth end-to-end backward compatible.
+- Define pre-1.0 package behavior deliberately. Release-please demotes a major
+  breaking bump to a minor release before 1.0. The policy must say what
+  compatibility a `0.y.z` consumer may rely on and must not imply ordinary
+  post-1.0 SemVer guarantees while automation follows a different rubric.
+- Preserve the bundled-release fact: the Python code and contract corpus ship
+  in one `aces-sdl` artifact. This gives a coordinated release unit but does not
+  erase independent contract ids or make an older external processor/backend
+  compatible with a newer corpus automatically.
+- A deprecation record must identify the exact surface, first release or
+  contract lineage carrying the notice, replacement, migration reference,
+  removal eligibility rule, and any security exception. Notice without a
+  supported replacement and migration path is not a complete deprecation.
+- Removal must be explicit and evidence-backed. For published schemas, retain
+  ADR-061 version-bump rules and manifest tombstones. For Python/API/CLI/SDL
+  surfaces, use their existing release notes, tests, diagnostics, and
+  compatibility seams. Do not encode every removal in the schema manifest.
+- Security removals need a named exception path that can shorten ordinary
+  notice while recording impact, affected versions, mitigation, and migration.
+  "Security" must not become an unreviewed bypass for arbitrary breaking
+  changes.
+- Deprecation notices are non-fatal while the old surface remains supported.
+  Actual removal or an unsupported version fails through the owning surface's
+  existing error envelope. Do not turn a lifecycle notice into an SDL semantic
+  error, or hide an invalid removed construct as a non-fatal advisory.
+- Migration guidance must be version-pair and surface specific. Human-readable
+  notes belong under the existing `docs/migration/` boundary; parser/CLI
+  messages may link or point to them. An automated migrator is justified only
+  for deterministic transformations and must be idempotent, preserve source
+  data, report lossy/ambiguous cases, and fail closed rather than silently drop
+  unknown fields.
+- Compatibility adapters remain at the owning boundary: `aces.*` re-exports in
+  the compatibility tree, SDL normalization/composition in `aces_sdl`, contract
+  readers in `aces_contracts`, CLI presentation in `aces_cli`. Do not create a
+  cross-package migration service or make runtime/backend layers reinterpret
+  authored source.
+
+## Required Incumbents
+
+- Release and package identity:
+  `.github/workflows/release-please.yml`, `release-please-config.json`,
+  `.release-please-manifest.json`, `implementations/python/pyproject.toml`,
+  installed-distribution metadata, `aces_cli.main --version`, and
+  `docs/explain/releasing.md`.
+- Release classification and audit trail: `tools/check_pr_title.py`,
+  `.github/workflows/pr-title-lint.yml`, Conventional Commit squash titles,
+  release-please's release PR, Git tag, GitHub Release, PyPI artifact, and
+  generated `CHANGELOG.md`.
+- Published contracts: ADR-009, ADR-061, `contracts/README.md`,
+  `contracts/schema-publication-manifest.json`,
+  `tools/check_schema_publication.py`, `tools/check_generated_schemas.py`,
+  `tools/check_json_artifacts.py`, `schema_bundle()`, and the existing valid and
+  invalid fixture suites.
+- Contract version vocabulary: `aces_contracts.versions`,
+  `aces_contracts.manifest_authority`, closed `ContractModel` DTOs, processor,
+  backend, participant implementation, control-plane, profile, and conformance
+  models that consume those exact ids.
+- SDL/module compatibility: `Scenario`, `ModuleDescriptor`, `ImportDecl`,
+  `Lockfile`, `TrustPolicy`, `_satisfies_version()`, digest/signature/version
+  gates, whole-scenario semantic validation, and module registry tests.
+- Compatibility direction and ownership: ADR-010,
+  `tools/policy/adr_policy.yaml`, `tools/policy/repo_policy.py`, owning packages
+  under `implementations/python/packages/`, and wrapper-only
+  `implementations/python/src/aces/`.
+- Diagnostics and errors: `specs/sdl/diagnostics.md`, SDL error classes,
+  `aces_contracts.diagnostics`, Typer's current user-facing errors,
+  `ControlPlaneSecurityConfig.strict_defaults()`, bounded `HTTPException`
+  details, audit records, and the redacted internal-error handler.
+- Repository workflow: `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `noxfile.py`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, `tools/verify_all.py`, ADR index and
+  immutability checks, docs build, and existing release/schema/manifest tests.
+
+## Whole-Repo View
+
+The intended design is repository governance, not a local schema edit. Its
+scope includes:
+
+- normative policy prose under `specs/` and the authority manifest that makes
+  that prose binding;
+- the policy ADR, ADR index, acceptance pin, and ADR-061 relationship;
+- package version metadata, release-please configuration, PR title policy,
+  release workflow permissions, Git tags, PyPI publication, and changelog;
+- published schemas, fixtures, profiles, concept catalogs, schema publication
+  manifest, contract corpus packaging, generated-schema parity, and contract
+  allowlists;
+- SDL scenario/module versions, module import ranges, lockfiles, trust policy,
+  parser normalization, deprecation messages, and semantic diagnostics;
+- processor/backend/participant manifest identity, supported contract ids,
+  compatibility declarations, conformance profiles, and runtime admission;
+- explanatory release, migration, SDL, API, and contributor documentation;
+- owning packages and compatibility-only wrappers; and
+- policy, contract, unit, conformance, docs, and release-workflow tests in the
+  canonical nox graph.
+
+No database, service repository, runtime state store, or new controller is
+needed to state this policy. Git-tracked specs, manifests, release metadata,
+and tests are the persistence and audit surfaces.
+
+## Cross-Cutting Layers
+
+The intended design must pass every layer it touches:
+
+- Normative authority gate: binding rules live under `specs/`; the ADR records
+  why. Reference Python models, examples, docs, and generated schemas remain
+  consumers/evidence. A new top-level authority root or duplicate governance
+  schema is not required.
+- Release-input validation: PR titles are untrusted GitHub event data and must
+  continue through `tools/check_pr_title.py`, which parses event JSON without
+  shell interpolation. Breaking markers and release types must match
+  release-please configuration and the normative policy.
+- Release security: retain pinned GitHub Actions, least-privilege job
+  permissions, PyPI OIDC trusted publishing, protected environment use, and no
+  stored PyPI token. A future release-policy check must not require secrets or
+  widen `contents`, `pull-requests`, or `id-token` permissions.
+- Package/config shapes: keep release-please's JSON config and manifest,
+  `pyproject.toml` project version, and installed distribution metadata as the
+  package seams. Do not add environment-variable version overrides or a second
+  version file.
+- Schema publication gate: schema paths remain normalized, repo-relative, and
+  contained under `contracts/schemas/`; ids match filenames; hashes and change
+  descriptions match content; stable incompatible edits require a new lineage;
+  removals carry tombstones. Generated-schema parity remains evidence, not
+  authority.
+- Contract and SDL validation: exact schema discriminators and supported
+  contract ids continue through closed Pydantic models, semantic validators,
+  JSON Schema validation, profile/conformance checks, and manifest authority
+  allowlists. Compatibility policy must not bypass these gates with coercion or
+  "best effort" fallback.
+- Module trust and version gate: module constraints continue through
+  `packaging` specifier parsing or exact-string fallback, then lockfile,
+  registry allowlist, signature, digest, export-hash, archive-safety, and
+  whole-scenario validation. A version match is not a trust decision.
+- Auth and control-plane gate: the design adds no endpoint. If a future API
+  exposes version/support information, it must reuse strict default auth,
+  read-role dependencies, request-size guards, published DTOs, audit events,
+  and redacted errors. Compatibility status must never grant authorization.
+- Secret-handling gate: versions, lifecycle records, compatibility reports,
+  migrations, release notes, and diagnostics must not carry tokens, private
+  keys, registry credentials, environment dumps, private configuration, or raw
+  payloads. No secret file or new secret is needed for governance validation.
+- OS/process exposure gate: keep version and base-revision values as ordinary
+  validated data. Do not put credentials in process argv, shell-interpolate PR
+  titles or migration input, execute user-provided version strings, or add
+  subprocess-based version discovery when distribution metadata and Git
+  artifacts already exist.
+- Error-envelope gate: accepted-but-deprecated use gets a bounded notice in the
+  owning channel; unsupported or removed input gets the existing SDL,
+  contract, CLI, conformance, or HTTP error. Messages may name surface ids and
+  versions but must not dump full artifacts, environment state, tracebacks, or
+  secrets.
+- Observability and audit: package evolution is visible through the release PR,
+  tag, GitHub Release, PyPI artifact, and `CHANGELOG.md`; schema evolution
+  through hashes, `last_change`, tombstones, and CI; policy verification through
+  nox `START`/`PASS`/`FAIL` events. Do not add runtime logs, telemetry, or a
+  database audit table for repository governance.
+
+## Extensibility Seam
+
+The extension seam is the normative surface-class matrix. Each row owns:
+
+- identifier and comparison syntax;
+- source of truth;
+- producer and consumer roles;
+- structural, semantic, behavioral, and operational compatibility claims;
+- stability and lifecycle rules;
+- deprecation notice and removal eligibility parameters; and
+- required migration evidence.
+
+The obvious future variation is a new independently released artifact family
+or a different notice window for an existing class. It should add or amend one
+matrix row and extend the owning manifest/checker, not require edits to every
+parser, controller, DTO, service, repository, exception, and workflow.
+Lifecycle thresholds belong as named policy parameters in the normative spec;
+surface-specific machine enforcement stays with the existing schema manifest,
+release workflow, module registry, or compatibility wrapper gate.
+
+## Existing Drift To Resolve Deliberately
+
+- `.gc/plan-rules.md`, `docs/explain/releasing.md`, the release workflow, and
+  `CHANGELOG.md` say release-please owns releases and that feature work does not
+  add fragments. `README.md`, `CONTRIBUTING.md`, the pull-request template, and
+  `specs/authority/authority-boundary.yaml` still describe towncrier and
+  `changelog.d/`; `changelog.d/` currently exists. The policy must name one
+  workflow (release-please is the operating incumbent) and the repository must
+  not retain contradictory contributor instructions.
+- `docs/conf.py` reports `0.1.0` while the project and release manifest report
+  `0.19.1`. CLI and compatibility fallbacks also use `0.1.0`, while processor
+  and backend fallbacks use `0.0.0+unknown`; the FastAPI OpenAPI document
+  hard-codes `0.1.0`. The design must classify package version, API description
+  version, and "not installed" fallback instead of synchronizing unrelated
+  literals blindly.
+- No checked-in schema is currently `stable`, so ADR-061's breaking-change
+  path is exercised mainly by synthetic policy tests. Promotion criteria and
+  regression evidence must be explicit before the first stable promotion.
+- `ImportDecl.path` is described as deprecated but accepted without an emitted
+  lifecycle notice. Removed scoring fields have a useful parser migration
+  pointer, while `docs/migration/README.md` only records historical repository
+  moves. These are evidence that deprecation notices and migration guidance are
+  not yet a coherent cross-surface lifecycle.
+- `supported_contract_versions` names exact ids, and apparatus compatibility
+  names implementations without version constraints. Renaming or expanding
+  those published shapes is itself a compatibility change; governance must
+  document present meaning before proposing a new negotiation surface.
+- ADR-061's compatibility classifier is deliberately conservative and
+  incomplete. Its result must be described as the enforced structural floor,
+  not proof of semantic or implementation-reader compatibility.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- one universal `Version`, `Compatibility`, `Deprecation`, or `Migration`
+  runtime model spanning package, schema, module, apparatus, and domain
+  artifacts;
+- treating SemVer, PEP 440, contract `vN` suffixes, state schema discriminators,
+  source release ids, and ADR status as interchangeable;
+- calling a change compatible without naming direction, producer, consumer,
+  and structural/semantic/behavioral/operational dimension;
+- equating JSON Schema acceptance with compatibility for older closed-world
+  Pydantic readers;
+- using package release bumps instead of independent contract ids, or using a
+  new contract id for every package patch;
+- reinterpreting `supported_contract_versions` as ranges, or
+  `compatibility.processors/backends` as version negotiation, without a new
+  governed contract change;
+- duplicating the schema manifest, contract allowlists, module version matcher,
+  release version file, changelog generator, validation helpers, diagnostics,
+  exception hierarchy, or compatibility workflow;
+- editing accepted ADR-061 without supersession or a recorded ADR-059
+  amendment;
+- silently accepting removed syntax, dropping unknown migration data, applying
+  lossy auto-fixes, or allowing adapters to become permanent undocumented
+  semantics;
+- emitting deprecation warnings from multiple layers for one use, or turning
+  notices into fatal semantic errors before removal;
+- hand-editing package versions or `CHANGELOG.md`, reviving a parallel
+  towncrier workflow, or deriving release policy from stale docs;
+- adding an unauthenticated version endpoint, environment-driven compatibility
+  override, token-bearing argv, raw-payload error, or runtime persistence layer
+  for repository policy; and
+- claiming a support window, migration capability, stable contract, or
+  compatibility guarantee that no test or release artifact demonstrates.
+
+## Non-Goals And Implementation Boundaries
+
+- Implementing GOV-901, GOV-902, or GOV-903 in this preflight note.
+- Writing the issue implementation plan or deciding the spawned issues' work
+  sequencing.
+- Creating the umbrella ADR, normative governance spec, lifecycle registry,
+  schema, fixture, validator, migration guide, migrator, warning, adapter, or
+  release gate.
+- Changing package versions, tags, release-please behavior, changelog history,
+  branch protection, PyPI publication, or support commitments.
+- Promoting any schema to `stable`, changing a contract id, adding version
+  negotiation, or redefining existing manifest fields.
+- Removing compatibility wrappers, deprecated SDL syntax, legacy documents,
+  or stale version literals during architecture preflight.
+- Redesigning parser normalization, semantic validation, module trust,
+  apparatus admission, control-plane auth, persistence, logging, or error
+  handling.
+- Guaranteeing compatibility with arbitrary pre-policy releases or external
+  implementations for which the repository has no conformance evidence.

--- a/specs/README.md
+++ b/specs/README.md
@@ -36,6 +36,8 @@ hook).
   `prose` family of the `specs/` root.
 - `concept-authority/` — concept-family and controlled-vocabulary
   authority artifacts (governed by ADR-012)
+- `evolution/` — ecosystem versioning, deprecation, removal, and migration
+  governance for GOV-901, GOV-902, and GOV-903 (governed by ADR-075)
 - `sdl/` — the language-neutral normative SDL authoring specification
   (the catalog set the published `contracts/schemas/sdl/` schemas must
   agree with; governed by ADR-001 and ADR-009)

--- a/specs/evolution/README.md
+++ b/specs/evolution/README.md
@@ -1,0 +1,13 @@
+# Evolution Governance
+
+This directory contains normative ACES ecosystem policy for artifact
+evolution: versioning, compatibility, deprecation, removal, and migration.
+
+The governing decision is
+[ADR-075](../../docs/decisions/adrs/adr-075-ecosystem-versioning-deprecation-and-migration-governance.md).
+
+## Files
+
+- [`versioning-deprecation-and-migration.md`](versioning-deprecation-and-migration.md)
+  defines the normative surface-class matrix and rules for GOV-901, GOV-902,
+  and GOV-903.

--- a/specs/evolution/versioning-deprecation-and-migration.md
+++ b/specs/evolution/versioning-deprecation-and-migration.md
@@ -1,0 +1,183 @@
+# Versioning, Deprecation, and Migration Governance
+
+This specification is normative for ACES ecosystem evolution policy. It
+implements the joint design surface for GOV-901, GOV-902, and GOV-903.
+
+## Scope
+
+This policy governs versioning, compatibility claims, deprecation records,
+removal eligibility, and migration guidance for repository-governed ecosystem
+surfaces.
+
+It does not create a universal runtime version registry, cross-package
+migration service, API endpoint, database table, or exception hierarchy. Each
+surface remains owned by its existing authority, checker, schema, validator,
+or adapter boundary.
+
+## Terms
+
+**Version identifier** means a surface-local value that identifies a release,
+lineage, payload shape, source artifact, or domain artifact.
+
+**Producer** means the surface that writes, publishes, emits, or serves an
+artifact.
+
+**Consumer** means the surface that reads, imports, validates, executes, or
+otherwise depends on the artifact.
+
+**Backward compatibility** means a newer consumer accepts and preserves the
+meaning of older producer output for the named surface and dimension.
+
+**Forward compatibility** means an older consumer accepts and safely handles
+newer producer output for the named surface and dimension.
+
+**Full compatibility** means both backward and forward compatibility hold for
+the named surface and dimension.
+
+**Structural acceptance** means the consumer accepts the artifact's syntactic
+or schema shape.
+
+**Semantic equivalence** means accepted input preserves the same ACES meaning.
+
+**Behavioral compatibility** means runtime, CLI, API, validation, or
+conformance behavior remains within the documented contract.
+
+**Operational interoperability** means independently released components can
+work together under documented admission, capability, and deployment rules.
+
+## Surface-Class Matrix
+
+Each surface class owns its version meaning and compatibility rule.
+
+| Surface class | Authority | Identifier syntax | Compatibility relation | Lifecycle record | Migration evidence |
+|---|---|---|---|---|---|
+| Python distribution | `implementations/python/pyproject.toml`, release-please config, Git tag, PyPI artifact | SemVer package version and matching `vX.Y.Z` tag | Consumer code imports installed package APIs for the documented release | Release PR, GitHub Release, generated `CHANGELOG.md` | Release notes and package/API docs |
+| Published JSON Schema | ADR-061 and `contracts/schema-publication-manifest.json` | Contract id such as `backend-manifest-v2`; wire discriminator such as `backend-manifest/v2` | Schema lineage and stability-specific structural compatibility | Manifest `stability`, `last_change`, and `removed_schemas` tombstones | Schema diff, fixtures, checker output, and contract docs |
+| Closed contract DTO and wire envelope | `aces_contracts.versions`, contract models, manifest authority | Exact discriminator such as `workflow-step-state/v1` | Exact payload-shape selection by owning reader | Contract ADR/spec and release notes | Reader validation tests and conformance fixtures |
+| Processor/backend support declaration | Manifest models and manifest authority allowlists | Exact governed contract ids, not version ranges | Declared support for named counterpart contract ids | Manifest contract lineage and conformance result | Manifest update, fixture, and conformance report |
+| Apparatus or implementation identity | Processor, backend, and participant manifests | Product/component identity version string | Operational interoperability declared by manifest capability blocks | Manifest release and conformance profile | Backend/processor/participant conformance evidence |
+| SDL scenario and module | SDL spec, module registry, lockfile, trust policy | Scenario/module version and import version constraint | Import constraint satisfaction plus registry, digest, signature, and semantic validation | SDL/module documentation and release notes | Migration note or deterministic source rewrite |
+| Experiment task, run, study, evidence, or domain artifact | Owning experiment-core spec and contract | Domain-specific artifact version | Domain semantic or provenance compatibility | Owning ADR/spec and contract lineage | Domain fixtures, replay/evidence checks, or migration note |
+| ADR | ADR-000 and ADR-059 | ADR number plus status | Citable accepted content, not runtime compatibility | Status, pin, amendment row, or supersession | New ADR or recorded amendment |
+| Ground Control requirement | Ground Control requirement graph | Requirement UID and status | Traceability/workflow state, not artifact compatibility | Requirement status and IMPLEMENTS/TESTS/DOCUMENTS links | Post-merge traceability reconciliation |
+
+New surface classes extend this table and their owning checker or
+documentation. They do not create a central runtime registry by default.
+
+## Compatibility Claims
+
+A compatibility claim is valid only when it names:
+
+- the surface class;
+- producer and consumer;
+- direction: backward, forward, or full;
+- dimension: structural, semantic, behavioral, or operational;
+- version or lineage range under discussion; and
+- verification evidence.
+
+A bare statement that a change is "compatible" is incomplete.
+
+Structural acceptance is not semantic compatibility. A JSON Schema accepting
+an object does not prove the object preserves SDL meaning, conformance
+behavior, or runtime interoperability.
+
+For published JSON Schemas, ADR-061 remains authoritative. Optional properties,
+enum additions, and looser constraints can be additive to schema structure, but
+they are not automatically forward-compatible with older closed readers. A PR
+claiming end-to-end compatibility for such a change must show reader evidence
+or scope the claim to structural schema compatibility only.
+
+Before the Python package reaches 1.0, release-please may classify breaking
+changes as minor releases according to the repository's release configuration.
+Consumers must not infer post-1.0 SemVer stability from a `0.y.z` package
+release unless a specific surface policy states it.
+
+## Deprecation
+
+A deprecation is a lifecycle notice for a still-supported surface. It is not a
+schema stability class, ADR status, requirement status, or semantic validation
+error by itself.
+
+A complete deprecation record names:
+
+- exact surface and identifier;
+- first release, contract lineage, or documentation version carrying the
+  notice;
+- replacement surface or explicit no-replacement rationale;
+- migration reference;
+- minimum notice window or removal eligibility rule;
+- verification evidence that the old surface remains supported during the
+  notice window; and
+- security exception, if the ordinary notice window is shortened.
+
+Deprecated-but-supported use must remain non-fatal. The owning channel may emit
+a bounded notice, advisory, warning, release-note entry, or documentation
+marker. Actual removal or unsupported use fails through the owning surface's
+existing SDL, contract, CLI, conformance, or HTTP error envelope.
+
+Security exceptions may shorten ordinary notice only when the record names the
+affected versions, impact, mitigation, migration path, and review authority.
+The word "security" is not a blanket bypass for unreviewed breaking changes.
+
+## Removal
+
+Removal is allowed only after a complete deprecation record reaches its removal
+eligibility rule, or under a documented security exception.
+
+Published JSON Schema removal follows ADR-061 and must leave the required
+manifest tombstone. Other surface removals use their owning evidence:
+release notes, ADR/spec updates, fixtures, tests, conformance reports, or
+diagnostics.
+
+Removal must not silently reinterpret old input as new input. If a removed
+surface appears, the owning reader fails with a bounded, surface-specific
+message and, when available, points to the migration reference.
+
+## Migration
+
+Migration guidance is surface-specific and version-pair oriented. A migration
+record names:
+
+- source surface and version or lineage;
+- target surface and version or lineage;
+- transformation type: manual, assisted, or automated;
+- data preservation rules;
+- ambiguous or lossy cases;
+- validation command or evidence; and
+- rollback or no-rollback statement.
+
+Human-readable migration notes belong under the existing documentation
+boundary. Automated migrators are justified only for deterministic
+transformations. They must be idempotent, preserve source data, report
+ambiguous or lossy cases, and fail closed rather than drop unknown fields.
+
+Compatibility adapters stay at the owning boundary:
+
+- legacy `aces.*` re-exports stay in the compatibility tree;
+- SDL normalization and module composition stay in `aces_sdl`;
+- contract readers stay in `aces_contracts`;
+- CLI presentation stays in `aces_cli`; and
+- backend/runtime layers do not reinterpret authored source to hide migration
+  needs.
+
+## Verification
+
+Changes governed by this policy use the repository's existing gates unless a
+surface adds a more specific checker:
+
+- release classification and version bump evidence: PR title guard,
+  release-please config, release PR, Git tag, GitHub Release, and PyPI
+  artifact;
+- published schema evolution: schema publication checker, generated-schema
+  parity, fixture validation, manifest hashes, change ledger, and tombstones;
+- ADR evolution: ADR index and accepted-content pin gate;
+- SDL/module evolution: parser, validator, module registry, lockfile, trust,
+  signature, digest, and semantic tests;
+- contract and manifest evolution: closed DTO validation, manifest authority,
+  fixtures, profiles, and conformance checks; and
+- repository completion: `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, `tools/verify_all.py`, and the
+  canonical nox verification graph.
+
+No secret, environment dump, credential, or private configuration is required
+to validate this policy.


### PR DESCRIPTION
## Summary

Adds the joint ecosystem evolution-governance decision and normative policy for versioning, compatibility, deprecation, removal, and migration across ACES surfaces.

## Requirement UIDs

- `GOV-901`
- `GOV-902`
- `GOV-903`

## Related Issues

Closes #90

## ADR Impact

- ADR-075

## Changes

- Added ADR-075 as the umbrella decision for ecosystem versioning, deprecation, and migration governance.
- Added `specs/evolution/versioning-deprecation-and-migration.md` with the normative surface-class matrix and policy rules.
- Indexed the new ADR and specs evolution area, and retained the preflight guardrails note for issue 90.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

`pre-commit run --all-files`; `ACES_REQUIREMENT_UID=GOV-901 implementations/python/.venv/bin/python tools/check_repo_policy.py`; `ACES_REQUIREMENT_UID=GOV-901 implementations/python/.venv/bin/python tools/check_requirement_governance.py` (Ground Control timed out and the tool exited through its skip path); `ACES_REQUIREMENT_UID=GOV-901 implementations/python/.venv/bin/python tools/verify_all.py`; `ACES_REQUIREMENT_UID=GOV-901 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: docs/decisions/adrs/adr-075-ecosystem-versioning-deprecation-and-migration-governance.md, specs/evolution/versioning-deprecation-and-migration.md, specs/evolution/README.md
- TESTS: tools/check_repo_policy.py, tools/check_requirement_governance.py, tools/verify_all.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.