### PR TITLE
chore(evolution): add deprecation-record ledger and policy gate (GOV-902)

### DIFF
--- a/contracts/schemas/README.md
+++ b/contracts/schemas/README.md
@@ -10,8 +10,8 @@ single implementation language or package layout.
 Current published schemas cover:
 - SDL normalized authoring objects (not raw YAML presentation)
 - instantiated scenarios and canonical instantiated snapshots
-- backend manifests (`v1` legacy plus shared-apparatus `v2`)
-- processor manifests (`v1` legacy plus shared-apparatus `v2`)
+- backend manifests (shared-apparatus `v2`)
+- processor manifests (shared-apparatus `v2`)
 - concept-authority catalogs
 - reference model catalogs
 - UCO alignment evidence
@@ -79,9 +79,9 @@ particular:
 - backend capability blocks must declare concrete provisioning and orchestration
   surfaces rather than empty shells
 
-`v1` backend and processor manifests remain checked in as deprecated legacy
-schema artifacts. The reference stack, contract tests, and conformance profiles
-use `v2`.
+Only the shared-apparatus `v2` backend and processor manifests are published;
+no `v1` backend or processor manifest schema is checked in. The reference
+stack, contract tests, and conformance profiles use `v2`.
 
 ## Concept Authority Catalog
 

