### PR TITLE
refactor: clear PR 753 Sonar findings

### DIFF
--- a/implementations/python/packages/aces_contracts/contracts.py
+++ b/implementations/python/packages/aces_contracts/contracts.py
@@ -7899,9 +7899,7 @@ class ReusableAssetTrustPolicyModel(ContractModel):
         return json_schema
 
 
-def schema_bundle() -> dict[str, dict[str, Any]]:
-    """Return the repo-published JSON Schemas for external contracts."""
-
+def _raw_schema_bundle() -> dict[str, dict[str, Any]]:
     from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel
 
     from .provenance import SDLLineageLedgerModel
@@ -7910,7 +7908,7 @@ def schema_bundle() -> dict[str, dict[str, Any]]:
         ScientificCompletenessTaxonomyModel,
     )
 
-    bundle = {
+    return {
         "aces-semantic-invariants-v1": _aces_semantic_invariant_profile_schema_for_bundle(),
         "sdl-authoring-input-v1": Scenario.model_json_schema(),
         "instantiated-scenario-v1": InstantiatedScenario.model_json_schema(),
@@ -7979,6 +7977,12 @@ def schema_bundle() -> dict[str, dict[str, Any]]:
         "associated-artifact-manifest-v1": AssociatedArtifactManifestModel.model_json_schema(),
         "reusable-asset-trust-policy-v1": ReusableAssetTrustPolicyModel.model_json_schema(),
     }
+
+
+def schema_bundle() -> dict[str, dict[str, Any]]:
+    """Return the repo-published JSON Schemas for external contracts."""
+
+    bundle = _raw_schema_bundle()
     _add_aces_invariant(
         bundle["scientific-completeness-taxonomy-v1"],
         "scientific-completeness-taxonomy-rectangular",

--- a/implementations/python/packages/aces_mcp/tools/reference.py
+++ b/implementations/python/packages/aces_mcp/tools/reference.py
@@ -11,9 +11,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-# ---------------------------------------------------------------------------
 # Docs / examples on disk — allowlisted filenames only
-# ---------------------------------------------------------------------------
 
 
 def _find_repo_root(start: Path) -> Path:
@@ -60,9 +58,7 @@ def _read_example(name: str) -> str:
     return path.read_text()
 
 
-# ---------------------------------------------------------------------------
 # Section-level reference snippets
-# ---------------------------------------------------------------------------
 
 # Maps each section name to the heading anchor used in sections.md so we
 # can extract just the relevant portion.

--- a/implementations/python/packages/aces_processor/planner.py
+++ b/implementations/python/packages/aces_processor/planner.py
@@ -55,111 +55,26 @@ def _planned_resource(address: str, domain: RuntimeDomain, resource_type: str, r
 def _collect_resources(model: RuntimeModel) -> dict[str, PlannedResource]:
     resources: dict[str, PlannedResource] = {}
 
-    for address, resource in model.networks.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.PROVISIONING,
-            "network",
-            resource,
-        )
-    for address, resource in model.node_deployments.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.PROVISIONING,
-            "node",
-            resource,
-        )
-    for address, resource in model.feature_bindings.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.PROVISIONING,
-            "feature-binding",
-            resource,
-        )
-    for address, resource in model.content_placements.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.PROVISIONING,
-            "content-placement",
-            resource,
-        )
-    for address, resource in model.account_placements.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.PROVISIONING,
-            "account-placement",
-            resource,
-        )
-    for address, resource in model.inject_bindings.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "inject-binding",
-            resource,
-        )
-    for address, resource in model.injects.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "inject",
-            resource,
-        )
-    for address, resource in model.events.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "event",
-            resource,
-        )
-    for address, resource in model.scripts.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "script",
-            resource,
-        )
-    for address, resource in model.stories.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "story",
-            resource,
-        )
-    for address, resource in model.workflows.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.ORCHESTRATION,
-            "workflow",
-            resource,
-        )
-    for address, resource in model.condition_bindings.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.EVALUATION,
-            "condition-binding",
-            resource,
-        )
-    for address, resource in model.propositions.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.EVALUATION,
-            "proposition",
-            resource,
-        )
-    for address, resource in model.assertions.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.EVALUATION,
-            "assertion",
-            resource,
-        )
-    for address, resource in model.objectives.items():
-        resources[address] = _planned_resource(
-            address,
-            RuntimeDomain.EVALUATION,
-            "objective",
-            resource,
-        )
+    resource_groups = (
+        (model.networks, RuntimeDomain.PROVISIONING, "network"),
+        (model.node_deployments, RuntimeDomain.PROVISIONING, "node"),
+        (model.feature_bindings, RuntimeDomain.PROVISIONING, "feature-binding"),
+        (model.content_placements, RuntimeDomain.PROVISIONING, "content-placement"),
+        (model.account_placements, RuntimeDomain.PROVISIONING, "account-placement"),
+        (model.inject_bindings, RuntimeDomain.ORCHESTRATION, "inject-binding"),
+        (model.injects, RuntimeDomain.ORCHESTRATION, "inject"),
+        (model.events, RuntimeDomain.ORCHESTRATION, "event"),
+        (model.scripts, RuntimeDomain.ORCHESTRATION, "script"),
+        (model.stories, RuntimeDomain.ORCHESTRATION, "story"),
+        (model.workflows, RuntimeDomain.ORCHESTRATION, "workflow"),
+        (model.condition_bindings, RuntimeDomain.EVALUATION, "condition-binding"),
+        (model.propositions, RuntimeDomain.EVALUATION, "proposition"),
+        (model.assertions, RuntimeDomain.EVALUATION, "assertion"),
+        (model.objectives, RuntimeDomain.EVALUATION, "objective"),
+    )
+    for group, domain, resource_type in resource_groups:
+        for address, resource in group.items():
+            resources[address] = _planned_resource(address, domain, resource_type, resource)
 
     return resources
 

--- a/tools/policy/oversized_allowlist.yaml
+++ b/tools/policy/oversized_allowlist.yaml
@@ -16,7 +16,6 @@ files:
   - implementations/python/packages/aces_contracts/workflow.py
   - implementations/python/packages/aces_mcp/tools/authoring.py
   - implementations/python/packages/aces_mcp/tools/inspection.py
-  - implementations/python/packages/aces_mcp/tools/reference.py
   - implementations/python/packages/aces_operations/_evidence_run_artifact.py
   - implementations/python/packages/aces_processor/compiler.py
   - implementations/python/packages/aces_processor/models.py


### PR DESCRIPTION
## Summary

- reduce `aces_mcp.tools.reference` below Sonar's 500-line file limit and remove its stale oversized-file allowlist entry
- split raw schema construction from schema decoration so both functions remain below Sonar's 100-line function limit
- replace repeated planner resource collection blocks with an order-preserving table-driven loop

## Why

PR #753 merged `dev` into `main`, but its SonarCloud quality gate reported three new maintainability violations (`python:S104` and `python:S138`). This behavior-preserving refactor clears those violations so the next `dev` promotion can pass the strict zero-new-issues gate.

## Impact

No contract, schema, planner ordering, or MCP response behavior changes. The patch only reduces source and function size.

## Requirement Context

- Requirement UID: `MOD-001`
- Related PR: #753

## Validation

- full `tools/verify_all.py` graph: passed
- 3,650 unit tests passed; 1 skipped; 46 deselected
- 34 integration tests passed; 2 environment-dependent libvirt tests skipped
- 92% aggregate coverage
- policy, hygiene, lint, schema drift, contract validation, and docs build passed