### PR TITLE
fix: reject ambiguous SDL mapping keys

### DIFF
--- a/docs/explain/sdl/parser.md
+++ b/docs/explain/sdl/parser.md
@@ -1,12 +1,17 @@
 # SDL Parser Behavior
 
-The parser (`aces.core.sdl.parser`) transforms raw YAML into a validated `Scenario` object through three stages: key normalization, shorthand expansion, and model construction.
+The parser (`aces.core.sdl.parser`) transforms raw YAML into a validated
+`Scenario` object through source-marked safe composition, mapping-key
+validation, key normalization, shorthand expansion, and model construction.
 
 This layer is intentionally about syntax, normalization, and structural model
 construction. It is usually an `FM0` surface under the repository's
 [coding standards](../reference/coding-standards.md): parser work normally
 needs ordinary tests, not state-machine modeling or solver-backed formal
 artifacts, unless it also introduces new semantic invariants above raw syntax.
+The mapping-key injectivity gate is such an invariant and is treated as `FM1`:
+table-driven and property tests pin ambiguity rejection and literal-map
+preservation.
 
 ## Key Normalization
 
@@ -24,6 +29,17 @@ nodes:
   My-Switch:
     Type: Switch
 ```
+
+Field aliases do not imply precedence. Writing both `Name` and `name`, or both
+`password-strength` and `password_strength`, in one structural mapping is a
+fatal `sdl.mapping_key_conflict`. Exact duplicates are also fatal in
+user-defined and native maps, but distinct literal keys such as `Web-App` and
+`web_app` remain distinct identifiers.
+
+The check runs over the composed YAML node graph before a Python dictionary is
+constructed, so it retains both authored spellings and source ranges. YAML
+anchors remain supported. A `<<` merge is accepted only when all inherited and
+local effective keys are disjoint; cyclic aliases are rejected.
 
 ## Shorthand Expansion
 
@@ -81,11 +97,13 @@ be migrated to SDL before parsing.
 
 ## Validation Pipeline
 
-1. **YAML parsing** — `yaml.safe_load()`
-2. **Key normalization** — lowercase field keys, preserve user names
-3. **Shorthand expansion** — source, infrastructure, roles, min-score, feature lists
-4. **Pydantic construction** — structural validation (types, ranges, required fields)
-5. **Semantic validation** — cross-reference checks plus variable-reference checks (22 passes, see [validation.md](validation.md))
+1. **Safe YAML composition** — build a source-marked standard-tag node graph
+2. **Mapping-key preflight** — reject exact, normalized, and merge conflicts
+3. **Safe construction** — construct native values only after ambiguity checks
+4. **Key normalization** — lowercase field keys, preserve user names
+5. **Shorthand expansion** — source, infrastructure, roles, min-score, feature lists
+6. **Pydantic construction** — structural validation (types, ranges, required fields)
+7. **Semantic validation** — cross-reference checks plus variable-reference checks (see [validation.md](validation.md))
 
 On success, the returned `Scenario` may still carry non-fatal advisories in `scenario.advisories` (for example, VM nodes without explicit `resources`).
 
@@ -93,6 +111,7 @@ On success, the returned `Scenario` may still carry non-fatal advisories in `sce
 
 ```python
 from aces.core.sdl import parse_sdl, parse_sdl_file
+from aces_sdl import load_sdl_fragment
 
 # Parse from string
 scenario = parse_sdl(yaml_string)
@@ -102,6 +121,13 @@ scenario = parse_sdl_file(Path("scenario.yaml"))
 
 # Structural validation only (skip cross-reference checks)
 scenario = parse_sdl(yaml_string, skip_semantic_validation=True)
+
+# Advanced authoring tools can preflight a fragment at its final address.
+nodes = load_sdl_fragment(
+    nodes_yaml,
+    mapping_keys="literal",
+    base_pointer="/nodes",
+)
 ```
 
 Use `parse_sdl_file(...)` for SDL that uses top-level `imports:`. Import
@@ -127,5 +153,7 @@ shorthand. They are resolved by the composition layer, not expanded into
 
 ## Error Types
 
-- `SDLParseError` — YAML syntax errors, structural validation failures
+- `SDLParseError` — YAML syntax errors and structural validation failures;
+  mapping-key failures carry structured `.diagnostics` with stable code, JSON
+  Pointer, authored spellings, and source ranges
 - `SDLValidationError` — semantic validation failures (has `.errors` list with all issues)