--- a/implementations/python/tests/test_authority_boundary.py
+++ b/implementations/python/tests/test_authority_boundary.py
@@ -4,12 +4,17 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.check_authority_boundary import (  # noqa: E402
+    _REQUIRED_ARTIFACT_FAMILY_FIELDS,
+    _REQUIRED_AUTHORITY_ROOT_FIELDS,
+    _REQUIRED_NON_NORMATIVE_ROOT_FIELDS,
+    _REQUIRED_SCHEMA_AUTHORITY_FIELDS,
     ADR_AUTHORITY_RELATIVE_PATH,
     ADR_REFS,
     ADR_SEAM_REF,
@@ -25,6 +30,26 @@ from tools.check_authority_boundary import (  # noqa: E402
     SPECS_README_RELATIVE_PATH,
     evaluate_authority_boundary,
 )
+
+
+def _policy_without_entry_field(section: str, index: int, field: str) -> str:
+    """Return `_GOOD_POLICY` with one field deleted from a list entry.
+
+    Parses the canonical YAML, drops `section[index][field]`, and re-dumps.
+    Used to exercise every field of a `_REQUIRED_*_FIELDS` tuple (rather than a
+    single hand-picked field) so dropping a field from the tuple in production
+    leaves a failing test.
+    """
+    data = yaml.safe_load(_GOOD_POLICY)
+    del data[section][index][field]
+    return yaml.safe_dump(data, sort_keys=False)
+
+
+def _policy_without_schema_authority_field(field: str) -> str:
+    data = yaml.safe_load(_GOOD_POLICY)
+    del data["schema_authority"][field]
+    return yaml.safe_dump(data, sort_keys=False)
+
 
 # --------------------------------------------------------------------------- #
 # Canonical, well-formed authority-boundary YAML used as the positive case    #
@@ -104,6 +129,12 @@ normative_artifact_families:
     family: governance-guidance
     requirement_refs:
       - AUT-811
+  - id: deprecation_records
+    artifact: specs/evolution/deprecation-records.yaml
+    authority: ecosystem deprecation and lifecycle records
+    family: deprecation-records
+    requirement_refs:
+      - GOV-902
 """
 
 # ADR-009 is immutable; the drift guard requires every authority-root token
@@ -233,6 +264,13 @@ def _seed_repo(
     guidance_path.parent.mkdir(parents=True, exist_ok=True)
     if not guidance_path.exists():
         guidance_path.write_text("profile: aces-agent-guidance\n", encoding="utf-8")
+
+    # The canonical deprecation-records ledger (GOV-902) is likewise classified
+    # in _GOOD_POLICY and must exist on disk for the positive case.
+    deprecation_path = tmp_path / "specs" / "evolution" / "deprecation-records.yaml"
+    deprecation_path.parent.mkdir(parents=True, exist_ok=True)
+    if not deprecation_path.exists():
+        deprecation_path.write_text("policy: ecosystem-deprecation-records\n", encoding="utf-8")
 
     for root in authority_roots:
         _materialise_root(tmp_path, root)
@@ -382,6 +420,12 @@ _TOP_LEVEL_FIELD_CASES = [
             "    family: governance-guidance\n"
             "    requirement_refs:\n"
             "      - AUT-811\n"
+            "  - id: deprecation_records\n"
+            "    artifact: specs/evolution/deprecation-records.yaml\n"
+            "    authority: ecosystem deprecation and lifecycle records\n"
+            "    family: deprecation-records\n"
+            "    requirement_refs:\n"
+            "      - GOV-902\n"
         ),
     ),
 ]
@@ -487,15 +531,16 @@ def test_legacy_top_level_dirs_non_list_value_is_rejected(tmp_path: Path) -> Non
     assert _flagged(failures, "authority-boundary-field-type")
 
 
-def test_authority_root_required_id_is_rejected(tmp_path: Path) -> None:
-    # An authority_roots entry missing `id` is a malformation, not a default.
-    body = _GOOD_POLICY.replace(
-        "  - id: normative_prose\n    root: specs/\n    authority: normative prose specifications\n    family: prose\n",
-        "  - root: specs/\n    authority: normative prose specifications\n    family: prose\n",
-        1,
-    )
+@pytest.mark.parametrize("field", _REQUIRED_AUTHORITY_ROOT_FIELDS)
+def test_authority_root_required_fields_are_rejected(tmp_path: Path, field: str) -> None:
+    # An authority_roots entry missing ANY required field is a malformation, not
+    # a default. Parametrised over the full tuple so dropping a field from
+    # _REQUIRED_AUTHORITY_ROOT_FIELDS in production leaves a failing test.
+    body = _policy_without_entry_field("authority_roots", 0, field)
     failures = evaluate_authority_boundary(_seed_repo(tmp_path, policy_body=body))
-    assert _flagged(failures, "authority-boundary-entry-field")
+    assert any(
+        f.rule_id == "authority-boundary-entry-field" and f"required field: {field}" in f.message for f in failures
+    ), f"expected an entry-field failure naming {field!r}; got: {[f.render() for f in failures]}"
 
 
 def test_authority_root_must_end_with_slash(tmp_path: Path) -> None:
@@ -635,18 +680,15 @@ def test_authority_root_with_only_keep_marker_is_flagged_as_empty(tmp_path: Path
     )
 
 
-def test_non_normative_root_required_id_is_rejected(tmp_path: Path) -> None:
-    # Symmetric coverage to test_authority_root_required_id_is_rejected:
-    # a non_normative_roots entry missing `id` must fail the entry-field
-    # check. Without this test the entry-field validation loop in
-    # _check_non_normative_roots is entirely untested.
-    body = _GOOD_POLICY.replace(
-        "  - id: reference_implementations\n    root: implementations/\n    note: reference code only\n",
-        "  - root: implementations/\n    note: reference code only\n",
-        1,
-    )
+@pytest.mark.parametrize("field", _REQUIRED_NON_NORMATIVE_ROOT_FIELDS)
+def test_non_normative_root_required_fields_are_rejected(tmp_path: Path, field: str) -> None:
+    # Symmetric full-tuple coverage for _check_non_normative_roots: every
+    # required field of a non_normative_roots entry must be enforced.
+    body = _policy_without_entry_field("non_normative_roots", 0, field)
     failures = evaluate_authority_boundary(_seed_repo(tmp_path, policy_body=body))
-    assert _flagged(failures, "authority-boundary-entry-field")
+    assert any(
+        f.rule_id == "authority-boundary-entry-field" and f"required field: {field}" in f.message for f in failures
+    ), f"expected an entry-field failure naming {field!r}; got: {[f.render() for f in failures]}"
 
 
 def test_legacy_dir_present_at_root_is_flagged(tmp_path: Path) -> None:
@@ -829,6 +871,18 @@ def test_contracts_readme_missing_adr_019_reference_is_flagged(tmp_path: Path) -
 # --------------------------------------------------------------------------- #
 # schema_authority block invariants.                                          #
 # --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("field", _REQUIRED_SCHEMA_AUTHORITY_FIELDS)
+def test_schema_authority_required_subfields_are_rejected(tmp_path: Path, field: str) -> None:
+    # Dropping any required sub-field from an otherwise-present schema_authority
+    # block must fail — the whole-block-absence case (_TOP_LEVEL_FIELD_CASES)
+    # does not cover per-sub-field requiredness.
+    body = _policy_without_schema_authority_field(field)
+    failures = evaluate_authority_boundary(_seed_repo(tmp_path, policy_body=body))
+    assert any(
+        f.rule_id == "authority-boundary-entry-field" and f"required field: {field}" in f.message for f in failures
+    ), f"expected a schema_authority entry-field failure naming {field!r}; got: {[f.render() for f in failures]}"
 
 
 def test_schema_authority_normative_root_must_match_authority_root(tmp_path: Path) -> None:
@@ -1193,15 +1247,22 @@ _NAF_BLOCK = (
     "    family: governance-guidance\n"
     "    requirement_refs:\n"
     "      - AUT-811\n"
+    "  - id: deprecation_records\n"
+    "    artifact: specs/evolution/deprecation-records.yaml\n"
+    "    authority: ecosystem deprecation and lifecycle records\n"
+    "    family: deprecation-records\n"
+    "    requirement_refs:\n"
+    "      - GOV-902\n"
 )
 
 
 def test_canonical_artifact_family_binding_pins_agent_guidance() -> None:
-    # The agent-guidance AUT-811 profile is the pinned governance-guidance
-    # artifact; a rename of the constant surfaces in the suite rather than
-    # silently relaxing the gate.
+    # The agent-guidance AUT-811 profile and the GOV-902 deprecation-records
+    # ledger are the pinned artifact families; a rename of either constant
+    # surfaces in the suite rather than silently relaxing the gate.
     assert CANONICAL_ARTIFACT_FAMILY_BINDING == {
         "specs/agent-guidance/agent-guidance.yaml": "governance-guidance",
+        "specs/evolution/deprecation-records.yaml": "deprecation-records",
     }
 
 
@@ -1226,11 +1287,16 @@ def test_artifact_family_relabel_is_flagged(tmp_path: Path) -> None:
     assert _flagged(failures, "authority-boundary-artifact-family-canonical-binding")
 
 
-def test_artifact_family_missing_required_field_is_flagged(tmp_path: Path) -> None:
-    # An entry missing `family` is a malformation, not a default.
-    body = _GOOD_POLICY.replace("    family: governance-guidance\n", "", 1)
+@pytest.mark.parametrize("field", _REQUIRED_ARTIFACT_FAMILY_FIELDS)
+def test_artifact_family_missing_required_field_is_flagged(tmp_path: Path, field: str) -> None:
+    # An artifact-family entry missing ANY required field is a malformation, not
+    # a default — full-tuple coverage over _REQUIRED_ARTIFACT_FAMILY_FIELDS.
+    body = _policy_without_entry_field("normative_artifact_families", 0, field)
     failures = evaluate_authority_boundary(_seed_repo(tmp_path, policy_body=body))
-    assert _flagged(failures, "authority-boundary-artifact-family-entry-field")
+    assert any(
+        f.rule_id == "authority-boundary-artifact-family-entry-field" and f"required field: {field}" in f.message
+        for f in failures
+    ), f"expected an artifact-family entry-field failure naming {field!r}; got: {[f.render() for f in failures]}"
 
 
 def test_artifact_family_entry_must_be_mapping(tmp_path: Path) -> None:

--- a/implementations/python/tests/test_deprecation_lifecycle.py
+++ b/implementations/python/tests/test_deprecation_lifecycle.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.check_deprecation_lifecycle import (  # noqa: E402
+    _REQUIRED_RECORD_FIELDS,
+    _REQUIRED_TOP_LEVEL_FIELDS,
+    ADR_REF,
+    CANONICAL_DEPRECATION_RECORD_IDS,
+    DEPRECATION_RECORDS_RELATIVE_PATH,
+    POLICY_VALUE,
+    REQUIREMENT_REF,
+    SCHEMA_PUBLICATION_MANIFEST,
+    SPEC_RELATIVE_PATH,
+    STATUSES,
+    SURFACE_CLASSES,
+    evaluate_deprecation_records,
+)
+
+# --------------------------------------------------------------------------- #
+# A minimal, well-formed deprecation-records ledger used as the positive case  #
+# and as the starting point for every mutation test. It mirrors the real      #
+# specs/evolution/deprecation-records.yaml shape.                             #
+# --------------------------------------------------------------------------- #
+
+
+def _good_ledger() -> dict:
+    # Includes both canonical (retention-floor) records so the positive case and
+    # every mutation starting point satisfies CANONICAL_DEPRECATION_RECORD_IDS.
+    # records[0] is a canonical record; mutation tests operate on it.
+    return {
+        "policy": POLICY_VALUE,
+        "requirement_refs": [REQUIREMENT_REF],
+        "adr_refs": [ADR_REF],
+        "spec": SPEC_RELATIVE_PATH,
+        "records": [
+            {
+                "id": "aces-compat-namespace",
+                "surface_class": "python-distribution",
+                "identifier": "implementations/python/src/aces/ (legacy aces.* namespace)",
+                "status": "deprecated",
+                "first_notice": "ADR-010 (example)",
+                "replacement": "the owning packages under implementations/python/packages/",
+                "migration_reference": "docs/decisions/adrs/adr-010-...md",
+                "notice_window": "supported through the pre-1.0 series",
+                "verification_evidence": "check_repo_policy.py enforces wrapper-only + import ban",
+            },
+            {
+                "id": "sdl-import-path-field",
+                "surface_class": "sdl-scenario-module",
+                "identifier": "ImportDecl.path (module import 'path:' field)",
+                "status": "deprecated",
+                "first_notice": "ADR-053 (example)",
+                "replacement": "the 'source:' field",
+                "migration_reference": "docs/explain/sdl/parser.md",
+                "notice_window": "supported indefinitely as a backward-compatible alias",
+                "verification_evidence": "parser normalises the legacy field; tests exercise both forms",
+            },
+        ],
+    }
+
+
+def _write_repo(
+    tmp_path: Path,
+    ledger: object,
+    *,
+    write_spec: bool = True,
+    manifest: dict | None = None,
+) -> Path:
+    """Materialise a minimal repo layout under ``tmp_path`` and return it.
+
+    ``ledger`` is dumped to the canonical records path. The spec file the ledger
+    points at is written unless ``write_spec`` is False, and a schema
+    publication manifest is written when ``manifest`` is provided.
+    """
+    records_path = tmp_path / DEPRECATION_RECORDS_RELATIVE_PATH
+    records_path.parent.mkdir(parents=True, exist_ok=True)
+    records_path.write_text(yaml.safe_dump(ledger, sort_keys=False), encoding="utf-8")
+
+    if write_spec:
+        spec_path = tmp_path / SPEC_RELATIVE_PATH
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text("# evolution policy (test stub)\n", encoding="utf-8")
+
+    if manifest is not None:
+        manifest_path = tmp_path / SCHEMA_PUBLICATION_MANIFEST
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        import json
+
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    return tmp_path
+
+
+def _rule_ids(tmp_path: Path) -> set[str]:
+    return {failure.rule_id for failure in evaluate_deprecation_records(tmp_path)}
+
+
+# --------------------------------------------------------------------------- #
+# Positive cases.                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_real_repo_ledger_conforms() -> None:
+    """The checked-in ledger must pass its own gate."""
+    assert evaluate_deprecation_records(REPO_ROOT) == []
+
+
+def test_good_ledger_passes(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _good_ledger())
+    assert evaluate_deprecation_records(tmp_path) == []
+
+
+def test_no_replacement_rationale_is_accepted(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    record = ledger["records"][0]
+    del record["replacement"]
+    record["no_replacement_rationale"] = "the surface is withdrawn with no successor by design"
+    _write_repo(tmp_path, ledger)
+    assert evaluate_deprecation_records(tmp_path) == []
+
+
+def test_complete_security_exception_is_accepted(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["security_exception"] = {
+        "affected_versions": "0.1.0 through 0.19.1",
+        "impact": "example impact",
+        "mitigation": "example mitigation",
+        "migration": "example migration path",
+        "review_authority": "maintainers",
+    }
+    _write_repo(tmp_path, ledger)
+    assert evaluate_deprecation_records(tmp_path) == []
+
+
+def test_removed_schema_with_tombstone_is_accepted(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0].update(
+        {
+            "surface_class": "published-json-schema",
+            "status": "removed",
+            "removal_record": "release note X; ADR-061 tombstone",
+            "removal_tombstone": "contracts/schemas/old/legacy-v1.json",
+        }
+    )
+    manifest = {
+        "schema_version": "schema-publication-manifest/v1",
+        "hash_algorithm": "sha256",
+        "schemas": [],
+        "removed_schemas": [{"schema_path": "contracts/schemas/old/legacy-v1.json", "summary": "removed"}],
+    }
+    _write_repo(tmp_path, ledger, manifest=manifest)
+    assert evaluate_deprecation_records(tmp_path) == []
+
+
+# --------------------------------------------------------------------------- #
+# Negative cases — one per rule_id.                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_file(tmp_path: Path) -> None:
+    assert "deprecation-records-missing" in _rule_ids(tmp_path)
+
+
+def test_parse_error(tmp_path: Path) -> None:
+    records_path = tmp_path / DEPRECATION_RECORDS_RELATIVE_PATH
+    records_path.parent.mkdir(parents=True, exist_ok=True)
+    records_path.write_text("policy: [unterminated\n", encoding="utf-8")
+    assert "deprecation-records-parse" in _rule_ids(tmp_path)
+
+
+def test_top_level_not_mapping(tmp_path: Path) -> None:
+    _write_repo(tmp_path, ["not", "a", "mapping"])
+    assert "deprecation-records-shape" in _rule_ids(tmp_path)
+
+
+@pytest.mark.parametrize("field", _REQUIRED_TOP_LEVEL_FIELDS)
+def test_missing_top_level_field(tmp_path: Path, field: str) -> None:
+    # Parametrised over the FULL required-tuple so dropping any field from the
+    # tuple leaves a failing test, not a silent no-op.
+    ledger = _good_ledger()
+    del ledger[field]
+    _write_repo(tmp_path, ledger)
+    failures = evaluate_deprecation_records(tmp_path)
+    assert any(f.rule_id == "deprecation-records-field" and field in f.message for f in failures), (
+        f"expected a missing-field failure naming {field!r}; got: {[f.render() for f in failures]}"
+    )
+
+
+def test_records_wrong_type(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"] = "not-a-list"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-field-type" in _rule_ids(tmp_path)
+
+
+def test_wrong_policy_value(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["policy"] = "something-else"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-policy-value" in _rule_ids(tmp_path)
+
+
+def test_missing_requirement_ref(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["requirement_refs"] = ["OTHER-001"]
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-requirement-ref" in _rule_ids(tmp_path)
+
+
+def test_missing_adr_ref(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["adr_refs"] = ["ADR-999"]
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-adr-ref" in _rule_ids(tmp_path)
+
+
+def test_spec_missing_on_disk(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _good_ledger(), write_spec=False)
+    assert "deprecation-records-spec-missing" in _rule_ids(tmp_path)
+
+
+@pytest.mark.parametrize("field", _REQUIRED_RECORD_FIELDS)
+def test_record_missing_required_field(tmp_path: Path, field: str) -> None:
+    # Full-tuple coverage: every required record field is exercised, and the
+    # failure must name the dropped field (not merely fire the generic rule).
+    ledger = _good_ledger()
+    del ledger["records"][0][field]
+    _write_repo(tmp_path, ledger)
+    failures = evaluate_deprecation_records(tmp_path)
+    assert any(f.rule_id == "deprecation-records-entry-field" and field in f.message for f in failures), (
+        f"expected a missing-field failure naming {field!r}; got: {[f.render() for f in failures]}"
+    )
+
+
+def test_record_empty_field(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["identifier"] = "   "
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-entry-field" in _rule_ids(tmp_path)
+
+
+def test_duplicate_record_id(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"].append(copy.deepcopy(ledger["records"][0]))
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-entry-duplicate" in _rule_ids(tmp_path)
+
+
+def test_unknown_surface_class(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["surface_class"] = "not-a-real-surface"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-surface-class" in _rule_ids(tmp_path)
+
+
+def test_bad_status(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["status"] = "sunset"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-status" in _rule_ids(tmp_path)
+
+
+def test_both_replacement_and_no_replacement(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["no_replacement_rationale"] = "conflicting"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-replacement" in _rule_ids(tmp_path)
+
+
+def test_neither_replacement_nor_rationale(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    del ledger["records"][0]["replacement"]
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-replacement" in _rule_ids(tmp_path)
+
+
+def test_incomplete_security_exception(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["security_exception"] = {"impact": "only one field"}
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-security-exception" in _rule_ids(tmp_path)
+
+
+def test_removed_without_removal_record(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0]["status"] = "removed"
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-removal-record" in _rule_ids(tmp_path)
+
+
+def test_removed_schema_without_tombstone(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0].update(
+        {
+            "surface_class": "published-json-schema",
+            "status": "removed",
+            "removal_record": "release note",
+        }
+    )
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-removal-tombstone" in _rule_ids(tmp_path)
+
+
+def test_removed_schema_tombstone_not_in_manifest(tmp_path: Path) -> None:
+    ledger = _good_ledger()
+    ledger["records"][0].update(
+        {
+            "surface_class": "published-json-schema",
+            "status": "removed",
+            "removal_record": "release note",
+            "removal_tombstone": "contracts/schemas/absent.json",
+        }
+    )
+    manifest = {
+        "schema_version": "schema-publication-manifest/v1",
+        "hash_algorithm": "sha256",
+        "schemas": [],
+        "removed_schemas": [],
+    }
+    _write_repo(tmp_path, ledger, manifest=manifest)
+    assert "deprecation-records-removal-tombstone" in _rule_ids(tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# Retention floor — lifecycle history may not silently disappear.             #
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_ledger_is_rejected(tmp_path: Path) -> None:
+    # An authoritative record surface that permits `records: []` would let all
+    # lifecycle history be erased while the gate stays green.
+    ledger = _good_ledger()
+    ledger["records"] = []
+    _write_repo(tmp_path, ledger)
+    assert "deprecation-records-canonical-record-missing" in _rule_ids(tmp_path)
+
+
+def test_dropping_a_canonical_record_is_rejected(tmp_path: Path) -> None:
+    # Deleting an established record (leaving the other) must fail: an existing
+    # deprecation is permanent lifecycle history, not something a later diff can
+    # silently remove.
+    ledger = _good_ledger()
+    dropped = ledger["records"].pop()  # remove sdl-import-path-field
+    _write_repo(tmp_path, ledger)
+    failures = evaluate_deprecation_records(tmp_path)
+    assert any(f.rule_id == "deprecation-records-canonical-record-missing" for f in failures)
+    assert any(dropped["id"] in f.message for f in failures), (
+        f"expected the dropped record id to be named; got: {[f.render() for f in failures]}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Guard the pinned constants so a rename surfaces here.                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_canonical_record_ids_are_pinned() -> None:
+    assert {"aces-compat-namespace", "sdl-import-path-field"} == CANONICAL_DEPRECATION_RECORD_IDS
+
+
+def test_surface_classes_cover_known_matrix_rows() -> None:
+    assert {"python-distribution", "sdl-scenario-module", "published-json-schema"} <= SURFACE_CLASSES
+
+
+def test_statuses_are_deprecated_and_removed() -> None:
+    assert {"deprecated", "removed"} == STATUSES

--- a/noxfile.py
+++ b/noxfile.py
@@ -522,6 +522,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
             "skipped on staged check; runs on push and verify",
         )
         reporter.skip(
+            "policy / deprecation lifecycle records",
+            "skipped on staged check; runs on push and verify",
+        )
+        reporter.skip(
             "policy / concept authority governance",
             "skipped on staged check; runs on push and verify",
         )
@@ -549,6 +553,10 @@ def _run_policy(session: nox.Session, reporter: SessionReporter, *args: str) -> 
         reporter.run(
             "policy / authority boundary ADR",
             lambda: _run_project_python(session, "tools/check_authority_boundary.py"),
+        )
+        reporter.run(
+            "policy / deprecation lifecycle records",
+            lambda: _run_project_python(session, "tools/check_deprecation_lifecycle.py"),
         )
         reporter.run(
             "policy / concept authority governance",

--- a/specs/authority/authority-boundary.yaml
+++ b/specs/authority/authority-boundary.yaml
@@ -148,3 +148,10 @@ normative_artifact_families:
     family: governance-guidance
     requirement_refs:
       - AUT-811
+
+  - id: deprecation_records
+    artifact: specs/evolution/deprecation-records.yaml
+    authority: ecosystem deprecation and lifecycle records (GOV-902)
+    family: deprecation-records
+    requirement_refs:
+      - GOV-902

--- a/specs/evolution/README.md
+++ b/specs/evolution/README.md
@@ -11,3 +11,6 @@ The governing decision is
 - [`versioning-deprecation-and-migration.md`](versioning-deprecation-and-migration.md)
   defines the normative surface-class matrix and rules for GOV-901, GOV-902,
   and GOV-903.
+- [`deprecation-records.yaml`](deprecation-records.yaml) is the reviewable
+  record surface for GOV-902 deprecation and lifecycle notices, validated by
+  `tools/check_deprecation_lifecycle.py` against the complete-record contract.

--- a/specs/evolution/deprecation-records.yaml
+++ b/specs/evolution/deprecation-records.yaml
@@ -1,0 +1,63 @@
+# Ecosystem Deprecation Records (GOV-902)
+#
+# Canonical, reviewable record surface for repository-governed deprecation and
+# removal notices across ecosystem surfaces. Required reading:
+#
+#   specs/evolution/versioning-deprecation-and-migration.md
+#     -- the normative operational policy (Deprecation / Removal sections);
+#        each record below satisfies the complete-record contract it defines
+#   docs/decisions/adrs/adr-075-ecosystem-versioning-deprecation-and-migration-governance.md
+#     -- the architectural decision that mandates explicit deprecation records
+#
+# This file is a CI-time GOVERNANCE record surface, not a runtime lifecycle
+# registry, migration service, persistence layer, or endpoint (ADR-075 forbids
+# those). tools/check_deprecation_lifecycle.py validates every record against
+# the 7-field contract and fails closed on an incomplete record, so
+# supersession and removal stay predictable and reviewable (GOV-902). Each
+# record points back to its owning surface's existing authority; it does not
+# replace that authority. A deprecation is a lifecycle notice for a
+# still-supported surface (status: deprecated); removal (status: removed) is
+# allowed only after a record reaches its removal-eligibility rule, and for a
+# published-json-schema surface it references the ADR-061 removed_schemas
+# tombstone rather than duplicating it.
+#
+# Adding the next deprecation is one record here plus, when it is a new surface
+# family, a row in the surface-class matrix — never a central runtime service.
+
+policy: ecosystem-deprecation-records
+
+requirement_refs:
+  - GOV-902
+
+adr_refs:
+  - ADR-075
+
+spec: specs/evolution/versioning-deprecation-and-migration.md
+
+records:
+  # The legacy `aces.*` re-export namespace. ADR-010 treats it as
+  # compatibility-only and one-directional; the spec (migration section) blesses
+  # it staying in the compatibility tree. It carried no complete lifecycle
+  # record until GOV-902.
+  - id: aces-compat-namespace
+    surface_class: python-distribution
+    identifier: "implementations/python/src/aces/ (the legacy `aces.*` re-export namespace)"
+    status: deprecated
+    first_notice: "ADR-010 (repository realignment order and compatibility policy)"
+    replacement: "the owning packages under implementations/python/packages/ (aces_sdl, aces_contracts, aces_cli, aces_runtime, and siblings)"
+    migration_reference: "docs/decisions/adrs/adr-010-repository-realignment-order-and-compatibility-policy.md; docs/explain/sdl/runtime-architecture.md"
+    notice_window: "Supported through the pre-1.0 package series; removal eligible no earlier than the first major (post-1.0) package release and only via a complete removal record."
+    verification_evidence: "tools/check_repo_policy.py enforces the compatibility-wrapper-only rule for aces.* modules and the one-way import ban (owning packages must not import aces.*), proving the layer remains a supported wrapper during the notice window."
+
+  # The module-import `path:` field, superseded by `source:` in ADR-053. The
+  # parser still accepts it as a backward-compatible alias, normalizing it to
+  # the `local:{path}` source form.
+  - id: sdl-import-path-field
+    surface_class: sdl-scenario-module
+    identifier: "ImportDecl.path (the module-import `path:` field)"
+    status: deprecated
+    first_notice: "ADR-053 (SDL module composition for inventory-backed scenarios)"
+    replacement: "the `source:` field (path form `local:{path}`)"
+    migration_reference: "docs/decisions/adrs/adr-053-sdl-module-composition-for-inventory-backed-scenarios.md; docs/explain/sdl/parser.md"
+    notice_window: "Supported indefinitely as a backward-compatible alias; removal eligible only after a complete removal record and a deterministic source rewrite per the migration rules."
+    verification_evidence: "aces_sdl.scenario.ImportDecl.normalized_source maps a `path:` value to `local:{path}`, and validate_source_fields keeps deprecated-but-supported use non-fatal; parser tests exercise both the `source:` and `path:` forms."

--- a/specs/evolution/versioning-deprecation-and-migration.md
+++ b/specs/evolution/versioning-deprecation-and-migration.md
@@ -119,6 +119,16 @@ Security exceptions may shorten ordinary notice only when the record names the
 affected versions, impact, mitigation, migration path, and review authority.
 The word "security" is not a blanket bypass for unreviewed breaking changes.
 
+Repository-governed deprecation records are recorded in
+`specs/evolution/deprecation-records.yaml` and validated by
+`tools/check_deprecation_lifecycle.py`, which fails closed on any record that
+omits a required field. That ledger is the single reviewable surface for these
+notices — a CI-time governance record, not a runtime lifecycle registry,
+migration service, or endpoint — and each record cites its owning surface's
+existing authority rather than replacing it. A record whose `status` is
+`removed` on a published JSON Schema surface references the ADR-061
+`removed_schemas` tombstone rather than duplicating it.
+
 ## Removal
 
 Removal is allowed only after a complete deprecation record reaches its removal
@@ -177,6 +187,10 @@ surface adds a more specific checker:
 - published schema evolution: schema publication checker, generated-schema
   parity, fixture validation, manifest hashes, change ledger, and tombstones;
 - ADR evolution: ADR index and accepted-content pin gate;
+- deprecation and lifecycle records: `specs/evolution/deprecation-records.yaml`
+  validated by `tools/check_deprecation_lifecycle.py` (complete-record contract,
+  removal-eligibility, and — for published schemas — a required ADR-061
+  `removed_schemas` tombstone reference);
 - SDL/module evolution: parser, validator, module registry, lockfile, trust,
   signature, digest, and semantic tests;
 - contract and manifest evolution: closed DTO validation, manifest authority,

--- a/tools/check_authority_boundary.py
+++ b/tools/check_authority_boundary.py
@@ -119,6 +119,7 @@ CANONICAL_LEGACY_TOP_LEVEL_DIRS: tuple[str, ...] = ("schemas", "conformance", "s
 # pins roots, so the classification cannot be silently dropped or relabelled.
 CANONICAL_ARTIFACT_FAMILY_BINDING: dict[str, str] = {
     "specs/agent-guidance/agent-guidance.yaml": "governance-guidance",
+    "specs/evolution/deprecation-records.yaml": "deprecation-records",
 }
 
 # Required top-level fields and per-entry fields. Used by both the YAML shape

--- a/tools/check_deprecation_lifecycle.py
+++ b/tools/check_deprecation_lifecycle.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402, I001
+"""Structural gate for the GOV-902 ecosystem deprecation and lifecycle rules.
+
+ADR-075 ("Ecosystem Versioning, Deprecation, and Migration Governance") and
+its normative spec ``specs/evolution/versioning-deprecation-and-migration.md``
+decide that deprecations must be explicit, complete records so that
+supersession and removal are predictable and reviewable. GOV-902 says the
+ecosystem **shall** define those deprecation and lifecycle rules.
+
+The canonical, reviewable record surface lives in
+``specs/evolution/deprecation-records.yaml`` (per ADR-009, normative prose and
+its data live under ``specs/``). This checker pins the record contract: every
+record must name the seven fields the spec requires -- exact surface and
+identifier, first-notice version, replacement or explicit no-replacement
+rationale, migration reference, notice window / removal-eligibility rule, and
+verification evidence that the old surface stays supported (plus a reviewed
+security exception if the ordinary window is shortened). Removal
+(``status: removed``) is allowed only with a removal record, and for a
+published JSON Schema surface the removal must reference an existing
+``removed_schemas`` tombstone in the schema publication manifest (ADR-061),
+not a duplicate mechanism.
+
+This is a CI-time governance gate over static data, not a runtime lifecycle
+registry, migration service, persistence layer, or endpoint (ADR-075 forbids
+those). Failures use ``tools.policy.common.PolicyFailure`` and the CLI honours
+``--json`` and the shared ``tools/policy/exceptions.yaml`` waiver mechanism,
+matching the other policy gates (``check_authority_boundary.py``,
+``check_adr_immutability.py``, ``check_assurance_policy.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import yaml
+
+from tools.policy.common import (
+    PolicyFailure,
+    apply_exceptions,
+    failures_to_json,
+    load_exceptions,
+)
+
+# --------------------------------------------------------------------------- #
+# Canonical paths and pinned invariants. Test code imports these directly so   #
+# a rename here surfaces in the test suite rather than silently in production. #
+# --------------------------------------------------------------------------- #
+
+DEPRECATION_RECORDS_RELATIVE_PATH = "specs/evolution/deprecation-records.yaml"
+SPEC_RELATIVE_PATH = "specs/evolution/versioning-deprecation-and-migration.md"
+SCHEMA_PUBLICATION_MANIFEST = "contracts/schema-publication-manifest.json"
+
+REQUIREMENT_REF = "GOV-902"
+ADR_REF = "ADR-075"
+POLICY_VALUE = "ecosystem-deprecation-records"
+
+# Surface-class keys, bound to the rows of the surface-class matrix in
+# specs/evolution/versioning-deprecation-and-migration.md. A record may not
+# name a surface the policy does not recognise; extending the matrix with a new
+# family adds a key here (and a row + owner in the spec), which is the
+# documented extension seam.
+SURFACE_CLASSES: frozenset[str] = frozenset(
+    {
+        "python-distribution",
+        "published-json-schema",
+        "closed-contract-dto",
+        "processor-backend-support",
+        "apparatus-identity",
+        "sdl-scenario-module",
+        "experiment-artifact",
+        "adr",
+        "ground-control-requirement",
+    }
+)
+
+STATUSES: frozenset[str] = frozenset({"deprecated", "removed"})
+
+# The retention floor: record ids that MUST remain present in the ledger. A
+# deprecation record is lifecycle history, so it may not silently disappear --
+# once a construct is deprecated, that fact is permanent (its `status` may
+# later advance to `removed`, but its identity is retained). Pinning the known
+# ids here means an empty or truncated ledger fails the gate, mirroring the
+# canonical-floor pattern the authority-boundary gate uses for its roots and
+# artifact families. Retiring a record id is a deliberate, reviewable edit to
+# this floor -- exactly the predictability GOV-902 requires.
+CANONICAL_DEPRECATION_RECORD_IDS: frozenset[str] = frozenset(
+    {
+        "aces-compat-namespace",
+        "sdl-import-path-field",
+    }
+)
+
+# The published-schema surface is the only one whose removal is governed by a
+# machine-readable tombstone (ADR-061). A `removed` record on this surface must
+# point at an existing tombstone rather than asserting removal in prose.
+_PUBLISHED_SCHEMA_SURFACE = "published-json-schema"
+
+_REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = (
+    "policy",
+    "requirement_refs",
+    "adr_refs",
+    "spec",
+    "records",
+)
+
+# Fields every record must carry regardless of status. `replacement` is handled
+# separately (exactly one of replacement / no_replacement_rationale).
+_REQUIRED_RECORD_FIELDS: tuple[str, ...] = (
+    "id",
+    "surface_class",
+    "identifier",
+    "status",
+    "first_notice",
+    "migration_reference",
+    "notice_window",
+    "verification_evidence",
+)
+
+_SECURITY_EXCEPTION_FIELDS: tuple[str, ...] = (
+    "affected_versions",
+    "impact",
+    "mitigation",
+    "migration",
+    "review_authority",
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers.                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _fail(rule_id: str, message: str, path: str | None = None) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _is_str(value: object) -> bool:
+    return isinstance(value, str)
+
+
+def _nonempty_str(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _str_list(value: object) -> list[str] | None:
+    """Return ``value`` as a list of strings, or None if it is not one.
+
+    A list with a non-string element is rejected so the gate does not silently
+    coerce ``[GOV-902, 17]`` into strings and keep passing.
+    """
+    if not isinstance(value, list):
+        return None
+    if not all(isinstance(item, str) for item in value):
+        return None
+    return list(value)
+
+
+# --------------------------------------------------------------------------- #
+# Top-level shape and references.                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _check_top_level(raw: dict, source_path: str) -> list[PolicyFailure]:
+    failures: list[PolicyFailure] = []
+    for field in _REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in raw:
+            failures.append(
+                _fail(
+                    "deprecation-records-field",
+                    f"required top-level field is missing: {field}",
+                    source_path,
+                )
+            )
+
+    if "policy" in raw and not _is_str(raw["policy"]):
+        failures.append(
+            _fail(
+                "deprecation-records-field-type",
+                f"policy must be a string; got {type(raw['policy']).__name__}",
+                source_path,
+            )
+        )
+    elif "policy" in raw and raw["policy"] != POLICY_VALUE:
+        failures.append(
+            _fail(
+                "deprecation-records-policy-value",
+                f"policy must equal {POLICY_VALUE!r}; got {raw['policy']!r}",
+                source_path,
+            )
+        )
+
+    requirement_refs = raw.get("requirement_refs")
+    if "requirement_refs" in raw and _str_list(requirement_refs) is None:
+        failures.append(
+            _fail(
+                "deprecation-records-field-type",
+                "requirement_refs must be a list of strings",
+                source_path,
+            )
+        )
+    elif _str_list(requirement_refs) is not None and REQUIREMENT_REF not in requirement_refs:
+        failures.append(
+            _fail(
+                "deprecation-records-requirement-ref",
+                f"requirement_refs must include {REQUIREMENT_REF}; got {requirement_refs!r}",
+                source_path,
+            )
+        )
+
+    adr_refs = raw.get("adr_refs")
+    if "adr_refs" in raw and _str_list(adr_refs) is None:
+        failures.append(
+            _fail(
+                "deprecation-records-field-type",
+                "adr_refs must be a list of strings",
+                source_path,
+            )
+        )
+    elif _str_list(adr_refs) is not None and ADR_REF not in adr_refs:
+        failures.append(
+            _fail(
+                "deprecation-records-adr-ref",
+                f"adr_refs must include {ADR_REF}; got {adr_refs!r}",
+                source_path,
+            )
+        )
+
+    if "spec" in raw and not _nonempty_str(raw["spec"]):
+        failures.append(
+            _fail(
+                "deprecation-records-field-type",
+                "spec must be a non-empty string path",
+                source_path,
+            )
+        )
+
+    if "records" in raw and not isinstance(raw["records"], list):
+        failures.append(
+            _fail(
+                "deprecation-records-field-type",
+                f"records must be a list; got {type(raw['records']).__name__}",
+                source_path,
+            )
+        )
+    return failures
+
+
+def _check_spec_present(repo_root: Path, raw: dict, source_path: str) -> list[PolicyFailure]:
+    spec = raw.get("spec")
+    if not _nonempty_str(spec):
+        return []  # type/shape failure already reported
+    if not (repo_root / spec).is_file():
+        return [
+            _fail(
+                "deprecation-records-spec-missing",
+                f"spec path {spec!r} does not exist on disk",
+                source_path,
+            )
+        ]
+    return []
+
+
+# --------------------------------------------------------------------------- #
+# Per-record checks.                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _load_removed_schema_paths(repo_root: Path) -> set[str]:
+    """Return the set of ``schema_path`` values recorded as removed_schemas
+    tombstones in the schema publication manifest (empty if absent)."""
+    manifest_path = repo_root / SCHEMA_PUBLICATION_MANIFEST
+    if not manifest_path.is_file():
+        return set()
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    removed = manifest.get("removed_schemas")
+    if not isinstance(removed, list):
+        return set()
+    paths: set[str] = set()
+    for entry in removed:
+        if isinstance(entry, dict) and _nonempty_str(entry.get("schema_path")):
+            paths.add(entry["schema_path"])
+    return paths
+
+
+def _check_security_exception(entry: dict, index: int, source_path: str) -> list[PolicyFailure]:
+    exception = entry.get("security_exception")
+    if exception is None:
+        return []
+    if not isinstance(exception, dict):
+        return [
+            _fail(
+                "deprecation-records-security-exception",
+                f"records[{index}].security_exception must be a mapping when present",
+                source_path,
+            )
+        ]
+    failures: list[PolicyFailure] = []
+    for field in _SECURITY_EXCEPTION_FIELDS:
+        if not _nonempty_str(exception.get(field)):
+            failures.append(
+                _fail(
+                    "deprecation-records-security-exception",
+                    (
+                        f"records[{index}].security_exception must name a non-empty {field!r} "
+                        "(affected versions, impact, mitigation, migration, and review authority)"
+                    ),
+                    source_path,
+                )
+            )
+    return failures
+
+
+def _check_removal(
+    entry: dict,
+    index: int,
+    removed_schema_paths: set[str],
+    source_path: str,
+) -> list[PolicyFailure]:
+    """Validate the extra invariants for a ``status: removed`` record."""
+    failures: list[PolicyFailure] = []
+    if not _nonempty_str(entry.get("removal_record")):
+        failures.append(
+            _fail(
+                "deprecation-records-removal-record",
+                (
+                    f"records[{index}] has status 'removed' but no non-empty 'removal_record' "
+                    "(removal is allowed only after a complete deprecation record reaches its "
+                    "removal-eligibility rule)"
+                ),
+                source_path,
+            )
+        )
+    if entry.get("surface_class") == _PUBLISHED_SCHEMA_SURFACE:
+        tombstone = entry.get("removal_tombstone")
+        if not _nonempty_str(tombstone):
+            failures.append(
+                _fail(
+                    "deprecation-records-removal-tombstone",
+                    (
+                        f"records[{index}] removes a {_PUBLISHED_SCHEMA_SURFACE} surface and must name a "
+                        "'removal_tombstone' schema_path recorded in the schema publication manifest"
+                    ),
+                    source_path,
+                )
+            )
+        elif tombstone not in removed_schema_paths:
+            failures.append(
+                _fail(
+                    "deprecation-records-removal-tombstone",
+                    (
+                        f"records[{index}].removal_tombstone {tombstone!r} is not a removed_schemas "
+                        f"tombstone in {SCHEMA_PUBLICATION_MANIFEST} (ADR-061 governs published-schema removal)"
+                    ),
+                    source_path,
+                )
+            )
+    return failures
+
+
+def _check_records(repo_root: Path, raw: dict, source_path: str) -> list[PolicyFailure]:
+    raw_records = raw.get("records")
+    if not isinstance(raw_records, list):
+        return []  # type-level failure already reported
+
+    removed_schema_paths = _load_removed_schema_paths(repo_root)
+    failures: list[PolicyFailure] = []
+    seen_ids: set[str] = set()
+
+    for index, entry in enumerate(raw_records):
+        if not isinstance(entry, dict):
+            failures.append(
+                _fail(
+                    "deprecation-records-entry-field",
+                    f"records[{index}] must be a mapping; got {type(entry).__name__}",
+                    source_path,
+                )
+            )
+            continue
+
+        entry_ok = True
+        for field in _REQUIRED_RECORD_FIELDS:
+            if field not in entry:
+                failures.append(
+                    _fail(
+                        "deprecation-records-entry-field",
+                        f"records[{index}] is missing required field: {field}",
+                        source_path,
+                    )
+                )
+                entry_ok = False
+            elif not _nonempty_str(entry[field]):
+                failures.append(
+                    _fail(
+                        "deprecation-records-entry-field",
+                        f"records[{index}].{field} must be a non-empty string",
+                        source_path,
+                    )
+                )
+                entry_ok = False
+
+        # Exactly one of replacement / no_replacement_rationale. The spec allows
+        # a no-replacement deprecation, but it must carry an explicit rationale.
+        has_replacement = _nonempty_str(entry.get("replacement"))
+        has_no_replacement = _nonempty_str(entry.get("no_replacement_rationale"))
+        if has_replacement == has_no_replacement:
+            failures.append(
+                _fail(
+                    "deprecation-records-replacement",
+                    (f"records[{index}] must name exactly one of 'replacement' or 'no_replacement_rationale'"),
+                    source_path,
+                )
+            )
+
+        # id uniqueness (only meaningful once the id itself is a valid string).
+        entry_id = entry.get("id")
+        if _nonempty_str(entry_id):
+            if entry_id in seen_ids:
+                failures.append(
+                    _fail(
+                        "deprecation-records-entry-duplicate",
+                        f"records[{index}].id {entry_id!r} is duplicated",
+                        source_path,
+                    )
+                )
+            seen_ids.add(entry_id)
+
+        surface = entry.get("surface_class")
+        if _nonempty_str(surface) and surface not in SURFACE_CLASSES:
+            failures.append(
+                _fail(
+                    "deprecation-records-surface-class",
+                    (
+                        f"records[{index}].surface_class {surface!r} is not a recognised surface "
+                        f"class; expected one of {sorted(SURFACE_CLASSES)}"
+                    ),
+                    source_path,
+                )
+            )
+
+        status = entry.get("status")
+        if _nonempty_str(status) and status not in STATUSES:
+            failures.append(
+                _fail(
+                    "deprecation-records-status",
+                    f"records[{index}].status {status!r} must be one of {sorted(STATUSES)}",
+                    source_path,
+                )
+            )
+
+        failures.extend(_check_security_exception(entry, index, source_path))
+
+        if status == "removed":
+            failures.extend(_check_removal(entry, index, removed_schema_paths, source_path))
+
+        _ = entry_ok  # per-field failures already recorded; kept for readability
+    return failures
+
+
+def _check_canonical_record_floor(raw: dict, source_path: str) -> list[PolicyFailure]:
+    """Enforce the retention floor: every canonical record id must be present.
+
+    Deprecation records are lifecycle history. An empty or truncated ledger --
+    ``records: []`` or a diff that drops a checked-in record -- would let that
+    history disappear while the gate stays green, because the per-record checks
+    pass vacuously over whatever entries remain. Pinning the known ids means the
+    authoritative record set cannot be silently emptied; a record's ``status``
+    may advance (e.g. deprecated -> removed) but its identity is retained.
+    """
+    raw_records = raw.get("records")
+    present_ids = set()
+    if isinstance(raw_records, list):
+        present_ids = {
+            entry["id"] for entry in raw_records if isinstance(entry, dict) and _nonempty_str(entry.get("id"))
+        }
+    failures: list[PolicyFailure] = []
+    for canonical_id in sorted(CANONICAL_DEPRECATION_RECORD_IDS):
+        if canonical_id not in present_ids:
+            failures.append(
+                _fail(
+                    "deprecation-records-canonical-record-missing",
+                    (
+                        f"the canonical deprecation record {canonical_id!r} is missing; established "
+                        "lifecycle records may not be removed from the ledger (retiring one is a "
+                        "deliberate edit to CANONICAL_DEPRECATION_RECORD_IDS)"
+                    ),
+                    source_path,
+                )
+            )
+    return failures
+
+
+# --------------------------------------------------------------------------- #
+# Top-level entry point.                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def evaluate_deprecation_records(repo_root: Path) -> list[PolicyFailure]:
+    """Return the list of structural failures for the GOV-902 deprecation-record
+    surface (empty list = OK)."""
+    records_path = repo_root / DEPRECATION_RECORDS_RELATIVE_PATH
+    if not records_path.is_file():
+        return [
+            _fail(
+                "deprecation-records-missing",
+                f"deprecation records surface not found: {DEPRECATION_RECORDS_RELATIVE_PATH}",
+                DEPRECATION_RECORDS_RELATIVE_PATH,
+            )
+        ]
+
+    try:
+        raw = yaml.safe_load(records_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [
+            _fail(
+                "deprecation-records-parse",
+                f"failed to parse {DEPRECATION_RECORDS_RELATIVE_PATH}: {exc}",
+                DEPRECATION_RECORDS_RELATIVE_PATH,
+            )
+        ]
+
+    if not isinstance(raw, dict):
+        return [
+            _fail(
+                "deprecation-records-shape",
+                f"{DEPRECATION_RECORDS_RELATIVE_PATH} must be a YAML mapping at the top level",
+                DEPRECATION_RECORDS_RELATIVE_PATH,
+            )
+        ]
+
+    failures: list[PolicyFailure] = []
+    failures.extend(_check_top_level(raw, DEPRECATION_RECORDS_RELATIVE_PATH))
+    failures.extend(_check_spec_present(repo_root, raw, DEPRECATION_RECORDS_RELATIVE_PATH))
+    failures.extend(_check_records(repo_root, raw, DEPRECATION_RECORDS_RELATIVE_PATH))
+    failures.extend(_check_canonical_record_floor(raw, DEPRECATION_RECORDS_RELATIVE_PATH))
+    return failures
+
+
+# --------------------------------------------------------------------------- #
+# CLI.                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate the GOV-902 ecosystem deprecation and lifecycle records (ADR-075)."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (defaults to the repo containing this file).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    failures = evaluate_deprecation_records(args.repo_root)
+    exceptions_file = args.repo_root / "tools" / "policy" / "exceptions.yaml"
+    if exceptions_file.is_file():
+        failures = apply_exceptions(failures, load_exceptions(args.repo_root))
+    if failures:
+        if args.json:
+            print(failures_to_json(failures))
+        else:
+            for failure in failures:
+                print(failure.render(), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Realizes GOV-902 (Deprecation & Lifecycle Rules) on existing authorities, following the GOV-901 pattern (#240). The joint design (#90 → PR #718) *defined* the deprecation/removal rules in ADR-075 + `specs/evolution/versioning-deprecation-and-migration.md`, but those clauses were orphaned normative prose with no enforcement. This PR makes them **predictable and reviewable**: a single normative deprecation-record surface plus a fail-closed policy gate, and it brings the repo's real, previously-unrecorded deprecations into conforming records.

This is a CI-time governance surface (mirroring the `specs/authority/authority-boundary.yaml` + checker idiom) — **not** a runtime lifecycle registry, migration service, persistence layer, or endpoint (ADR-075 forbids those). Each record cites its owning surface's existing authority rather than replacing it.

## Related Issues

Closes #241

## Requirement Context

- Requirement UID: `GOV-902` (already ACTIVE)
- ADRs touched: ADR-075 (realized; unchanged — stays `proposed`); ADR-009 / ADR-019 (authority boundary extended with the new artifact family)
- Ground Control project: `aces-sdl`

## Changes

- Add `specs/evolution/deprecation-records.yaml` — the reviewable record surface, seeded with the two real deprecations found in assessment: the legacy `aces.*` compatibility namespace (ADR-010) and the SDL import `path:` field (ADR-053).
- Add `tools/check_deprecation_lifecycle.py` — a policy-session gate enforcing the 7-field deprecation-record contract, a **retention floor** (established records cannot be silently emptied/dropped), removal-eligibility, and — for published schemas — a required ADR-061 `removed_schemas` tombstone reference.
- Wire the checker into `noxfile.py` `_run_policy` (runs on push/verify; skipped on `--staged`, matching the sibling gates).
- Classify the ledger in `specs/authority/authority-boundary.yaml` and pin it in `tools/check_authority_boundary.py` as the `deprecation-records` normative artifact family (mirrors the agent-guidance precedent).
- Record the enforcement surface in the evolution spec (Deprecation + Verification sections) and `specs/evolution/README.md`.
- Correct a stale claim in `contracts/schemas/README.md` that "`v1` backend and processor manifests remain checked in as deprecated legacy" — no such `*-manifest-v1` schemas exist on disk (only `v2`). Honest lifecycle documentation, same theme as GOV-901's honest version literals.
- Add `implementations/python/tests/test_deprecation_lifecycle.py` and extend `test_authority_boundary.py` with full required-field-tuple coverage.

## Test Plan

- [x] Relevant tests pass (141 tests across the two suites)
- [x] `uvx nox -s verify` passes locally (policy, requirement governance, authority boundary + new deprecation-lifecycle gate, ADR immutability, schema/generated parity, ruff, Sphinx, pytest)
- [x] Docs build passes (part of verify)

## Ground Control Checks

- **IMPLEMENTS `GOV-902`:** `specs/evolution/deprecation-records.yaml`, `tools/check_deprecation_lifecycle.py`
- **TESTS `GOV-902`:** `implementations/python/tests/test_deprecation_lifecycle.py`
- **Reviews (pre-push):** codex — 1 finding (the gate accepted an empty ledger) fixed with a canonical retention floor + tests; test-quality — 1 class finding (partial required-field-tuple coverage) fixed with full-tuple parametrized tests across both suites. Both decision records are on the issue thread; the maintainer authorized proceeding to push.

## Notes for Review

All review findings were fixed in this PR. ADR-075 remains `proposed` (acceptance is a separate governance decision, not an implementation step). No shipped-package behavior changes, so the title is `chore:` and release-please cuts no release.
