### PR TITLE
feat(libvirt): add guest-observed realization probes (ASR-519)

### DIFF
--- a/contracts/realization-envelopes/libvirt-qemu/guest-certified-appliance-v1.json
+++ b/contracts/realization-envelopes/libvirt-qemu/guest-certified-appliance-v1.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "realization-envelope/v1",
+  "contract_id": "realization-envelope-v1",
+  "id": "libvirt-qemu.guest-certified-appliance.v1",
+  "expression": {
+    "schema_version": "realization-envelope/v1",
+    "id": "libvirt-qemu.guest-certified-appliance.expression.v1",
+    "scope": "scenario",
+    "domains": {},
+    "bindings": [],
+    "closure": []
+  },
+  "configuration": {
+    "mode": "guest-certified-appliance",
+    "architecture": "x86_64",
+    "image_policy": "guest-certified-appliance/serial-fact-channel/v1",
+    "network_policy": "generated-appliance-network",
+    "supported_node_types": [
+      "switch",
+      "vm"
+    ],
+    "supported_os_families": [
+      "linux"
+    ],
+    "supported_content_types": [
+      "file"
+    ],
+    "supported_account_features": [
+      "disabled",
+      "groups",
+      "home",
+      "shell"
+    ],
+    "supports_acls": false,
+    "memory_mib": {
+      "minimum": 64,
+      "maximum": 256
+    },
+    "vcpus": {
+      "minimum": 1,
+      "maximum": 2
+    },
+    "configuration_digest": "sha256:b33ad469eaf1a47963e49da8adc7376fc22880ac3e6126b427239daa00dc6d99"
+  },
+  "concerns": [
+    {
+      "concern": "topology",
+      "disposition": "realized",
+      "observation_strength": "daemon-observed",
+      "mechanism": "libvirt-domain-network-readback",
+      "transformations": []
+    },
+    {
+      "concern": "architecture",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-uname-readback",
+      "transformations": []
+    },
+    {
+      "concern": "image",
+      "disposition": "realized",
+      "observation_strength": "daemon-observed",
+      "mechanism": "generated-appliance-attachment-readback",
+      "transformations": []
+    },
+    {
+      "concern": "resource-allocation",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-proc-resource-readback",
+      "transformations": []
+    },
+    {
+      "concern": "network",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-link-address-readback",
+      "transformations": []
+    },
+    {
+      "concern": "content-placement",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-file-content-readback",
+      "transformations": []
+    },
+    {
+      "concern": "account-placement",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-account-posture-readback",
+      "transformations": []
+    },
+    {
+      "concern": "feature-binding",
+      "disposition": "unsupported",
+      "observation_strength": "none",
+      "mechanism": null,
+      "transformations": []
+    },
+    {
+      "concern": "service",
+      "disposition": "realized",
+      "observation_strength": "guest-observed",
+      "mechanism": "guest-service-state-readback",
+      "transformations": []
+    },
+    {
+      "concern": "acl",
+      "disposition": "unsupported",
+      "observation_strength": "none",
+      "mechanism": null,
+      "transformations": []
+    }
+  ],
+  "digest": "sha256:8416a600a6f1864e1b80e49fa60eef5f423f9249f2ea7dc56e14d8a669e33e2e"
+}

--- a/docs/decisions/issue-715-asr-519-guest-observed-libvirt-probes-preflight.md
+++ b/docs/decisions/issue-715-asr-519-guest-observed-libvirt-probes-preflight.md
@@ -1,0 +1,326 @@
+# Issue 715 / ASR-519 Guest-Observed Libvirt Probes Preflight
+
+Date: 2026-07-12
+
+Requirement: ASR-519.
+
+This note records architecture guardrails for proving selected libvirt
+realization concerns from inside a booted guest. It is guidance only: it does
+not add a probe, image, envelope, schema, test, command, or evidence report, and
+it is not an implementation plan.
+
+No new ADR is required. ADR-021, ADR-066, ADR-070, and the issue #100 and #714
+preflights already own the claim, evidence-plane, realization-envelope, and
+configuration-identity boundaries. This note applies them to issue #715.
+
+## Binding Sources
+
+- ADR-021 requires falsification evidence before a realization claim is
+  demonstrated. ADR-066 separates operational observation, captured evidence,
+  and derived analysis.
+- ADR-070, `specs/formal/realization/envelope-semantics.md`, the published
+  `realization-envelope-v1` schema, and issue #100 own configuration-specific
+  envelope identity and the closed concern/observation-strength taxonomy.
+- `specs/formal/realization/explicitness-and-realization.md` and the issue #491
+  preflight own SEM-218 exactness and origin provenance. Backend origin is not
+  guest observation.
+- The issue #603, #604, #606, #714, and #615 preflights own production apply,
+  ownership-safe teardown, target conformance, TechVault honesty, and evidence
+  boundaries.
+- `ProvisioningPlan`, `Realization`, `DomainSpec`, `NetworkSpec`,
+  `RealizationObservation`, `DriverResult`, `Diagnostic`, `ApplyResult`,
+  `OperationStatus`, and `RuntimeSnapshot` are the incumbent execution and
+  error surfaces.
+- `aces_operations.libvirt_evidence_run`, `_evidence_run_artifact`,
+  `_evidence_run_validation`, `_techvault_cleanup`, `run_artifacts`, and the
+  existing libvirt CLI commands are the incumbent proof workflow, validation,
+  redaction, cleanup, and persistence surfaces.
+
+## Architecture Decisions And Guardrails
+
+### Select a truthful material configuration
+
+The current `techvault-appliance-v1` configuration deliberately boots a
+generated initramfs and rejects concrete images, cloud-init placements,
+services, and ACLs. Keep that configuration and its weaker daemon-only claims
+intact. It cannot become guest-certified merely by attaching a probe.
+
+A canonical image/appliance proof must select a separately constructible,
+versioned material configuration and realization envelope. Its secret-free
+configuration identity must cover at least the image/appliance content digest,
+architecture, boot/firmware and seed policy, network policy, supported concern
+set, guest-observation transport and probe-policy version, and any injected
+environment-visible attestation mechanism. Host paths, connection handles,
+credentials, and raw probe configuration are not digest input.
+
+Image resolution is target configuration, not new SDL syntax. An authored
+source reference must resolve through one closed, configuration-selected image
+policy to bytes whose digest is verified before libvirt mutation. A missing,
+mutable, mismatched, or unverified image fails before define/create. Do not
+overwrite the existing published envelope while retaining its id/digest, and do
+not reuse the generic envelope's driver-reported cloud-init claims as
+guest-observed proof.
+
+Manifest capability projection, selected envelope, provisioner identity, driver
+mode, and evidence binding must all name the same normalized configuration.
+Unknown or inconsistent target config continues to fail through
+`_validate_config_keys()`, `_selected_driver_mode()`,
+`_validate_manifest_mode()`, the envelope loader, and the provisioner's
+identity gate.
+
+### Keep one concern inventory and layered observation
+
+Derive the field-addressed concern inventory from the existing
+`ProvisioningPlan` -> `Realization` -> `DomainSpec`/`NetworkSpec` path. Probe
+selection, comparison, artifact assembly, and mutation tests consume that
+inventory; they must not reparse SDL, inspect YAML dictionaries, or maintain a
+TechVault-only list of authored fields.
+
+The maximum claim is determined per field, not per domain:
+
+| Claim | Required observation |
+| --- | --- |
+| Native domain identity/state and attachment | ownership-checked libvirt daemon readback |
+| Requested vCPU/memory | exact daemon definition plus bounded guest-visible CPU/memory corroboration |
+| Guest network attachment/addressing | daemon attachment correlated with guest link/MAC/IP readback |
+| Boot readiness | fresh guest transport response; domain `active` is insufficient |
+| Initialization completion | guest-reported completion for the selected initialization mechanism, with no failure state |
+| File/directory/dataset content | guest-side type, mode, bounded membership, and expected content digest/value comparison |
+| Account properties | guest-side identity, groups, home, shell, disabled/credential posture without returning credential material |
+| Feature/service state | concern-specific installed/configured identity and active behavior; a listener alone is insufficient |
+| ACL behavior | positive and negative behavior at the declared enforcement boundary, correlated to the affected addresses |
+
+`RealizationObservation` remains the bounded fact carrier and must use
+`ObservationStrength.GUEST_OBSERVED` only for a fact actually read at that
+boundary. `Diagnostic` remains the failure carrier. Evolve the existing
+`NativeLibvirtProbe` injection seam to return typed observations and diagnostics;
+do not add a public probe DTO, exception hierarchy, logging-only result, or a
+second concern enum. The current boolean/`detail` `ProbeResult` is not an
+evidence or error envelope and raw detail must not escape the probe boundary.
+
+Observation proceeds through explicit stages: daemon state, guest transport,
+initialization, concern probes, and cleanup. A later stage cannot repair or
+upgrade a failed earlier stage. Each stage has a bounded timeout under one
+overall deadline. Timeout, partial boot, unavailable transport, initialization
+failure, missing/malformed/duplicate observation, unexpected type, and value
+mismatch are distinct stable diagnostic codes that name the safe ACES address
+and observation level.
+
+### Prove freshness and bind the evidence
+
+A fresh per-run, non-secret challenge must enter the guest through the selected
+configuration's disclosed initialization/attestation mechanism and be read back
+by the guest observer. The challenge is operational augmentation, not authored
+scenario meaning; classify it through the existing SEM-225 augmentation carrier
+as environment-visible and comparability-relevant. A prior boot, cached
+cloud-init result, old driver snapshot, or response without the current
+challenge cannot pass.
+
+Clear run-local observation state before every apply attempt and publish it only
+after complete validation. Evidence assembly binds each normalized observation
+to the control-plane operation id, ACES operation/address and field path,
+concern, selected envelope/configuration digests, image/appliance digest,
+observation source and level, UTC observation timestamp, and a `sha256:`
+correlation derived from the ownership-verified native identity. Raw UUIDs,
+MACs used only for correlation, instance ids, and native names are not portable
+identity and do not enter the artifact.
+
+The operation id is joined at the operations/control-plane boundary after
+`submit_provisioning()`; do not widen `LibvirtDriver.realize()` merely to pass
+control-plane metadata into backend IO. The driver supplies fresh addressed
+observations and bounded native correlation material, while the evidence
+producer supplies run/operation identity and timestamp. Validation must reject
+unjoined, stale, cross-operation, cross-envelope, or duplicate evidence.
+
+### Fail and clean up closed
+
+Production realization still enters through
+`RuntimeManager.plan()` -> `RuntimeControlPlane.submit_provisioning()` ->
+`LibvirtProvisioner.apply()` -> the injected native driver. A direct driver
+call, hand-built `DomainSpec`, pre-existing VM, or fake connection can test a
+leaf but cannot satisfy the native-proof gate.
+
+Guest proof is part of commit eligibility for the selected guest-certified
+configuration. The provisioner cannot return success, changed addresses, a new
+envelope/provenance claim, or a committed snapshot until all required daemon
+and guest observations pass. Every failure preserves the baseline portable
+snapshot. Unexpected backend output still passes through `_call_backend_apply()`
+and the existing result/snapshot/SEM-218 gates.
+
+Cleanup runs in a `finally`-equivalent path after every attempt, including
+planning-after-construction errors, timeout, partial boot, guest-probe failure,
+artifact-validation failure, and interrupted evidence production. The current
+live/evidence flows clean only after a successful captured snapshot; issue #715
+must not retain that limitation. Reuse deterministic ACES ownership stamps and
+verified absence rules. Verify domains, networks, owned filters, disks/overlays,
+seed media, and probe/attestation artifacts. Missing private driver inventory or
+lookup uncertainty is not absence. Any residual or unverifiable category makes
+the run fail and is reported only as a safe category/count plus ACES address.
+
+### Keep one claim-bearing evidence workflow
+
+Extend the existing `aces.libvirt.scenario-evidence-run/v1` local artifact and
+`validate_libvirt_evidence_run_artifact()` source/redaction/binding gates; do not
+create a guest-proof schema or a third report assembler. The TechVault live-gate
+manifest may remain a bounded operator summary, but it must delegate to or
+reference the same validated run result rather than independently decide guest
+success. It may never upgrade or omit the canonical artifact's source labels,
+failures, binding, or cleanup outcome.
+
+Continue using `run_artifact_path()`, safe run-id validation, canonical JSON,
+full pre-write validation, and `atomic_write_json_artifact()`. A failed run may
+emit a redacted failure artifact only when the validator admits that shape; it
+cannot set `passed=true` or publish realized facts after failed cleanup. The
+operator/self-hosted entry point remains under `aces libvirt`; it must retain an
+explicit destructive confirmation and return non-zero on any failed stage.
+
+Hermetic fake-driver/probe tests validate orchestration and falsification but
+cannot satisfy the native-proof gate. Committed proof must be generated by the
+same operator command against a real libvirt/QEMU daemon through the production
+apply path, validate before commit, identify the selected envelope/image by
+digest, and contain no host-specific or secret material.
+
+## Required Cross-Cutting Reuse
+
+- **SDL and planning:** `parse_sdl_file()`, closed SDL models,
+  `instantiate_scenario()`, `SemanticValidator`, `RuntimeManager.plan()`,
+  `CompiledRealizationRequirement`, `realization_support_diagnostics()`,
+  `realization_disclosure()`, `ProvisioningPlan`, and processor dependency and
+  delete ordering.
+- **Envelope and manifest:** `BackendRealizationEnvelopeModel`,
+  `RealizationConcern`, `ConcernDisposition`, `ObservationStrength`, canonical
+  digest helpers, `load_libvirt_realization_envelope()`,
+  `backend_manifest_payload()`, `BackendManifestV2Model`, and existing
+  capability/manifest consistency checks.
+- **Libvirt:** `interpret_provisioning_plan()`, `Realization`, `DomainSpec`,
+  `NetworkSpec`, `RealizationObservation`, `DriverResult`,
+  `TechVaultNativeLibvirtDriver`, structured XML builders, private seed
+  workspace safeguards, deterministic ownership UUIDs, safe absence detection,
+  and current rollback/cleanup helpers.
+- **Runtime, errors, and persistence:** `RuntimeControlPlane`,
+  `_call_backend_diagnostics()`, `_call_backend_apply()`, `Diagnostic`,
+  `Severity`, `OperationReceipt`, `OperationStatus`, `ApplyResult`,
+  `RuntimeSnapshot`, realization provenance/envelope carriers,
+  `ControlPlaneStore`, atomic store writes, and audit events.
+- **Evidence and workflow:** `libvirt_evidence_run`,
+  `validate_libvirt_evidence_run_artifact()`, `redaction_violations()`,
+  `cleanup_native_snapshot()`, `run_artifact_path()`,
+  `atomic_write_json_artifact()`, the existing libvirt CLI group, and
+  `run_target_conformance()` for backend-neutral conformance.
+- **Contract governance:** if the published envelope carrier changes, update
+  the hand-governed schema, model/generator parity, valid/invalid fixtures,
+  `contracts/schema-publication-manifest.json`, packaged corpus, and
+  `specs/authority/authority-boundary.yaml`. Evolve the shared contract only
+  when its current closed fields cannot express a portable fact.
+
+## Security And Whole-Path Gates
+
+- **Input and shape:** scenario input passes the parser, closed Pydantic shapes,
+  semantic validator, compiler/planner, plan model, envelope relation/identity,
+  provisioner capability and concern gates, then observation completeness/value
+  validation. Unknown input or unsupported concerns fail before IO; probes do
+  not parse authored SDL.
+- **Target/config:** all driver mode, image policy, probe transport/policy,
+  timeouts, and augmentation choices pass one extended `_validate_config_keys()`
+  and normalized target configuration before manifest construction. Library
+  callers receive the same validation as Typer callers. Image bytes and probe
+  policy are digest-bound; paths, handles, and credentials are not serialized.
+- **Authentication/authorization:** no new HTTP route is required. In-process
+  operator execution retains explicit confirmation. If provisioning is exposed
+  through HTTP, it keeps `ControlPlaneSecurityConfig.strict_defaults()`, verified
+  bearer/proxy identity, backend/operator roles, target scope after either auth
+  mechanism, request-size limits, idempotency fingerprints, and audit events.
+  Guest-probe capability does not grant a caller general guest command execution.
+- **Secrets:** connection URIs with user information, passwords, tokens, private
+  keys, cloud-init bodies, account material, probe credentials, environment
+  dumps, and connector/transport reprs never enter CLI argv, digests,
+  diagnostics, audit details, snapshots, fixtures, artifacts, or command output.
+  Prefer a libvirt guest-agent or equivalent injected transport that needs no
+  guest credential. Any later SSH transport must use an injected credential
+  handle, strict host identity verification, and bounded allowlisted operations;
+  accepting a password/key CLI option is forbidden.
+- **Guest/host OS exposure:** attach only the selected, disclosed guest channel;
+  it is not a generic remote shell surface. Probe requests are fixed,
+  concern-specific, read-only, size-bounded, and allowlisted. Parse bounded
+  structured output and discard raw stdout/stderr. If a subprocess leaf is
+  unavoidable, use fixed argv, no `shell=True`, bounded timeouts, controlled
+  cwd/environment, and no secret argv or environment entries. Keep libvirt
+  imports lazy and generated secret-bearing seed files under the existing
+  ownership/symlink/mode protections.
+- **Errors/logging:** public failure data is a stable package-local diagnostic
+  code, safe address, observation level, and generic message. Do not propagate
+  `ProbeResult.detail`, `str(exc)`, raw agent replies, XML, command output,
+  paths, native ids, or tracebacks through `_backend_call_failed()`, CLI output,
+  logs, audit, or evidence. Operational logging is supplemental; it cannot be
+  the only failure or evidence channel.
+- **Persistence/evidence:** runtime snapshots and operation records retain only
+  portable ACES state and typed envelope/provenance. Guest facts belong in the
+  validated evidence artifact, not `RuntimeSnapshot.metadata`,
+  `ApplyResult.details`, or a private observation database. The shared redaction
+  gate and artifact validator run before atomic persistence.
+- **Cleanup:** the host layer verifies owned native objects and every run-local
+  artifact category after success and failure. It neither scans/deletes by name
+  prefix nor treats all lookup exceptions as absence. Residual state prevents a
+  passing operation/report.
+
+## Extensibility Seam
+
+The seam is the normalized material target configuration selecting a versioned
+envelope plus the existing injected `NativeLibvirtProbe`/driver boundary. The
+observer is parameterized by the canonical concern inventory, safe ACES
+address/field path, per-stage/overall deadlines, selected probe-policy version,
+and envelope identity, and returns only `RealizationObservation` and
+`Diagnostic` values.
+
+A second image family, architecture, initialization system, libvirt guest-agent
+implementation, or credential-free transport adds a configuration/envelope
+variant and observer implementation. It must not require changes to SDL syntax,
+the concern enum, planner actions, runtime control-plane route, error hierarchy,
+store, report writer, or evidence-source taxonomy.
+
+## Falsification Guardrails And Gotchas
+
+- Mutations must cover false handles, inactive/wrong domains, CPU or memory
+  mismatch, wrong NIC/MAC/IP, missing current challenge, stale prior snapshot,
+  partial boot, guest transport timeout/unavailability, omitted or failed
+  initialization, missing/duplicate/type-coerced facts, wrong content digest,
+  wrong account properties, synthesized/wrong service identity, ACL positive or
+  negative mismatch, envelope/image/probe-policy mismatch, and incomplete
+  cleanup.
+- Every failed mutation asserts a failed `OperationStatus`, empty
+  `changed_addresses`, unchanged in-memory and persisted baseline snapshots, no
+  new realization provenance/envelope claim, no passing evidence artifact, and
+  verified cleanup or a redacted residual-state failure.
+- Do not equate active domain, ping, TCP connect, guest-agent availability,
+  cloud-init `done`, package presence, process presence, or a seed descriptor
+  with all nested concerns. Each is evidence only for its exact named fact.
+- Do not compare authored/planned data with an echo written into the guest and
+  call that independent observation. The probe must read the realized system or
+  exercise behavior at the enforcement boundary; the per-run challenge proves
+  freshness, not concern correctness.
+- Do not expose a generic command runner, accept probe commands from SDL, infer
+  checks from service names, duplicate the concern inventory, or make raw probe
+  output part of the evidence schema.
+- Do not let a fake driver/probe, direct driver call, hand-built spec,
+  pre-existing guest, skipped cleanup, or self-skipping integration test produce
+  the committed native proof.
+- Do not broaden the default hermetic verification graph to require libvirt,
+  QEMU/KVM, privileges, a host image, network access, or credentials. The
+  self-hosted proof is an explicit separate gate.
+
+## Non-Goals And Implementation Boundaries
+
+- No implementation of issue #715 in this preflight.
+- No new SDL syntax, universal image registry, backend profile, capability
+  language, public probe DTO/schema, control-plane route, exception hierarchy,
+  persistence service, observation database, or parallel report format.
+- No general-purpose guest management/remote-execution API and no participant
+  observation capability claim. Backend guest realization evidence remains
+  operational/captured evidence unless a separate governed participant boundary
+  projects it.
+- No claim that one canonical guest proves all images, operating systems,
+  services, ACL mechanisms, TechVault applications, SOC detection quality,
+  backend equivalence, or envelope subsumption.
+- No issue #716 honesty-conformance runner or issue #717 final scenario
+  certification. Issue #715 supplies concern-specific observations that those
+  downstream gates may consume.

--- a/examples/scenarios/techvault-guest-certified.sdl.yaml
+++ b/examples/scenarios/techvault-guest-certified.sdl.yaml
@@ -1,0 +1,29 @@
+name: techvault-guest-certified
+description: >
+  Minimal guest-certified realization scenario. One bounded appliance node boots
+  through the production apply path and is certified from inside the guest -
+  resource allocation, network addressing, file content, and service state are
+  read back from the realized guest, freshness-bound to a per-run challenge, with
+  verified teardown. Used by `aces libvirt techvault guest-certify` and the
+  opt-in real-daemon proof.
+nodes:
+  guest-net:
+    type: switch
+  guest-vm:
+    type: vm
+    os: linux
+    resources: {ram: 128 MiB, cpu: 1}
+    services:
+      - {name: beacon, port: 9000, protocol: tcp}
+content:
+  guest-marker:
+    type: file
+    target: guest-vm
+    path: /etc/aces/marker
+    text: "guest-certified realization marker\n"
+    sensitive: false
+infrastructure:
+  guest-net:
+    properties: {cidr: 192.0.2.0/24, gateway: 192.0.2.1, internal: true}
+  guest-vm:
+    links: [guest-net]