--- a/docs/explain/sdl/testing.md
+++ b/docs/explain/sdl/testing.md
@@ -66,7 +66,10 @@ cd implementations/python && \
 uv run --extra dev pytest tests/test_sdl_fuzz.py -m fuzz -v
 ```
 
-Property-based testing using [Hypothesis](https://hypothesis.readthedocs.io/). Generates ~1,050 random inputs per run across 6 fuzz strategies:
+Property-based testing using [Hypothesis](https://hypothesis.readthedocs.io/).
+The dedicated mapping-key property tests run in the standard suite; the fuzz
+session adds mutation coverage and generates about 1,150 inputs per run across
+8 strategies:
 
 | Test | Strategy | Examples |
 |------|----------|----------|
@@ -76,6 +79,8 @@ Property-based testing using [Hypothesis](https://hypothesis.readthedocs.io/). G
 | `test_fuzz_service_ports` | Random port/protocol/name combos | 100 |
 | `test_fuzz_vulnerability_class_validation` | Random CWE class strings | 100 |
 | `test_fuzz_feature_dependency_cycles` | Random dependency graphs | 100 |
+| `test_fuzz_structural_key_alias_mutations_fail_closed` | Normalized field-alias collisions | 50 |
+| `test_fuzz_exact_identifier_duplicate_mutations_fail_closed` | Exact symbol-key duplicates | 50 |
 
 The invariant: the parser **never** raises an unhandled exception. Every input either produces a valid `Scenario` or raises `SDLParseError`/`SDLValidationError`.
 
@@ -131,12 +136,14 @@ Use the corpus leg that matches the artifact's purpose:
   specimens rather than reusable examples. Add them to the relevant `SCENARIOS`
   list so the parametrized tests pick them up.
 - **Negative-path cases** should stay close to the parser, model, or validator
-  rule they exercise. Do not add invalid files under `examples/scenarios/`;
-  that directory is the positive example corpus.
+  rule they exercise. Parser-negative SDL fixtures live under
+  `implementations/python/tests/data/sdl/invalid/`. Do not add invalid files
+  under `examples/scenarios/`; that directory is the positive example corpus.
 
 All scenario corpus loading should continue to flow through the existing
-`load_scenario()` / `parse_sdl()` boundary so it receives the same `yaml.safe_load`
-parsing, Pydantic structural validation, semantic validation, advisory logging,
+`load_scenario()` / `parse_sdl()` boundary so it receives the same source-marked
+safe composition, mapping-key preflight, Pydantic structural validation,
+semantic validation, advisory logging,
 and `ScenarioValidationError`/`SDLParseError`/`SDLValidationError` behavior as
 the rest of the SDL stack.
 

--- a/implementations/python/packages/aces_mcp/tools/authoring.py
+++ b/implementations/python/packages/aces_mcp/tools/authoring.py
@@ -113,7 +113,7 @@ def register(mcp: FastMCP) -> None:
             return f"INPUT TOO LARGE — limit is {_MAX_INPUT_BYTES} bytes."
 
         import yaml as _yaml
-        from aces_sdl import SDLParseError, SDLValidationError, parse_sdl
+        from aces_sdl import SDLParseError, SDLValidationError, load_sdl_fragment, parse_sdl
 
         section = section.strip().lower().replace("-", "_")
         valid_sections = {
@@ -140,18 +140,24 @@ def register(mcp: FastMCP) -> None:
 
         # Build a minimal valid wrapper
         try:
-            section_data = _yaml.safe_load(section_yaml)
-        except _yaml.YAMLError as exc:
-            return f"YAML ERROR in section content:\n{exc}"
+            section_data = load_sdl_fragment(
+                section_yaml,
+                mapping_keys="literal",
+                base_pointer=f"/{section}",
+            )
+        except SDLParseError as exc:
+            label = "PARSE ERROR" if any(item.code != "sdl.parse" for item in exc.diagnostics) else "YAML ERROR"
+            return f"{label} in section content:\n{exc.details}"
 
         wrapper: dict = {}
         if context_yaml:
             try:
-                ctx = _yaml.safe_load(context_yaml)
+                ctx = load_sdl_fragment(context_yaml)
                 if isinstance(ctx, dict):
                     wrapper.update(ctx)
-            except _yaml.YAMLError as exc:
-                return f"YAML ERROR in context_yaml:\n{exc}"
+            except SDLParseError as exc:
+                label = "PARSE ERROR" if any(item.code != "sdl.parse" for item in exc.diagnostics) else "YAML ERROR"
+                return f"{label} in context_yaml:\n{exc.details}"
 
         # Force a safe synthetic name — always last so context_yaml cannot
         # override it and cause confusing error messages.

--- a/implementations/python/packages/aces_mcp/tools/operation_support.py
+++ b/implementations/python/packages/aces_mcp/tools/operation_support.py
@@ -139,7 +139,7 @@ def stage_ok(stage: str, *, detail: str = "ok") -> dict[str, str]:
     return {"stage": stage, "status": "ok", "detail": detail}
 
 
-def stage_error(stage: str, error: Any) -> dict[str, Any]:
+def stage_error(stage: str, error: object) -> dict[str, Any]:
     structured = getattr(error, "diagnostics", ())
     if structured:
         return {

--- a/implementations/python/packages/aces_mcp/tools/operation_support.py
+++ b/implementations/python/packages/aces_mcp/tools/operation_support.py
@@ -54,7 +54,7 @@ def compile_pipeline(sdl_content: str, parameters_json: str) -> dict[str, Any]:
     try:
         scenario = parse_sdl(sdl_content)
     except SDLParseError as exc:
-        return {"error": stage_error("parse", exc.details), "stages": stages, "scenario": None, "model": None}
+        return {"error": stage_error("parse", exc), "stages": stages, "scenario": None, "model": None}
     except SDLValidationError as exc:
         return {
             "error": {
@@ -139,7 +139,15 @@ def stage_ok(stage: str, *, detail: str = "ok") -> dict[str, str]:
     return {"stage": stage, "status": "ok", "detail": detail}
 
 
-def stage_error(stage: str, message: str) -> dict[str, Any]:
+def stage_error(stage: str, error: Any) -> dict[str, Any]:
+    structured = getattr(error, "diagnostics", ())
+    if structured:
+        return {
+            "status": "invalid",
+            "stage": stage,
+            "diagnostics": [item.as_dict() for item in structured],
+        }
+    message = getattr(error, "details", str(error))
     return {
         "status": "invalid",
         "stage": stage,

--- a/implementations/python/packages/aces_mcp/tools/operations.py
+++ b/implementations/python/packages/aces_mcp/tools/operations.py
@@ -162,7 +162,7 @@ def register(mcp: FastMCP) -> None:
                 skip_semantic_validation=not semantic_validation,
             )
         except SDLParseError as exc:
-            return json_response(stage_error("parse", exc.details))
+            return json_response(stage_error("parse", exc))
         except SDLValidationError as exc:
             return json_response(
                 {

--- a/implementations/python/packages/aces_sdl/__init__.py
+++ b/implementations/python/packages/aces_sdl/__init__.py
@@ -10,12 +10,16 @@ from importlib import import_module
 __all__ = [
     "instantiate_scenario",
     "InstantiatedScenario",
+    "load_sdl_fragment",
     "parse_sdl",
     "parse_sdl_file",
     "Scenario",
     "SDLError",
     "SDLInstantiationError",
+    "SDLParseDiagnostic",
     "SDLParseError",
+    "SDLSourcePosition",
+    "SDLSourceRange",
     "SDLValidationError",
     "VARIABLE_TOKEN_PATTERN",
 ]
@@ -25,7 +29,10 @@ def __getattr__(name: str):
     if name in {
         "SDLError",
         "SDLInstantiationError",
+        "SDLParseDiagnostic",
         "SDLParseError",
+        "SDLSourcePosition",
+        "SDLSourceRange",
         "SDLValidationError",
     }:
         module = import_module("aces_sdl._errors")
@@ -33,7 +40,7 @@ def __getattr__(name: str):
         module = import_module("aces_sdl._base")
     elif name == "instantiate_scenario":
         module = import_module("aces_sdl.instantiate")
-    elif name in {"parse_sdl", "parse_sdl_file"}:
+    elif name in {"load_sdl_fragment", "parse_sdl", "parse_sdl_file"}:
         module = import_module("aces_sdl.parser")
     elif name in {"InstantiatedScenario", "Scenario"}:
         module = import_module("aces_sdl.scenario")

--- a/implementations/python/packages/aces_sdl/_errors.py
+++ b/implementations/python/packages/aces_sdl/_errors.py
@@ -5,11 +5,71 @@ SDLValidationError collects all issues from a validation pass rather
 than failing on the first error.
 """
 
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 
 class SDLError(Exception):
     """Base exception for all SDL operations."""
+
+
+@dataclass(frozen=True)
+class SDLSourcePosition:
+    """One-based source position."""
+
+    line: int
+    column: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {"line": self.line, "column": self.column}
+
+
+@dataclass(frozen=True)
+class SDLSourceRange:
+    """Half-open source range for one authored token."""
+
+    start: SDLSourcePosition
+    end: SDLSourcePosition
+
+    def as_dict(self) -> dict[str, dict[str, int]]:
+        return {"start": self.start.as_dict(), "end": self.end.as_dict()}
+
+
+@dataclass(frozen=True)
+class SDLParseDiagnostic:
+    """Structured diagnostic produced before SDL model construction."""
+
+    code: str
+    message: str
+    pointer: str
+    primary_range: SDLSourceRange
+    authored_keys: tuple[str, str] | None = None
+    related_range: SDLSourceRange | None = None
+    related_message: str | None = None
+    stage: str = "parse"
+    severity: str = "error"
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "stage": self.stage,
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "path": self.pointer,
+            "range": self.primary_range.as_dict(),
+        }
+        if self.authored_keys is not None:
+            payload["authored_keys"] = list(self.authored_keys)
+        if self.related_range is not None:
+            payload["related"] = [
+                {
+                    "message": self.related_message or "Related authored key.",
+                    "range": self.related_range.as_dict(),
+                }
+            ]
+        return payload
 
 
 class SDLParseError(SDLError):
@@ -20,9 +80,16 @@ class SDLParseError(SDLError):
         details: Detailed error message.
     """
 
-    def __init__(self, message: str, path: Path | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        path: Path | None = None,
+        *,
+        diagnostics: Iterable[SDLParseDiagnostic] = (),
+    ) -> None:
         self.path = path
         self.details = message
+        self.diagnostics = tuple(diagnostics)
         prefix = f"{path}: " if path else ""
         super().__init__(f"{prefix}{message}")
 

--- a/implementations/python/packages/aces_sdl/_language_diagnostics.py
+++ b/implementations/python/packages/aces_sdl/_language_diagnostics.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ._errors import SDLParseError
+
 
 def invalid(
     stage: str,
@@ -33,3 +35,14 @@ def diagnostic(
     if location is not None:
         payload["range"] = {"start": location, "end": location}
     return payload
+
+
+def parse_error(error: SDLParseError) -> dict[str, Any]:
+    """Preserve structured parser diagnostics in language-service responses."""
+    if error.diagnostics:
+        return {
+            "status": "invalid",
+            "stage": "parse",
+            "diagnostics": [item.as_dict() for item in error.diagnostics],
+        }
+    return invalid("parse", "sdl.parse", error.details)

--- a/implementations/python/packages/aces_sdl/_language_references.py
+++ b/implementations/python/packages/aces_sdl/_language_references.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from collections.abc import Collection
 from typing import Any
 
-import yaml
-from yaml.error import MarkedYAMLError, YAMLError
 from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
-from ._language_diagnostics import invalid as _invalid
+from ._errors import SDLParseError
+from ._language_diagnostics import parse_error as _parse_error
 from ._language_metadata import REFERENCE_COMPLETION_TARGETS
+from ._yaml_loader import compose_sdl_yaml
 
-_CODE_PARSE = "sdl.parse"
 _SUCCESS_REFERENCE_TARGETS = frozenset({"conditions"})
 
 
@@ -23,6 +22,8 @@ def find_references(
     section_fields: Collection[str],
 ) -> dict[str, Any]:
     """Return definition and occurrence locations for an SDL symbol."""
+    if not sdl_content.strip():
+        return {"status": "ok", "symbol": symbol, "definitions": [], "occurrences": []}
     root, error = _compose_yaml(sdl_content)
     if error is not None:
         return error
@@ -49,16 +50,9 @@ def find_references(
 
 def _compose_yaml(sdl_content: str) -> tuple[Node | None, dict[str, Any] | None]:
     try:
-        return yaml.compose(sdl_content), None
-    except MarkedYAMLError as exc:
-        return None, _invalid(
-            "parse",
-            _CODE_PARSE,
-            str(exc.problem or exc),
-            location=_location_from_mark(exc.problem_mark),
-        )
-    except YAMLError as exc:
-        return None, _invalid("parse", _CODE_PARSE, str(exc))
+        return compose_sdl_yaml(sdl_content), None
+    except SDLParseError as exc:
+        return None, _parse_error(exc)
 
 
 def _collect_definitions(root: Node, section_fields: Collection[str]) -> list[dict[str, Any]]:

--- a/implementations/python/packages/aces_sdl/_language_references.py
+++ b/implementations/python/packages/aces_sdl/_language_references.py
@@ -23,27 +23,23 @@ def find_references(
 ) -> dict[str, Any]:
     """Return definition and occurrence locations for an SDL symbol."""
     if not sdl_content.strip():
-        return {"status": "ok", "symbol": symbol, "definitions": [], "occurrences": []}
-    root, error = _compose_yaml(sdl_content)
-    if error is not None:
-        return error
+        result = {"status": "ok", "symbol": symbol, "definitions": [], "occurrences": []}
+    else:
+        root, error = _compose_yaml(sdl_content)
+        result = error if error is not None else _reference_result(root, symbol, section_fields)
+    return result
+
+
+def _reference_result(root: Node | None, symbol: str, section_fields: Collection[str]) -> dict[str, Any]:
     if root is None:
         return {"status": "ok", "symbol": symbol, "definitions": [], "occurrences": []}
-
     definitions = _collect_definitions(root, section_fields)
-    matching_definitions = [definition for definition in definitions if _definition_matches_symbol(definition, symbol)]
     occurrences: list[dict[str, Any]] = []
-    _collect_occurrences(
-        root,
-        symbol,
-        [],
-        occurrences,
-        qualified_section=_qualified_symbol_section(symbol),
-    )
+    _collect_occurrences(root, symbol, [], occurrences, qualified_section=_qualified_symbol_section(symbol))
     return {
         "status": "ok",
         "symbol": symbol,
-        "definitions": matching_definitions,
+        "definitions": [item for item in definitions if _definition_matches_symbol(item, symbol)],
         "occurrences": occurrences,
     }
 

--- a/implementations/python/packages/aces_sdl/_mapping_scopes.py
+++ b/implementations/python/packages/aces_sdl/_mapping_scopes.py
@@ -1,0 +1,77 @@
+"""Classify SDL mappings whose keys are authored identifiers rather than fields."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class MappingScope(str, Enum):
+    """Key interpretation for one mapping node."""
+
+    STRUCTURAL = "structural"
+    LITERAL = "literal"
+
+
+HASHMAP_SECTIONS = frozenset(
+    {
+        "nodes",
+        "infrastructure",
+        "features",
+        "conditions",
+        "vulnerabilities",
+        "entities",
+        "injects",
+        "events",
+        "scripts",
+        "stories",
+        "content",
+        "accounts",
+        "relationships",
+        "agents",
+        "action_contracts",
+        "observation_boundaries",
+        "outcome_interpretation_rules",
+        "behavior_specifications",
+        "evidence_requirements",
+        "objectives",
+        "workflows",
+        "variables",
+    }
+)
+
+NESTED_HASHMAP_FIELDS = frozenset(
+    {
+        "features",
+        "conditions",
+        "injects",
+        "roles",
+        "log_options",
+        "labels",
+        "driver_options",
+        "ipam_options",
+        "facts",
+        "entities",
+        "events",
+        "steps",
+        "extensions",
+    }
+)
+
+
+def normalize_field_key(key: str) -> str:
+    """Return the canonical spelling of an SDL structural field key."""
+    return key.lower().replace("-", "_")
+
+
+def is_literal_map_field(
+    key: str,
+    *,
+    value_is_mapping: bool,
+    value_is_sequence: bool,
+) -> bool:
+    """Return whether a structural field's immediate child keys are literal."""
+    if key in HASHMAP_SECTIONS:
+        return value_is_mapping
+    if key in NESTED_HASHMAP_FIELDS:
+        return True
+    return key == "properties" and value_is_sequence

--- a/implementations/python/packages/aces_sdl/_yaml_loader.py
+++ b/implementations/python/packages/aces_sdl/_yaml_loader.py
@@ -1,0 +1,409 @@
+"""Safe, source-marked YAML composition for the SDL authoring boundary."""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
+
+from ._errors import (
+    SDLParseDiagnostic,
+    SDLParseError,
+    SDLSourcePosition,
+    SDLSourceRange,
+)
+from ._mapping_scopes import MappingScope, is_literal_map_field, normalize_field_key
+
+_BOOL_TAG = "tag:yaml.org,2002:bool"
+_MERGE_TAG = "tag:yaml.org,2002:merge"
+_STRING_TAG = "tag:yaml.org,2002:str"
+
+
+class _SDLSafeLoader(yaml.SafeLoader):
+    """SafeLoader that preserves implicit YAML 1.1 boolean-like map keys."""
+
+    def __init__(self, stream: str) -> None:
+        super().__init__(stream)
+        self._sdl_mapping_key_context: list[bool] = []
+
+    def compose_node(self, parent: Node | None, index: Node | None) -> Node:
+        is_mapping_key = isinstance(parent, MappingNode) and index is None
+        self._sdl_mapping_key_context.append(is_mapping_key)
+        try:
+            return super().compose_node(parent, index)
+        finally:
+            self._sdl_mapping_key_context.pop()
+
+    def resolve(self, kind: type[Node], value: str | None, implicit: Any) -> str:
+        tag = super().resolve(kind, value, implicit)
+        if (
+            kind is ScalarNode
+            and self._sdl_mapping_key_context
+            and self._sdl_mapping_key_context[-1]
+            and tag == _BOOL_TAG
+        ):
+            return _STRING_TAG
+        return tag
+
+
+@dataclass(frozen=True)
+class _Entry:
+    canonical: str
+    authored: str
+    key_node: ScalarNode
+
+
+@dataclass(frozen=True)
+class _EffectiveMapping:
+    entries: tuple[_Entry, ...]
+    conflicts: tuple[tuple[_Entry, _Entry], ...]
+
+
+class _MappingAnalyzer:
+    def __init__(self) -> None:
+        self.diagnostics: list[SDLParseDiagnostic] = []
+        self._effective_cache: dict[tuple[int, MappingScope], _EffectiveMapping] = {}
+        self._diagnostic_keys: set[tuple[Any, ...]] = set()
+        self._walked: set[tuple[int, MappingScope]] = set()
+
+    def analyze(
+        self,
+        root: Node,
+        *,
+        scope: MappingScope,
+        base_tokens: list[str],
+    ) -> tuple[SDLParseDiagnostic, ...]:
+        self._walk(root, scope=scope, tokens=base_tokens, active=set())
+        return tuple(
+            sorted(
+                self.diagnostics,
+                key=lambda item: (
+                    item.primary_range.start.line,
+                    item.primary_range.start.column,
+                    item.code,
+                    item.pointer,
+                ),
+            )
+        )
+
+    def _walk(
+        self,
+        node: Node,
+        *,
+        scope: MappingScope,
+        tokens: list[str],
+        active: set[int],
+    ) -> None:
+        identity = id(node)
+        if identity in active:
+            self._add(
+                SDLParseDiagnostic(
+                    code="sdl.alias_cycle",
+                    message="Cyclic YAML aliases are not valid SDL authoring input.",
+                    pointer=_encode_pointer(tokens),
+                    primary_range=_range_from_node(node),
+                )
+            )
+            return
+
+        walk_key = (identity, scope)
+        if walk_key in self._walked:
+            return
+        self._walked.add(walk_key)
+
+        if not isinstance(node, (MappingNode, SequenceNode)):
+            return
+        active.add(identity)
+        try:
+            if isinstance(node, SequenceNode):
+                for index, item in enumerate(node.value):
+                    self._walk(item, scope=scope, tokens=[*tokens, str(index)], active=active)
+                return
+
+            effective = self._effective_mapping(node, scope=scope, active=set())
+            for first, conflicting in effective.conflicts:
+                pointer = _encode_pointer([*tokens, conflicting.canonical])
+                if first.authored == conflicting.authored:
+                    message = f"Duplicate mapping key '{conflicting.authored}'."
+                else:
+                    message = (
+                        f"Structural field keys '{first.authored}' and '{conflicting.authored}' "
+                        f"both address '{conflicting.canonical}'."
+                    )
+                self._add(
+                    SDLParseDiagnostic(
+                        code="sdl.mapping_key_conflict",
+                        message=message,
+                        pointer=pointer,
+                        authored_keys=(first.authored, conflicting.authored),
+                        primary_range=_range_from_node(conflicting.key_node),
+                        related_range=_range_from_node(first.key_node),
+                        related_message=f"First authored key '{first.authored}'.",
+                    )
+                )
+
+            for key_node, value_node in node.value:
+                if _is_merge_key(key_node):
+                    self._walk_merge_value(value_node, scope=scope, tokens=tokens, active=active)
+                    continue
+                authored = _authored_key(key_node)
+                if not _is_string_key(key_node):
+                    message = (
+                        "SDL top-level mapping keys must be strings"
+                        if not tokens
+                        else f"SDL mapping key '{authored}' must be a string."
+                    )
+                    self._add(
+                        SDLParseDiagnostic(
+                            code="sdl.mapping_key_type",
+                            message=message,
+                            pointer=_encode_pointer([*tokens, authored]),
+                            primary_range=_range_from_node(key_node),
+                        )
+                    )
+                    continue
+                canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
+                child_tokens = [*tokens, canonical]
+                if scope is MappingScope.STRUCTURAL and is_literal_map_field(
+                    canonical,
+                    value_is_mapping=isinstance(value_node, MappingNode),
+                    value_is_sequence=isinstance(value_node, SequenceNode),
+                ):
+                    child_scope = MappingScope.LITERAL
+                else:
+                    child_scope = MappingScope.STRUCTURAL
+                self._walk(value_node, scope=child_scope, tokens=child_tokens, active=active)
+        finally:
+            active.remove(identity)
+
+    def _walk_merge_value(
+        self,
+        node: Node,
+        *,
+        scope: MappingScope,
+        tokens: list[str],
+        active: set[int],
+    ) -> None:
+        if isinstance(node, MappingNode):
+            self._walk(node, scope=scope, tokens=tokens, active=active)
+        elif isinstance(node, SequenceNode):
+            for item in node.value:
+                self._walk(item, scope=scope, tokens=tokens, active=active)
+
+    def _effective_mapping(
+        self,
+        node: MappingNode,
+        *,
+        scope: MappingScope,
+        active: set[int],
+    ) -> _EffectiveMapping:
+        cache_key = (id(node), scope)
+        cached = self._effective_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        if id(node) in active:
+            return _EffectiveMapping((), ())
+
+        active.add(id(node))
+        ordered: list[_Entry] = []
+        conflicts: list[tuple[_Entry, _Entry]] = []
+        seen: dict[str, _Entry] = {}
+
+        def add(entry: _Entry) -> None:
+            previous = seen.get(entry.canonical)
+            if previous is None:
+                seen[entry.canonical] = entry
+                ordered.append(entry)
+            else:
+                conflicts.append((previous, entry))
+
+        try:
+            merge_keys: list[ScalarNode] = []
+            for key_node, value_node in node.value:
+                if not _is_merge_key(key_node):
+                    continue
+                if isinstance(key_node, ScalarNode):
+                    merge_keys.append(key_node)
+                for source in _merge_sources(value_node):
+                    if id(source) in active:
+                        continue
+                    inherited = self._effective_mapping(source, scope=scope, active=active)
+                    for entry in inherited.entries:
+                        add(entry)
+
+            for first, conflicting in zip(merge_keys, merge_keys[1:], strict=False):
+                add(_Entry("<<", "<<", first))
+                add(_Entry("<<", "<<", conflicting))
+
+            for key_node, _value_node in node.value:
+                if not _is_string_key(key_node) or _is_merge_key(key_node):
+                    continue
+                assert isinstance(key_node, ScalarNode)
+                authored = key_node.value
+                canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
+                add(_Entry(canonical, authored, key_node))
+        finally:
+            active.remove(id(node))
+
+        result = _EffectiveMapping(tuple(ordered), tuple(conflicts))
+        self._effective_cache[cache_key] = result
+        return result
+
+    def _add(self, diagnostic: SDLParseDiagnostic) -> None:
+        related = diagnostic.related_range
+        key = (
+            diagnostic.code,
+            diagnostic.pointer,
+            diagnostic.primary_range.start.line,
+            diagnostic.primary_range.start.column,
+            related.start.line if related else None,
+            related.start.column if related else None,
+        )
+        if key not in self._diagnostic_keys:
+            self._diagnostic_keys.add(key)
+            self.diagnostics.append(diagnostic)
+
+
+def load_sdl_yaml(
+    content: str,
+    *,
+    path: Path | None = None,
+    scope: MappingScope = MappingScope.STRUCTURAL,
+    base_pointer: str = "",
+) -> Any:
+    """Validate and safely construct one SDL YAML document or fragment."""
+    prepared = _prepare_content(content, path=path)
+    loader: _SDLSafeLoader | None = None
+    try:
+        loader = _SDLSafeLoader(prepared)
+        root = loader.get_single_node()
+        if root is None:
+            raise SDLParseError("SDL content is empty", path=path)
+        _validate_mapping_keys(root, path=path, scope=scope, base_pointer=base_pointer)
+        return loader.construct_document(root)
+    except SDLParseError:
+        raise
+    except yaml.YAMLError as exc:
+        raise _yaml_parse_error(exc, path=path) from exc
+    finally:
+        if loader is not None:
+            loader.dispose()
+
+
+def compose_sdl_yaml(
+    content: str,
+    *,
+    path: Path | None = None,
+    scope: MappingScope = MappingScope.STRUCTURAL,
+    base_pointer: str = "",
+) -> Node:
+    """Compose and key-validate SDL YAML while retaining source nodes."""
+    prepared = _prepare_content(content, path=path)
+    loader: _SDLSafeLoader | None = None
+    try:
+        loader = _SDLSafeLoader(prepared)
+        root = loader.get_single_node()
+        if root is None:
+            raise SDLParseError("SDL content is empty", path=path)
+        _validate_mapping_keys(root, path=path, scope=scope, base_pointer=base_pointer)
+        return root
+    except SDLParseError:
+        raise
+    except yaml.YAMLError as exc:
+        raise _yaml_parse_error(exc, path=path) from exc
+    finally:
+        if loader is not None:
+            loader.dispose()
+
+
+def _validate_mapping_keys(
+    root: Node,
+    *,
+    path: Path | None,
+    scope: MappingScope,
+    base_pointer: str,
+) -> None:
+    diagnostics = _MappingAnalyzer().analyze(root, scope=scope, base_tokens=_decode_pointer(base_pointer))
+    if not diagnostics:
+        return
+    rendered: list[str] = []
+    for item in diagnostics:
+        location = item.primary_range.start
+        detail = (
+            f"[{item.code}] {item.pointer or '/'} at line {location.line}, column {location.column}: {item.message}"
+        )
+        if item.related_range is not None:
+            related = item.related_range.start
+            detail += f" First declaration at line {related.line}, column {related.column}."
+        rendered.append(detail)
+    details = "SDL mapping-key validation failed:\n  " + "\n  ".join(rendered)
+    raise SDLParseError(details, path=path, diagnostics=diagnostics)
+
+
+def _prepare_content(content: str, *, path: Path | None) -> str:
+    prepared = textwrap.dedent(content)
+    if not prepared.strip():
+        raise SDLParseError("SDL content is empty", path=path)
+    return prepared
+
+
+def _yaml_parse_error(error: yaml.YAMLError, *, path: Path | None) -> SDLParseError:
+    mark = getattr(error, "problem_mark", None)
+    problem = getattr(error, "problem", None)
+    if mark is None:
+        return SDLParseError(f"Invalid YAML: {error}", path=path)
+    position = SDLSourcePosition(mark.line + 1, mark.column + 1)
+    diagnostic = SDLParseDiagnostic(
+        code="sdl.parse",
+        message=str(problem or error),
+        pointer="",
+        primary_range=SDLSourceRange(start=position, end=position),
+    )
+    return SDLParseError(f"Invalid YAML: {error}", path=path, diagnostics=(diagnostic,))
+
+
+def _is_merge_key(node: Node) -> bool:
+    return isinstance(node, ScalarNode) and node.tag == _MERGE_TAG
+
+
+def _is_string_key(node: Node) -> bool:
+    return isinstance(node, ScalarNode) and node.tag == _STRING_TAG
+
+
+def _authored_key(node: Node) -> str:
+    if isinstance(node, ScalarNode):
+        return node.value
+    return "?"
+
+
+def _merge_sources(node: Node) -> tuple[MappingNode, ...]:
+    if isinstance(node, MappingNode):
+        return (node,)
+    if isinstance(node, SequenceNode):
+        return tuple(item for item in node.value if isinstance(item, MappingNode))
+    return ()
+
+
+def _range_from_node(node: Node) -> SDLSourceRange:
+    return SDLSourceRange(
+        start=SDLSourcePosition(node.start_mark.line + 1, node.start_mark.column + 1),
+        end=SDLSourcePosition(node.end_mark.line + 1, node.end_mark.column + 1),
+    )
+
+
+def _encode_pointer(tokens: list[str]) -> str:
+    if not tokens:
+        return ""
+    return "/" + "/".join(token.replace("~", "~0").replace("/", "~1") for token in tokens)
+
+
+def _decode_pointer(pointer: str) -> list[str]:
+    if not pointer:
+        return []
+    if not pointer.startswith("/"):
+        raise ValueError("base_pointer must be an RFC 6901 pointer")
+    return [token.replace("~1", "/").replace("~0", "~") for token in pointer[1:].split("/")]

--- a/implementations/python/packages/aces_sdl/_yaml_loader.py
+++ b/implementations/python/packages/aces_sdl/_yaml_loader.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import textwrap
-from dataclasses import dataclass
+from collections.abc import Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,7 @@ from ._errors import (
 from ._mapping_scopes import MappingScope, is_literal_map_field, normalize_field_key
 
 _BOOL_TAG = "tag:yaml.org,2002:bool"
+_EMPTY_CONTENT_MESSAGE = "SDL content is empty"
 _MERGE_TAG = "tag:yaml.org,2002:merge"
 _STRING_TAG = "tag:yaml.org,2002:str"
 
@@ -63,6 +65,24 @@ class _EffectiveMapping:
     conflicts: tuple[tuple[_Entry, _Entry], ...]
 
 
+@dataclass
+class _EffectiveAccumulator:
+    entries: list[_Entry] = field(default_factory=list)
+    conflicts: list[tuple[_Entry, _Entry]] = field(default_factory=list)
+    seen: dict[str, _Entry] = field(default_factory=dict)
+
+    def add(self, entry: _Entry) -> None:
+        previous = self.seen.get(entry.canonical)
+        if previous is None:
+            self.seen[entry.canonical] = entry
+            self.entries.append(entry)
+        else:
+            self.conflicts.append((previous, entry))
+
+    def build(self) -> _EffectiveMapping:
+        return _EffectiveMapping(tuple(self.entries), tuple(self.conflicts))
+
+
 class _MappingAnalyzer:
     def __init__(self) -> None:
         self.diagnostics: list[SDLParseDiagnostic] = []
@@ -100,85 +120,102 @@ class _MappingAnalyzer:
     ) -> None:
         identity = id(node)
         if identity in active:
-            self._add(
-                SDLParseDiagnostic(
-                    code="sdl.alias_cycle",
-                    message="Cyclic YAML aliases are not valid SDL authoring input.",
-                    pointer=_encode_pointer(tokens),
-                    primary_range=_range_from_node(node),
-                )
+            self._add_alias_cycle(node, tokens)
+        else:
+            walk_key = (identity, scope)
+            if walk_key not in self._walked and isinstance(node, (MappingNode, SequenceNode)):
+                self._walked.add(walk_key)
+                active.add(identity)
+                try:
+                    if isinstance(node, MappingNode):
+                        self._walk_mapping(node, scope=scope, tokens=tokens, active=active)
+                    else:
+                        self._walk_sequence(node, scope=scope, tokens=tokens, active=active)
+                finally:
+                    active.remove(identity)
+
+    def _add_alias_cycle(self, node: Node, tokens: list[str]) -> None:
+        self._add(
+            SDLParseDiagnostic(
+                code="sdl.alias_cycle",
+                message="Cyclic YAML aliases are not valid SDL authoring input.",
+                pointer=_encode_pointer(tokens),
+                primary_range=_range_from_node(node),
             )
+        )
+
+    def _walk_sequence(
+        self,
+        node: SequenceNode,
+        *,
+        scope: MappingScope,
+        tokens: list[str],
+        active: set[int],
+    ) -> None:
+        for index, item in enumerate(node.value):
+            self._walk(item, scope=scope, tokens=[*tokens, str(index)], active=active)
+
+    def _walk_mapping(
+        self,
+        node: MappingNode,
+        *,
+        scope: MappingScope,
+        tokens: list[str],
+        active: set[int],
+    ) -> None:
+        effective = self._effective_mapping(node, scope=scope, active=set())
+        for first, conflicting in effective.conflicts:
+            self._add_conflict(first, conflicting, tokens)
+        for key_node, value_node in node.value:
+            self._walk_mapping_entry(key_node, value_node, scope=scope, tokens=tokens, active=active)
+
+    def _add_conflict(self, first: _Entry, conflicting: _Entry, tokens: list[str]) -> None:
+        self._add(
+            SDLParseDiagnostic(
+                code="sdl.mapping_key_conflict",
+                message=_conflict_message(first, conflicting),
+                pointer=_encode_pointer([*tokens, conflicting.canonical]),
+                authored_keys=(first.authored, conflicting.authored),
+                primary_range=_range_from_node(conflicting.key_node),
+                related_range=_range_from_node(first.key_node),
+                related_message=f"First authored key '{first.authored}'.",
+            )
+        )
+
+    def _walk_mapping_entry(
+        self,
+        key_node: Node,
+        value_node: Node,
+        *,
+        scope: MappingScope,
+        tokens: list[str],
+        active: set[int],
+    ) -> None:
+        if _is_merge_key(key_node):
+            self._walk_merge_value(value_node, scope=scope, tokens=tokens, active=active)
             return
-
-        walk_key = (identity, scope)
-        if walk_key in self._walked:
+        authored = _authored_key(key_node)
+        if not _is_string_key(key_node):
+            self._add_key_type_diagnostic(key_node, authored, tokens)
             return
-        self._walked.add(walk_key)
+        canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
+        child_scope = _child_scope(scope, canonical, value_node)
+        self._walk(value_node, scope=child_scope, tokens=[*tokens, canonical], active=active)
 
-        if not isinstance(node, (MappingNode, SequenceNode)):
-            return
-        active.add(identity)
-        try:
-            if isinstance(node, SequenceNode):
-                for index, item in enumerate(node.value):
-                    self._walk(item, scope=scope, tokens=[*tokens, str(index)], active=active)
-                return
-
-            effective = self._effective_mapping(node, scope=scope, active=set())
-            for first, conflicting in effective.conflicts:
-                pointer = _encode_pointer([*tokens, conflicting.canonical])
-                if first.authored == conflicting.authored:
-                    message = f"Duplicate mapping key '{conflicting.authored}'."
-                else:
-                    message = (
-                        f"Structural field keys '{first.authored}' and '{conflicting.authored}' "
-                        f"both address '{conflicting.canonical}'."
-                    )
-                self._add(
-                    SDLParseDiagnostic(
-                        code="sdl.mapping_key_conflict",
-                        message=message,
-                        pointer=pointer,
-                        authored_keys=(first.authored, conflicting.authored),
-                        primary_range=_range_from_node(conflicting.key_node),
-                        related_range=_range_from_node(first.key_node),
-                        related_message=f"First authored key '{first.authored}'.",
-                    )
-                )
-
-            for key_node, value_node in node.value:
-                if _is_merge_key(key_node):
-                    self._walk_merge_value(value_node, scope=scope, tokens=tokens, active=active)
-                    continue
-                authored = _authored_key(key_node)
-                if not _is_string_key(key_node):
-                    message = (
-                        "SDL top-level mapping keys must be strings"
-                        if not tokens
-                        else f"SDL mapping key '{authored}' must be a string."
-                    )
-                    self._add(
-                        SDLParseDiagnostic(
-                            code="sdl.mapping_key_type",
-                            message=message,
-                            pointer=_encode_pointer([*tokens, authored]),
-                            primary_range=_range_from_node(key_node),
-                        )
-                    )
-                    continue
-                canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
-                child_tokens = [*tokens, canonical]
-                if scope is MappingScope.STRUCTURAL and is_literal_map_field(
-                    canonical,
-                    value_is_mapping=isinstance(value_node, MappingNode),
-                    value_is_sequence=isinstance(value_node, SequenceNode),
-                ):
-                    child_scope = MappingScope.LITERAL
-                else:
-                    child_scope = MappingScope.STRUCTURAL
-                self._walk(value_node, scope=child_scope, tokens=child_tokens, active=active)
-        finally:
-            active.remove(identity)
+    def _add_key_type_diagnostic(self, key_node: Node, authored: str, tokens: list[str]) -> None:
+        message = (
+            "SDL top-level mapping keys must be strings"
+            if not tokens
+            else f"SDL mapping key '{authored}' must be a string."
+        )
+        self._add(
+            SDLParseDiagnostic(
+                code="sdl.mapping_key_type",
+                message=message,
+                pointer=_encode_pointer([*tokens, authored]),
+                primary_range=_range_from_node(key_node),
+            )
+        )
 
     def _walk_merge_value(
         self,
@@ -209,49 +246,65 @@ class _MappingAnalyzer:
             return _EffectiveMapping((), ())
 
         active.add(id(node))
-        ordered: list[_Entry] = []
-        conflicts: list[tuple[_Entry, _Entry]] = []
-        seen: dict[str, _Entry] = {}
-
-        def add(entry: _Entry) -> None:
-            previous = seen.get(entry.canonical)
-            if previous is None:
-                seen[entry.canonical] = entry
-                ordered.append(entry)
-            else:
-                conflicts.append((previous, entry))
-
+        accumulator = _EffectiveAccumulator()
         try:
-            merge_keys: list[ScalarNode] = []
-            for key_node, value_node in node.value:
-                if not _is_merge_key(key_node):
-                    continue
-                if isinstance(key_node, ScalarNode):
-                    merge_keys.append(key_node)
-                for source in _merge_sources(value_node):
-                    if id(source) in active:
-                        continue
-                    inherited = self._effective_mapping(source, scope=scope, active=active)
-                    for entry in inherited.entries:
-                        add(entry)
-
-            for first, conflicting in zip(merge_keys, merge_keys[1:], strict=False):
-                add(_Entry("<<", "<<", first))
-                add(_Entry("<<", "<<", conflicting))
-
-            for key_node, _value_node in node.value:
-                if not _is_string_key(key_node) or _is_merge_key(key_node):
-                    continue
-                assert isinstance(key_node, ScalarNode)
-                authored = key_node.value
-                canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
-                add(_Entry(canonical, authored, key_node))
+            merge_keys = self._inherit_merge_entries(node, scope=scope, active=active, accumulator=accumulator)
+            self._record_duplicate_merge_keys(merge_keys, accumulator)
+            self._add_local_entries(node, scope=scope, accumulator=accumulator)
         finally:
             active.remove(id(node))
 
-        result = _EffectiveMapping(tuple(ordered), tuple(conflicts))
+        result = accumulator.build()
         self._effective_cache[cache_key] = result
         return result
+
+    def _inherit_merge_entries(
+        self,
+        node: MappingNode,
+        *,
+        scope: MappingScope,
+        active: set[int],
+        accumulator: _EffectiveAccumulator,
+    ) -> list[ScalarNode]:
+        merge_keys: list[ScalarNode] = []
+        for key_node, value_node in node.value:
+            if not _is_merge_key(key_node):
+                continue
+            assert isinstance(key_node, ScalarNode)
+            merge_keys.append(key_node)
+            for source in _merge_sources(value_node):
+                if id(source) in active:
+                    continue
+                inherited = self._effective_mapping(source, scope=scope, active=active)
+                for entry in inherited.entries:
+                    accumulator.add(entry)
+        return merge_keys
+
+    @staticmethod
+    def _record_duplicate_merge_keys(
+        merge_keys: list[ScalarNode],
+        accumulator: _EffectiveAccumulator,
+    ) -> None:
+        if len(merge_keys) < 2:
+            return
+        first = _Entry("<<", "<<", merge_keys[0])
+        for key_node in merge_keys[1:]:
+            accumulator.conflicts.append((first, _Entry("<<", "<<", key_node)))
+
+    @staticmethod
+    def _add_local_entries(
+        node: MappingNode,
+        *,
+        scope: MappingScope,
+        accumulator: _EffectiveAccumulator,
+    ) -> None:
+        for key_node, _value_node in node.value:
+            if not _is_string_key(key_node) or _is_merge_key(key_node):
+                continue
+            assert isinstance(key_node, ScalarNode)
+            authored = key_node.value
+            canonical = normalize_field_key(authored) if scope is MappingScope.STRUCTURAL else authored
+            accumulator.add(_Entry(canonical, authored, key_node))
 
     def _add(self, diagnostic: SDLParseDiagnostic) -> None:
         related = diagnostic.related_range
@@ -274,7 +327,7 @@ def load_sdl_yaml(
     path: Path | None = None,
     scope: MappingScope = MappingScope.STRUCTURAL,
     base_pointer: str = "",
-) -> Any:
+) -> object:
     """Validate and safely construct one SDL YAML document or fragment."""
     prepared = _prepare_content(content, path=path)
     loader: _SDLSafeLoader | None = None
@@ -282,7 +335,7 @@ def load_sdl_yaml(
         loader = _SDLSafeLoader(prepared)
         root = loader.get_single_node()
         if root is None:
-            raise SDLParseError("SDL content is empty", path=path)
+            raise SDLParseError(_EMPTY_CONTENT_MESSAGE, path=path)
         _validate_mapping_keys(root, path=path, scope=scope, base_pointer=base_pointer)
         return loader.construct_document(root)
     except SDLParseError:
@@ -308,7 +361,7 @@ def compose_sdl_yaml(
         loader = _SDLSafeLoader(prepared)
         root = loader.get_single_node()
         if root is None:
-            raise SDLParseError("SDL content is empty", path=path)
+            raise SDLParseError(_EMPTY_CONTENT_MESSAGE, path=path)
         _validate_mapping_keys(root, path=path, scope=scope, base_pointer=base_pointer)
         return root
     except SDLParseError:
@@ -347,7 +400,7 @@ def _validate_mapping_keys(
 def _prepare_content(content: str, *, path: Path | None) -> str:
     prepared = textwrap.dedent(content)
     if not prepared.strip():
-        raise SDLParseError("SDL content is empty", path=path)
+        raise SDLParseError(_EMPTY_CONTENT_MESSAGE, path=path)
     return prepared
 
 
@@ -380,12 +433,28 @@ def _authored_key(node: Node) -> str:
     return "?"
 
 
-def _merge_sources(node: Node) -> tuple[MappingNode, ...]:
+def _merge_sources(node: Node) -> Iterator[MappingNode]:
     if isinstance(node, MappingNode):
-        return (node,)
-    if isinstance(node, SequenceNode):
-        return tuple(item for item in node.value if isinstance(item, MappingNode))
-    return ()
+        yield node
+    elif isinstance(node, SequenceNode):
+        yield from (item for item in node.value if isinstance(item, MappingNode))
+
+
+def _child_scope(scope: MappingScope, canonical: str, value_node: Node) -> MappingScope:
+    is_literal = scope is MappingScope.STRUCTURAL and is_literal_map_field(
+        canonical,
+        value_is_mapping=isinstance(value_node, MappingNode),
+        value_is_sequence=isinstance(value_node, SequenceNode),
+    )
+    return MappingScope.LITERAL if is_literal else MappingScope.STRUCTURAL
+
+
+def _conflict_message(first: _Entry, conflicting: _Entry) -> str:
+    if first.authored == conflicting.authored:
+        return f"Duplicate mapping key '{conflicting.authored}'."
+    return (
+        f"Structural field keys '{first.authored}' and '{conflicting.authored}' both address '{conflicting.canonical}'."
+    )
 
 
 def _range_from_node(node: Node) -> SDLSourceRange:

--- a/implementations/python/packages/aces_sdl/language_service.py
+++ b/implementations/python/packages/aces_sdl/language_service.py
@@ -15,6 +15,7 @@ import yaml
 from ._errors import SDLParseError, SDLValidationError
 from ._language_diagnostics import diagnostic as _diagnostic
 from ._language_diagnostics import invalid as _invalid
+from ._language_diagnostics import parse_error as _parse_error
 from ._language_edit import apply_edit
 from ._language_metadata import REFERENCE_COMPLETION_TARGETS, SECTION_FIELD_COMPLETIONS
 from ._language_references import find_references
@@ -22,8 +23,6 @@ from .parser import _load_normalized_data, parse_sdl
 from .scenario import Scenario
 
 _MAX_INPUT_BYTES = 64 * 1024
-_CODE_PARSE = "sdl.parse"
-
 _SCENARIO_METADATA_FIELDS = frozenset({"name", "version", "description", "module", "imports"})
 _SECTION_FIELDS = tuple(field for field in Scenario.model_fields if field not in _SCENARIO_METADATA_FIELDS)
 _TOP_LEVEL_KEYS = tuple(Scenario.model_fields)
@@ -98,7 +97,7 @@ def language_format(sdl_content: str) -> dict[str, Any]:
     try:
         data = _load_normalized_data(sdl_content)
     except SDLParseError as exc:
-        return _invalid("parse", _CODE_PARSE, exc.details)
+        return _parse_error(exc)
 
     formatted = yaml.safe_dump(
         data,
@@ -127,7 +126,7 @@ def language_diagnostics(
             skip_semantic_validation=not semantic_validation,
         )
     except SDLParseError as exc:
-        return _invalid("parse", _CODE_PARSE, exc.details)
+        return _parse_error(exc)
     except SDLValidationError as exc:
         return {
             "status": "invalid",
@@ -160,7 +159,7 @@ def apply_structured_edit(
     try:
         data = _load_normalized_data(sdl_content)
     except SDLParseError as exc:
-        return _invalid("parse", _CODE_PARSE, exc.details)
+        return _parse_error(exc)
 
     try:
         tokens = _split_pointer(pointer)
@@ -185,7 +184,7 @@ def _load_completion_data(sdl_content: str) -> tuple[dict[str, Any], dict[str, A
     try:
         return _load_normalized_data(sdl_content), None
     except SDLParseError as exc:
-        return {}, _invalid("parse", _CODE_PARSE, exc.details)
+        return {}, _parse_error(exc)
 
 
 def _completion_target_section(pointer: list[str]) -> str | None:

--- a/implementations/python/packages/aces_sdl/parser.py
+++ b/implementations/python/packages/aces_sdl/parser.py
@@ -86,7 +86,7 @@ def load_sdl_fragment(
     *,
     mapping_keys: Literal["structural", "literal"] = "structural",
     base_pointer: str = "",
-) -> Any:
+) -> object:
     """Safely load an SDL YAML fragment with the canonical key preflight."""
     return load_sdl_yaml(
         content,

--- a/implementations/python/packages/aces_sdl/parser.py
+++ b/implementations/python/packages/aces_sdl/parser.py
@@ -6,77 +6,40 @@ Provides ``parse_sdl()`` as the primary entry point. Handles:
 - Shorthand expansion (``source: "pkg"`` → ``{name: "pkg", version: "*"}``)
 """
 
-import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-import yaml
 from pydantic import ValidationError
 
 from ._base import contains_variable_token, is_variable_ref
 from ._errors import SDLParseError, SDLValidationError
+from ._mapping_scopes import (
+    HASHMAP_SECTIONS,
+    NESTED_HASHMAP_FIELDS,
+    MappingScope,
+    is_literal_map_field,
+    normalize_field_key,
+)
+from ._yaml_loader import load_sdl_yaml
 from .scenario import ExpandedScenario, Scenario
 from .validator import SemanticValidator
 
 # Top-level sections that are HashMaps of user-defined identifiers.
 # Keys inside these are scenario-author names (e.g., "web-server")
 # and must NOT be transformed.
-_HASHMAP_SECTIONS = frozenset(
-    {
-        "nodes",
-        "infrastructure",
-        "features",
-        "conditions",
-        "vulnerabilities",
-        "entities",
-        "injects",
-        "events",
-        "scripts",
-        "stories",
-        "content",
-        "accounts",
-        "relationships",
-        "agents",
-        "action_contracts",
-        "observation_boundaries",
-        "outcome_interpretation_rules",
-        "behavior_specifications",
-        "evidence_requirements",
-        "objectives",
-        "workflows",
-        "variables",
-    }
-)
+_HASHMAP_SECTIONS = HASHMAP_SECTIONS
 
 # Fields within struct models that are also HashMaps of user-defined keys.
-_NESTED_HASHMAP_FIELDS = frozenset(
-    {
-        "features",  # VM.features (dict[str, str])
-        "conditions",  # VM.conditions (dict[str, str])
-        "injects",  # VM.injects (dict[str, str])
-        "roles",  # Node.roles (dict[str, Role])
-        "log_options",  # RuntimeContainerConfiguration.log_options preserves native engine option keys
-        "labels",  # ImageConfig.labels preserves case-sensitive native image label keys
-        "driver_options",  # RuntimeNetworkBackendDetail.driver_options preserves native network driver keys
-        "ipam_options",  # RuntimeNetworkBackendDetail.ipam_options preserves native IPAM driver keys
-        "facts",  # Entity.facts (dict[str, str])
-        "entities",  # Entity.entities (dict[str, Entity])
-        "events",  # Script.events (dict[str, int])
-        "steps",  # Workflow.steps (dict[str, WorkflowStep])
-        # ParticipantBehaviorSpecification.extensions preserves governed x-owner:term keys.
-        "extensions",
-    }
-)
+_NESTED_HASHMAP_FIELDS = NESTED_HASHMAP_FIELDS
 
 
 def _child_is_hashmap_field(key: str, value: Any) -> bool:
     """Return whether the children of ``key`` are user-defined hashmap keys."""
-    if key in _HASHMAP_SECTIONS:
-        return isinstance(value, dict)
-    if key in _NESTED_HASHMAP_FIELDS:
-        return True
-    # Complex properties use list items like ``[{switch-name: "10.0.0.10"}]``.
-    return key == "properties" and isinstance(value, list)
+    return is_literal_map_field(
+        key,
+        value_is_mapping=isinstance(value, dict),
+        value_is_sequence=isinstance(value, list),
+    )
 
 
 def _normalize_field_key(k: Any) -> Any:
@@ -84,10 +47,8 @@ def _normalize_field_key(k: Any) -> Any:
     # PyYAML's YAML 1.1 rules can coerce bare keys like ``on``/``off`` to bools.
     # SDL field keys are schema-defined strings, so normalize those legacy bool
     # coercions back into the field names we actually support.
-    if isinstance(k, bool):
-        return "on" if k else "off"
     if isinstance(k, str):
-        return k.lower().replace("-", "_")
+        return normalize_field_key(k)
     return k
 
 
@@ -118,6 +79,20 @@ def _normalize_keys(data: Any, is_hashmap: bool = False) -> Any:
         # user-defined keys, list items within it do too.
         return [_normalize_keys(item, is_hashmap=is_hashmap) for item in data]
     return data
+
+
+def load_sdl_fragment(
+    content: str,
+    *,
+    mapping_keys: Literal["structural", "literal"] = "structural",
+    base_pointer: str = "",
+) -> Any:
+    """Safely load an SDL YAML fragment with the canonical key preflight."""
+    return load_sdl_yaml(
+        content,
+        scope=MappingScope(mapping_keys),
+        base_pointer=base_pointer,
+    )
 
 
 def _reject_variable_mapping_keys(
@@ -400,14 +375,7 @@ def _load_normalized_data(
     *,
     path: Path | None = None,
 ) -> dict[str, Any]:
-    content = textwrap.dedent(content).strip()
-    if not content:
-        raise SDLParseError("SDL content is empty", path=path)
-
-    try:
-        raw = yaml.safe_load(content)
-    except yaml.YAMLError as e:
-        raise SDLParseError(f"Invalid YAML: {e}", path=path) from e
+    raw = load_sdl_yaml(content, path=path)
 
     if not isinstance(raw, dict):
         raise SDLParseError("SDL must be a YAML mapping (not a scalar or list)", path=path)

--- a/implementations/python/tests/data/sdl/invalid/mapping-key-cycle.yaml
+++ b/implementations/python/tests/data/sdl/invalid/mapping-key-cycle.yaml
@@ -1,0 +1,5 @@
+name: cyclic-alias
+nodes: &nodes
+  sw:
+    type: switch
+    roles: *nodes

--- a/implementations/python/tests/data/sdl/invalid/mapping-key-exact-root.yaml
+++ b/implementations/python/tests/data/sdl/invalid/mapping-key-exact-root.yaml
@@ -1,0 +1,2 @@
+name: first
+name: second

--- a/implementations/python/tests/data/sdl/invalid/mapping-key-merge.yaml
+++ b/implementations/python/tests/data/sdl/invalid/mapping-key-merge.yaml
@@ -1,0 +1,12 @@
+name: merge-conflict
+nodes:
+  first:
+    type: vm
+    resources: &resources
+      ram: 1 gib
+      cpu: 1
+  second:
+    type: vm
+    resources:
+      <<: *resources
+      cpu: 2

--- a/implementations/python/tests/data/sdl/invalid/mapping-key-normalized-nested.yaml
+++ b/implementations/python/tests/data/sdl/invalid/mapping-key-normalized-nested.yaml
@@ -1,0 +1,5 @@
+name: normalized-nested
+nodes:
+  sw:
+    Type: switch
+    type: switch

--- a/implementations/python/tests/test_mcp_server.py
+++ b/implementations/python/tests/test_mcp_server.py
@@ -272,6 +272,21 @@ class TestAuthoringTools:
         )
         assert "YAML ERROR" in text
 
+    def test_validate_section_rejects_duplicates_before_fragment_round_trip(self, server):
+        text = _call(
+            server,
+            "sdl_validate_section",
+            {
+                "section": "nodes",
+                "section_yaml": "sw:\n  Type: switch\n  type: switch",
+            },
+        )
+
+        assert "PARSE ERROR" in text
+        assert "sdl.mapping_key_conflict" in text
+        assert "/nodes/sw/type" in text
+        assert "line 3, column 3" in text
+
     def test_validate_section_bad_section(self, server):
         text = _call(
             server,
@@ -630,6 +645,17 @@ class TestOperationTools:
         assert payload["status"] == "invalid"
         assert payload["stage"] == "semantic_validation"
         assert "ghost-feature" in payload["diagnostics"][0]["message"]
+
+    @pytest.mark.parametrize("tool", ["sdl_parse", "sdl_compile"])
+    def test_operation_tools_preserve_mapping_conflict_diagnostics(self, server, tool):
+        payload = _json_call(server, tool, {"sdl_content": "Name: first\nname: second\n"})
+
+        assert payload["status"] == "invalid"
+        diagnostic = payload["diagnostics"][0]
+        assert diagnostic["code"] == "sdl.mapping_key_conflict"
+        assert diagnostic["path"] == "/name"
+        assert diagnostic["authored_keys"] == ["Name", "name"]
+        assert diagnostic["range"]["start"] == {"line": 2, "column": 1}
 
     def test_compile_summarizes_runtime_model(self, server):
         payload = _json_call(server, "sdl_compile", {"sdl_content": FULL_SDL})

--- a/implementations/python/tests/test_sdl_fuzz.py
+++ b/implementations/python/tests/test_sdl_fuzz.py
@@ -397,3 +397,49 @@ def test_fuzz_feature_dependency_cycles(features):
         parse_sdl(yaml_str)
     except (SDLParseError, SDLValidationError):
         pass
+
+
+@given(
+    pair=st.sampled_from(
+        [
+            ("Password-Strength", "password_strength"),
+            ("PASSWORD_STRENGTH", "password-strength"),
+            ("password-strength", "Password_Strength"),
+        ]
+    )
+)
+@settings(max_examples=50, deadline=2000)
+def test_fuzz_structural_key_alias_mutations_fail_closed(pair):
+    """Generated field aliases must never overwrite an earlier spelling."""
+    first, second = pair
+    source = f"""\
+name: fuzz-aliases
+nodes:
+  host: {{type: switch}}
+accounts:
+  alice:
+    username: alice
+    node: host
+    {first}: strong
+    {second}: weak
+"""
+
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl(source)
+    assert excinfo.value.diagnostics[0].code == "sdl.mapping_key_conflict"
+
+
+@given(identifier=slugs)
+@settings(max_examples=50, deadline=2000)
+def test_fuzz_exact_identifier_duplicate_mutations_fail_closed(identifier):
+    """Generated duplicate symbol definitions must fail before construction."""
+    source = f"""\
+name: fuzz-duplicates
+nodes:
+  {identifier}: {{type: switch}}
+  {identifier}: {{type: switch}}
+"""
+
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl(source)
+    assert excinfo.value.diagnostics[0].code == "sdl.mapping_key_conflict"

--- a/implementations/python/tests/test_yaml_mapping_keys.py
+++ b/implementations/python/tests/test_yaml_mapping_keys.py
@@ -1,0 +1,375 @@
+"""Fail-closed tests for authored SDL mapping keys."""
+
+from pathlib import Path
+
+import pytest
+from aces_sdl import SDLParseDiagnostic, SDLParseError, parse_sdl, parse_sdl_file
+from aces_sdl.language_service import (
+    apply_structured_edit,
+    language_completions,
+    language_diagnostics,
+    language_format,
+    language_references,
+)
+from hypothesis import given
+from hypothesis import strategies as st
+
+FIXTURE_DIR = Path(__file__).parent / "data" / "sdl" / "invalid"
+
+
+def _conflicts(source: str):
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl(source, skip_semantic_validation=True)
+    diagnostics = excinfo.value.diagnostics
+    assert diagnostics
+    assert all(item.code == "sdl.mapping_key_conflict" for item in diagnostics)
+    return diagnostics
+
+
+def test_exact_duplicate_root_key_is_rejected_before_model_construction() -> None:
+    diagnostics = _conflicts("name: first\nname: second\n")
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].pointer == "/name"
+    assert diagnostics[0].authored_keys == ("name", "name")
+
+
+def test_normalized_nested_field_aliases_conflict() -> None:
+    diagnostics = _conflicts(
+        """\
+name: aliases
+nodes:
+  sw:
+    Type: switch
+    type: switch
+"""
+    )
+
+    assert diagnostics[0].pointer == "/nodes/sw/type"
+    assert diagnostics[0].authored_keys == ("Type", "type")
+
+
+def test_exact_duplicate_literal_identifier_is_rejected() -> None:
+    diagnostics = _conflicts(
+        """\
+name: literal-duplicate
+nodes:
+  sw: {type: switch}
+  sw: {type: switch}
+"""
+    )
+
+    assert diagnostics[0].pointer == "/nodes/sw"
+
+
+def test_literal_identifiers_are_not_field_normalized() -> None:
+    scenario = parse_sdl(
+        """\
+name: literal-identifiers
+nodes:
+  Web-App: {type: switch}
+  web_app: {type: switch}
+"""
+    )
+
+    assert tuple(scenario.nodes) == ("Web-App", "web_app")
+
+
+def test_implicit_yaml_11_boolean_like_identifiers_remain_distinct_strings() -> None:
+    scenario = parse_sdl(
+        """\
+name: boolean-like-identifiers
+nodes:
+  on: {type: switch}
+  true: {type: switch}
+  OFF: {type: switch}
+  false: {type: switch}
+"""
+    )
+
+    assert tuple(scenario.nodes) == ("on", "true", "OFF", "false")
+
+
+def test_explicit_non_string_mapping_key_is_rejected_with_a_source_range() -> None:
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl("name: invalid-key\nnodes:\n  !!int 1: {type: switch}\n")
+
+    diagnostic = excinfo.value.diagnostics[0]
+    assert diagnostic.code == "sdl.mapping_key_type"
+    assert diagnostic.pointer == "/nodes/1"
+    assert diagnostic.primary_range.start.line == 3
+    assert diagnostic.primary_range.start.column == 3
+
+
+def test_merge_source_and_local_field_must_be_disjoint() -> None:
+    diagnostics = _conflicts(
+        """\
+name: merge-conflict
+nodes:
+  first:
+    type: vm
+    resources: &resources
+      ram: 1 gib
+      cpu: 1
+  second:
+    type: vm
+    resources:
+      <<: *resources
+      cpu: 2
+"""
+    )
+
+    assert diagnostics[0].pointer == "/nodes/second/resources/cpu"
+    assert diagnostics[0].authored_keys == ("cpu", "cpu")
+
+
+def test_merge_sources_must_be_pairwise_disjoint_and_collect_all_conflicts() -> None:
+    diagnostics = _conflicts(
+        """\
+name: merge-sources
+nodes:
+  first:
+    type: vm
+    resources: &first
+      ram: 1 gib
+      cpu: 1
+  second:
+    type: vm
+    resources: &second
+      RAM: 2 gib
+      CPU: 2
+  third:
+    type: vm
+    resources:
+      <<: [*first, *second]
+"""
+    )
+
+    assert [item.pointer for item in diagnostics] == [
+        "/nodes/third/resources/ram",
+        "/nodes/third/resources/cpu",
+    ]
+    assert diagnostics[0].authored_keys == ("ram", "RAM")
+
+
+def test_disjoint_merge_remains_valid() -> None:
+    scenario = parse_sdl(
+        """\
+name: merge-disjoint
+nodes:
+  first:
+    type: vm
+    resources: &resources
+      ram: 1 gib
+      cpu: 1
+  second:
+    type: vm
+    resources:
+      <<: *resources
+"""
+    )
+
+    assert scenario.nodes["second"].resources.cpu == 1
+
+
+def test_cyclic_alias_graph_fails_cleanly() -> None:
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl(
+            """\
+name: cyclic-alias
+nodes: &nodes
+  sw:
+    type: switch
+    roles: *nodes
+"""
+        )
+
+    assert excinfo.value.diagnostics[0].code == "sdl.alias_cycle"
+
+
+def test_non_printable_input_fails_cleanly_across_loader_entry_points() -> None:
+    with pytest.raises(SDLParseError, match="special characters are not allowed"):
+        parse_sdl("\x1b")
+
+    payload = language_references("\x1b", "symbol")
+    assert payload["status"] == "invalid"
+    assert payload["diagnostics"][0]["code"] == "sdl.parse"
+
+
+def test_collects_conflicts_in_document_order() -> None:
+    diagnostics = _conflicts(
+        """\
+Name: first
+name: second
+Version: 1.0.0
+version: 2.0.0
+"""
+    )
+
+    assert [item.pointer for item in diagnostics] == ["/name", "/version"]
+
+
+def test_conflict_diagnostic_has_one_based_token_ranges() -> None:
+    diagnostic = _conflicts("Name: first\nname: second\n")[0]
+
+    assert diagnostic.primary_range.as_dict() == {
+        "start": {"line": 2, "column": 1},
+        "end": {"line": 2, "column": 5},
+    }
+    assert diagnostic.related_range.as_dict() == {
+        "start": {"line": 1, "column": 1},
+        "end": {"line": 1, "column": 5},
+    }
+    assert isinstance(diagnostic, SDLParseDiagnostic)
+
+
+def test_conflict_diagnostic_never_exposes_mapping_values() -> None:
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl("name: public\nname: TOP-SECRET-VALUE\n")
+
+    assert "TOP-SECRET-VALUE" not in str(excinfo.value)
+
+
+def test_conflict_pointer_uses_rfc_6901_escaping() -> None:
+    diagnostics = _conflicts(
+        """\
+name: escaped-pointer
+nodes:
+  "a/b~c": {type: switch}
+  "a/b~c": {type: switch}
+"""
+    )
+
+    assert diagnostics[0].pointer == "/nodes/a~1b~0c"
+
+
+def test_file_entry_point_preserves_file_and_key_diagnostics(tmp_path: Path) -> None:
+    source = tmp_path / "scenario.yaml"
+    source.write_text("name: first\nname: second\n", encoding="utf-8")
+
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl_file(source)
+
+    assert excinfo.value.path == source
+    assert excinfo.value.diagnostics[0].pointer == "/name"
+
+
+def test_language_diagnostics_preserve_structured_conflict_fields() -> None:
+    payload = language_diagnostics("Name: first\nname: second\n")
+
+    assert payload["status"] == "invalid"
+    assert payload["diagnostics"] == [
+        {
+            "stage": "parse",
+            "severity": "error",
+            "code": "sdl.mapping_key_conflict",
+            "message": "Structural field keys 'Name' and 'name' both address 'name'.",
+            "path": "/name",
+            "authored_keys": ["Name", "name"],
+            "range": {
+                "start": {"line": 2, "column": 1},
+                "end": {"line": 2, "column": 5},
+            },
+            "related": [
+                {
+                    "message": "First authored key 'Name'.",
+                    "range": {
+                        "start": {"line": 1, "column": 1},
+                        "end": {"line": 1, "column": 5},
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def test_language_references_rejects_ambiguous_documents() -> None:
+    payload = language_references(
+        "name: refs\nnodes:\n  sw: {type: switch}\n  sw: {type: switch}\n",
+        "sw",
+    )
+
+    assert payload["status"] == "invalid"
+    assert payload["diagnostics"][0]["code"] == "sdl.mapping_key_conflict"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda source: language_format(source),
+        lambda source: language_completions(source),
+        lambda source: apply_structured_edit(source, operation="set", pointer="/description", value="x"),
+    ],
+    ids=["format", "completions", "structured-edit"],
+)
+def test_authoring_reads_reject_ambiguity_before_rewriting(operation) -> None:
+    payload = operation("Name: first\nname: second\n")
+
+    assert payload["status"] == "invalid"
+    assert payload["diagnostics"][0]["code"] == "sdl.mapping_key_conflict"
+
+
+def test_imported_module_uses_the_same_mapping_key_boundary(tmp_path: Path) -> None:
+    imported = tmp_path / "common.yaml"
+    imported.write_text("name: common\nnodes:\n  sw: {type: switch}\n  sw: {type: switch}\n", encoding="utf-8")
+    root = tmp_path / "root.yaml"
+    root.write_text(
+        "name: root\nimports:\n  - path: common.yaml\n    namespace: shared\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SDLParseError) as excinfo:
+        parse_sdl_file(root)
+
+    assert excinfo.value.path == imported
+    assert excinfo.value.diagnostics[0].pointer == "/nodes/sw"
+
+
+@pytest.mark.parametrize("fixture", sorted(FIXTURE_DIR.glob("mapping-key-*.yaml")), ids=lambda path: path.stem)
+def test_negative_mapping_key_fixtures_fail_closed(fixture: Path) -> None:
+    with pytest.raises(SDLParseError):
+        parse_sdl_file(fixture, skip_semantic_validation=True)
+
+
+_STRUCTURAL_ALIAS_PAIRS = st.sampled_from(
+    [
+        ("Password-Strength", "password_strength"),
+        ("PASSWORD_STRENGTH", "password-strength"),
+        ("password-strength", "Password_Strength"),
+    ]
+)
+
+
+@given(_STRUCTURAL_ALIAS_PAIRS)
+def test_property_distinct_structural_aliases_never_overwrite(pair: tuple[str, str]) -> None:
+    first, second = pair
+    diagnostics = _conflicts(
+        f"""\
+name: generated-aliases
+nodes:
+  host: {{type: switch}}
+accounts:
+  alice:
+    username: alice
+    node: host
+    {first}: strong
+    {second}: weak
+"""
+    )
+
+    assert diagnostics[0].pointer == "/accounts/alice/password_strength"
+
+
+@given(st.sampled_from([("Web-App", "web_app"), ("DB", "db"), ("a-b", "a_b")]))
+def test_property_literal_identifier_aliases_remain_distinct(pair: tuple[str, str]) -> None:
+    first, second = pair
+    scenario = parse_sdl(
+        f"""\
+name: generated-identifiers
+nodes:
+  {first}: {{type: switch}}
+  {second}: {{type: switch}}
+"""
+    )
+
+    assert set(scenario.nodes) == {first, second}

--- a/specs/sdl/diagnostics.md
+++ b/specs/sdl/diagnostics.md
@@ -12,9 +12,10 @@ An SDL document is checked at three stages, in order. Each is **fail-closed**:
 a problem at a stage stops the document from advancing past that stage.
 
 1. **Parse / structural.** YAML loading and structural shape: the root is a
-   mapping, keys are strings, values have the right shapes, and **no unknown key
-   is present** ([document-model.md §4](document-model.md)). A structural problem
-   is a parse error.
+   mapping, keys are strings, mapping entries remain unique before and after
+   field-key normalisation, values have the right shapes, and **no unknown key is
+   present** ([document-model.md §4](document-model.md)). A structural problem is
+   a parse error.
 2. **Semantic validation.** Cross-section reference resolution
    ([references.md](references.md)), uniqueness, acyclicity, control-flow
    closure, and the runtime-family invariants
@@ -32,8 +33,10 @@ a problem at a stage stops the document from advancing past that stage.
 The semantic-validation and instantiation stages **collect all errors in a pass**
 and report them together, rather than failing at the first problem. An author
 fixing a document sees the full set of errors a stage found, not one error at a
-time. (Parsing may stop at the first structural fault that prevents
-interpretation.)
+time. Parsing may stop at the first structural fault that prevents composition
+of a YAML node graph. Once that graph is available, the mapping-key preflight
+collects all exact duplicates, merge conflicts, and field-key normalisation
+collisions before construction; none is hidden by a last-write-wins mapping.
 
 ## 3. Errors are fatal
 
@@ -127,3 +130,37 @@ A future change that moves a condition between the error and advisory channels,
 or that adds a new diagnostic category, **MUST** apply this criterion and be
 reflected here, in the published schemas, and in the reference implementation
 together, so the boundary stays single-sourced.
+
+## 6. Mapping-key diagnostics
+
+Exact duplicate keys, conflicting effective keys introduced by `<<`, and
+distinct structural field spellings that normalise to one field use the stable
+diagnostic code `sdl.mapping_key_conflict`. They are fatal at the `parse` stage
+and **MUST** be raised before Pydantic or any other SDL model constructor sees
+the mapping.
+
+An explicitly non-string or complex mapping key uses
+`sdl.mapping_key_type`. A cyclic YAML alias graph uses `sdl.alias_cycle`. These
+conditions are likewise fatal at the `parse` stage and carry the canonical
+target path and primary source range; they do not have a second authored-key
+range when no competing declaration exists.
+
+Each diagnostic **MUST** carry:
+
+1. the canonical target path as an RFC 6901 JSON Pointer, with schema field
+   segments canonicalised and user-defined/native-map segments preserved and
+   escaped;
+2. both authored key spellings (the spellings are identical for an exact
+   duplicate); and
+3. the one-based line and column range of both key tokens. The later/conflicting
+   key is the primary range and the earlier key is a related range. When the
+   conflict is contributed through a YAML merge, the ranges identify the
+   original key declarations and the canonical path identifies the effective
+   target mapping.
+
+The reference implementation continues to use `SDLParseError` for this failure;
+it **MUST NOT** introduce a parallel exception hierarchy. Public structured
+adapters (including language-service and MCP responses) preserve the code,
+stage, canonical path, and both ranges. Plain-text CLI/library rendering may
+format the same fields as prose but must not replace them with raw YAML values or
+silently downgrade the error to a generic model-validation failure.

--- a/specs/sdl/document-model.md
+++ b/specs/sdl/document-model.md
@@ -15,11 +15,21 @@ and instantiation rules.
 1. An SDL document **MUST** be a YAML 1.1/1.2 document whose top-level value is a
    mapping. A document whose root is a sequence, scalar, or null is not a valid
    SDL document.
-2. Every top-level key **MUST** be a string. Field keys are matched
-   case-sensitively after enum/value normalisation (§5); a key that is not a
-   defined top-level field is rejected (§4).
+2. Every mapping key **MUST** denote a string. In particular, SDL treats an
+   implicitly typed YAML 1.1 spelling such as `on`, `off`, `yes`, or `no` as
+   the authored string spelling when it occurs in key position; it does not
+   allow the YAML loader to turn that spelling into a boolean map key. A
+   non-scalar or explicitly non-string key is rejected.
 3. A document **MUST** be loadable by a safe YAML loader. Constructor tags that
    instantiate arbitrary types **MUST NOT** be honoured.
+4. Every authored mapping entry **MUST** remain distinguishable until the SDL
+   parser has checked key uniqueness. An exact duplicate key at any depth is a
+   parse/structural error; a loader **MUST NOT** construct a last-write-wins
+   dictionary first.
+
+This uniqueness rule follows the YAML 1.2.2 representation model, in which a
+mapping is an unordered association of unique keys and non-unique keys are a
+loading failure ([YAML 1.2.2 §§3.2.1.1, 3.3](https://yaml.org/spec/1.2.2/)).
 
 ## 2. Top-level organisation
 
@@ -65,23 +75,51 @@ to match `contracts/schemas/sdl/sdl-authoring-input-v1.json`.
 3. Closure exists so that a typo in a field name (`vulnerabilites`) fails the
    document rather than silently dropping content. Authors **MUST NOT** rely on
    undeclared keys to carry data.
+4. YAML anchors and aliases remain authoring conveniences, but they do not
+   weaken closure or uniqueness. A merge key (`<<`) is valid only when the
+   effective entries contributed by every merge source and every local entry
+   remain unique after the scope-appropriate key rules in §5 are applied. A
+   merge conflict is a parse/structural error rather than an implicit precedence
+   rule. This is a deliberate ACES restriction over the YAML 1.1 merge-key
+   working draft, which otherwise defines source and local override precedence
+   ([YAML 1.1 merge type](https://yaml.org/type/merge.html)). Cyclic alias
+   graphs are invalid.
 
 > *Implementation evidence (non-normative): the reference models set
 > `extra="forbid"` on the shared SDL base model.*
 
-## 5. Value normalisation
+## 5. Field and value normalisation
 
 1. Enum-valued fields accept their value case-insensitively, and accept a hyphen
    as an alias for an underscore in the value text, so that an authoring value
    such as `search-index` and `search_index` denote the same enum member. This
    is an authoring convenience; the normalised (canonical) form is what the
    document means.
-2. Normalisation applies to enum **values**, not to user-defined identifier
-   **keys**. A user-defined key is preserved verbatim as the element's
-   identifier (§6).
-3. A field that holds a variable placeholder (`${…}`) is **not** normalised as an
+2. Structural field keys retain the authoring aliases established by ADR-001:
+   matching is case-insensitive and `-` is accepted as an alias for `_`.
+   Therefore `semantic-version` and `semantic_version` both address the
+   canonical field `semantic_version`.
+3. Field-key aliases do not create a precedence rule. If two keys in one
+   effective mapping address the same canonical field, including through a YAML
+   merge, the mapping is ambiguous and **MUST** fail during parsing before model
+   construction. The diagnostic contract is defined in
+   [diagnostics.md §6](diagnostics.md).
+4. Field-key normalisation applies only while traversing a schema-defined
+   structural mapping. It **MUST NOT** be applied to user-defined identifier
+   maps, extension maps, or native option/label maps. Keys in those maps are
+   preserved verbatim, including case, hyphens, underscores, and YAML 1.1
+   boolean-like spellings; only exact duplicate identifiers are rejected.
+5. A field that holds a variable placeholder (`${…}`) is **not** normalised as an
    enum value; the placeholder is preserved until instantiation
    ([variables-and-instantiation.md](variables-and-instantiation.md)).
+
+Formally, let `c_scope(k)` lowercase a key and replace hyphens with underscores
+in a structural mapping, and be the identity function in a literal mapping. For every
+pair of distinct entries `i` and `j` in an effective mapping (including merge
+contributions), well-formedness requires
+`c_scope(key_i) != c_scope(key_j)`. This injectivity condition is checked over
+the authored node graph; mapped values do not participate in the comparison or
+its diagnostics.
 
 ## 6. Identifier rules for user-defined keys
 
@@ -120,7 +158,7 @@ of the authored document with progressively fewer unresolved constructs:
 1. **Authored.** The document as written. It **MAY** contain module imports and
    `${…}` variable placeholders. Full semantic validation
    ([references.md](references.md), [diagnostics.md](diagnostics.md)) applies to
-   the authored document, treating unresolved placeholders per §5.3.
+   the authored document, treating unresolved placeholders per §5.5.
 2. **Expanded.** If the document declares a module or imports
    ([sections.md](sections.md) — `module`, `imports`), module composition is
    applied **before** full semantic validation, producing an expanded document


### PR DESCRIPTION
## Summary

Makes the SDL authoring boundary fail closed before model construction: exact YAML duplicates, normalized structural aliases, merge overlaps, invalid key types, and cyclic aliases now produce stable source-ranged diagnostics without rewriting user identifiers.

## Requirement UIDs

- `DSL-105`

## Related Issues

Closes #720

## ADR Impact

- ADR-001
- ADR-007
- ADR-009

## Changes

- Compose SDL YAML with a standard-tag SafeLoader and validate effective mapping-key injectivity before constructing Python dictionaries.
- Preserve literal identifiers and YAML 1.1 boolean-like key spellings while rejecting ambiguous structural aliases and merge overlaps.
- Propagate typed parse diagnostics through string/file parsing, imports, language services, MCP operations, and section-fragment validation.
- Document the normative rule and its deliberate restriction over YAML 1.1 merge precedence.
- Add negative fixtures, normal-gate properties, fuzz mutations, and adapter regression coverage.

## Test Plan

- [x] `tools/verify_all.py` passes
- [x] 3,108 standard tests and 30 integration tests pass with 92% coverage
- [x] Dedicated fuzz session passes all 8 properties
- [x] Schema publication/drift, lint, policy, and Sphinx documentation checks pass
- [x] Pre-push code and test-quality reviews are clean

## Ground Control Checks

- [x] Repository policy and requirement governance checked for `DSL-105`
- [x] `gc_assert_quality_gates` passes
- [x] Actual source diff re-screened as not security relevant with no GRC gaps

## Traceability

- IMPLEMENTS: DSL-105 <- implementations/python/packages/aces_sdl/_yaml_loader.py, DSL-105 <- implementations/python/packages/aces_sdl/parser.py, DSL-105 <- specs/sdl/document-model.md, DSL-105 <- specs/sdl/diagnostics.md
- TESTS: DSL-105 <- implementations/python/tests/test_yaml_mapping_keys.py, DSL-105 <- implementations/python/tests/test_mcp_server.py, DSL-105 <- implementations/python/tests/test_sdl_fuzz.py

## Checklist

- [x] Code follows project coding standards (`docs/explain/reference/coding-standards.md`)
- [x] FM1 injectivity invariant is stated and property-tested
- [x] Published schemas are unchanged because duplicate YAML entries cannot be represented by JSON object instances
- [x] Changelog fragment is not added; release-please owns release notes and versions
- [x] Normative and explanatory documentation is updated

## Documentation

Updated `specs/sdl/document-model.md`, `specs/sdl/diagnostics.md`, and the parser/testing guides.
