### PR TITLE
refactor(conformance): drop redundant tuple() constructors (S7496)

### DIFF
--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -1247,7 +1247,7 @@ def run_target_conformance(
     participant_claim_gaps = participant_runtime_capability_contract_gaps(target.manifest)
     observation_claim_gaps = observation_capability_contract_gaps(target.manifest)
     claim_gaps = (*participant_claim_gaps, *observation_claim_gaps)
-    capability_gaps = tuple((*surface_gaps, *claim_gaps))
+    capability_gaps = (*surface_gaps, *claim_gaps)
     passed = fixture_report.passed and not contract_gaps and not capability_gaps
     diagnostics = list(fixture_report.diagnostics)
     if contract_gaps:
@@ -1276,7 +1276,7 @@ def run_target_conformance(
             )
         )
     target_cases = _target_adapter_cases(target, effective_profile, reference_scenario=reference_scenario)
-    cases = tuple((*fixture_report.cases, *target_cases))
+    cases = (*fixture_report.cases, *target_cases)
     passed = passed and all(case.passed for case in target_cases)
     return BackendConformanceReport(
         profile=_to_profile_id(effective_profile),


### PR DESCRIPTION
## Why

The `dev` → `main` promotion (**PR #740**) now fails SonarCloud on a single new
violation — **`python:S7496`** "Remove the redundant tuple constructor call" at
`aces_conformance/conformance.py`. SonarCloud activated this rule since the earlier
scans, and it flags `tuple((*a, *b))` where the inner starred expression is already
a tuple. (Not from the modularity split in #743 — this line came in with #741.)

## What

Unwrap both occurrences in `conformance.py`:

```python
capability_gaps = tuple((*surface_gaps, *claim_gaps))  ->  (*surface_gaps, *claim_gaps)
cases          = tuple((*fixture_report.cases, *target_cases))  ->  (*fixture_report.cases, *target_cases)
```

Semantically identical (`(*a, *b)` is already a tuple); the `tuple(...)` wrapper is
pure redundancy.

## Verification

- `ruff check` / `format` clean; conformance test suite green (83 passed).
- Clears the last SonarCloud `new_violations` on PR #740 (was 1).

Requirement: **MOD-001** (code-quality cleanup).