--- a/implementations/python/packages/aces_backend_libvirt/_techvault_native_helpers.py
+++ b/implementations/python/packages/aces_backend_libvirt/_techvault_native_helpers.py
@@ -1,0 +1,28 @@
+"""Small self-contained helpers for the native TechVault libvirt drivers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def default_connector(connection_uri: str) -> object | None:
+    """Open a real libvirt connection lazily (imports libvirt on demand)."""
+
+    import importlib
+
+    libvirt = importlib.import_module("libvirt")
+    return libvirt.open(connection_uri)
+
+
+def default_kernel_path() -> Path:
+    """Return a host kernel image path suitable for booting a generated appliance."""
+
+    running = Path(f"/boot/vmlinuz-{os.uname().release}")
+    if running.exists():
+        return running
+    candidates = sorted(Path("/boot").glob("vmlinuz-*"))
+    return candidates[-1] if candidates else Path("/boot/vmlinuz")
+
+
+__all__ = ["default_connector", "default_kernel_path"]

--- a/implementations/python/packages/aces_backend_libvirt/envelopes.py
+++ b/implementations/python/packages/aces_backend_libvirt/envelopes.py
@@ -12,11 +12,13 @@ from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel,
 class LibvirtDriverMode(str, Enum):
     GENERIC = "generic"
     TECHVAULT_APPLIANCE = "techvault-appliance"
+    GUEST_CERTIFIED_APPLIANCE = "guest-certified-appliance"
 
 
 _ARTIFACTS = {
     LibvirtDriverMode.GENERIC: "generic-v1.json",
     LibvirtDriverMode.TECHVAULT_APPLIANCE: "techvault-appliance-v1.json",
+    LibvirtDriverMode.GUEST_CERTIFIED_APPLIANCE: "guest-certified-appliance-v1.json",
 }
 
 

--- a/implementations/python/packages/aces_backend_libvirt/guest_appliance.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_appliance.py
@@ -28,9 +28,14 @@ _APPLETS = (
     "netstat", "nc", "kill", "cp", "ls",
 )  # fmt: skip
 
-_BASELINE_PASSWD = "root:x:0:0:root:/root:/bin/sh\n"  # noqa: S105 - an /etc/passwd file line, not a credential
-_BASELINE_GROUP = "root:x:0:\n"
-_BASELINE_SHADOW = "root:x:19000:0:99999:7:::\n"
+# Baseline account-database file lines written into the appliance rootfs. These
+# are /etc/{passwd,group,shadow} record formats for the root account, not secrets.
+_ROOT_ACCOUNT_LINE = "root:x:0:0:root:/root:/bin/sh\n"
+_ROOT_GROUP_LINE = "root:x:0:\n"
+_ROOT_SHADOW_LINE = "root:x:19000:0:99999:7:::\n"
+
+# Shared shell guard reused across the account/service read loops.
+_SKIP_IF_NO_NAME = '  [ -n "$name" ] || continue'
 
 
 @dataclass
@@ -68,9 +73,9 @@ def _write_guest_root(root: Path, busybox_path: Path, domain: Mapping[str, objec
     shutil.copy2(busybox_path, bin_dir / "busybox")
     for applet in _APPLETS:
         (bin_dir / applet).symlink_to("busybox")
-    (etc_dir / "passwd").write_text(_BASELINE_PASSWD, encoding="utf-8")
-    (etc_dir / "group").write_text(_BASELINE_GROUP, encoding="utf-8")
-    (etc_dir / "shadow").write_text(_BASELINE_SHADOW, encoding="utf-8")
+    (etc_dir / "passwd").write_text(_ROOT_ACCOUNT_LINE, encoding="utf-8")
+    (etc_dir / "group").write_text(_ROOT_GROUP_LINE, encoding="utf-8")
+    (etc_dir / "shadow").write_text(_ROOT_SHADOW_LINE, encoding="utf-8")
     _write_placement_specs(guest_dir, files_dir, domain)
     (guest_dir / "domain.json").write_text(json.dumps(domain, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     (root / "init").write_text(_init_script(domain), encoding="utf-8")
@@ -147,7 +152,7 @@ def _init_script(domain: Mapping[str, object]) -> str:
 _REALIZE_SNIPPET = [
     "if [ -f /etc/aces/guest/accounts ]; then",
     "while IFS='|' read name groups shell home disabled; do",
-    '  [ -n "$name" ] || continue',
+    _SKIP_IF_NO_NAME,
     '  [ -n "$home" ] || home=/home/$name',
     '  [ -n "$shell" ] || shell=/bin/sh',
     '  mkdir -p "$home"',
@@ -160,8 +165,12 @@ _REALIZE_SNIPPET = [
     "  for g in $groups; do",
     "    IFS=$oldifs",
     '    [ -n "$g" ] || { IFS=,; continue; }',
-    '    if grep -q "^$g:" /etc/group; then sed -i "s/^\\($g:[^:]*:[^:]*:\\)\\(.*\\)$/\\1\\2,$name/" /etc/group;',
-    "    else gid=$(awk -F: 'BEGIN{m=2000}$3>=m{m=$3+1}END{print m}' /etc/group); echo \"$g:x:$gid:$name\" >> /etc/group; fi",
+    '    if grep -q "^$g:" /etc/group; then',
+    '      sed -i "s/^\\($g:[^:]*:[^:]*:\\)\\(.*\\)$/\\1\\2,$name/" /etc/group',
+    "    else",
+    "      gid=$(awk -F: 'BEGIN{m=2000}$3>=m{m=$3+1}END{print m}' /etc/group)",
+    '      echo "$g:x:$gid:$name" >> /etc/group',
+    "    fi",
     "    IFS=,",
     "  done",
     "  IFS=$oldifs",
@@ -177,7 +186,7 @@ _REALIZE_SNIPPET = [
     "fi",
     "if [ -f /etc/aces/guest/services ]; then",
     "while IFS='|' read name port; do",
-    '  [ -n "$name" ] || continue',
+    _SKIP_IF_NO_NAME,
     '  ( while true; do echo aces-guest-service | nc -l -p "$port" >/dev/null 2>&1 || sleep 1; done ) &',
     "  echo $! > /run/aces-svc-$name.pid",
     "done < /etc/aces/guest/services",
@@ -210,12 +219,13 @@ _REPORT_SNIPPET = [
     "fi",
     "if [ -f /etc/aces/guest/accounts ]; then",
     "while IFS='|' read name groups shell home disabled; do",
-    '  [ -n "$name" ] || continue',
+    _SKIP_IF_NO_NAME,
     '  entry=$(grep "^$name:" /etc/passwd) || continue',
     '  uid=$(echo "$entry" | cut -d: -f3)',
     '  h=$(echo "$entry" | cut -d: -f6)',
     '  sh=$(echo "$entry" | cut -d: -f7)',
-    "  grps=$(awk -F: -v u=\"$name\" '{n=split($4,a,\",\"); for(i=1;i<=n;i++) if(a[i]==u) print $1}' /etc/group | sort | tr '\\n' ',' | sed 's/,$//')",
+    '  grps=$(awk -F: -v u="$name" \'{n=split($4,a,","); for(i=1;i<=n;i++) if(a[i]==u) print $1}\' /etc/group \\',
+    "    | sort | tr '\\n' ',' | sed 's/,$//')",
     '  spw=$(grep "^$name:" /etc/shadow | cut -d: -f2)',
     "  dis=0; case \"$spw\" in '!'*|'*'*) dis=1;; esac",
     '  echo "account $name $uid $h $sh $dis $grps"',
@@ -223,7 +233,7 @@ _REPORT_SNIPPET = [
     "fi",
     "if [ -f /etc/aces/guest/services ]; then",
     "while IFS='|' read name port; do",
-    '  [ -n "$name" ] || continue',
+    _SKIP_IF_NO_NAME,
     '  lis=0; netstat -ln 2>/dev/null | grep -q ":$port " && lis=1',
     '  pid=0; [ -f "/run/aces-svc-$name.pid" ] && kill -0 "$(cat /run/aces-svc-$name.pid)" 2>/dev/null && pid=1',
     '  echo "service $name $port $lis $pid"',

--- a/implementations/python/packages/aces_backend_libvirt/guest_appliance.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_appliance.py
@@ -1,0 +1,241 @@
+"""Guest-observing initramfs appliance for guest-certified libvirt runs.
+
+Builds a BusyBox appliance that realizes bounded account, file, and service
+placements inside the guest, then reads the *realized* system back (its own
+``/proc``, ``/etc``, link state, file digests, service state) and emits a
+bounded, line-oriented fact report to the file-backed serial fact channel. The
+fresh per-run challenge is read from the kernel command line, so the appliance
+image bytes (and therefore their digest) are independent of the challenge.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .techvault_appliance import _cpio_newc, _shell_quote
+
+_APPLETS = (
+    "sh", "mount", "mdev", "ip", "ifconfig", "sleep", "cat", "hostname", "printf", "echo",
+    "uname", "nproc", "awk", "sed", "grep", "cut", "tr", "sort", "head", "wc",
+    "sha256sum", "stat", "id", "mkdir", "chmod", "chown", "touch", "dirname", "basename",
+    "netstat", "nc", "kill", "cp", "ls",
+)  # fmt: skip
+
+_BASELINE_PASSWD = "root:x:0:0:root:/root:/bin/sh\n"  # noqa: S105 - an /etc/passwd file line, not a credential
+_BASELINE_GROUP = "root:x:0:\n"
+_BASELINE_SHADOW = "root:x:19000:0:99999:7:::\n"
+
+
+@dataclass
+class GuestObservingInitramfsBuilder:
+    """Build a guest-observing appliance that certifies concerns from inside."""
+
+    busybox_path: Path = Path("/usr/bin/busybox")
+
+    def build(self, *, domain: Mapping[str, object], target: Path) -> Path:
+        with tempfile.TemporaryDirectory(prefix="aces-guest-initramfs-") as tmp:
+            root = Path(tmp)
+            _write_guest_root(root, self.busybox_path, domain)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            payload = _cpio_newc(root)
+            target.write_bytes(gzip.compress(payload, compresslevel=6))
+        return target
+
+
+def _write_guest_root(root: Path, busybox_path: Path, domain: Mapping[str, object]) -> None:
+    bin_dir = root / "bin"
+    etc_dir = root / "etc"
+    guest_dir = etc_dir / "aces" / "guest"
+    files_dir = guest_dir / "files"
+    for directory in (
+        bin_dir,
+        files_dir,
+        root / "proc",
+        root / "sys",
+        root / "dev",
+        root / "tmp",
+        root / "run",
+        root / "home",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(busybox_path, bin_dir / "busybox")
+    for applet in _APPLETS:
+        (bin_dir / applet).symlink_to("busybox")
+    (etc_dir / "passwd").write_text(_BASELINE_PASSWD, encoding="utf-8")
+    (etc_dir / "group").write_text(_BASELINE_GROUP, encoding="utf-8")
+    (etc_dir / "shadow").write_text(_BASELINE_SHADOW, encoding="utf-8")
+    _write_placement_specs(guest_dir, files_dir, domain)
+    (guest_dir / "domain.json").write_text(json.dumps(domain, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (root / "init").write_text(_init_script(domain), encoding="utf-8")
+    os.chmod(root / "init", 0o700)
+    os.chmod(bin_dir / "busybox", 0o700)
+
+
+def _write_placement_specs(guest_dir: Path, files_dir: Path, domain: Mapping[str, object]) -> None:
+    accounts = [
+        "|".join(
+            (
+                str(item.get("name", "")),
+                ",".join(str(group) for group in _as_sequence(item.get("groups"))),
+                str(item.get("shell", "")),
+                str(item.get("home", "")),
+                "1" if item.get("disabled") else "0",
+            )
+        )
+        for item in _as_sequence(domain.get("accounts"))
+        if isinstance(item, Mapping)
+    ]
+    content_lines = []
+    for index, item in enumerate(_as_sequence(domain.get("content"))):
+        if not isinstance(item, Mapping):
+            continue
+        (files_dir / str(index)).write_text(str(item.get("content", "")), encoding="utf-8")
+        content_lines.append("|".join((str(item.get("path", "")), str(item.get("mode", "0644")), str(index))))
+    services = [
+        "|".join((str(item.get("name", "")), str(item.get("port", ""))))
+        for item in _as_sequence(domain.get("services"))
+        if isinstance(item, Mapping)
+    ]
+    (guest_dir / "accounts").write_text("\n".join(accounts) + ("\n" if accounts else ""), encoding="utf-8")
+    (guest_dir / "content").write_text("\n".join(content_lines) + ("\n" if content_lines else ""), encoding="utf-8")
+    (guest_dir / "services").write_text("\n".join(services) + ("\n" if services else ""), encoding="utf-8")
+
+
+def _init_script(domain: Mapping[str, object]) -> str:
+    lines = [
+        "#!/bin/sh",
+        "export PATH=/bin",
+        "mount -t proc proc /proc",
+        "mount -t sysfs sysfs /sys",
+        "mount -t devtmpfs devtmpfs /dev 2>/dev/null || mdev -s",
+        f"hostname {_shell_quote(str(domain.get('name', 'aces-node')))}",
+        "ip link set lo up",
+        "for iface_path in /sys/class/net/*; do",
+        "  iface=${iface_path##*/}",
+        '  [ "$iface" = lo ] && continue',
+        '  mac=$(cat "$iface_path/address")',
+        '  ip link set "$iface" up',
+        '  case "$mac" in',
+    ]
+    for interface in _as_sequence(domain.get("interfaces")):
+        if not isinstance(interface, Mapping):
+            continue
+        lines.extend(
+            [
+                f"    {interface.get('mac')})",
+                f'      ip addr add {interface.get("ip")}/{interface.get("cidr_prefix")} dev "$iface"',
+                "      ;;",
+            ]
+        )
+    lines.extend(["  esac", "done"])
+    lines.extend(_REALIZE_SNIPPET)
+    lines.append("sleep 1")
+    lines.append("challenge=$(cat /proc/cmdline | tr ' ' '\\n' | sed -n 's/^aces.challenge=//p')")
+    lines.extend(_REPORT_SNIPPET)
+    lines.append("while true; do sleep 3600; done")
+    lines.append("")
+    return "\n".join(lines)
+
+
+_REALIZE_SNIPPET = [
+    "if [ -f /etc/aces/guest/accounts ]; then",
+    "while IFS='|' read name groups shell home disabled; do",
+    '  [ -n "$name" ] || continue',
+    '  [ -n "$home" ] || home=/home/$name',
+    '  [ -n "$shell" ] || shell=/bin/sh',
+    '  mkdir -p "$home"',
+    "  uid=$(awk -F: 'BEGIN{m=1000}$3>=m{m=$3+1}END{print m}' /etc/passwd)",
+    '  echo "$name:x:$uid:$uid:aces:$home:$shell" >> /etc/passwd',
+    '  echo "$name:x:$uid:" >> /etc/group',
+    '  if [ "$disabled" = 1 ]; then echo "$name:!:19000:0:99999:7:::" >> /etc/shadow;',
+    '  else echo "$name:*:19000:0:99999:7:::" >> /etc/shadow; fi',
+    "  oldifs=$IFS; IFS=,",
+    "  for g in $groups; do",
+    "    IFS=$oldifs",
+    '    [ -n "$g" ] || { IFS=,; continue; }',
+    '    if grep -q "^$g:" /etc/group; then sed -i "s/^\\($g:[^:]*:[^:]*:\\)\\(.*\\)$/\\1\\2,$name/" /etc/group;',
+    "    else gid=$(awk -F: 'BEGIN{m=2000}$3>=m{m=$3+1}END{print m}' /etc/group); echo \"$g:x:$gid:$name\" >> /etc/group; fi",
+    "    IFS=,",
+    "  done",
+    "  IFS=$oldifs",
+    "done < /etc/aces/guest/accounts",
+    "fi",
+    "if [ -f /etc/aces/guest/content ]; then",
+    "while IFS='|' read path mode idx; do",
+    '  [ -n "$path" ] || continue',
+    '  mkdir -p "$(dirname "$path")"',
+    '  cp "/etc/aces/guest/files/$idx" "$path"',
+    '  chmod "$mode" "$path"',
+    "done < /etc/aces/guest/content",
+    "fi",
+    "if [ -f /etc/aces/guest/services ]; then",
+    "while IFS='|' read name port; do",
+    '  [ -n "$name" ] || continue',
+    '  ( while true; do echo aces-guest-service | nc -l -p "$port" >/dev/null 2>&1 || sleep 1; done ) &',
+    "  echo $! > /run/aces-svc-$name.pid",
+    "done < /etc/aces/guest/services",
+    "fi",
+]
+
+_REPORT_SNIPPET = [
+    "FC=/dev/ttyS1",
+    "{",
+    "echo 'ACES-GUEST-FACTS v1'",
+    'echo "challenge $challenge"',
+    'echo "architecture $(uname -m)"',
+    'echo "vcpus $(nproc)"',
+    "echo \"memory_mib $(awk '/MemTotal/{print int($2/1024)}' /proc/meminfo)\"",
+    "for iface_path in /sys/class/net/*; do",
+    '  iface=${iface_path##*/}; [ "$iface" = lo ] && continue',
+    '  mac=$(cat "$iface_path/address")',
+    "  ip4=$(ip -4 -o addr show dev \"$iface\" 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)",
+    '  up=0; [ "$(cat "$iface_path/operstate" 2>/dev/null)" = up ] && up=1',
+    '  echo "iface $mac ${ip4:-none} $up"',
+    "done",
+    "if [ -f /etc/aces/guest/content ]; then",
+    "while IFS='|' read path mode idx; do",
+    '  [ -n "$path" ] || continue',
+    '  [ -f "$path" ] || continue',
+    "  d=$(sha256sum \"$path\" | cut -d' ' -f1)",
+    "  m=$(stat -c '%a' \"$path\" 2>/dev/null)",
+    '  echo "content $path $d $m"',
+    "done < /etc/aces/guest/content",
+    "fi",
+    "if [ -f /etc/aces/guest/accounts ]; then",
+    "while IFS='|' read name groups shell home disabled; do",
+    '  [ -n "$name" ] || continue',
+    '  entry=$(grep "^$name:" /etc/passwd) || continue',
+    '  uid=$(echo "$entry" | cut -d: -f3)',
+    '  h=$(echo "$entry" | cut -d: -f6)',
+    '  sh=$(echo "$entry" | cut -d: -f7)',
+    "  grps=$(awk -F: -v u=\"$name\" '{n=split($4,a,\",\"); for(i=1;i<=n;i++) if(a[i]==u) print $1}' /etc/group | sort | tr '\\n' ',' | sed 's/,$//')",
+    '  spw=$(grep "^$name:" /etc/shadow | cut -d: -f2)',
+    "  dis=0; case \"$spw\" in '!'*|'*'*) dis=1;; esac",
+    '  echo "account $name $uid $h $sh $dis $grps"',
+    "done < /etc/aces/guest/accounts",
+    "fi",
+    "if [ -f /etc/aces/guest/services ]; then",
+    "while IFS='|' read name port; do",
+    '  [ -n "$name" ] || continue',
+    '  lis=0; netstat -ln 2>/dev/null | grep -q ":$port " && lis=1',
+    '  pid=0; [ -f "/run/aces-svc-$name.pid" ] && kill -0 "$(cat /run/aces-svc-$name.pid)" 2>/dev/null && pid=1',
+    '  echo "service $name $port $lis $pid"',
+    "done < /etc/aces/guest/services",
+    "fi",
+    "echo 'init complete'",
+    '} > "$FC" 2>/dev/null',
+]
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    return value if isinstance(value, list | tuple) else ()
+
+
+__all__ = ["GuestObservingInitramfsBuilder"]

--- a/implementations/python/packages/aces_backend_libvirt/guest_certified_driver.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_certified_driver.py
@@ -1,0 +1,153 @@
+"""Native libvirt driver that certifies realization from inside the guest.
+
+Extends :class:`TechVaultNativeLibvirtDriver` with the guest-observation stage:
+after ownership-safe define/create and daemon readback, it boots a
+guest-observing appliance, reads concern-specific facts back through the
+credential-free fact channel, and refuses to finalize unless the fresh,
+challenge-bound guest observations match the requested realization. The
+challenge rides the kernel command line (not the appliance image), so the
+appliance content digest stays stable across runs while every report is bound to
+this boot.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+from aces_contracts.diagnostics import Diagnostic
+
+from .driver import DomainSpec, NetworkSpec, RealizationObservation
+from .drivers.libvirt import _aces_uuid
+from .guest_appliance import GuestObservingInitramfsBuilder
+from .guest_observation import GuestObservationConfig, correlation_digest, observe_guest
+from .guest_transport import FileSerialGuestFactTransport, GuestFactTransport
+from .techvault_appliance import InitramfsBuilder
+from .techvault_concerns import guest_certified_spec_diagnostics
+from .techvault_matrix import domain_xml as _domain_xml
+from .techvault_matrix import native_matrix as _native_matrix
+from .techvault_native import DriverResult, TechVaultNativeLibvirtDriver, _artifact_token
+
+_SAFE_CHALLENGE_RE = re.compile(r"^[a-f0-9]{16,64}$")
+
+
+@dataclass
+class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
+    """Realize TechVault domains and certify concerns from inside the guest."""
+
+    driver_mode: ClassVar[str] = "guest-certified-appliance"
+
+    initramfs_builder: InitramfsBuilder = field(default_factory=GuestObservingInitramfsBuilder)
+    guest_transport: GuestFactTransport = field(default_factory=FileSerialGuestFactTransport)
+    guest_config: GuestObservationConfig = field(default_factory=GuestObservationConfig)
+    challenge: str | None = None
+    last_guest_observations: tuple[RealizationObservation, ...] = ()
+    last_guest_facts: dict[str, object] = field(default_factory=dict)
+    last_guest_binding: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.challenge is None:
+            self.challenge = secrets.token_hex(16)
+        elif not _SAFE_CHALLENGE_RE.match(self.challenge):
+            raise ValueError("guest-certified challenge must be a lowercase hex token")
+
+    def _admission_diagnostics(
+        self,
+        networks: tuple[NetworkSpec, ...],
+        domains: tuple[DomainSpec, ...],
+        envelope: object,
+    ) -> list[Diagnostic]:
+        from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel
+
+        assert isinstance(envelope, BackendRealizationEnvelopeModel)
+        return guest_certified_spec_diagnostics(
+            networks=networks,
+            domains=domains,
+            envelope=envelope,
+            name_prefix=self.name_prefix,
+        )
+
+    def _build_matrix(
+        self,
+        networks: tuple[NetworkSpec, ...],
+        domains: tuple[DomainSpec, ...],
+    ) -> dict[str, object]:
+        return _native_matrix(
+            networks=networks,
+            domains=domains,
+            name_prefix=self.name_prefix,
+            include_placements=True,
+        )
+
+    def _render_domain_xml(self, domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
+        address = str(domain.get("address", ""))
+        fact_channel = self._fact_channel_path(address)
+        fact_channel.parent.mkdir(parents=True, exist_ok=True)
+        return _domain_xml(
+            domain,
+            kernel=kernel,
+            initrd=initrd,
+            appliance="guest-certified",
+            challenge=self.challenge,
+            fact_channel_path=fact_channel,
+        )
+
+    def _guest_stage(
+        self,
+        connection: object,
+        matrix: Mapping[str, object],
+        specs: tuple[tuple[NetworkSpec, ...], tuple[DomainSpec, ...]],
+        observations: tuple[RealizationObservation, ...],
+    ) -> tuple[tuple[RealizationObservation, ...], list[Diagnostic]]:
+        del connection, specs, observations
+        assert self.challenge is not None
+        outcome = observe_guest(
+            matrix=matrix,
+            transport=self.guest_transport,
+            challenge=self.challenge,
+            config=self.guest_config,
+            fact_channel_path_for=self._fact_channel_path,
+        )
+        if outcome.diagnostics:
+            return (), list(outcome.diagnostics)
+        self.last_guest_observations = outcome.observations
+        self.last_guest_facts = dict(outcome.facts)
+        self.last_guest_binding = self._guest_binding(matrix)
+        return outcome.observations, []
+
+    def destroy(self, *, networks: tuple[str, ...], domains: tuple[str, ...]) -> DriverResult:
+        result = super().destroy(networks=networks, domains=domains)
+        if (networks or domains) and not result.diagnostics:
+            self.last_guest_observations = ()
+            self.last_guest_facts = {}
+            self.last_guest_binding = {}
+        return result
+
+    def _cleanup_artifacts(self, address: str) -> None:
+        super()._cleanup_artifacts(address)
+        with suppress(OSError):
+            self._fact_channel_path(address).unlink()
+
+    def _fact_channel_path(self, address: str) -> Path:
+        return self.state_dir / "guest-facts" / f"{_artifact_token(address)}.facts"
+
+    def _guest_binding(self, matrix: Mapping[str, object]) -> dict[str, object]:
+        domains = [item for item in matrix.get("domains", ()) if isinstance(item, Mapping)]
+        correlations = {
+            str(domain.get("address", "")): correlation_digest(_aces_uuid(str(domain.get("address", ""))))
+            for domain in domains
+        }
+        return {
+            "challenge": self.challenge,
+            "probe_policy": self.guest_config.probe_policy,
+            "correlations": correlations,
+        }
+
+
+__all__ = ["GuestCertifiedLibvirtDriver"]

--- a/implementations/python/packages/aces_backend_libvirt/guest_observation.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_observation.py
@@ -1,0 +1,351 @@
+"""Concern-specific guest observation for guest-certified libvirt runs.
+
+Boot readiness and initialization completion are staged gates that must pass
+before any concern fact is trusted; a later stage never repairs an earlier one.
+Each accepted fact is read *from inside the realized guest* (its own ``/proc``,
+``/sys``, ``/etc`` and link/file/account/service state), not echoed from the
+plan, and is carried as a :class:`RealizationObservation` with
+``ObservationStrength.GUEST_OBSERVED``. Failures are stable, redacted
+:class:`Diagnostic` codes that name the safe ACES address and the observation
+level. A fresh per-run challenge proves the report belongs to this boot, not a
+cached or prior one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.realization_envelope import ObservationStrength, RealizationConcern
+
+from .driver import RealizationObservation
+from .guest_transport import (
+    FAILURE_TIMEOUT,
+    FAILURE_UNAVAILABLE,
+    GuestFactTransport,
+    parse_guest_facts,
+)
+from .techvault_matrix import as_sequence
+
+_DOMAIN = "runtime"
+_CODE_TRANSPORT_UNAVAILABLE = "libvirt-backend.guest.transport-unavailable"
+_CODE_BOOT_TIMEOUT = "libvirt-backend.guest.boot-timeout"
+_CODE_INIT_INCOMPLETE = "libvirt-backend.guest.init-incomplete"
+_CODE_CHALLENGE_MISMATCH = "libvirt-backend.guest.challenge-mismatch"
+_CODE_OBSERVATION_MALFORMED = "libvirt-backend.guest.observation-malformed"
+_CODE_OBSERVATION_DUPLICATE = "libvirt-backend.guest.observation-duplicate"
+_CODE_OBSERVATION_MISSING = "libvirt-backend.guest.observation-missing"
+_CODE_OBSERVATION_MISMATCH = "libvirt-backend.guest.observation-mismatch"
+
+_FAILURE_CODES = {FAILURE_UNAVAILABLE: _CODE_TRANSPORT_UNAVAILABLE, FAILURE_TIMEOUT: _CODE_BOOT_TIMEOUT}
+
+_MESSAGES = {
+    _CODE_TRANSPORT_UNAVAILABLE: "Guest fact transport was unavailable at the disclosed channel.",
+    _CODE_BOOT_TIMEOUT: "Guest did not report boot readiness within the observation deadline.",
+    _CODE_INIT_INCOMPLETE: "Guest initialization did not report completion.",
+    _CODE_CHALLENGE_MISMATCH: "Guest report did not carry the fresh per-run challenge.",
+    _CODE_OBSERVATION_MALFORMED: "Guest report was malformed or missing its bounded fact header.",
+    _CODE_OBSERVATION_DUPLICATE: "Guest report carried duplicate observations for a singleton fact.",
+    _CODE_OBSERVATION_MISSING: "Guest did not report every concern in the guest-observed inventory.",
+    _CODE_OBSERVATION_MISMATCH: "Guest-observed concern values did not match the requested realization.",
+}
+
+_Key = tuple[str, str, RealizationConcern]
+
+
+@dataclass(frozen=True)
+class GuestObservationConfig:
+    """Per-stage and overall deadlines plus the disclosed probe-policy version."""
+
+    probe_policy: str = "serial-fact-channel/v1"
+    transport_deadline_seconds: float = 120.0
+
+
+@dataclass(frozen=True)
+class _GuestOutcome:
+    observations: tuple[RealizationObservation, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
+    facts: Mapping[str, object] = field(default_factory=dict)
+
+
+def guest_observation(
+    address: str, field_path: str, concern: RealizationConcern, value: object
+) -> RealizationObservation:
+    """Build a bounded guest-observed fact carrier for one concern field."""
+
+    return RealizationObservation(
+        address=address,
+        field_path=field_path,
+        concern=concern,
+        source=ObservationStrength.GUEST_OBSERVED,
+        value=value,
+    )
+
+
+def observe_guest(
+    *,
+    matrix: Mapping[str, object],
+    transport: GuestFactTransport,
+    challenge: str,
+    config: GuestObservationConfig,
+    fact_channel_path_for: Callable[[str], Path],
+) -> _GuestOutcome:
+    """Run the staged guest observation for every domain in ``matrix``."""
+
+    observations: list[RealizationObservation] = []
+    diagnostics: list[Diagnostic] = []
+    facts_by_address: dict[str, object] = {}
+    domains = [item for item in as_sequence(matrix.get("domains")) if isinstance(item, Mapping)]
+    for domain in domains:
+        address = str(domain.get("address", ""))
+        parsed, stage_diag = _read_and_validate(domain, transport, challenge, config, fact_channel_path_for)
+        if stage_diag is not None:
+            diagnostics.append(stage_diag)
+            continue
+        assert parsed is not None
+        observations.extend(_domain_observations(domain, parsed))
+        facts_by_address[address] = _bounded_facts(parsed)
+    if not diagnostics:
+        expected = expected_guest_observations(domains)
+        diagnostics.extend(guest_observation_diagnostics(expected=expected, observations=tuple(observations)))
+    return _GuestOutcome(tuple(observations), tuple(diagnostics), facts_by_address)
+
+
+def _read_and_validate(
+    domain: Mapping[str, object],
+    transport: GuestFactTransport,
+    challenge: str,
+    config: GuestObservationConfig,
+    fact_channel_path_for: Callable[[str], Path],
+) -> tuple[Mapping[str, object] | None, Diagnostic | None]:
+    address = str(domain.get("address", ""))
+    text, failure = transport.read(
+        address=address,
+        fact_channel_path=fact_channel_path_for(address),
+        deadline_seconds=config.transport_deadline_seconds,
+    )
+    if failure is not None:
+        return None, _diagnostic(_FAILURE_CODES.get(failure, _CODE_TRANSPORT_UNAVAILABLE), address)
+    parsed = parse_guest_facts(text or "")
+    if parsed is None:
+        return None, _diagnostic(_CODE_OBSERVATION_MALFORMED, address)
+    if parsed.get("duplicate"):
+        return None, _diagnostic(_CODE_OBSERVATION_DUPLICATE, address)
+    if not parsed.get("init_complete"):
+        return None, _diagnostic(_CODE_INIT_INCOMPLETE, address)
+    if parsed.get("challenge") != challenge:
+        return None, _diagnostic(_CODE_CHALLENGE_MISMATCH, address)
+    return parsed, None
+
+
+def _domain_observations(
+    domain: Mapping[str, object], parsed: Mapping[str, object]
+) -> tuple[RealizationObservation, ...]:
+    address = str(domain.get("address", ""))
+    requested_memory = _as_int(domain.get("memory_mib"))
+    guest_memory = _as_int(parsed.get("memory_mib"))
+    corroborated = requested_memory > 0 and requested_memory // 2 <= guest_memory <= requested_memory
+    return (
+        guest_observation(
+            address, "guest-architecture", RealizationConcern.ARCHITECTURE, str(parsed.get("architecture") or "")
+        ),
+        guest_observation(address, "guest-vcpus", RealizationConcern.RESOURCE_ALLOCATION, _as_int(parsed.get("vcpus"))),
+        guest_observation(address, "guest-memory-corroborated", RealizationConcern.RESOURCE_ALLOCATION, corroborated),
+        guest_observation(address, "guest-network", RealizationConcern.NETWORK, _observed_network(parsed)),
+        guest_observation(address, "guest-content", RealizationConcern.CONTENT_PLACEMENT, _observed_content(parsed)),
+        guest_observation(address, "guest-account", RealizationConcern.ACCOUNT_PLACEMENT, _observed_accounts(parsed)),
+        guest_observation(address, "guest-service", RealizationConcern.SERVICE, _observed_services(parsed)),
+    )
+
+
+def expected_guest_observations(domains: Sequence[Mapping[str, object]]) -> dict[_Key, object]:
+    """Project the guest-observed inventory the plan requires per domain."""
+
+    expected: dict[_Key, object] = {}
+    for domain in domains:
+        address = str(domain.get("address", ""))
+        expected[(address, "guest-architecture", RealizationConcern.ARCHITECTURE)] = "x86_64"
+        expected[(address, "guest-vcpus", RealizationConcern.RESOURCE_ALLOCATION)] = _as_int(domain.get("vcpus"))
+        expected[(address, "guest-memory-corroborated", RealizationConcern.RESOURCE_ALLOCATION)] = True
+        expected[(address, "guest-network", RealizationConcern.NETWORK)] = _expected_network(domain)
+        expected[(address, "guest-content", RealizationConcern.CONTENT_PLACEMENT)] = _expected_content(domain)
+        expected[(address, "guest-account", RealizationConcern.ACCOUNT_PLACEMENT)] = _expected_accounts(domain)
+        expected[(address, "guest-service", RealizationConcern.SERVICE)] = _expected_services(domain)
+    return expected
+
+
+def guest_observation_diagnostics(
+    *,
+    expected: Mapping[_Key, object],
+    observations: tuple[RealizationObservation, ...],
+) -> list[Diagnostic]:
+    """Require exactly one matching guest-observed fact per expected concern field."""
+
+    observed: dict[_Key, list[RealizationObservation]] = {}
+    for item in observations:
+        observed.setdefault((item.address, item.field_path, item.concern), []).append(item)
+    missing: set[str] = set()
+    mismatched: set[str] = set()
+    for key, expected_value in expected.items():
+        candidates = observed.get(key, [])
+        if not candidates or any(item.source is not ObservationStrength.GUEST_OBSERVED for item in candidates):
+            missing.add(key[0])
+        elif (
+            len(candidates) != 1
+            or type(candidates[0].value) is not type(expected_value)
+            or candidates[0].value != expected_value
+        ):
+            mismatched.add(key[0])
+    diagnostics = [_diagnostic(_CODE_OBSERVATION_MISSING, address) for address in sorted(missing)]
+    diagnostics.extend(_diagnostic(_CODE_OBSERVATION_MISMATCH, address) for address in sorted(mismatched - missing))
+    return diagnostics
+
+
+def correlation_digest(native_identity: str) -> str:
+    """Return a redacted sha256 correlation for an ownership-verified native id."""
+
+    return "sha256:" + hashlib.sha256(native_identity.encode("utf-8")).hexdigest()
+
+
+# --- observed projections (actual guest readings) ------------------------------
+
+
+def _observed_network(parsed: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('mac')}|{item.get('ipv4')}"
+            for item in as_sequence(parsed.get("interfaces"))
+            if isinstance(item, Mapping) and item.get("up")
+        )
+    )
+
+
+def _observed_content(parsed: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('path')}|{item.get('sha256')}|{_norm_mode(str(item.get('mode', '')))}"
+            for item in as_sequence(parsed.get("content"))
+            if isinstance(item, Mapping)
+        )
+    )
+
+
+def _observed_accounts(parsed: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(_account_token(item) for item in as_sequence(parsed.get("accounts")) if isinstance(item, Mapping))
+    )
+
+
+def _observed_services(parsed: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('name')}|{item.get('port')}|{_flag(item.get('listening'))}|{_flag(item.get('pid_present'))}"
+            for item in as_sequence(parsed.get("services"))
+            if isinstance(item, Mapping)
+        )
+    )
+
+
+# --- expected projections (plan-derived) ---------------------------------------
+
+
+def _expected_network(domain: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('mac')}|{item.get('ip')}"
+            for item in as_sequence(domain.get("interfaces"))
+            if isinstance(item, Mapping)
+        )
+    )
+
+
+def _expected_content(domain: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('path')}|{_content_digest(str(item.get('content', '')))}|{_norm_mode(str(item.get('mode', '')))}"
+            for item in as_sequence(domain.get("content"))
+            if isinstance(item, Mapping)
+        )
+    )
+
+
+def _expected_accounts(domain: Mapping[str, object]) -> tuple[str, ...]:
+    tokens = []
+    for item in as_sequence(domain.get("accounts")):
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("name", ""))
+        home = str(item.get("home") or f"/home/{name}")
+        shell = str(item.get("shell") or "/bin/sh")
+        groups = ",".join(sorted(str(group) for group in as_sequence(item.get("groups"))))
+        tokens.append(f"{name}|{home}|{shell}|{_flag(item.get('disabled'))}|{groups}")
+    return tuple(sorted(tokens))
+
+
+def _expected_services(domain: Mapping[str, object]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            f"{item.get('name')}|{item.get('port')}|1|1"
+            for item in as_sequence(domain.get("services"))
+            if isinstance(item, Mapping)
+        )
+    )
+
+
+def _account_token(item: Mapping[str, object]) -> str:
+    name = str(item.get("name", ""))
+    home = str(item.get("home", ""))
+    shell = str(item.get("shell", ""))
+    groups = ",".join(sorted(str(group) for group in as_sequence(item.get("groups"))))
+    return f"{name}|{home}|{shell}|{_flag(item.get('disabled'))}|{groups}"
+
+
+def _bounded_facts(parsed: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "architecture": str(parsed.get("architecture") or ""),
+        "vcpus": _as_int(parsed.get("vcpus")),
+        "memory_mib": _as_int(parsed.get("memory_mib")),
+        "interfaces": _observed_network(parsed),
+        "content": _observed_content(parsed),
+        "accounts": _observed_accounts(parsed),
+        "services": _observed_services(parsed),
+    }
+
+
+def _content_digest(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _norm_mode(mode: str) -> str:
+    return mode.lstrip("0") or "0"
+
+
+def _flag(value: object) -> str:
+    return "1" if value else "0"
+
+
+def _as_int(value: object) -> int:
+    return value if isinstance(value, int) else -1
+
+
+def _diagnostic(code: str, address: str) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        domain=_DOMAIN,
+        address=address,
+        message=_MESSAGES.get(code, "Guest observation did not succeed."),
+        severity=Severity.ERROR,
+    )
+
+
+__all__ = [
+    "GuestObservationConfig",
+    "correlation_digest",
+    "expected_guest_observations",
+    "guest_observation",
+    "guest_observation_diagnostics",
+    "observe_guest",
+]

--- a/implementations/python/packages/aces_backend_libvirt/guest_observation.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_observation.py
@@ -130,15 +130,27 @@ def _read_and_validate(
     if failure is not None:
         return None, _diagnostic(_FAILURE_CODES.get(failure, _CODE_TRANSPORT_UNAVAILABLE), address)
     parsed = parse_guest_facts(text or "")
-    if parsed is None:
-        return None, _diagnostic(_CODE_OBSERVATION_MALFORMED, address)
-    if parsed.get("duplicate"):
-        return None, _diagnostic(_CODE_OBSERVATION_DUPLICATE, address)
-    if not parsed.get("init_complete"):
-        return None, _diagnostic(_CODE_INIT_INCOMPLETE, address)
-    if parsed.get("challenge") != challenge:
-        return None, _diagnostic(_CODE_CHALLENGE_MISMATCH, address)
+    code = _staging_failure_code(parsed, challenge)
+    if code is not None:
+        return None, _diagnostic(code, address)
     return parsed, None
+
+
+def _staging_failure_code(parsed: Mapping[str, object] | None, challenge: str) -> str | None:
+    """Return the first staged-observation failure code, or None when the report is trusted.
+
+    Boot readiness, initialization, and freshness are ordered gates; a later gate never
+    repairs an earlier one, so the first failing check wins.
+    """
+
+    if parsed is None:
+        return _CODE_OBSERVATION_MALFORMED
+    staged = (
+        (bool(parsed.get("duplicate")), _CODE_OBSERVATION_DUPLICATE),
+        (not parsed.get("init_complete"), _CODE_INIT_INCOMPLETE),
+        (parsed.get("challenge") != challenge, _CODE_CHALLENGE_MISMATCH),
+    )
+    return next((code for failed, code in staged if failed), None)
 
 
 def _domain_observations(
@@ -263,13 +275,12 @@ def _expected_network(domain: Mapping[str, object]) -> tuple[str, ...]:
 
 
 def _expected_content(domain: Mapping[str, object]) -> tuple[str, ...]:
-    return tuple(
-        sorted(
-            f"{item.get('path')}|{_content_digest(str(item.get('content', '')))}|{_norm_mode(str(item.get('mode', '')))}"
-            for item in as_sequence(domain.get("content"))
-            if isinstance(item, Mapping)
-        )
-    )
+    def token(item: Mapping[str, object]) -> str:
+        digest = _content_digest(str(item.get("content", "")))
+        mode = _norm_mode(str(item.get("mode", "")))
+        return f"{item.get('path')}|{digest}|{mode}"
+
+    return tuple(sorted(token(item) for item in as_sequence(domain.get("content")) if isinstance(item, Mapping)))
 
 
 def _expected_accounts(domain: Mapping[str, object]) -> tuple[str, ...]:

--- a/implementations/python/packages/aces_backend_libvirt/guest_transport.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_transport.py
@@ -1,0 +1,218 @@
+"""Credential-free guest-fact transport for guest-certified libvirt runs.
+
+The guest-certified appliance writes a bounded, line-oriented fact report to a
+dedicated file-backed serial channel (``/dev/ttyS1`` in the guest maps to a
+run-local host file). The host reads that file through the :class:`GuestFactTransport`
+seam and parses it into a bounded structured mapping. This transport carries no
+credential and is not a general command channel: the guest emits fixed,
+read-only, size-bounded facts and nothing else. A future libvirt guest-agent
+transport can replace this implementation without changing the observer, the
+concern taxonomy, or the evidence schema.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+FACT_HEADER = "ACES-GUEST-FACTS v1"
+INIT_COMPLETE_MARKER = "init complete"
+
+# Bounds keep a hostile or malfunctioning guest from flooding host memory or the
+# evidence artifact. A well-formed report is far under every limit.
+_MAX_FACT_BYTES = 64 * 1024
+_MAX_LINES = 512
+_MAX_LINE_CHARS = 512
+_MAX_ENTRIES = 64
+
+# Stable transport-stage failure suffixes (namespaced by the observer).
+FAILURE_UNAVAILABLE = "transport-unavailable"
+FAILURE_TIMEOUT = "boot-timeout"
+
+
+class GuestFactTransport(Protocol):
+    """Read one guest's bounded fact report through the disclosed channel."""
+
+    def read(self, *, address: str, fact_channel_path: Path, deadline_seconds: float) -> tuple[str | None, str | None]:
+        """Return ``(text, None)`` on success or ``(None, failure_suffix)`` on failure."""
+        ...
+
+
+@dataclass(frozen=True)
+class FileSerialGuestFactTransport:
+    """Read the guest fact report from a file-backed serial channel.
+
+    Polls the run-local host file the guest serial device is bound to until the
+    guest has emitted its terminal ``init complete`` marker or the deadline
+    elapses. Never raises: an unreadable channel is reported as a typed failure
+    suffix so the caller emits a redacted diagnostic instead of an exception.
+    """
+
+    poll_seconds: float = 0.5
+
+    def read(self, *, address: str, fact_channel_path: Path, deadline_seconds: float) -> tuple[str | None, str | None]:
+        del address
+        deadline = time.monotonic() + max(0.0, deadline_seconds)
+        saw_channel = False
+        while True:
+            text = _read_bounded(fact_channel_path)
+            if text is not None:
+                saw_channel = True
+                if _contains_terminal_marker(text):
+                    return text, None
+            if time.monotonic() >= deadline:
+                if saw_channel:
+                    return None, FAILURE_TIMEOUT
+                return None, FAILURE_UNAVAILABLE
+            time.sleep(self.poll_seconds)
+
+
+def _read_bounded(path: Path) -> str | None:
+    try:
+        with path.open("rb") as stream:
+            payload = stream.read(_MAX_FACT_BYTES + 1)
+    except OSError:
+        return None
+    if len(payload) > _MAX_FACT_BYTES:
+        payload = payload[:_MAX_FACT_BYTES]
+    return payload.decode("utf-8", errors="replace")
+
+
+def _contains_terminal_marker(text: str) -> bool:
+    return any(line.strip() == INIT_COMPLETE_MARKER for line in text.splitlines())
+
+
+def parse_guest_facts(text: str) -> Mapping[str, object] | None:
+    """Parse the bounded line-oriented guest report into a structured mapping.
+
+    Returns ``None`` when the header is absent or the report is unparseable.
+    Unknown lines are ignored; bounds are enforced so a malformed report cannot
+    produce an unbounded structure.
+    """
+
+    lines = text.splitlines()[:_MAX_LINES]
+    if not lines or lines[0].strip() != FACT_HEADER:
+        return None
+    facts: dict[str, object] = {
+        "challenge": None,
+        "init_complete": False,
+        "architecture": None,
+        "vcpus": None,
+        "memory_mib": None,
+        "interfaces": [],
+        "content": [],
+        "accounts": [],
+        "services": [],
+        "duplicate": False,
+    }
+    seen: set[str] = set()
+    for raw in lines[1:]:
+        _consume_line(facts, raw[:_MAX_LINE_CHARS].rstrip("\n"), seen)
+    return facts
+
+
+_SCALAR_KEYS = frozenset({"challenge", "architecture", "vcpus", "memory_mib"})
+
+
+def _consume_line(facts: dict[str, object], line: str, seen: set[str]) -> None:
+    stripped = line.strip()
+    if stripped == INIT_COMPLETE_MARKER:
+        facts["init_complete"] = True
+        return
+    parts = stripped.split(" ")
+    key = parts[0] if parts else ""
+    fields = parts[1:]
+    handler = _LINE_HANDLERS.get(key)
+    if handler is None:
+        return
+    # A repeated singleton fact (same key) or an identical repeated list line is a
+    # duplicate observation: record it distinctly rather than silently collapsing it.
+    marker = key if key in _SCALAR_KEYS else stripped
+    if marker in seen:
+        facts["duplicate"] = True
+    else:
+        seen.add(marker)
+    handler(facts, fields)
+
+
+def _set_scalar(name: str, cast: object):
+    def _apply(facts: dict[str, object], fields: list[str]) -> None:
+        if fields:
+            facts[name] = cast(fields[0]) if cast is not str else fields[0]  # type: ignore[operator]
+
+    return _apply
+
+
+def _append(name: str, arity: int, build):
+    def _apply(facts: dict[str, object], fields: list[str]) -> None:
+        bucket = facts[name]
+        if isinstance(bucket, list) and len(bucket) < _MAX_ENTRIES and len(fields) >= arity:
+            entry = build(fields)
+            if entry is not None:
+                bucket.append(entry)
+
+    return _apply
+
+
+def _to_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _iface_entry(fields: list[str]) -> dict[str, object]:
+    return {"mac": fields[0], "ipv4": fields[1], "up": fields[2] == "1"}
+
+
+def _content_entry(fields: list[str]) -> dict[str, object]:
+    return {"path": fields[0], "sha256": fields[1], "mode": fields[2]}
+
+
+def _account_entry(fields: list[str]) -> dict[str, object]:
+    # The trailing groups field is optional: an account with no supplemental groups
+    # emits five fields (the empty groups token is trimmed away by the transport).
+    groups = [group for group in fields[5].split(",") if group] if len(fields) > 5 else []
+    return {
+        "name": fields[0],
+        "uid": _to_int(fields[1]),
+        "home": fields[2],
+        "shell": fields[3],
+        "disabled": fields[4] == "1",
+        "groups": sorted(groups),
+    }
+
+
+def _service_entry(fields: list[str]) -> dict[str, object]:
+    return {
+        "name": fields[0],
+        "port": _to_int(fields[1]),
+        "listening": fields[2] == "1",
+        "pid_present": fields[3] == "1",
+    }
+
+
+_LINE_HANDLERS = {
+    "challenge": _set_scalar("challenge", str),
+    "architecture": _set_scalar("architecture", str),
+    "vcpus": _set_scalar("vcpus", _to_int),
+    "memory_mib": _set_scalar("memory_mib", _to_int),
+    "iface": _append("interfaces", 3, _iface_entry),
+    "content": _append("content", 3, _content_entry),
+    "account": _append("accounts", 5, _account_entry),
+    "service": _append("services", 4, _service_entry),
+}
+
+
+__all__ = [
+    "FACT_HEADER",
+    "FAILURE_TIMEOUT",
+    "FAILURE_UNAVAILABLE",
+    "INIT_COMPLETE_MARKER",
+    "FileSerialGuestFactTransport",
+    "GuestFactTransport",
+    "parse_guest_facts",
+]

--- a/implementations/python/packages/aces_backend_libvirt/guest_transport.py
+++ b/implementations/python/packages/aces_backend_libvirt/guest_transport.py
@@ -13,10 +13,12 @@ concern taxonomy, or the evidence schema.
 from __future__ import annotations
 
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+
+_Handler = Callable[[dict[str, object], list[str]], None]
 
 FACT_HEADER = "ACES-GUEST-FACTS v1"
 INIT_COMPLETE_MARKER = "init complete"
@@ -138,21 +140,19 @@ def _consume_line(facts: dict[str, object], line: str, seen: set[str]) -> None:
     handler(facts, fields)
 
 
-def _set_scalar(name: str, cast: object):
+def _set_scalar(name: str, cast: Callable[[str], object]) -> _Handler:
     def _apply(facts: dict[str, object], fields: list[str]) -> None:
         if fields:
-            facts[name] = cast(fields[0]) if cast is not str else fields[0]  # type: ignore[operator]
+            facts[name] = cast(fields[0])
 
     return _apply
 
 
-def _append(name: str, arity: int, build):
+def _append(name: str, arity: int, build: Callable[[list[str]], dict[str, object]]) -> _Handler:
     def _apply(facts: dict[str, object], fields: list[str]) -> None:
         bucket = facts[name]
         if isinstance(bucket, list) and len(bucket) < _MAX_ENTRIES and len(fields) >= arity:
-            entry = build(fields)
-            if entry is not None:
-                bucket.append(entry)
+            bucket.append(build(fields))
 
     return _apply
 

--- a/implementations/python/packages/aces_backend_libvirt/techvault_concerns.py
+++ b/implementations/python/packages/aces_backend_libvirt/techvault_concerns.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 from collections.abc import Mapping
 
 from aces_contracts.diagnostics import Diagnostic, Severity
@@ -52,6 +53,8 @@ _GUEST_PLACEMENTS = frozenset(
         "feature-binding",
     }
 )
+
+_SAFE_TOKEN_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 
 def techvault_admission_diagnostics(
@@ -190,6 +193,86 @@ def techvault_spec_diagnostics(
         diagnostics.extend(_domain_spec_diagnostics(spec, envelope, network_addresses))
     diagnostics.extend(_network_capacity_diagnostics(networks, domains))
     return diagnostics
+
+
+def guest_certified_spec_diagnostics(
+    *,
+    networks: tuple[NetworkSpec, ...],
+    domains: tuple[DomainSpec, ...],
+    envelope: BackendRealizationEnvelopeModel,
+    name_prefix: str,
+) -> list[Diagnostic]:
+    """Admit the bounded placements the guest-certified appliance realizes.
+
+    Unlike the daemon-only appliance, this mode boots accounts, files, and a
+    bounded service into the guest and reads them back, so those placements are
+    accepted. Requested images, ACLs, packages, runcmd, hostname overrides, and
+    out-of-envelope resources remain rejected before any native mutation.
+    """
+
+    diagnostics: list[Diagnostic] = []
+    diagnostics.extend(_name_diagnostics(networks, domains, name_prefix))
+    network_addresses = {spec.address for spec in networks}
+    for spec in networks:
+        diagnostics.extend(_network_spec_diagnostics(spec))
+    for spec in domains:
+        diagnostics.extend(_guest_domain_spec_diagnostics(spec, envelope, network_addresses))
+    diagnostics.extend(_network_capacity_diagnostics(networks, domains))
+    return diagnostics
+
+
+def _guest_domain_spec_diagnostics(
+    spec: DomainSpec,
+    envelope: BackendRealizationEnvelopeModel,
+    network_addresses: set[str],
+) -> list[Diagnostic]:
+    return [
+        *_domain_resource_diagnostics(spec, envelope),
+        *_domain_image_diagnostics(spec),
+        *_domain_metadata_diagnostics(spec),
+        *_domain_acl_diagnostics(spec),
+        *_domain_network_diagnostics(spec, network_addresses),
+        *_guest_placement_bounds_diagnostics(spec),
+        *_guest_service_bounds_diagnostics(spec),
+    ]
+
+
+def _guest_placement_bounds_diagnostics(spec: DomainSpec) -> list[Diagnostic]:
+    cloud_init = spec.cloud_init
+    if cloud_init is None:
+        return []
+    unsupported = (
+        bool(cloud_init.packages) or bool(cloud_init.runcmd) or cloud_init.hostname not in {None, "", spec.name}
+    )
+    unsafe_content = any(not _safe_guest_path(item.path) for item in cloud_init.write_files)
+    unsafe_account = any(not _SAFE_TOKEN_RE.match(user.name) for user in cloud_init.users)
+    if unsupported or unsafe_content or unsafe_account:
+        return [
+            _diagnostic(
+                _CODE_GUEST_PLACEMENT_UNSUPPORTED,
+                spec.address,
+                "Guest-certified appliance realizes bounded accounts and files only; "
+                "packages, runcmd, hostname overrides, unsafe paths, and unsafe account names are rejected.",
+            )
+        ]
+    return []
+
+
+def _guest_service_bounds_diagnostics(spec: DomainSpec) -> list[Diagnostic]:
+    invalid = any(not _SAFE_TOKEN_RE.match(service.name) or not 1 <= service.port <= 65535 for service in spec.services)
+    if not invalid:
+        return []
+    return [
+        _diagnostic(
+            _CODE_SERVICE_UNSUPPORTED,
+            spec.address,
+            "Guest-certified services require a libvirt-safe name and a valid port.",
+        )
+    ]
+
+
+def _safe_guest_path(path: str) -> bool:
+    return path.startswith("/") and ".." not in path.split("/")
 
 
 def _domain_spec_diagnostics(
@@ -477,6 +560,7 @@ def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
 
 
 __all__ = [
+    "guest_certified_spec_diagnostics",
     "techvault_admission_diagnostics",
     "techvault_observation_diagnostics",
     "techvault_spec_diagnostics",

--- a/implementations/python/packages/aces_backend_libvirt/techvault_matrix.py
+++ b/implementations/python/packages/aces_backend_libvirt/techvault_matrix.py
@@ -22,12 +22,19 @@ def native_matrix(
     networks: tuple[NetworkSpec, ...],
     domains: tuple[DomainSpec, ...],
     name_prefix: str,
+    include_placements: bool = False,
 ) -> dict[str, object]:
     runtime_networks = [runtime_network(spec, name_prefix) for spec in networks]
     runtime_network_by_address = {str(item["address"]): item for item in runtime_networks}
     allocations = allocate_interfaces(domains, runtime_network_by_address, name_prefix)
     runtime_domains = [
-        runtime_domain(spec, name_prefix=name_prefix, interfaces=allocations.get(spec.address, ())) for spec in domains
+        runtime_domain(
+            spec,
+            name_prefix=name_prefix,
+            interfaces=allocations.get(spec.address, ()),
+            include_placements=include_placements,
+        )
+        for spec in domains
     ]
     return {
         "substrate": _SUBSTRATE,
@@ -91,8 +98,9 @@ def runtime_domain(
     *,
     name_prefix: str,
     interfaces: tuple[dict[str, object], ...],
+    include_placements: bool = False,
 ) -> dict[str, object]:
-    return {
+    domain: dict[str, object] = {
         "address": spec.address,
         "name": spec.name,
         "runtime_name": runtime_name(name_prefix, spec.address, spec.name),
@@ -100,6 +108,35 @@ def runtime_domain(
         "vcpus": spec.vcpus,
         "interfaces": list(interfaces),
     }
+    if include_placements:
+        domain.update(domain_placements(spec))
+    return domain
+
+
+def domain_placements(spec: DomainSpec) -> dict[str, object]:
+    """Project a domain's realizable content/account/service placements.
+
+    Guest-certified realization boots these placements into the appliance and
+    reads them back from inside the guest; daemon-only modes ignore them.
+    """
+
+    cloud_init = spec.cloud_init
+    accounts = [
+        {
+            "name": user.name,
+            "groups": sorted(user.groups),
+            "shell": user.shell,
+            "home": user.home,
+            "disabled": bool(user.lock_passwd),
+        }
+        for user in (cloud_init.users if cloud_init is not None else ())
+    ]
+    content = [
+        {"path": item.path, "content": item.content, "mode": item.permissions}
+        for item in (cloud_init.write_files if cloud_init is not None else ())
+    ]
+    services = [{"name": service.name, "port": service.port} for service in spec.services]
+    return {"accounts": accounts, "content": content, "services": services}
 
 
 def network_xml(network: Mapping[str, object]) -> str:
@@ -124,7 +161,15 @@ def network_xml(network: Mapping[str, object]) -> str:
     return ET.tostring(root, encoding="unicode")
 
 
-def domain_xml(domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
+def domain_xml(
+    domain: Mapping[str, object],
+    *,
+    kernel: Path,
+    initrd: Path,
+    appliance: str = "techvault",
+    challenge: str | None = None,
+    fact_channel_path: Path | None = None,
+) -> str:
     root = ET.Element("domain", {"type": "qemu"})
     ET.SubElement(root, "name").text = str(domain.get("runtime_name", ""))
     ET.SubElement(root, "uuid").text = _aces_uuid(str(domain.get("address", "")))
@@ -134,7 +179,7 @@ def domain_xml(domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> s
     ET.SubElement(os_node, "type", {"arch": "x86_64"}).text = "hvm"
     ET.SubElement(os_node, "kernel").text = str(kernel)
     ET.SubElement(os_node, "initrd").text = str(initrd)
-    ET.SubElement(os_node, "cmdline").text = "console=ttyS0 panic=-1 aces.appliance=techvault"
+    ET.SubElement(os_node, "cmdline").text = _domain_cmdline(appliance, challenge)
     features = ET.SubElement(root, "features")
     ET.SubElement(features, "acpi")
     devices = ET.SubElement(root, "devices")
@@ -143,6 +188,10 @@ def domain_xml(domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> s
     ET.SubElement(serial, "target", {"port": "0"})
     console = ET.SubElement(devices, "console", {"type": "pty"})
     ET.SubElement(console, "target", {"type": "serial", "port": "0"})
+    if fact_channel_path is not None:
+        fact_serial = ET.SubElement(devices, "serial", {"type": "file"})
+        ET.SubElement(fact_serial, "source", {"path": str(fact_channel_path)})
+        ET.SubElement(fact_serial, "target", {"port": "1"})
     for interface_spec in as_sequence(domain.get("interfaces")):
         if not isinstance(interface_spec, Mapping):
             continue
@@ -175,4 +224,19 @@ def as_sequence(value: object) -> Sequence[object]:
     return value if isinstance(value, list | tuple) else ()
 
 
-__all__ = ["as_sequence", "domain_xml", "native_matrix", "network_xml", "runtime_name", "safe_name"]
+def _domain_cmdline(appliance: str, challenge: str | None) -> str:
+    parts = ["console=ttyS0", "panic=-1", f"aces.appliance={appliance}"]
+    if challenge:
+        parts.append(f"aces.challenge={challenge}")
+    return " ".join(parts)
+
+
+__all__ = [
+    "as_sequence",
+    "domain_placements",
+    "domain_xml",
+    "native_matrix",
+    "network_xml",
+    "runtime_name",
+    "safe_name",
+]

--- a/implementations/python/packages/aces_backend_libvirt/techvault_native.py
+++ b/implementations/python/packages/aces_backend_libvirt/techvault_native.py
@@ -214,18 +214,19 @@ class TechVaultNativeLibvirtDriver:
     ) -> DriverResult:
         networks, domains = specs
         network_handles, domain_handles = handles
-        observation_diagnostics = techvault_observation_diagnostics(
+        diagnostics = techvault_observation_diagnostics(
             networks=networks,
             domains=domains,
             result=DriverResult(observations=observations),
         )
-        if observation_diagnostics:
-            observation_diagnostics.extend(self._rollback(connection, network_handles, domain_handles))
-            return DriverResult(diagnostics=tuple(observation_diagnostics))
-        guest_observations, guest_diagnostics = self._guest_stage(connection, matrix, specs, observations)
-        if guest_diagnostics:
-            guest_diagnostics.extend(self._rollback(connection, network_handles, domain_handles))
-            return DriverResult(diagnostics=tuple(guest_diagnostics))
+        # Staged: the guest observation runs only after the daemon gate passes and a
+        # later stage never repairs an earlier one.
+        guest_observations: tuple[RealizationObservation, ...] = ()
+        if not diagnostics:
+            guest_observations, diagnostics = self._guest_stage(connection, matrix, specs, observations)
+        if diagnostics:
+            diagnostics.extend(self._rollback(connection, network_handles, domain_handles))
+            return DriverResult(diagnostics=tuple(diagnostics))
         try:
             binding = self._material_binding(envelope_digest, configuration_digest)
             snapshot = snapshot_from_observations(matrix, observations, binding=binding)
@@ -260,11 +261,13 @@ class TechVaultNativeLibvirtDriver:
     ) -> dict[str, object]:
         return _native_matrix(networks=networks, domains=domains, name_prefix=self.name_prefix)
 
-    def _render_domain_xml(self, domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
+    # Base extension hooks need no instance state; the guest-certified subclass overrides them.
+    @staticmethod
+    def _render_domain_xml(domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
         return _domain_xml(domain, kernel=kernel, initrd=initrd)
 
+    @staticmethod
     def _guest_stage(
-        self,
         connection: object,
         matrix: Mapping[str, object],
         specs: tuple[tuple[NetworkSpec, ...], tuple[DomainSpec, ...]],
@@ -584,7 +587,7 @@ def _artifact_token(address: str) -> str:
 
 _MESSAGES = {
     _CODE_UNAVAILABLE: "Libvirt connection is unavailable for native TechVault realization.",
-    _CODE_RESIDUAL_STATE: "Native TechVault rollback could not verify cleanup for '{address}'; residual state may remain.",
+    _CODE_RESIDUAL_STATE: "TechVault rollback could not verify cleanup for '{address}'; residual state may remain.",
     _CODE_OWNERSHIP_CONFLICT: "Native object for '{address}' is not owned by that ACES address; refusing mutation.",
     _CODE_READBACK_FAILED: "Native libvirt TechVault readback for '{address}' did not succeed.",
 }

--- a/implementations/python/packages/aces_backend_libvirt/techvault_native.py
+++ b/implementations/python/packages/aces_backend_libvirt/techvault_native.py
@@ -8,15 +8,20 @@ substrate boundary here is libvirt.
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar, Protocol, cast
+from typing import TYPE_CHECKING, ClassVar, Protocol, cast
 from urllib.parse import urlsplit
 
 from aces_contracts.diagnostics import Diagnostic, Severity
+
+from ._techvault_native_helpers import default_connector as _default_connector
+from ._techvault_native_helpers import default_kernel_path as _default_kernel_path
+
+if TYPE_CHECKING:
+    from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel
 
 from .driver import (
     DomainHandle,
@@ -149,15 +154,10 @@ class TechVaultNativeLibvirtDriver:
         domains: tuple[DomainSpec, ...],
     ) -> DriverResult:
         envelope = load_libvirt_realization_envelope(self.driver_mode)
-        spec_diagnostics = techvault_spec_diagnostics(
-            networks=networks,
-            domains=domains,
-            envelope=envelope,
-            name_prefix=self.name_prefix,
-        )
+        spec_diagnostics = self._admission_diagnostics(networks, domains, envelope)
         if spec_diagnostics:
             return DriverResult(diagnostics=tuple(spec_diagnostics))
-        matrix = _native_matrix(networks=networks, domains=domains, name_prefix=self.name_prefix)
+        matrix = self._build_matrix(networks, domains)
         self.state_dir.mkdir(parents=True, exist_ok=True)
         try:
             connection = self._conn()
@@ -222,6 +222,10 @@ class TechVaultNativeLibvirtDriver:
         if observation_diagnostics:
             observation_diagnostics.extend(self._rollback(connection, network_handles, domain_handles))
             return DriverResult(diagnostics=tuple(observation_diagnostics))
+        guest_observations, guest_diagnostics = self._guest_stage(connection, matrix, specs, observations)
+        if guest_diagnostics:
+            guest_diagnostics.extend(self._rollback(connection, network_handles, domain_handles))
+            return DriverResult(diagnostics=tuple(guest_diagnostics))
         try:
             binding = self._material_binding(envelope_digest, configuration_digest)
             snapshot = snapshot_from_observations(matrix, observations, binding=binding)
@@ -233,8 +237,43 @@ class TechVaultNativeLibvirtDriver:
         return DriverResult(
             networks=tuple(network_handles),
             domains=tuple(domain_handles),
-            observations=observations,
+            observations=(*observations, *guest_observations),
         )
+
+    def _admission_diagnostics(
+        self,
+        networks: tuple[NetworkSpec, ...],
+        domains: tuple[DomainSpec, ...],
+        envelope: object,
+    ) -> list[Diagnostic]:
+        return techvault_spec_diagnostics(
+            networks=networks,
+            domains=domains,
+            envelope=cast("BackendRealizationEnvelopeModel", envelope),
+            name_prefix=self.name_prefix,
+        )
+
+    def _build_matrix(
+        self,
+        networks: tuple[NetworkSpec, ...],
+        domains: tuple[DomainSpec, ...],
+    ) -> dict[str, object]:
+        return _native_matrix(networks=networks, domains=domains, name_prefix=self.name_prefix)
+
+    def _render_domain_xml(self, domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
+        return _domain_xml(domain, kernel=kernel, initrd=initrd)
+
+    def _guest_stage(
+        self,
+        connection: object,
+        matrix: Mapping[str, object],
+        specs: tuple[tuple[NetworkSpec, ...], tuple[DomainSpec, ...]],
+        observations: tuple[RealizationObservation, ...],
+    ) -> tuple[tuple[RealizationObservation, ...], list[Diagnostic]]:
+        """Daemon-only modes contribute no guest observations; subclasses override."""
+
+        del connection, matrix, specs, observations
+        return (), []
 
     def _define_networks(
         self, connection: object, matrix: Mapping[str, object]
@@ -344,7 +383,7 @@ class TechVaultNativeLibvirtDriver:
             )
             make_libvirt_readable(initrd)
             self._artifacts[address] = (kernel, initrd)
-            native = _call(connection, "defineXML", _domain_xml(domain, kernel=kernel, initrd=initrd))
+            native = _call(connection, "defineXML", self._render_domain_xml(domain, kernel=kernel, initrd=initrd))
             if not self.define_only:
                 native.create()
         except _OwnershipConflict:
@@ -517,13 +556,6 @@ class TechVaultNativeLibvirtDriver:
             return False
 
 
-def _default_connector(connection_uri: str) -> object | None:
-    import importlib
-
-    libvirt = importlib.import_module("libvirt")
-    return libvirt.open(connection_uri)
-
-
 def _call(connection: object, method_name: str, payload: str) -> _NativeResource:
     method = cast(Callable[[str], _NativeResource], getattr(connection, method_name))
     return method(payload)
@@ -550,23 +582,15 @@ def _artifact_token(address: str) -> str:
     return _aces_uuid(address).replace("-", "")
 
 
-def _default_kernel_path() -> Path:
-    running = Path(f"/boot/vmlinuz-{os.uname().release}")
-    if running.exists():
-        return running
-    candidates = sorted(Path("/boot").glob("vmlinuz-*"))
-    return candidates[-1] if candidates else Path("/boot/vmlinuz")
+_MESSAGES = {
+    _CODE_UNAVAILABLE: "Libvirt connection is unavailable for native TechVault realization.",
+    _CODE_RESIDUAL_STATE: "Native TechVault rollback could not verify cleanup for '{address}'; residual state may remain.",
+    _CODE_OWNERSHIP_CONFLICT: "Native object for '{address}' is not owned by that ACES address; refusing mutation.",
+    _CODE_READBACK_FAILED: "Native libvirt TechVault readback for '{address}' did not succeed.",
+}
+_DEFAULT_MESSAGE = "Native libvirt TechVault operation for '{address}' did not succeed."
 
 
 def _diagnostic(code: str, address: str) -> Diagnostic:
-    if code == _CODE_UNAVAILABLE:
-        message = "Libvirt connection is unavailable for native TechVault realization."
-    elif code == _CODE_RESIDUAL_STATE:
-        message = f"Native TechVault rollback could not verify cleanup for '{address}'; residual state may remain."
-    elif code == _CODE_OWNERSHIP_CONFLICT:
-        message = f"Native object for '{address}' is not owned by that ACES address; refusing mutation."
-    elif code == _CODE_READBACK_FAILED:
-        message = f"Native libvirt TechVault readback for '{address}' did not succeed."
-    else:
-        message = f"Native libvirt TechVault operation for '{address}' did not succeed."
+    message = _MESSAGES.get(code, _DEFAULT_MESSAGE).format(address=address)
     return Diagnostic(code=code, domain=_DOMAIN, address=address, message=message, severity=Severity.ERROR)

--- a/implementations/python/packages/aces_cli/libvirt.py
+++ b/implementations/python/packages/aces_cli/libvirt.py
@@ -10,6 +10,8 @@ import typer
 from aces_operations.libvirt_evidence_run import LibvirtEvidenceRunConfig, run_libvirt_evidence_run
 from aces_operations.techvault_live import TechVaultLiveConfig, validate_techvault_live
 
+_DEFAULT_CONNECTION_URI = "qemu:///system"
+
 app = typer.Typer(help="Libvirt backend operations.")
 techvault_app = typer.Typer(help="TechVault operational scenario checks.")
 app.add_typer(techvault_app, name="techvault")
@@ -61,7 +63,7 @@ def validate_live(
         help="Skip the native libvirt resource confirmation prompt.",
     ),
     connection_uri: str = typer.Option(
-        "qemu:///system",
+        _DEFAULT_CONNECTION_URI,
         "--connection-uri",
         callback=_noncredential_connection_uri,
         help="libvirt connection URI.",
@@ -104,7 +106,7 @@ def guest_certify(
     run_id: str | None = typer.Option(None, "--run-id", help="Run id for the evidence artifact."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the native libvirt resource confirmation prompt."),
     connection_uri: str = typer.Option(
-        "qemu:///system",
+        _DEFAULT_CONNECTION_URI,
         "--connection-uri",
         callback=_noncredential_connection_uri,
         help="libvirt connection URI.",
@@ -156,7 +158,7 @@ def validate_evidence(
         help="Realize the libvirt substrate natively (requires a libvirt daemon); default is deterministic.",
     ),
     connection_uri: str = typer.Option(
-        "qemu:///system",
+        _DEFAULT_CONNECTION_URI,
         "--connection-uri",
         callback=_noncredential_connection_uri,
         help="libvirt connection URI (native-live only).",

--- a/implementations/python/packages/aces_cli/libvirt.py
+++ b/implementations/python/packages/aces_cli/libvirt.py
@@ -21,6 +21,13 @@ This will create native libvirt/QEMU resources for the selected TechVault
 scenario and write a live-gate archive under the output directory.
 """
 
+_GUEST_WARNING = """\
+This will boot a guest-observing libvirt/QEMU appliance for the selected
+scenario through the production apply path, read realization facts back from
+inside the guest, and write a machine-readable scenario-evidence artifact under
+the output directory. Native resources are created and then torn down.
+"""
+
 
 def _noncredential_connection_uri(value: str) -> str:
     parsed = urlsplit(value)
@@ -73,6 +80,50 @@ def validate_live(
         project_dir=project_dir.resolve(),
         run_id=resolved_run_id,
         config=TechVaultLiveConfig(
+            connection_uri=connection_uri,
+        ),
+    )
+    typer.echo(report.render())
+    if not report.passed:
+        raise typer.Exit(code=1)
+
+
+@techvault_app.command("guest-certify")
+def guest_certify(
+    scenario: Path = typer.Option(
+        Path("examples/scenarios/techvault-guest-certified.sdl.yaml"),
+        "--scenario",
+        help="ACES SDL scenario to boot and certify from inside the guest.",
+    ),
+    project_dir: Path = typer.Option(
+        Path("."),
+        "--project-dir",
+        "--output-dir",
+        help="Output directory for the guest-certified scenario-evidence artifact.",
+    ),
+    run_id: str | None = typer.Option(None, "--run-id", help="Run id for the evidence artifact."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the native libvirt resource confirmation prompt."),
+    connection_uri: str = typer.Option(
+        "qemu:///system",
+        "--connection-uri",
+        callback=_noncredential_connection_uri,
+        help="libvirt connection URI.",
+    ),
+) -> None:
+    """Boot a guest-observing appliance and emit the guest-certified evidence artifact."""
+
+    if not yes:
+        typer.echo(_GUEST_WARNING)
+        if not typer.confirm("Continue?", default=False):
+            typer.echo("Aborted.")
+            raise typer.Exit(code=0)
+    resolved_run_id = run_id or datetime.now(UTC).strftime("aces_libvirt_guest_%Y%m%dT%H%M%SZ")
+    report = run_libvirt_evidence_run(
+        scenario_path=scenario.resolve(),
+        project_dir=project_dir.resolve(),
+        run_id=resolved_run_id,
+        config=LibvirtEvidenceRunConfig(
+            evidence_source_mode="guest-certified",
             connection_uri=connection_uri,
         ),
     )

--- a/implementations/python/packages/aces_operations/_evidence_run_artifact.py
+++ b/implementations/python/packages/aces_operations/_evidence_run_artifact.py
@@ -84,7 +84,9 @@ def assemble_artifact(inputs: EvidenceArtifactInputs) -> dict[str, Any]:
         "scenario": scenario_section,
         "compiled_artifact": _compiled_artifact_section(model),
         "backend": _backend_section(manifest, mode, substrate_realized, native_cleanup_verified),
-        "realization_facts": _realization_facts_section(model, native_snapshot, native_cleanup_verified),
+        "realization_facts": _realization_facts_section(
+            model, native_snapshot, native_cleanup_verified, inputs.guest_observed
+        ),
         "realized_topology": _topology_section(model, native_snapshot, unrealized_capabilities),
         "participant_action_proof": _participant_proof_section(proof),
         "terminal_observation": _terminal_observation_section(proof["snapshot"]),
@@ -210,6 +212,7 @@ def _realization_facts_section(
     model: CompiledModel,
     native_snapshot: Mapping[str, Any] | None,
     cleanup_verified: bool | None,
+    guest_observed: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     observed = native_snapshot if isinstance(native_snapshot, Mapping) else {}
     daemon_domains = observed.get("domains", ())
@@ -234,16 +237,25 @@ def _realization_facts_section(
             "domains": list(daemon_domains) if isinstance(daemon_domains, list | tuple) else [],
             "networks": list(daemon_networks) if isinstance(daemon_networks, list | tuple) else [],
         },
-        "guest_observed": {
-            "source": "guest-observed",
-            "status": "not-observed",
-        },
+        "guest_observed": _guest_observed_section(guest_observed),
         "cleanup": {
             "source": "driver-reported",
             "status": _cleanup_status(cleanup_verified),
         },
         "binding": observed.get("binding"),
     }
+
+
+def _guest_observed_section(guest_observed: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the guest-observed fact section: the bound report, or a not-observed stub.
+
+    A daemon-only run discloses ``not-observed`` honestly; a guest-certified run
+    embeds the operation-joined, challenge-bound, per-domain guest report.
+    """
+
+    if not isinstance(guest_observed, Mapping):
+        return {"source": "guest-observed", "status": "not-observed"}
+    return {**guest_observed, "source": "guest-observed"}
 
 
 def _cleanup_status(cleanup_verified: bool | None) -> str:

--- a/implementations/python/packages/aces_operations/_evidence_run_types.py
+++ b/implementations/python/packages/aces_operations/_evidence_run_types.py
@@ -116,3 +116,4 @@ class EvidenceArtifactInputs:
     native_snapshot: Mapping[str, Any] | None
     native_cleanup_verified: bool | None
     unrealized_capabilities: tuple[str, ...] = ()
+    guest_observed: Mapping[str, Any] | None = None

--- a/implementations/python/packages/aces_operations/_evidence_run_validation.py
+++ b/implementations/python/packages/aces_operations/_evidence_run_validation.py
@@ -145,31 +145,41 @@ def _validate_guest_observations(facts: Mapping[str, Any]) -> list[str]:
     guest = facts.get("guest_observed")
     if not isinstance(guest, Mapping) or guest.get("status") == "not-observed":
         return []
+    problems = _validate_guest_metadata(guest)
+    domains = guest.get("domains")
+    if not isinstance(domains, list | tuple) or not domains:
+        return [*problems, "guest observation requires at least one observed domain"]
+    daemon_addresses = _daemon_domain_addresses(facts)
+    for item in domains:
+        problems.extend(_validate_guest_domain(item, daemon_addresses))
+    return problems
+
+
+_GUEST_METADATA_FIELDS = (
+    ("observation timestamp", "observed_at"),
+    ("probe policy", "probe_policy"),
+    ("fresh challenge", "challenge"),
+)
+
+
+def _validate_guest_metadata(guest: Mapping[str, Any]) -> list[str]:
     problems: list[str] = []
     if not _is_canonical_sha256(guest.get("operation_ref")):
         problems.append("guest observation requires a canonical operation reference")
     if not isinstance(guest.get("certifying"), bool):
         problems.append("guest observation requires an explicit certifying flag")
-    for label, field_name in (
-        ("observation timestamp", "observed_at"),
-        ("probe policy", "probe_policy"),
-        ("fresh challenge", "challenge"),
-    ):
-        if not _nonempty_string(guest.get(field_name)):
-            problems.append(f"guest observation requires a {label}")
-    domains = guest.get("domains")
-    if not isinstance(domains, list | tuple) or not domains:
-        problems.append("guest observation requires at least one observed domain")
-        return problems
-    daemon = facts.get("daemon_observed", {})
-    daemon_addresses = {
-        item.get("address")
-        for item in (daemon.get("domains", ()) if isinstance(daemon, Mapping) else ())
-        if isinstance(item, Mapping)
-    }
-    for item in domains:
-        problems.extend(_validate_guest_domain(item, daemon_addresses))
+    problems.extend(
+        f"guest observation requires a {label}"
+        for label, field_name in _GUEST_METADATA_FIELDS
+        if not _nonempty_string(guest.get(field_name))
+    )
     return problems
+
+
+def _daemon_domain_addresses(facts: Mapping[str, Any]) -> set[object]:
+    daemon = facts.get("daemon_observed", {})
+    domains = daemon.get("domains", ()) if isinstance(daemon, Mapping) else ()
+    return {item.get("address") for item in domains if isinstance(item, Mapping)}
 
 
 _GUEST_DOMAIN_FIELDS = ("architecture", "vcpus", "memory_mib", "network", "content", "accounts", "services")

--- a/implementations/python/packages/aces_operations/_evidence_run_validation.py
+++ b/implementations/python/packages/aces_operations/_evidence_run_validation.py
@@ -129,6 +129,65 @@ def _validate_realization_sources(payload: Mapping[str, Any]) -> list[str]:
     else:
         problems.extend(_validate_unrealized_substrate(facts, provenance, cleanup))
     problems.extend(_validate_guest_observation_boundary(payload))
+    problems.extend(_validate_guest_observations(facts))
+    return problems
+
+
+def _validate_guest_observations(facts: Mapping[str, Any]) -> list[str]:
+    """Validate the guest-observed fact section when a guest report is present.
+
+    A daemon-only run carries ``{"source": "guest-observed", "status": "not-observed"}``
+    and is skipped here. A guest-certified run must bind every observed domain to the
+    control-plane operation, a fresh challenge, a canonical native correlation, and a
+    daemon-observed domain (rejecting unjoined or cross-operation evidence).
+    """
+
+    guest = facts.get("guest_observed")
+    if not isinstance(guest, Mapping) or guest.get("status") == "not-observed":
+        return []
+    problems: list[str] = []
+    if not _is_canonical_sha256(guest.get("operation_ref")):
+        problems.append("guest observation requires a canonical operation reference")
+    if not isinstance(guest.get("certifying"), bool):
+        problems.append("guest observation requires an explicit certifying flag")
+    for label, field_name in (
+        ("observation timestamp", "observed_at"),
+        ("probe policy", "probe_policy"),
+        ("fresh challenge", "challenge"),
+    ):
+        if not _nonempty_string(guest.get(field_name)):
+            problems.append(f"guest observation requires a {label}")
+    domains = guest.get("domains")
+    if not isinstance(domains, list | tuple) or not domains:
+        problems.append("guest observation requires at least one observed domain")
+        return problems
+    daemon = facts.get("daemon_observed", {})
+    daemon_addresses = {
+        item.get("address")
+        for item in (daemon.get("domains", ()) if isinstance(daemon, Mapping) else ())
+        if isinstance(item, Mapping)
+    }
+    for item in domains:
+        problems.extend(_validate_guest_domain(item, daemon_addresses))
+    return problems
+
+
+_GUEST_DOMAIN_FIELDS = ("architecture", "vcpus", "memory_mib", "network", "content", "accounts", "services")
+
+
+def _validate_guest_domain(item: object, daemon_addresses: set[object]) -> list[str]:
+    if not isinstance(item, Mapping):
+        return ["guest observation domain must be a mapping"]
+    problems: list[str] = []
+    if not _is_canonical_sha256(item.get("correlation")):
+        problems.append("guest observation requires a canonical native correlation")
+    if item.get("address") not in daemon_addresses:
+        problems.append("guest observation is not joined to a daemon-observed domain")
+    problems.extend(
+        f"guest observation domain missing {field_name}"
+        for field_name in _GUEST_DOMAIN_FIELDS
+        if field_name not in item
+    )
     return problems
 
 
@@ -274,6 +333,9 @@ def _validate_unrealized_substrate(
     daemon_networks = daemon.get("networks", ()) if isinstance(daemon, Mapping) else ()
     if daemon_domains or daemon_networks or facts.get("binding") is not None:
         problems.append("unrealized substrate cannot publish daemon observations or realization binding")
+    guest = facts.get("guest_observed")
+    if isinstance(guest, Mapping) and guest.get("status") != "not-observed":
+        problems.append("unrealized substrate cannot publish guest observations")
     if provenance.get("cleanup_verified") is not None:
         problems.append("unrealized substrate cleanup must be not-applicable")
     if isinstance(cleanup, Mapping) and cleanup.get("status") != "not-required":
@@ -311,8 +373,8 @@ def _validate_binding_identity(binding: Mapping[str, Any], envelope: Mapping[str
     driver_digest = binding.get("driver_configuration_digest")
     if not _is_canonical_sha256(driver_digest):
         problems.append("realization binding requires a canonical driver configuration digest")
-    if binding.get("driver") != "techvault-appliance":
-        problems.append("realization binding driver does not match the TechVault appliance")
+    if binding.get("driver") not in {"techvault-appliance", "guest-certified-appliance"}:
+        problems.append("realization binding driver does not match a governed appliance mode")
     for field_name in ("connection_uri_digest", "name_prefix_digest"):
         if not _is_canonical_sha256(binding.get(field_name)):
             problems.append(f"realization binding requires canonical {field_name}")

--- a/implementations/python/packages/aces_operations/libvirt_evidence_run.py
+++ b/implementations/python/packages/aces_operations/libvirt_evidence_run.py
@@ -35,6 +35,7 @@ Artifact assembly lives in ``_evidence_run_artifact`` and validation in
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -73,7 +74,8 @@ __all__ = [
 
 _PROOF_EPISODE_ID = "proof-ep-1"
 
-EvidenceSourceMode = Literal["deterministic", "native-live"]
+EvidenceSourceMode = Literal["deterministic", "native-live", "guest-certified"]
+_NATIVE_MODES = frozenset({"native-live", "guest-certified"})
 
 
 @dataclass(frozen=True)
@@ -152,8 +154,8 @@ def run_libvirt_evidence_run(
         return LibvirtEvidenceRunReport(scenario_path.name, run_id, str(project_dir), mode, tuple(checks))
 
     native_driver: TechVaultNativeLibvirtDriver | None = None
-    if mode == "native-live":
-        native_driver = (driver_factory or _default_native_driver_factory(project_dir, run_id, settings))()
+    if mode in _NATIVE_MODES:
+        native_driver = (driver_factory or _default_native_driver_factory(project_dir, run_id, settings, mode))()
 
     try:
         target = create_libvirt_target(participant_runtime=True, driver=native_driver)
@@ -170,14 +172,31 @@ def run_libvirt_evidence_run(
     native_snapshot: Mapping[str, Any] | None = None
     native_cleanup_verified: bool | None = None
     unrealized_capabilities: tuple[str, ...] = ()
-    if mode == "native-live":
-        native_snapshot, realize_check, unrealized_capabilities = _realize_native_substrate(
-            execution_plan, control_plane, native_driver
-        )
-        checks.append(realize_check)
-        if native_snapshot is not None and native_driver is not None:
-            native_cleanup_verified, cleanup_diagnostics = cleanup_native_snapshot(native_driver, native_snapshot)
-            checks.append(EvidenceCheck("native_substrate_cleanup", native_cleanup_verified, cleanup_diagnostics))
+    guest_observed: Mapping[str, Any] | None = None
+    if mode in _NATIVE_MODES and native_driver is not None:
+        try:
+            native_snapshot, realize_check, unrealized_capabilities, operation_id = _realize_native_substrate(
+                execution_plan, control_plane, native_driver
+            )
+            checks.append(realize_check)
+            if native_snapshot is not None and mode == "guest-certified":
+                # Native-proof boundary: only the default production driver/transport
+                # (no injected factory) yields a certifying artifact. Injected fakes
+                # may exercise orchestration but are marked non-certifying so their
+                # evidence can never be published as a real guest certification.
+                guest_observed = _guest_observed_report(native_driver, operation_id, certifying=driver_factory is None)
+        finally:
+            # Cleanup runs after every attempt. A realized substrate is torn down and
+            # its verification recorded; a failed/unrealized attempt (the driver has
+            # already rolled back) is only reported when residue actually remains, so
+            # an honestly-unrealized run keeps cleanup not-applicable.
+            if native_snapshot is not None:
+                native_cleanup_verified, cleanup_diagnostics = _verify_native_cleanup(native_driver, native_snapshot)
+                checks.append(EvidenceCheck("native_substrate_cleanup", native_cleanup_verified, cleanup_diagnostics))
+            else:
+                residue_ok, residue_diagnostics = _sweep_residue(native_driver)
+                if not residue_ok:
+                    checks.append(EvidenceCheck("native_substrate_residue", False, residue_diagnostics))
 
     inputs = EvidenceArtifactInputs(
         scenario_path=scenario_path,
@@ -190,6 +209,7 @@ def run_libvirt_evidence_run(
         native_snapshot=native_snapshot,
         native_cleanup_verified=native_cleanup_verified,
         unrealized_capabilities=unrealized_capabilities,
+        guest_observed=guest_observed,
     )
     artifact, artifact_path = _finalize_artifact(inputs, project_dir, checks)
     return LibvirtEvidenceRunReport(
@@ -317,17 +337,25 @@ def _admit_one_action(
 
 
 def _default_native_driver_factory(
-    project_dir: Path, run_id: str, settings: LibvirtEvidenceRunConfig
+    project_dir: Path, run_id: str, settings: LibvirtEvidenceRunConfig, mode: str
 ) -> Callable[[], TechVaultNativeLibvirtDriver]:
-    """Build the default native libvirt driver factory for operator-run native-live mode.
+    """Build the default native libvirt driver factory for an operator-run native mode.
 
-    Mirrors the TechVault live gate: the driver connects to a real libvirt daemon at
-    realize time. In CI/tests a fake driver_factory is injected instead, so this is
-    never exercised without a daemon.
+    The driver connects to a real libvirt daemon at realize time; ``guest-certified``
+    selects the guest-observing driver. In CI/tests a fake driver_factory is injected
+    instead, so this is never exercised without a daemon.
     """
     state_dir = project_dir / "runs" / run_id / "scenario-evidence" / "libvirt"
 
     def factory() -> TechVaultNativeLibvirtDriver:
+        if mode == "guest-certified":
+            from aces_backend_libvirt.guest_certified_driver import GuestCertifiedLibvirtDriver
+
+            return GuestCertifiedLibvirtDriver(
+                state_dir=state_dir,
+                connection_uri=settings.connection_uri,
+                name_prefix="aces-evidence",
+            )
         return TechVaultNativeLibvirtDriver(
             state_dir=state_dir,
             connection_uri=settings.connection_uri,
@@ -337,25 +365,116 @@ def _default_native_driver_factory(
     return factory
 
 
+def _guest_observed_report(
+    native_driver: TechVaultNativeLibvirtDriver, operation_id: str | None, *, certifying: bool
+) -> Mapping[str, Any] | None:
+    """Assemble the operation-joined, challenge-bound guest report from the driver.
+
+    The control-plane operation id and observation timestamp are joined here, at the
+    operations boundary, rather than inside the backend driver. ``certifying`` records
+    whether the governed production driver was used; an injected fake driver yields a
+    non-certifying report that is externally distinguishable from a real proof.
+    """
+    observations = getattr(native_driver, "last_guest_observations", ())
+    if not observations:
+        return None
+    facts = getattr(native_driver, "last_guest_facts", {})
+    binding = getattr(native_driver, "last_guest_binding", {})
+    correlations = binding.get("correlations", {}) if isinstance(binding, Mapping) else {}
+    domains = [
+        {
+            "address": address,
+            "correlation": correlations.get(address),
+            "architecture": fact.get("architecture"),
+            "vcpus": fact.get("vcpus"),
+            "memory_mib": fact.get("memory_mib"),
+            "network": list(fact.get("interfaces", ())),
+            "content": list(fact.get("content", ())),
+            "accounts": list(fact.get("accounts", ())),
+            "services": list(fact.get("services", ())),
+        }
+        for address, fact in sorted(facts.items())
+        if isinstance(fact, Mapping)
+    ]
+    return {
+        # The raw control-plane operation id is a UUID and never portable identity;
+        # bind a redacted digest instead so the guest report joins the operation
+        # without leaking the UUID (the redaction gate forbids raw UUIDs).
+        "operation_ref": _operation_ref(operation_id),
+        "observed_at": datetime.now(UTC).isoformat(),
+        "certifying": certifying,
+        "probe_policy": binding.get("probe_policy") if isinstance(binding, Mapping) else None,
+        "challenge": binding.get("challenge") if isinstance(binding, Mapping) else None,
+        "domains": domains,
+    }
+
+
+def _operation_ref(operation_id: str | None) -> str | None:
+    if not operation_id:
+        return None
+    return "sha256:" + hashlib.sha256(operation_id.encode("utf-8")).hexdigest()
+
+
+def _verify_native_cleanup(
+    native_driver: TechVaultNativeLibvirtDriver, native_snapshot: Mapping[str, Any]
+) -> tuple[bool, tuple[str, ...]]:
+    """Tear down a realized substrate and verify native + guest-probe cleanup."""
+
+    verified, diagnostics = cleanup_native_snapshot(native_driver, native_snapshot)
+    if verified and getattr(native_driver, "last_guest_binding", {}):
+        return False, (*diagnostics, "guest probe artifacts were not fully cleaned")
+    return verified, diagnostics
+
+
+def _sweep_residue(native_driver: TechVaultNativeLibvirtDriver) -> tuple[bool, tuple[str, ...]]:
+    """Best-effort finally-path sweep after a failed/unrealized attempt.
+
+    The driver rolls back on failure, so the common case leaves no residue. Any
+    remaining realized address, non-empty snapshot, or residual guest binding is a
+    leak and is reported so the run cannot pass.
+    """
+    clean = (
+        not native_driver.realized_addresses()
+        and native_driver.last_snapshot == {}
+        and not getattr(native_driver, "last_guest_binding", {})
+    )
+    if clean:
+        return True, ()
+    residual = tuple(sorted(native_driver.realized_addresses()))
+    result = native_driver.destroy(networks=residual, domains=residual)
+    ok = (
+        not result.diagnostics
+        and not native_driver.realized_addresses()
+        and native_driver.last_snapshot == {}
+        and not getattr(native_driver, "last_guest_binding", {})
+    )
+    if ok:
+        return True, ()
+    diagnostics = tuple(f"{item.code} at {item.address}" for item in result.diagnostics)
+    return False, diagnostics or ("residual native or guest state remains after a failed attempt",)
+
+
 def _realize_native_substrate(
     execution_plan: ExecutionPlan,
     control_plane: RuntimeControlPlane,
     native_driver: TechVaultNativeLibvirtDriver | None,
-) -> tuple[Mapping[str, Any] | None, EvidenceCheck, tuple[str, ...]]:
+) -> tuple[Mapping[str, Any] | None, EvidenceCheck, tuple[str, ...], str | None]:
     """Realize the libvirt provisioning substrate (VMs + networks) for the scenario.
 
-    Native-live passes only when the runtime operation succeeds and the fresh driver
+    Native modes pass only when the runtime operation succeeds and the fresh driver
     report contains independently daemon-observed domains bound to the selected
     realization-envelope/configuration identity. A domain handle or planned matrix
-    alone is never sufficient.
+    alone is never sufficient. Returns the control-plane operation id so the evidence
+    producer can join it at this boundary.
     """
     if native_driver is None:
-        return None, EvidenceCheck("native_substrate_realization", False, ("no native driver",)), ()
+        return None, EvidenceCheck("native_substrate_realization", False, ("no native driver",)), (), None
     try:
         receipt = control_plane.submit_provisioning(execution_plan.provisioning)
+        operation_id = str(receipt.operation_id)
         status = control_plane.get_operation(receipt.operation_id)
     except Exception:
-        return None, EvidenceCheck("native_substrate_realization", False, ("native realization failed",)), ()
+        return None, EvidenceCheck("native_substrate_realization", False, ("native realization failed",)), (), None
     unrealized = _dedupe(
         f"{d.code}: {d.message}"
         for source in (execution_plan.diagnostics, () if status is None else status.diagnostics)
@@ -372,7 +491,7 @@ def _realize_native_substrate(
         if realized
         else ("libvirt backend realized no native substrate for this scenario; capabilities disclosed as unrealized",),
     )
-    return (snapshot if realized else None), check, unrealized
+    return (snapshot if realized else None), check, unrealized, operation_id
 
 
 def _dedupe(items: Iterable[str]) -> tuple[str, ...]:

--- a/implementations/python/packages/aces_operations/libvirt_evidence_run.py
+++ b/implementations/python/packages/aces_operations/libvirt_evidence_run.py
@@ -174,29 +174,9 @@ def run_libvirt_evidence_run(
     unrealized_capabilities: tuple[str, ...] = ()
     guest_observed: Mapping[str, Any] | None = None
     if mode in _NATIVE_MODES and native_driver is not None:
-        try:
-            native_snapshot, realize_check, unrealized_capabilities, operation_id = _realize_native_substrate(
-                execution_plan, control_plane, native_driver
-            )
-            checks.append(realize_check)
-            if native_snapshot is not None and mode == "guest-certified":
-                # Native-proof boundary: only the default production driver/transport
-                # (no injected factory) yields a certifying artifact. Injected fakes
-                # may exercise orchestration but are marked non-certifying so their
-                # evidence can never be published as a real guest certification.
-                guest_observed = _guest_observed_report(native_driver, operation_id, certifying=driver_factory is None)
-        finally:
-            # Cleanup runs after every attempt. A realized substrate is torn down and
-            # its verification recorded; a failed/unrealized attempt (the driver has
-            # already rolled back) is only reported when residue actually remains, so
-            # an honestly-unrealized run keeps cleanup not-applicable.
-            if native_snapshot is not None:
-                native_cleanup_verified, cleanup_diagnostics = _verify_native_cleanup(native_driver, native_snapshot)
-                checks.append(EvidenceCheck("native_substrate_cleanup", native_cleanup_verified, cleanup_diagnostics))
-            else:
-                residue_ok, residue_diagnostics = _sweep_residue(native_driver)
-                if not residue_ok:
-                    checks.append(EvidenceCheck("native_substrate_residue", False, residue_diagnostics))
+        native_snapshot, native_cleanup_verified, unrealized_capabilities, guest_observed = _run_native_mode(
+            mode, execution_plan, control_plane, native_driver, driver_factory, checks
+        )
 
     inputs = EvidenceArtifactInputs(
         scenario_path=scenario_path,
@@ -215,6 +195,49 @@ def run_libvirt_evidence_run(
     return LibvirtEvidenceRunReport(
         scenario_path.name, run_id, str(project_dir), mode, tuple(checks), artifact, artifact_path
     )
+
+
+def _run_native_mode(
+    mode: str,
+    execution_plan: ExecutionPlan,
+    control_plane: RuntimeControlPlane,
+    native_driver: TechVaultNativeLibvirtDriver,
+    driver_factory: Callable[[], TechVaultNativeLibvirtDriver] | None,
+    checks: list[EvidenceCheck],
+) -> tuple[Mapping[str, Any] | None, bool | None, tuple[str, ...], Mapping[str, Any] | None]:
+    """Realize the native substrate, capture any guest report, and clean up in a finally-path.
+
+    Native-proof boundary: only the default production driver/transport (no injected
+    factory) yields a certifying guest artifact; injected fakes are marked
+    non-certifying so their evidence can never be published as a real certification.
+    """
+    native_snapshot: Mapping[str, Any] | None = None
+    guest_observed: Mapping[str, Any] | None = None
+    unrealized: tuple[str, ...] = ()
+    try:
+        native_snapshot, realize_check, unrealized, operation_id = _realize_native_substrate(
+            execution_plan, control_plane, native_driver
+        )
+        checks.append(realize_check)
+        if native_snapshot is not None and mode == "guest-certified":
+            guest_observed = _guest_observed_report(native_driver, operation_id, certifying=driver_factory is None)
+    finally:
+        native_cleanup_verified = _append_cleanup_check(native_driver, native_snapshot, checks)
+    return native_snapshot, native_cleanup_verified, unrealized, guest_observed
+
+
+def _append_cleanup_check(
+    native_driver: TechVaultNativeLibvirtDriver, native_snapshot: Mapping[str, Any] | None, checks: list[EvidenceCheck]
+) -> bool | None:
+    """Cleanup runs after every attempt; residue on a failed/unrealized run is reported."""
+    if native_snapshot is not None:
+        verified, diagnostics = _verify_native_cleanup(native_driver, native_snapshot)
+        checks.append(EvidenceCheck("native_substrate_cleanup", verified, diagnostics))
+        return verified
+    residue_ok, residue_diagnostics = _sweep_residue(native_driver)
+    if not residue_ok:
+        checks.append(EvidenceCheck("native_substrate_residue", False, residue_diagnostics))
+    return None
 
 
 def _finalize_artifact(

--- a/implementations/python/tests/test_libvirt_backend_cli.py
+++ b/implementations/python/tests/test_libvirt_backend_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from aces_cli.main import app
+from aces_operations.libvirt_evidence_run import LibvirtEvidenceRunConfig
 from aces_operations.techvault_live import TechVaultLiveConfig
 from typer.testing import CliRunner
 
@@ -115,6 +116,89 @@ def test_libvirt_techvault_cli_has_no_unbound_memory_override(monkeypatch, tmp_p
             "--yes",
             "--appliance-memory-mib",
             "96",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert calls == []
+
+
+def test_libvirt_techvault_guest_certify_cli_invokes_evidence_run(monkeypatch, tmp_path):
+    calls: list[dict[str, object]] = []
+
+    def _run(**kwargs):
+        calls.append(kwargs)
+        return _Report()
+
+    monkeypatch.setattr("aces_cli.libvirt.run_libvirt_evidence_run", _run)
+    scenario = tmp_path / "scenario.sdl.yaml"
+    scenario.write_text("name: cli\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "libvirt",
+            "techvault",
+            "guest-certify",
+            "--scenario",
+            str(scenario),
+            "--project-dir",
+            str(tmp_path),
+            "--run-id",
+            "gc-cli",
+            "--yes",
+            "--connection-uri",
+            "qemu:///system",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "scenario_path": scenario.resolve(),
+            "project_dir": tmp_path.resolve(),
+            "run_id": "gc-cli",
+            "config": LibvirtEvidenceRunConfig(
+                evidence_source_mode="guest-certified",
+                connection_uri="qemu:///system",
+            ),
+        }
+    ]
+
+
+def test_libvirt_techvault_guest_certify_cli_returns_failure_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "aces_cli.libvirt.run_libvirt_evidence_run",
+        lambda **_kwargs: _Report(passed=False),
+    )
+    scenario = tmp_path / "scenario.sdl.yaml"
+    scenario.write_text("name: cli\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        ["libvirt", "techvault", "guest-certify", "--scenario", str(scenario), "--project-dir", str(tmp_path), "--yes"],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_libvirt_techvault_guest_certify_cli_rejects_credentials(monkeypatch, tmp_path):
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("aces_cli.libvirt.run_libvirt_evidence_run", lambda **kwargs: calls.append(kwargs))
+    scenario = tmp_path / "scenario.sdl.yaml"
+    scenario.write_text("name: cli\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "libvirt",
+            "techvault",
+            "guest-certify",
+            "--scenario",
+            str(scenario),
+            "--yes",
+            "--connection-uri",
+            "qemu+ssh://operator:credential@example/system",
         ],
     )
 

--- a/implementations/python/tests/test_libvirt_backend_guest_certified.py
+++ b/implementations/python/tests/test_libvirt_backend_guest_certified.py
@@ -1,0 +1,548 @@
+"""Hermetic guest-certified libvirt driver + guest-observation coverage.
+
+These tests exercise the guest-observation orchestration and its falsification
+paths with a fake libvirt connection and a stub fact transport. They validate
+staging, freshness, and concern comparison; per the preflight they cannot and do
+not satisfy the native-proof gate (that is the opt-in real-daemon certification).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from aces_backend_libvirt.cloudinit import CloudInitFile, CloudInitSpec, CloudInitUser
+from aces_backend_libvirt.driver import DomainSpec, NetworkSpec, ServiceSpec
+from aces_backend_libvirt.guest_appliance import GuestObservingInitramfsBuilder
+from aces_backend_libvirt.guest_certified_driver import GuestCertifiedLibvirtDriver
+from aces_backend_libvirt.techvault_matrix import mac_address
+
+_CHALLENGE = "deadbeefcafef00d"
+
+
+@dataclass
+class _StubTransport:
+    facts_by_address: dict[str, str | None]
+    failure: str | None = None
+
+    def read(self, *, address, fact_channel_path, deadline_seconds):  # noqa: ANN001, ANN201
+        del fact_channel_path, deadline_seconds
+        if self.failure is not None:
+            return None, self.failure
+        return self.facts_by_address.get(address), None
+
+
+class _NativeObject:
+    def __init__(self, name: str = "", xml: str = "") -> None:
+        self._name = name
+        self._xml = xml
+        self.created = False
+        self.destroyed = False
+        self.undefined = False
+
+    def name(self):
+        return self._name
+
+    def create(self):
+        self.created = True
+
+    def isActive(self):  # noqa: N802 - mirrors libvirt API
+        return int(self.created and not self.destroyed)
+
+    def XMLDesc(self, _flags=0):  # noqa: N802 - mirrors libvirt API
+        return self._xml
+
+    def UUIDString(self):  # noqa: N802 - mirrors libvirt API
+        import xml.etree.ElementTree as ET
+
+        return ET.fromstring(self._xml).findtext("uuid")  # noqa: S314 - test XML
+
+    def destroy(self):
+        self.destroyed = True
+
+    def undefine(self):
+        self.undefined = True
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.networks: dict[str, _NativeObject] = {}
+        self.domains: dict[str, _NativeObject] = {}
+
+    def networkDefineXML(self, xml: str):  # noqa: N802
+        native = _NativeObject(_name_from_xml(xml), xml)
+        self.networks[native.name()] = native
+        return native
+
+    def defineXML(self, xml: str):  # noqa: N802
+        native = _NativeObject(_name_from_xml(xml), xml)
+        self.domains[native.name()] = native
+        return native
+
+    def networkLookupByName(self, name: str):  # noqa: N802
+        return self.networks[name]
+
+    def lookupByName(self, name: str):  # noqa: N802
+        return self.domains[name]
+
+    def listAllDomains(self):  # noqa: N802
+        return [native for native in self.domains.values() if not native.undefined]
+
+    def listAllNetworks(self):  # noqa: N802
+        return [native for native in self.networks.values() if not native.undefined]
+
+
+def _name_from_xml(xml: str) -> str:
+    start = xml.index("<name>") + len("<name>")
+    return xml[start : xml.index("</name>")]
+
+
+@dataclass
+class _GuestFacts:
+    challenge: str = _CHALLENGE
+    architecture: str = "x86_64"
+    vcpus: int = 1
+    memory_mib: int = 120
+    interfaces: list[tuple[str, str, int]] = field(default_factory=list)
+    content: list[tuple[str, str, str]] = field(default_factory=list)
+    accounts: list[tuple[str, int, str, str, int, str]] = field(default_factory=list)
+    services: list[tuple[str, int, int, int]] = field(default_factory=list)
+    init_complete: bool = True
+
+    def render(self) -> str:
+        lines = [
+            "ACES-GUEST-FACTS v1",
+            f"challenge {self.challenge}",
+            f"architecture {self.architecture}",
+            f"vcpus {self.vcpus}",
+            f"memory_mib {self.memory_mib}",
+        ]
+        lines.extend(f"iface {mac} {ip} {up}" for mac, ip, up in self.interfaces)
+        lines.extend(f"content {path} {digest} {mode}" for path, digest, mode in self.content)
+        lines.extend(
+            f"account {name} {uid} {home} {shell} {dis} {groups}"
+            for name, uid, home, shell, dis, groups in self.accounts
+        )
+        lines.extend(f"service {name} {port} {lis} {pid}" for name, port, lis, pid in self.services)
+        if self.init_complete:
+            lines.append("init complete")
+        return "\n".join(lines) + "\n"
+
+
+def _sha(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _network() -> NetworkSpec:
+    return NetworkSpec(
+        address="scn.net",
+        name="net",
+        cidr="10.9.0.0/24",
+        gateway="10.9.0.1",
+        labels={"internal": "true"},
+    )
+
+
+def _domain() -> DomainSpec:
+    return DomainSpec(
+        address="scn.vm",
+        name="vm",
+        image_ref=None,
+        memory_mib=128,
+        vcpus=1,
+        networks=("scn.net",),
+        services=(ServiceSpec(name="beacon", port=9000),),
+        cloud_init=CloudInitSpec(
+            users=(
+                CloudInitUser(  # noqa: S604 - `shell` is a CloudInitUser account field, not a subprocess shell
+                    name="analyst", groups=("aces",), shell="/bin/sh", home="/home/analyst", lock_passwd=True
+                ),
+            ),
+            write_files=(CloudInitFile(path="/etc/aces/marker", content="hello", permissions="0644"),),
+        ),
+    )
+
+
+def _matching_facts() -> _GuestFacts:
+    mac = mac_address("scn.vm", "scn.net")
+    return _GuestFacts(
+        interfaces=[(mac, "10.9.0.10", 1)],
+        content=[("/etc/aces/marker", _sha("hello"), "644")],
+        accounts=[("analyst", 1000, "/home/analyst", "/bin/sh", 1, "aces")],
+        services=[("beacon", 9000, 1, 1)],
+    )
+
+
+def _driver(tmp_path: Path, connection: _FakeConnection, transport: _StubTransport) -> GuestCertifiedLibvirtDriver:
+    kernel = tmp_path / "vmlinuz"
+    kernel.write_bytes(b"kernel-bytes")
+    return GuestCertifiedLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=connection,
+        name_prefix="aces-gc",
+        kernel_path=kernel,
+        initramfs_builder=GuestObservingInitramfsBuilder(busybox_path=Path("/usr/bin/busybox")),
+        guest_transport=transport,
+        challenge=_CHALLENGE,
+    )
+
+
+def _realize(tmp_path: Path, facts: _GuestFacts | None, *, failure: str | None = None):
+    connection = _FakeConnection()
+    facts_map = {"scn.vm": facts.render() if facts is not None else None}
+    transport = _StubTransport(facts_by_address=facts_map, failure=failure)
+    driver = _driver(tmp_path, connection, transport)
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+    return driver, connection, result
+
+
+def _codes(result) -> set[str]:
+    return {diag.code for diag in result.diagnostics}
+
+
+def test_guest_certified_happy_path_realizes_and_certifies(tmp_path: Path) -> None:
+    driver, connection, result = _realize(tmp_path, _matching_facts())
+    assert result.diagnostics == ()
+    assert {handle.address for handle in result.domains} == {"scn.vm"}
+    guest_fields = {obs.field_path for obs in result.observations if obs.source.value == "guest-observed"}
+    assert {
+        "guest-architecture",
+        "guest-vcpus",
+        "guest-network",
+        "guest-content",
+        "guest-account",
+        "guest-service",
+    } <= guest_fields
+    assert driver.last_guest_binding["challenge"] == _CHALLENGE
+    assert "scn.vm" in driver.last_guest_facts
+    # Native objects remain (committed), not rolled back.
+    assert all(not native.destroyed for native in connection.domains.values())
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_code"),
+    [
+        ("transport-unavailable", "libvirt-backend.guest.transport-unavailable"),
+        ("boot-timeout", "libvirt-backend.guest.boot-timeout"),
+    ],
+)
+def test_transport_stage_failures_are_typed_and_roll_back(tmp_path: Path, failure: str, expected_code: str) -> None:
+    driver, connection, result = _realize(tmp_path, _matching_facts(), failure=failure)
+    assert expected_code in _codes(result)
+    assert driver.last_guest_observations == ()
+    assert all(native.destroyed for native in connection.domains.values())
+
+
+def test_missing_init_completion_fails(tmp_path: Path) -> None:
+    facts = _matching_facts()
+    facts.init_complete = False
+    _, connection, result = _realize(tmp_path, facts)
+    assert "libvirt-backend.guest.init-incomplete" in _codes(result)
+    assert all(native.destroyed for native in connection.domains.values())
+
+
+def test_stale_challenge_is_rejected(tmp_path: Path) -> None:
+    facts = _matching_facts()
+    facts.challenge = "0000000000000000"
+    _, _, result = _realize(tmp_path, facts)
+    assert "libvirt-backend.guest.challenge-mismatch" in _codes(result)
+
+
+def test_malformed_report_is_rejected(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={"scn.vm": "not a fact report"})
+    driver = _driver(tmp_path, connection, transport)
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+    assert "libvirt-backend.guest.observation-malformed" in _codes(result)
+
+
+@pytest.mark.parametrize("mutate", ["ip", "vcpus", "memory", "content", "account", "service", "missing_content"])
+def test_concern_mismatches_are_falsified(tmp_path: Path, mutate: str) -> None:
+    facts = _matching_facts()
+    mac = mac_address("scn.vm", "scn.net")
+    if mutate == "ip":
+        facts.interfaces = [(mac, "10.9.0.99", 1)]
+    elif mutate == "vcpus":
+        facts.vcpus = 2
+    elif mutate == "memory":
+        facts.memory_mib = 8  # below the corroboration floor
+    elif mutate == "content":
+        facts.content = [("/etc/aces/marker", _sha("tampered"), "644")]
+    elif mutate == "account":
+        facts.accounts = [("analyst", 1000, "/home/analyst", "/bin/bash", 1, "aces")]
+    elif mutate == "service":
+        facts.services = [("beacon", 9000, 0, 1)]
+    elif mutate == "missing_content":
+        facts.content = []
+    _, connection, result = _realize(tmp_path, facts)
+    assert "libvirt-backend.guest.observation-mismatch" in _codes(result)
+    assert all(native.destroyed for native in connection.domains.values())
+
+
+@pytest.mark.parametrize("second", ["vcpus 9", "vcpus 1", "challenge deadbeefcafef00d"])
+def test_duplicate_singleton_fact_is_falsified(tmp_path: Path, second: str) -> None:
+    # A repeated singleton fact (identical or conflicting) must be rejected distinctly
+    # rather than silently collapsed to the last value.
+    text = _matching_facts().render().replace("vcpus 1\n", f"vcpus 1\n{second}\n")
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={"scn.vm": text})
+    driver = _driver(tmp_path, connection, transport)
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+    assert "libvirt-backend.guest.observation-duplicate" in _codes(result)
+    assert all(native.destroyed for native in connection.domains.values())
+
+
+def test_account_without_supplemental_groups_is_certified(tmp_path: Path) -> None:
+    # An account with no supplemental groups is valid; the empty trailing groups
+    # field must not cause the account observation to be dropped.
+    mac = mac_address("scn.vm", "scn.net")
+    domain = DomainSpec(
+        address="scn.vm",
+        name="vm",
+        image_ref=None,
+        memory_mib=128,
+        vcpus=1,
+        networks=("scn.net",),
+        cloud_init=CloudInitSpec(
+            # noqa below: `shell` is a CloudInitUser account field, not a subprocess shell.
+            users=(CloudInitUser(name="loner", groups=(), shell="/bin/sh", home="/home/loner", lock_passwd=False),),  # noqa: S604
+        ),
+    )
+    facts = _GuestFacts(
+        interfaces=[(mac, "10.9.0.10", 1)],
+        accounts=[("loner", 1000, "/home/loner", "/bin/sh", 0, "")],
+    )
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={"scn.vm": facts.render()})
+    driver = _driver(tmp_path, connection, transport)
+    result = driver.realize(networks=(_network(),), domains=(domain,))
+    assert result.diagnostics == ()
+    account_obs = next(obs for obs in result.observations if obs.field_path == "guest-account")
+    assert account_obs.value == ("loner|/home/loner|/bin/sh|0|",)
+
+
+def test_requested_image_is_rejected_before_mutation(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={})
+    driver = _driver(tmp_path, connection, transport)
+    domain = DomainSpec(
+        address="scn.vm", name="vm", image_ref="ubuntu:24.04", memory_mib=128, vcpus=1, networks=("scn.net",)
+    )
+    result = driver.realize(networks=(_network(),), domains=(domain,))
+    assert "libvirt-backend.techvault.image-unsupported" in _codes(result)
+    assert connection.domains == {}
+
+
+def test_unsupported_placement_is_rejected(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={})
+    driver = _driver(tmp_path, connection, transport)
+    domain = DomainSpec(
+        address="scn.vm",
+        name="vm",
+        image_ref=None,
+        memory_mib=128,
+        vcpus=1,
+        networks=("scn.net",),
+        cloud_init=CloudInitSpec(packages=("nginx",)),
+    )
+    result = driver.realize(networks=(_network(),), domains=(domain,))
+    assert "libvirt-backend.techvault.guest-placement-unsupported" in _codes(result)
+    assert connection.domains == {}
+
+
+# --- evidence-run integration (full control-plane pipeline) --------------------
+
+
+class _FakeBuilder:
+    def build(self, *, domain, target: Path):  # noqa: ANN001, ANN201
+        del domain
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"initramfs")
+        return target
+
+
+def _bounded_guest_scenario(tmp_path: Path) -> Path:
+    scenario = tmp_path / "guest-certified.sdl.yaml"
+    scenario.write_text(
+        """\
+name: guest-certified
+nodes:
+  lab:
+    type: switch
+  demo:
+    type: vm
+    os: linux
+    resources: {ram: 128 MiB, cpu: 1}
+    services: []
+infrastructure:
+  lab:
+    properties: {cidr: 192.0.2.0/24, gateway: 192.0.2.1, internal: true}
+  demo:
+    links: [lab]
+""",
+        encoding="utf-8",
+    )
+    return scenario
+
+
+def _facts_from_matrix(matrix, challenge: str) -> dict[str, str]:
+    facts: dict[str, str] = {}
+    for domain in matrix["domains"]:
+        lines = [
+            "ACES-GUEST-FACTS v1",
+            f"challenge {challenge}",
+            "architecture x86_64",
+            f"vcpus {domain['vcpus']}",
+            f"memory_mib {max(64, int(domain['memory_mib']) - 8)}",
+        ]
+        lines.extend(f"iface {iface['mac']} {iface['ip']} 1" for iface in domain["interfaces"])
+        lines.append("init complete")
+        facts[domain["address"]] = "\n".join(lines) + "\n"
+    return facts
+
+
+def _guest_matrix(scenario: Path):
+    from aces_backend_libvirt.manifest import create_libvirt_manifest
+    from aces_backend_libvirt.realization import interpret_provisioning_plan
+    from aces_backend_libvirt.techvault_matrix import native_matrix
+    from aces_sdl.parser import parse_sdl_file
+
+    from aces.core.runtime.manager import RuntimeManager
+
+    scout = GuestCertifiedLibvirtDriver(
+        state_dir=scenario.parent / "scout",
+        connection=_FakeConnection(),
+        name_prefix="evidence-test",
+        kernel_path=_write_kernel(scenario.parent),
+        initramfs_builder=_FakeBuilder(),
+        guest_transport=_StubTransport(facts_by_address={}),
+        challenge=_CHALLENGE,
+    )
+    from aces_backend_libvirt import create_libvirt_target
+
+    target = create_libvirt_target(participant_runtime=True, driver=scout)
+    plan = RuntimeManager(target).plan(parse_sdl_file(scenario)).provisioning
+    capabilities = create_libvirt_manifest(driver_mode="guest-certified-appliance").capabilities.provisioner
+    realization = interpret_provisioning_plan(plan, provisioner_capabilities=capabilities)
+    return native_matrix(
+        networks=realization.networks,
+        domains=realization.domains,
+        name_prefix="evidence-test",
+        include_placements=True,
+    )
+
+
+def _write_kernel(directory: Path) -> Path:
+    kernel = directory / "vmlinuz"
+    kernel.write_bytes(b"kernel")
+    return kernel
+
+
+def _guest_factory(tmp_path: Path, transport: _StubTransport):
+    def factory():
+        return GuestCertifiedLibvirtDriver(
+            state_dir=tmp_path / "state",
+            connection=_FakeConnection(),
+            name_prefix="evidence-test",
+            kernel_path=_write_kernel(tmp_path),
+            initramfs_builder=_FakeBuilder(),
+            guest_transport=transport,
+            challenge=_CHALLENGE,
+        )
+
+    return factory
+
+
+def test_evidence_run_guest_certified_publishes_bound_observations(tmp_path: Path) -> None:
+    from aces_operations.libvirt_evidence_run import (
+        LibvirtEvidenceRunConfig,
+        run_libvirt_evidence_run,
+        validate_libvirt_evidence_run_artifact,
+    )
+
+    scenario = _bounded_guest_scenario(tmp_path)
+    facts = _facts_from_matrix(_guest_matrix(scenario), _CHALLENGE)
+    transport = _StubTransport(facts_by_address=facts)
+    report = run_libvirt_evidence_run(
+        scenario_path=scenario,
+        project_dir=tmp_path,
+        run_id="gc-live-1",
+        config=LibvirtEvidenceRunConfig(evidence_source_mode="guest-certified"),
+        driver_factory=_guest_factory(tmp_path, transport),
+    )
+    assert report.passed, report.render()
+    artifact = report.artifact
+    assert artifact is not None
+    assert validate_libvirt_evidence_run_artifact(artifact) == []
+    guest = artifact["realization_facts"]["guest_observed"]
+    assert guest["source"] == "guest-observed"
+    assert guest["challenge"] == _CHALLENGE
+    assert guest["operation_ref"].startswith("sha256:")
+    # Native-proof boundary: an injected fake driver factory can exercise the
+    # orchestration but must be marked non-certifying so its evidence can never be
+    # published as a real guest certification.
+    assert guest["certifying"] is False
+    assert guest["domains"] and all(domain["correlation"].startswith("sha256:") for domain in guest["domains"])
+    assert any(check.name == "native_substrate_cleanup" and check.passed for check in report.checks)
+
+
+def test_evidence_run_guest_certified_transport_failure_fails_closed(tmp_path: Path) -> None:
+    from aces_operations.libvirt_evidence_run import LibvirtEvidenceRunConfig, run_libvirt_evidence_run
+
+    scenario = _bounded_guest_scenario(tmp_path)
+    transport = _StubTransport(facts_by_address={}, failure="boot-timeout")
+    report = run_libvirt_evidence_run(
+        scenario_path=scenario,
+        project_dir=tmp_path,
+        run_id="gc-live-2",
+        config=LibvirtEvidenceRunConfig(evidence_source_mode="guest-certified"),
+        driver_factory=_guest_factory(tmp_path, transport),
+    )
+    assert not report.passed, report.render()
+    assert report.artifact["backend"]["realization_provenance"]["substrate_realized"] is False
+    assert report.artifact["realization_facts"]["guest_observed"] == {
+        "source": "guest-observed",
+        "status": "not-observed",
+    }
+
+
+def test_evidence_run_guest_certified_residual_probe_artifacts_fail_closed(tmp_path: Path) -> None:
+    # Native domains/networks are torn down cleanly, but residual guest-probe state
+    # survives: the run must fail closed rather than claim verified cleanup.
+    from aces_operations.libvirt_evidence_run import LibvirtEvidenceRunConfig, run_libvirt_evidence_run
+
+    class _ResidualGuestDriver(GuestCertifiedLibvirtDriver):
+        def destroy(self, *, networks: tuple[str, ...], domains: tuple[str, ...]):
+            result = super().destroy(networks=networks, domains=domains)
+            self.last_guest_binding = {"challenge": self.challenge}
+            return result
+
+    scenario = _bounded_guest_scenario(tmp_path)
+    facts = _facts_from_matrix(_guest_matrix(scenario), _CHALLENGE)
+    transport = _StubTransport(facts_by_address=facts)
+
+    def factory():
+        return _ResidualGuestDriver(
+            state_dir=tmp_path / "state",
+            connection=_FakeConnection(),
+            name_prefix="evidence-test",
+            kernel_path=_write_kernel(tmp_path),
+            initramfs_builder=_FakeBuilder(),
+            guest_transport=transport,
+            challenge=_CHALLENGE,
+        )
+
+    report = run_libvirt_evidence_run(
+        scenario_path=scenario,
+        project_dir=tmp_path,
+        run_id="gc-residual",
+        config=LibvirtEvidenceRunConfig(evidence_source_mode="guest-certified"),
+        driver_factory=factory,
+    )
+    assert not report.passed, report.render()
+    cleanup = next(check for check in report.checks if check.name == "native_substrate_cleanup")
+    assert not cleanup.passed
+    assert any("guest probe artifacts were not fully cleaned" in diag for diag in cleanup.diagnostics)

--- a/implementations/python/tests/test_libvirt_backend_guest_certified_real_libvirt.py
+++ b/implementations/python/tests/test_libvirt_backend_guest_certified_real_libvirt.py
@@ -1,0 +1,72 @@
+"""Opt-in real-libvirt certification for guest-observed realization probes.
+
+This is the native-proof gate: it boots the guest-observing appliance through the
+production apply path against an operator-selected real libvirt/QEMU daemon, reads
+concern facts back from inside the guest, and verifies teardown. It is skipped
+unless ``ACES_REAL_LIBVIRT_URI`` is set and the host has libvirt-python, cpio,
+BusyBox, and a readable kernel. Hermetic fake-driver tests cannot satisfy this
+gate.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from aces_operations.libvirt_evidence_run import (
+    LibvirtEvidenceRunConfig,
+    run_libvirt_evidence_run,
+    validate_libvirt_evidence_run_artifact,
+)
+from paths import EXAMPLES_DIR
+
+
+@pytest.mark.integration
+def test_guest_certified_real_libvirt_readback_and_cleanup(tmp_path):
+    """Certify guest-observed realization and verified cleanup on a real daemon."""
+
+    connection_uri = os.environ.get("ACES_REAL_LIBVIRT_URI")
+    if not connection_uri:
+        pytest.skip("set ACES_REAL_LIBVIRT_URI to run real-libvirt guest certification")
+    try:
+        libvirt = importlib.import_module("libvirt")
+    except ImportError:
+        pytest.skip("libvirt-python is unavailable")
+    if shutil.which("cpio") is None or not Path("/usr/bin/busybox").is_file():
+        pytest.skip("cpio and BusyBox are required for guest-observing appliance certification")
+    if not tuple(Path("/boot").glob("vmlinuz-*")):
+        pytest.skip("a readable host kernel is required for guest-observing appliance certification")
+
+    report = run_libvirt_evidence_run(
+        scenario_path=EXAMPLES_DIR / "techvault-guest-certified.sdl.yaml",
+        project_dir=tmp_path,
+        run_id="real-libvirt-guest-certification",
+        config=LibvirtEvidenceRunConfig(evidence_source_mode="guest-certified", connection_uri=connection_uri),
+    )
+
+    assert report.passed, report.render()
+    artifact = report.artifact
+    assert artifact is not None
+    assert validate_libvirt_evidence_run_artifact(artifact) == []
+    guest = artifact["realization_facts"]["guest_observed"]
+    assert guest["source"] == "guest-observed"
+    assert guest["operation_ref"].startswith("sha256:")
+    # The production driver (no injected factory) yields a certifying artifact.
+    assert guest["certifying"] is True
+    assert guest["domains"]
+
+    daemon = artifact["realization_facts"]["daemon_observed"]
+    observed_domains = {str(item.get("name")) for item in daemon["domains"]}
+    observed_networks = {str(item.get("name")) for item in daemon["networks"]}
+    connection = libvirt.open(connection_uri)
+    assert connection is not None
+    try:
+        remaining_domains = {item.name() for item in connection.listAllDomains()}
+        remaining_networks = {item.name() for item in connection.listAllNetworks()}
+    finally:
+        connection.close()
+    assert remaining_domains.isdisjoint(observed_domains)
+    assert remaining_networks.isdisjoint(observed_networks)

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -168,6 +168,7 @@ module_boundaries:
         aces_backend_libvirt:
           - aces_backend_libvirt.target
           - aces_backend_libvirt.techvault_native
+          - aces_backend_libvirt.guest_certified_driver
         aces_backend_protocols:
           - aces_backend_protocols.manifest
           - aces_backend_protocols.capabilities

--- a/tools/real-daemon/README.md
+++ b/tools/real-daemon/README.md
@@ -56,3 +56,44 @@ python real_daemon_smoke.py   # or: python libvirt_smoke.py
 For seeds/disks outside `/var/lib/libvirt/images`, the host needs
 `security_driver = "none"` and `user/group = "root"` in `/etc/libvirt/qemu.conf`
 (the AWS script sets these automatically).
+
+## Guest-certified realization proof (ASR-519, issue #715)
+
+`libvirt_smoke.py` proves substrate reconciliation/teardown at the *daemon* level.
+The **guest-certified** proof goes one layer deeper: it boots a guest-observing
+appliance through the production apply path and reads concern facts back **from
+inside the guest** (resource allocation, network addressing, file content, and
+service state), freshness-bound to a per-run challenge, then verifies teardown.
+Domain existence alone never satisfies it.
+
+The reproducible operator/self-hosted command is:
+
+```sh
+# Against a real libvirt/QEMU daemon (qemu:///system). Boots the appliance,
+# certifies from inside the guest, writes a machine-readable evidence artifact,
+# and returns non-zero on any failed stage.
+aces libvirt techvault guest-certify \
+  --scenario examples/scenarios/techvault-guest-certified.sdl.yaml \
+  --project-dir . --run-id guest-proof-1 --yes
+```
+
+It emits the `aces.libvirt.scenario-evidence-run/v1` artifact under
+`runs/<run-id>/scenario-evidence/libvirt-scenario-evidence-run.json`. The artifact
+is validated (source separation, binding, redaction) **before** it is written, so
+it contains no host paths, connection URIs, raw domain UUIDs, XML, or secrets; the
+guest report is bound to a redacted control-plane operation reference, the fresh
+challenge, the selected envelope/configuration + appliance digests, and a
+`sha256:` native correlation. The equivalent gate also runs as an opt-in pytest:
+
+```sh
+ACES_REAL_LIBVIRT_URI=qemu:///system \
+  uv run pytest -m integration \
+  implementations/python/tests/test_libvirt_backend_guest_certified_real_libvirt.py
+```
+
+Both are skipped by the default hermetic `nox verify` graph, which never requires
+libvirt, QEMU/KVM, privileges, a host image, network access, or credentials — the
+guest-certified proof is an explicit separate gate. The same host requirements
+apply (`security_driver = "none"` + `user/group = "root"` in
+`/etc/libvirt/qemu.conf` when boot artifacts and the run-local guest fact channel
+live outside `/var/lib/libvirt/images`; the AWS script sets these automatically).

--- a/tools/real-daemon/evidence/guest-certified-asr519-20260712T023403Z.json
+++ b/tools/real-daemon/evidence/guest-certified-asr519-20260712T023403Z.json
@@ -1,0 +1,491 @@
+{
+  "backend": {
+    "capability_profile": {
+      "observation_contract_gaps": [],
+      "participant_runtime_contract_gaps": []
+    },
+    "manifest": {
+      "capabilities": {
+        "evaluator": null,
+        "observation": null,
+        "orchestrator": null,
+        "participant_runtime": {
+          "constraints": {
+            "simulation_disclosure": "deterministic-simulation: no live libvirt domain execution; see docs/decisions/issue-614-libvirt-participant-runtime.md"
+          },
+          "feature_support": [
+            {
+              "constraint_refs": [],
+              "disclosure_refs": [
+                "docs/decisions/issue-614-libvirt-participant-runtime.md"
+              ],
+              "feature": "action_contracts",
+              "support_level": "disclosed_weak"
+            },
+            {
+              "constraint_refs": [],
+              "disclosure_refs": [
+                "docs/decisions/issue-614-libvirt-participant-runtime.md"
+              ],
+              "feature": "observation_boundaries",
+              "support_level": "disclosed_weak"
+            },
+            {
+              "constraint_refs": [],
+              "disclosure_refs": [
+                "docs/decisions/issue-614-libvirt-participant-runtime.md"
+              ],
+              "feature": "behavior_history",
+              "support_level": "disclosed_weak"
+            },
+            {
+              "constraint_refs": [],
+              "disclosure_refs": [
+                "docs/decisions/issue-614-libvirt-participant-runtime.md"
+              ],
+              "feature": "state_transitions",
+              "support_level": "disclosed_weak"
+            },
+            {
+              "constraint_refs": [],
+              "disclosure_refs": [
+                "docs/decisions/issue-614-libvirt-participant-runtime.md"
+              ],
+              "feature": "contention",
+              "support_level": "disclosed_weak"
+            }
+          ],
+          "name": "libvirt-deterministic-participant-runtime",
+          "supported_behavior_features": [
+            "action_contracts",
+            "behavior_history",
+            "observation_boundaries",
+            "state_transitions"
+          ],
+          "supported_interaction_features": [
+            "contention"
+          ],
+          "supported_participant_roles": [
+            "red"
+          ]
+        },
+        "provisioner": {
+          "constraints": {},
+          "max_total_nodes": null,
+          "name": "libvirt-provisioner",
+          "supported_account_features": [
+            "disabled",
+            "groups",
+            "home",
+            "shell"
+          ],
+          "supported_content_types": [
+            "file"
+          ],
+          "supported_node_types": [
+            "switch",
+            "vm"
+          ],
+          "supported_os_families": [
+            "linux"
+          ],
+          "supports_accounts": true,
+          "supports_acls": false
+        }
+      },
+      "compatibility": {
+        "processors": [
+          "aces-reference-processor"
+        ]
+      },
+      "concept_bindings": [
+        {
+          "family": "assets",
+          "scope": "capabilities.provisioner.supported_node_types"
+        },
+        {
+          "family": "assets",
+          "scope": "capabilities.provisioner.supported_os_families"
+        },
+        {
+          "family": "tools-and-artifacts",
+          "scope": "capabilities.provisioner.supported_content_types"
+        },
+        {
+          "family": "identities",
+          "scope": "capabilities.provisioner.supported_account_features"
+        }
+      ],
+      "constraints": {},
+      "identity": {
+        "name": "libvirt-qemu",
+        "version": "0.19.1"
+      },
+      "realization_envelope": {
+        "configuration_digest": "sha256:b33ad469eaf1a47963e49da8adc7376fc22880ac3e6126b427239daa00dc6d99",
+        "contract_id": "realization-envelope-v1",
+        "digest": "sha256:8416a600a6f1864e1b80e49fa60eef5f423f9249f2ea7dc56e14d8a669e33e2e",
+        "envelope_id": "libvirt-qemu.guest-certified-appliance.v1",
+        "schema_version": "realization-envelope/v1"
+      },
+      "realization_support": [
+        {
+          "constraints": {},
+          "disclosure_kinds": [
+            "backend-manifest-v2",
+            "operation-status-v1",
+            "runtime-snapshot-v1"
+          ],
+          "domain": "runtime-realization",
+          "support_mode": "constrained",
+          "supported_constraint_kinds": [
+            "account-feature",
+            "content-type",
+            "node-type",
+            "os-family"
+          ],
+          "supported_exact_requirement_kinds": [
+            "declared-capability-match"
+          ]
+        }
+      ],
+      "schema_version": "backend-manifest/v2",
+      "supported_contract_versions": [
+        "backend-manifest-v2",
+        "realization-envelope-v1",
+        "provisioning-plan-v1",
+        "operation-receipt-v1",
+        "operation-status-v1",
+        "runtime-snapshot-v1",
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
+        "participant-shared-state-record-v1",
+        "participant-joint-action-record-v1",
+        "participant-time-management-context-v1"
+      ]
+    },
+    "realization_provenance": {
+      "backend": "libvirt-qemu",
+      "basis": "daemon-observed-substrate",
+      "cleanup_verified": true,
+      "evidence_source_mode": "guest-certified",
+      "substrate_realized": true
+    }
+  },
+  "compiled_artifact": {
+    "compiled_address_sets": {
+      "action_contracts": [],
+      "networks": [
+        "provision.network.guest-net"
+      ],
+      "node_deployments": [
+        "provision.node.guest-vm"
+      ],
+      "objectives": [],
+      "observation_boundaries": [],
+      "participant_behaviors": []
+    },
+    "compiled_model_fingerprint": "sha256:b0ce6d650a49f579592b7746e84ab43e73ca3d31a7b3e2dd2a6620eb2fcee654",
+    "processor": "aces-reference-processor"
+  },
+  "defensive_evidence": {
+    "captured_at": "2026-07-12T02:36:12.707249+00:00",
+    "evaluator_evidence_channels": [],
+    "evidence_kind": "telemetry",
+    "evidence_source": "structural-evaluator-channel",
+    "loss_disclosure": "Deterministic mode: no live SOC substrate is booted. Wazuh/SOC defensive evidence is reported as the evaluator-only evidence channels declared by the scenario observation boundary, not upstream Wazuh detection output; no detection-quality claim is made. Daemon-observed libvirt substrate state is present, but it is not guest SOC observation.",
+    "payload_summary": "Evaluator-only Wazuh/SOC and policy-decision evidence channels are declared and kept off the participant view; neither evidence mode claims guest SOC readback.",
+    "redaction_state": "withheld",
+    "sensitivity": "restricted",
+    "visibility": "evaluator-only"
+  },
+  "evaluator_outcome": {
+    "history": [
+      {
+        "detail": "Scenario-evidence evaluator outcome derived from the structural participant proof.",
+        "details": {},
+        "event_type": "evaluation_completed",
+        "evidence_refs": [
+          "participant_action_proof"
+        ],
+        "max_score": null,
+        "passed": true,
+        "score": null,
+        "status": "ready",
+        "timestamp": "2026-07-12T02:36:12.707249+00:00"
+      }
+    ],
+    "limitations": [
+      "Evaluator outcome reflects the structural participant-loop proof; the libvirt backend ships no generic evaluator component, so this is a evidence-run evaluator record, not a generic backend evaluator result."
+    ],
+    "result": {
+      "detail": "Structural participant-loop proof over the libvirt deterministic participant runtime.",
+      "evidence_refs": [
+        "participant_action_proof",
+        "negative_boundary_checks"
+      ],
+      "max_score": null,
+      "observed_at": "2026-07-12T02:36:12.707249+00:00",
+      "passed": true,
+      "resource_type": "participant-loop-evaluation",
+      "run_id": "scenario-evidence",
+      "score": null,
+      "state_schema_version": "evaluation-result-state/v1",
+      "status": "ready",
+      "updated_at": "2026-07-12T02:36:12.707249+00:00"
+    }
+  },
+  "evidence_source_mode": "guest-certified",
+  "invariant_ledger_refs": {
+    "action_contracts": [],
+    "evidence_refs": [
+      "participant_action_proof",
+      "terminal_observation",
+      "defensive_evidence",
+      "negative_boundary_checks",
+      "evaluator_outcome"
+    ],
+    "note": "Stable ACES addresses and evidence refs for the Brad-Edwards/aces#600 cross-backend invariant ledger; no libvirt domain UUIDs, host paths, or APTL-private identifiers.",
+    "observation_boundaries": [],
+    "participant_behaviors": [],
+    "scenario_content_sha256": "sha256:54cfbf2301510771eff148748e60dc0917efbbf695270d9a5b837ee80bcbb454",
+    "scenario_name": "techvault-guest-certified"
+  },
+  "limitations": [
+    "The libvirt participant runtime uses the deterministic domain adapter; no live participant domain is executed (issue #614).",
+    "Wazuh/SOC evidence is evaluator-only structural evidence; daemon substrate state is not promoted to guest or application observation.",
+    "Deterministic mode does not realize a live libvirt substrate; topology and defensive evidence channels are compiled/structural, explicitly disclosed as not-live observations."
+  ],
+  "negative_boundary_checks": {
+    "all_internal_surfaces_withheld": true,
+    "checks": [],
+    "disclosure": "Negative boundary checks are evaluator-side derived analysis, not participant observations.",
+    "method": "Structural boundary analysis over the compiled observation boundary (hidden_refs) and the participant exposure policy (empty visible/disclosed refs). The participant action surface does not expose the internal DB, Wazuh, evaluator, or policy-gate surfaces.",
+    "value_status": "reported"
+  },
+  "non_claims": [
+    "No Wazuh detection-quality claim.",
+    "No model-defense robustness claim.",
+    "No byte-equivalence or application-internals equivalence claim between libvirt appliances and APTL containers.",
+    "No full semantic-equivalence claim beyond the invariant ledger in Brad-Edwards/aces#600."
+  ],
+  "participant_action_proof": {
+    "admitted_action_addresses": [],
+    "diagnostics": [],
+    "episode_states": {},
+    "lifecycle_clean": true,
+    "participant_disclosed_refs": [],
+    "participant_visible_refs": [],
+    "runtime": "libvirt-deterministic-participant-runtime",
+    "structural_validation_note": "Deep behavior-history and episode-snapshot invariant validation is performed by the issue #614 participant-runtime test suite (processor-layer iterators); this artifact records the libvirt participant-runtime lifecycle outcome."
+  },
+  "realization_facts": {
+    "authored": {
+      "scenario_name": "techvault-guest-certified",
+      "source": "authored"
+    },
+    "binding": {
+      "boot_artifact_digests": {
+        "initramfs": "sha256:5422c9311818db1935e9621a8e96e8e27b26ae014f4cc1b1e0ec47524f6e38cb",
+        "kernel": "sha256:bb4b6f0a792f26999ca7d881a183ec5ab94239073448ddd12cd28e579860face"
+      },
+      "configuration_digest": "sha256:b33ad469eaf1a47963e49da8adc7376fc22880ac3e6126b427239daa00dc6d99",
+      "connection_uri_digest": "sha256:9bea68fb783f6b3b82c458cf8ce5e62508864d50076287b24ca436af2d110eeb",
+      "driver": "guest-certified-appliance",
+      "driver_configuration_digest": "sha256:fd2ec007ef507306ae713c66031111c06f55113181a937401dfbd94abc7bfdb4",
+      "name_prefix_digest": "sha256:5ee63117aa996ced3460eb178f900164350fc8a3b17af78970decb6eed534b93",
+      "realization_envelope_digest": "sha256:8416a600a6f1864e1b80e49fa60eef5f423f9249f2ea7dc56e14d8a669e33e2e"
+    },
+    "cleanup": {
+      "source": "driver-reported",
+      "status": "verified"
+    },
+    "daemon_observed": {
+      "domains": [
+        {
+          "address": "provision.node.guest-vm",
+          "architecture": "x86_64",
+          "image_policy": "generated-initramfs-appliance",
+          "memory_mib": 128,
+          "name": "aces-evidence-guest-vm",
+          "network_attachments": [
+            "provision.network.guest-net"
+          ],
+          "observation_source": "daemon-observed",
+          "vcpus": 1
+        }
+      ],
+      "networks": [
+        {
+          "address": "provision.network.guest-net",
+          "cidr": "192.0.2.0/24",
+          "forward_mode": "none",
+          "gateway": "192.0.2.1",
+          "internal": true,
+          "name": "aces-evidence-guest-net",
+          "observation_source": "daemon-observed"
+        }
+      ],
+      "source": "daemon-observed"
+    },
+    "driver_reported": {
+      "realized_addresses": [
+        "provision.network.guest-net",
+        "provision.node.guest-vm"
+      ],
+      "source": "driver-reported"
+    },
+    "guest_observed": {
+      "certifying": true,
+      "challenge": "1c35d3b17f2c8a3bb3620a9509c15f79",
+      "domains": [
+        {
+          "accounts": [],
+          "address": "provision.node.guest-vm",
+          "architecture": "x86_64",
+          "content": [
+            "/etc/aces/marker|aabb38db6cd478c6dcbf41b2973d99a8e72cafe9a026df5808d5015452b38a55|644"
+          ],
+          "correlation": "sha256:e02c8435b23e310dbe541c17e94a776cf501b290b07e398dbb7a67c89c23d9bb",
+          "memory_mib": 78,
+          "network": [
+            "52:54:00:c4:7e:78|192.0.2.10"
+          ],
+          "services": [
+            "beacon|9000|1|1"
+          ],
+          "vcpus": 1
+        }
+      ],
+      "observed_at": "2026-07-12T02:36:12.288648+00:00",
+      "operation_ref": "sha256:d2ca251d7720b4ac56f091066a2d7488bbddd906c33a7bf770468e394c0cdbab",
+      "probe_policy": "serial-fact-channel/v1",
+      "source": "guest-observed"
+    },
+    "planned": {
+      "network_addresses": [
+        "provision.network.guest-net"
+      ],
+      "node_addresses": [
+        "provision.node.guest-vm"
+      ],
+      "source": "planned"
+    }
+  },
+  "realized_form_disclosures": [
+    {
+      "authored_ref": null,
+      "basis": "backend-realized",
+      "concern_id": "libvirt-backend-selection",
+      "concern_kind": "backend-selection",
+      "disclosure": "The libvirt-qemu backend supplied the run; live claims are limited to independently daemon-observed substrate fields.",
+      "evidence_refs": [],
+      "realized_by_ref": {
+        "ref_digest": null,
+        "ref_id": "libvirt-qemu",
+        "ref_kind": "backend",
+        "ref_path": null,
+        "ref_version": "0.19.1"
+      },
+      "realized_ref": null,
+      "realized_value_summary": "libvirt-qemu backend (0.19.1); substrate daemon-observed at bounded fields."
+    },
+    {
+      "authored_ref": null,
+      "basis": "backend-realized",
+      "concern_id": "libvirt-participant-implementation",
+      "concern_kind": "participant-implementation",
+      "disclosure": "The participant action proof uses the deterministic domain adapter; live domain execution is not performed.",
+      "evidence_refs": [],
+      "realized_by_ref": {
+        "ref_digest": null,
+        "ref_id": "libvirt-qemu",
+        "ref_kind": "backend",
+        "ref_path": null,
+        "ref_version": "0.19.1"
+      },
+      "realized_ref": null,
+      "realized_value_summary": "Deterministic libvirt participant runtime (no live domain execution); see issue #614."
+    }
+  ],
+  "realized_topology": {
+    "basis": "mixed-source",
+    "disclosure": "Compiled topology remains planned; the native surface contains only independently daemon-observed substrate fields.",
+    "native_surface": {
+      "domains": [
+        "aces-evidence-guest-vm"
+      ],
+      "networks": [
+        "aces-evidence-guest-net"
+      ],
+      "source": "daemon-observed",
+      "substrate": "libvirt-qemu-initramfs"
+    },
+    "network_attachment_matrix": {
+      "guest-vm": [
+        "guest-net"
+      ]
+    },
+    "networks": [
+      {
+        "address": "provision.network.guest-net",
+        "cidr": "192.0.2.0/24",
+        "gateway": "192.0.2.1",
+        "internal": true,
+        "name": "guest-net",
+        "source": "planned"
+      }
+    ],
+    "nodes": [
+      {
+        "address": "provision.node.guest-vm",
+        "name": "guest-vm",
+        "networks": [
+          "guest-net"
+        ],
+        "node_type": "vm",
+        "os_family": "linux",
+        "services": [
+          {
+            "name": "beacon",
+            "port": 9000,
+            "protocol": "tcp"
+          }
+        ],
+        "source": "planned"
+      }
+    ]
+  },
+  "recorded_at": "2026-07-12T02:36:12.707249+00:00",
+  "redaction_provenance": {
+    "policy": "Only allowlisted, bounded fields are copied into the artifact. Raw libvirt XML, domain UUIDs, QEMU command lines, host paths, connection URIs, credentials, private keys, and backend-private inspect payloads are never written.",
+    "provenance_refs": [
+      "docs/decisions/issue-615-libvirt-paper-evidence-preflight.md",
+      "docs/decisions/issue-614-libvirt-participant-runtime.md"
+    ],
+    "redacted_field_classes": [
+      "raw-libvirt-xml",
+      "domain-uuid",
+      "qemu-command-line",
+      "host-path",
+      "connection-uri",
+      "credential",
+      "private-key",
+      "backend-private-inspect-payload"
+    ]
+  },
+  "run_id": "asr519-20260712T023403Z",
+  "scenario": {
+    "content_sha256": "sha256:54cfbf2301510771eff148748e60dc0917efbbf695270d9a5b837ee80bcbb454",
+    "name": "techvault-guest-certified",
+    "relative_path": "examples/scenarios/techvault-guest-certified.sdl.yaml",
+    "version": "*"
+  },
+  "schema": "aces.libvirt.scenario-evidence-run/v1",
+  "terminal_observation": {
+    "behavior_history": {},
+    "disclosure": "The libvirt participant runtime emits a behavior-history event stream rather than a standalone SEM-210 observation envelope; the terminal participant view is reported as the behavior-history equivalent.",
+    "form": "behavior-history-equivalent"
+  }
+}

--- a/tools/real-daemon/evidence/guest-certified-asr519-20260712T031842Z.json
+++ b/tools/real-daemon/evidence/guest-certified-asr519-20260712T031842Z.json
@@ -190,7 +190,7 @@
     "processor": "aces-reference-processor"
   },
   "defensive_evidence": {
-    "captured_at": "2026-07-12T02:36:12.707249+00:00",
+    "captured_at": "2026-07-12T03:20:52.516205+00:00",
     "evaluator_evidence_channels": [],
     "evidence_kind": "telemetry",
     "evidence_source": "structural-evaluator-channel",
@@ -213,7 +213,7 @@
         "passed": true,
         "score": null,
         "status": "ready",
-        "timestamp": "2026-07-12T02:36:12.707249+00:00"
+        "timestamp": "2026-07-12T03:20:52.516205+00:00"
       }
     ],
     "limitations": [
@@ -226,14 +226,14 @@
         "negative_boundary_checks"
       ],
       "max_score": null,
-      "observed_at": "2026-07-12T02:36:12.707249+00:00",
+      "observed_at": "2026-07-12T03:20:52.516205+00:00",
       "passed": true,
       "resource_type": "participant-loop-evaluation",
       "run_id": "scenario-evidence",
       "score": null,
       "state_schema_version": "evaluation-result-state/v1",
       "status": "ready",
-      "updated_at": "2026-07-12T02:36:12.707249+00:00"
+      "updated_at": "2026-07-12T03:20:52.516205+00:00"
     }
   },
   "evidence_source_mode": "guest-certified",
@@ -287,13 +287,13 @@
     },
     "binding": {
       "boot_artifact_digests": {
-        "initramfs": "sha256:5422c9311818db1935e9621a8e96e8e27b26ae014f4cc1b1e0ec47524f6e38cb",
+        "initramfs": "sha256:303be8a7ce5a5b9b32c68a9b6469e24034483ef6d978bbcdd2e29ca577a29efd",
         "kernel": "sha256:bb4b6f0a792f26999ca7d881a183ec5ab94239073448ddd12cd28e579860face"
       },
       "configuration_digest": "sha256:b33ad469eaf1a47963e49da8adc7376fc22880ac3e6126b427239daa00dc6d99",
       "connection_uri_digest": "sha256:9bea68fb783f6b3b82c458cf8ce5e62508864d50076287b24ca436af2d110eeb",
       "driver": "guest-certified-appliance",
-      "driver_configuration_digest": "sha256:fd2ec007ef507306ae713c66031111c06f55113181a937401dfbd94abc7bfdb4",
+      "driver_configuration_digest": "sha256:0a314d970cd037fd46ebde0576ca601401e146181dd1549e525bab208a2c9e78",
       "name_prefix_digest": "sha256:5ee63117aa996ced3460eb178f900164350fc8a3b17af78970decb6eed534b93",
       "realization_envelope_digest": "sha256:8416a600a6f1864e1b80e49fa60eef5f423f9249f2ea7dc56e14d8a669e33e2e"
     },
@@ -338,7 +338,7 @@
     },
     "guest_observed": {
       "certifying": true,
-      "challenge": "1c35d3b17f2c8a3bb3620a9509c15f79",
+      "challenge": "fe994cd2e7866dd60b98e74e64a88cfb",
       "domains": [
         {
           "accounts": [],
@@ -358,8 +358,8 @@
           "vcpus": 1
         }
       ],
-      "observed_at": "2026-07-12T02:36:12.288648+00:00",
-      "operation_ref": "sha256:d2ca251d7720b4ac56f091066a2d7488bbddd906c33a7bf770468e394c0cdbab",
+      "observed_at": "2026-07-12T03:20:52.159020+00:00",
+      "operation_ref": "sha256:c18ba445c2cd1183774347891759b768d4863493c8e39626ed8885977031630c",
       "probe_policy": "serial-fact-channel/v1",
       "source": "guest-observed"
     },
@@ -457,7 +457,7 @@
       }
     ]
   },
-  "recorded_at": "2026-07-12T02:36:12.707249+00:00",
+  "recorded_at": "2026-07-12T03:20:52.516205+00:00",
   "redaction_provenance": {
     "policy": "Only allowlisted, bounded fields are copied into the artifact. Raw libvirt XML, domain UUIDs, QEMU command lines, host paths, connection URIs, credentials, private keys, and backend-private inspect payloads are never written.",
     "provenance_refs": [
@@ -475,7 +475,7 @@
       "backend-private-inspect-payload"
     ]
   },
-  "run_id": "asr519-20260712T023403Z",
+  "run_id": "asr519-20260712T031842Z",
   "scenario": {
     "content_sha256": "sha256:54cfbf2301510771eff148748e60dc0917efbbf695270d9a5b837ee80bcbb454",
     "name": "techvault-guest-certified",

--- a/tools/real-daemon/run_aws_guest_certify.sh
+++ b/tools/real-daemon/run_aws_guest_certify.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Provision an ephemeral AWS EC2 host with a real libvirt/QEMU daemon, run the
+# guest-certified realization proof (ASR-519, issue #715) against it through the
+# production apply path, pull back the redaction-safe machine-readable evidence
+# artifact, then tear everything down. This is the guest-observed counterpart to
+# run_aws_smoke.sh (which proves daemon-level reconciliation with a cirros disk).
+#
+# Usage:
+#   AWS_PROFILE=proof AWS_REGION=us-east-2 tools/real-daemon/run_aws_guest_certify.sh [--keep]
+#
+#   --keep   leave the instance running (skip teardown) for manual poking.
+#
+# On success the emitted evidence JSON is copied to
+#   tools/real-daemon/evidence/guest-certified-<run-id>.json
+# The instance uses TCG (software emulation); no bare-metal/nested-virt needed.
+set -euo pipefail
+
+PROFILE="${AWS_PROFILE:-proof}"
+REGION="${AWS_REGION:-us-east-2}"
+INSTANCE_TYPE="${INSTANCE_TYPE:-c5.2xlarge}"
+RUN_ID="${RUN_ID:-aws-guest-certified}"
+KEEP=0
+[ "${1:-}" = "--keep" ] && KEEP=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+KEY="$WORK/aces-guest-test.pem"
+NAME="aces-guest-certify-test"
+AWS=(aws --profile "$PROFILE" --region "$REGION")
+
+cleanup_aws() {
+  [ "$KEEP" = "1" ] && { echo "--keep: leaving instance ${IID:-?} (${IP:-?}) up"; return; }
+  echo "=== teardown ==="
+  [ -n "${IID:-}" ] && "${AWS[@]}" ec2 terminate-instances --instance-ids "$IID" >/dev/null 2>&1 || true
+  [ -n "${IID:-}" ] && "${AWS[@]}" ec2 wait instance-terminated --instance-ids "$IID" 2>/dev/null || true
+  [ -n "${SG:-}" ] && "${AWS[@]}" ec2 delete-security-group --group-id "$SG" >/dev/null 2>&1 || true
+  "${AWS[@]}" ec2 delete-key-pair --key-name "$NAME" >/dev/null 2>&1 || true
+  echo "torn down."
+}
+trap cleanup_aws EXIT
+
+echo "=== identity ==="; "${AWS[@]}" sts get-caller-identity --query Account --output text
+
+AMI=$("${AWS[@]}" ssm get-parameter --name /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id --query Parameter.Value --output text)
+MYIP=$(curl -s https://checkip.amazonaws.com)
+VPC=$("${AWS[@]}" ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)
+SUBNET=$("${AWS[@]}" ec2 describe-subnets --filters Name=default-for-az,Values=true --query 'Subnets[0].SubnetId' --output text)
+
+"${AWS[@]}" ec2 delete-key-pair --key-name "$NAME" >/dev/null 2>&1 || true
+"${AWS[@]}" ec2 create-key-pair --key-name "$NAME" --query KeyMaterial --output text > "$KEY"
+chmod 600 "$KEY"
+
+SG=$("${AWS[@]}" ec2 create-security-group --group-name "$NAME-sg" --description "aces guest-certify proof" --vpc-id "$VPC" --query GroupId --output text 2>/dev/null \
+  || "${AWS[@]}" ec2 describe-security-groups --filters Name=group-name,Values="$NAME-sg" --query 'SecurityGroups[0].GroupId' --output text)
+"${AWS[@]}" ec2 authorize-security-group-ingress --group-id "$SG" --protocol tcp --port 22 --cidr "$MYIP/32" >/dev/null 2>&1 || true
+
+cat > "$WORK/userdata.sh" <<'UD'
+#!/bin/bash
+set -x
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y qemu-system-x86 qemu-utils libvirt-daemon-system libvirt-clients libvirt-dev genisoimage python3-dev pkg-config build-essential curl rsync busybox-static cpio
+systemctl enable --now libvirtd
+usermod -aG libvirt,kvm ubuntu
+# The guest-observing appliance builder defaults to /usr/bin/busybox.
+[ -x /usr/bin/busybox ] || ln -sf "$(command -v busybox)" /usr/bin/busybox
+# test-host libvirt config so boot artifacts + the guest fact channel outside
+# /var/lib/libvirt/images are readable/writable by the qemu process.
+sed -i 's/^#*security_driver *=.*/security_driver = "none"/' /etc/libvirt/qemu.conf
+grep -q '^security_driver' /etc/libvirt/qemu.conf || echo 'security_driver = "none"' >> /etc/libvirt/qemu.conf
+sed -i 's/^#*user *=.*/user = "root"/; s/^#*group *=.*/group = "root"/' /etc/libvirt/qemu.conf
+systemctl restart libvirtd
+touch /var/lib/cloud/userdata-done
+UD
+
+IID=$("${AWS[@]}" ec2 run-instances --image-id "$AMI" --instance-type "$INSTANCE_TYPE" \
+  --key-name "$NAME" --security-group-ids "$SG" --subnet-id "$SUBNET" --associate-public-ip-address \
+  --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=30,VolumeType=gp3}' \
+  --user-data "file://$WORK/userdata.sh" \
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$NAME}]" \
+  --query 'Instances[0].InstanceId' --output text)
+echo "instance: $IID"
+"${AWS[@]}" ec2 wait instance-running --instance-ids "$IID"
+IP=$("${AWS[@]}" ec2 describe-instances --instance-ids "$IID" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+echo "public ip: $IP"
+
+SSHOPT=(-i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15)
+echo "=== wait for ssh + userdata ==="
+for _ in $(seq 1 40); do ssh "${SSHOPT[@]}" ubuntu@"$IP" "test -f /var/lib/cloud/userdata-done" 2>/dev/null && break; sleep 10; done
+
+echo "=== deploy code ==="
+ssh "${SSHOPT[@]}" ubuntu@"$IP" "mkdir -p /home/ubuntu/aces/implementations/python /home/ubuntu/aces/contracts /home/ubuntu/aces/examples"
+rsync -az --delete --exclude '.venv' --exclude '__pycache__' --exclude '.git' --exclude '.pytest_cache' --exclude '.nox' --exclude '*.pyc' \
+  -e "ssh ${SSHOPT[*]}" "$REPO_ROOT/implementations/python/" ubuntu@"$IP":/home/ubuntu/aces/implementations/python/
+rsync -az --delete --exclude '.git' -e "ssh ${SSHOPT[*]}" "$REPO_ROOT/contracts/" ubuntu@"$IP":/home/ubuntu/aces/contracts/
+rsync -az --delete --exclude '.git' -e "ssh ${SSHOPT[*]}" "$REPO_ROOT/examples/" ubuntu@"$IP":/home/ubuntu/aces/examples/
+scp "${SSHOPT[@]}" "$REPO_ROOT/.ground-control.yaml" ubuntu@"$IP":/home/ubuntu/aces/.ground-control.yaml
+# The editable build (hatch_build.py) reads the repo-root README for packaging.
+scp "${SSHOPT[@]}" "$REPO_ROOT/README.md" ubuntu@"$IP":/home/ubuntu/aces/README.md
+
+echo "=== install venv + libvirt-python ==="
+ssh "${SSHOPT[@]}" ubuntu@"$IP" "curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1; cd ~/aces/implementations/python && ~/.local/bin/uv sync --all-extras >/dev/null 2>&1 && ~/.local/bin/uv pip install libvirt-python >/dev/null 2>&1 && echo venv-ready"
+
+echo "=== run guest-certified proof ==="
+ssh "${SSHOPT[@]}" ubuntu@"$IP" "sudo bash -lc 'cd /home/ubuntu/aces && implementations/python/.venv/bin/python -c \"
+from pathlib import Path
+from aces_operations.libvirt_evidence_run import run_libvirt_evidence_run, LibvirtEvidenceRunConfig
+r = run_libvirt_evidence_run(scenario_path=Path(\\\"examples/scenarios/techvault-guest-certified.sdl.yaml\\\").resolve(), project_dir=Path(\\\"/home/ubuntu/aces/gc-out\\\"), run_id=\\\"$RUN_ID\\\", config=LibvirtEvidenceRunConfig(evidence_source_mode=\\\"guest-certified\\\", connection_uri=\\\"qemu:///system\\\"))
+print(r.render())
+import sys; sys.exit(0 if r.passed else 1)
+\"'"
+
+echo "=== pull evidence artifact ==="
+ssh "${SSHOPT[@]}" ubuntu@"$IP" "sudo chown -R ubuntu /home/ubuntu/aces/gc-out 2>/dev/null || true"
+mkdir -p "$REPO_ROOT/tools/real-daemon/evidence"
+scp "${SSHOPT[@]}" ubuntu@"$IP":/home/ubuntu/aces/gc-out/runs/"$RUN_ID"/scenario-evidence/libvirt-scenario-evidence-run.json \
+  "$REPO_ROOT/tools/real-daemon/evidence/guest-certified-$RUN_ID.json"
+echo "pulled: tools/real-daemon/evidence/guest-certified-$RUN_ID.json"


### PR DESCRIPTION
## Summary

Implements **ASR-519 / issue #715 (03 of 05)**: guest-observed libvirt realization probes. Populates the `guest_observed` evidence slot #714 reserved with concern-specific observers that boot a canonical appliance through the **production apply path** and read realized state **from inside the guest** — resource allocation, network addressing, file content, account posture, and service state — freshness-bound to a per-run challenge, with typed redacted failures and verified teardown. Domain existence never satisfies a nested-concern claim.

Requirement: `ASR-519` — Realization Honesty And Disclosure Conformance (MUST, Wave 3). No new ADR; applies ADR-021 (falsification-first), ADR-066 (evidence-plane separation), ADR-070 (realization envelope). Design note: `docs/decisions/issue-715-asr-519-guest-observed-libvirt-probes-preflight.md`.

## Changes

- **New material configuration + envelope**: `LibvirtDriverMode.GUEST_CERTIFIED_APPLIANCE` + `contracts/realization-envelopes/libvirt-qemu/guest-certified-appliance-v1.json` (guest-observed concern disclosures; distinct config/envelope digests — the daemon-only identity is untouched).
- **Credential-free guest transport** (`guest_transport.py`): a file-backed serial fact channel behind a `GuestFactTransport` seam (a future guest-agent impl swaps in), with a bounded, duplicate-rejecting parser.
- **Guest observer + gate** (`guest_observation.py`): staged observation (daemon → transport → init → concern probes → cleanup), `GUEST_OBSERVED` facts read from the realized system, distinct typed diagnostics (transport/timeout/init/challenge/malformed/duplicate/missing/mismatch).
- **Guest-observing appliance** (`guest_appliance.py`) + **guest-certified driver** (`guest_certified_driver.py`): realizes seeded content/account/service and reports real in-guest readings; challenge rides the kernel cmdline so the appliance digest is challenge-independent; guest proof is commit-eligibility.
- **Evidence** (`_evidence_run_artifact.py`, `_evidence_run_validation.py`, `libvirt_evidence_run.py`): populates + validates the `guest_observed` fact section (operation join, fresh challenge, canonical native correlation, daemon join); **native-proof boundary** — a `certifying` flag is true only for the production driver, so injected fakes are non-certifying and externally distinguishable; cleanup runs in a finally-path after every attempt (incl. residual guest-probe artifacts).
- **Operator command** `aces libvirt techvault guest-certify` + AWS proof harness `tools/real-daemon/run_aws_guest_certify.sh`; example scenario `examples/scenarios/techvault-guest-certified.sdl.yaml`.
- **Committed real-daemon evidence report** generated by the production path against a real libvirt/QEMU daemon: `tools/real-daemon/evidence/guest-certified-*.json` (`certifying: true`, redaction-safe, validates clean).

## Testing

- Hermetic orchestration + falsification tests (transport failure, partial boot, missing/duplicate/mismatch, wrong IP/vcpu/memory/content/account/service, unsupported placement/image), evidence-run integration (certifying=false for fakes), and residual-cleanup fail-closed coverage.
- Opt-in real-daemon certification (`ACES_REAL_LIBVIRT_URI`), skipped in the hermetic graph.
- `ruff` + `ruff format` clean; `check_repo_policy.py` + `check_generated_schemas.py` pass.

## Traceability (ASR-519)

- IMPLEMENTS: `guest_observation.py`, `guest_certified_driver.py`, `guest_transport.py`, `guest_appliance.py`, `libvirt_evidence_run.py`, `_evidence_run_validation.py`, `aces_cli/libvirt.py`, and `contracts/realization-envelopes/libvirt-qemu/guest-certified-appliance-v1.json` (SPEC).
- TESTS: `test_libvirt_backend_guest_certified.py`, `test_libvirt_backend_guest_certified_real_libvirt.py`.

## Ground Control Checks

- **Requirement**: ASR-519 stays ACTIVE; IMPLEMENTS + TESTS links reconciled post-merge.
- **Realization honesty**: guest concerns are read from the realized guest (not echoed); unsupported concerns (feature-binding, ACL) disclosed honestly; injected fakes can never mint a certifying artifact.
- **Non-goals**: no #716 conformance runner or #717 final certification; one canonical guest does not prove all images/OS/mechanisms.

Closes #715
