### PR TITLE
fix: preserve explicitness provenance at runtime

### DIFF
--- a/docs/decisions/issue-760-sem-218-provenance-preservation-preflight.md
+++ b/docs/decisions/issue-760-sem-218-provenance-preservation-preflight.md
@@ -1,0 +1,103 @@
+# Issue 760 SEM-218 Provenance Preservation Preflight
+
+Date: 2026-07-13
+
+Issue: #760. Requirement: none; the issue is the delivery contract.
+
+This note narrows the existing issue #491 SEM-218 runtime-realization preflight
+to the provenance-loss defect. It records architecture guardrails only and does
+not implement the compiler or runtime change.
+
+## Decision
+
+`ExplicitnessRecord.provenance` is the canonical origin classification at the
+SDL-to-runtime boundary. The compiler must preserve that value on the existing
+`CompiledRealizationRequirement`; the honoured branch of
+`realization_disclosure()` must copy it to the existing
+`RealizationProvenanceEntry`. Only a value selected by the backend because the
+declared value was not honoured is `BACKEND_REALIZED`. The compiled field must
+be required rather than defaulting to `AUTHOR_DECLARED`; a default would let a
+future constructor silently recreate the same attribution bug.
+
+This is an internal typed-carrier repair. It does not add a public field: the
+published `runtime-snapshot-v1` schema, `RealizationProvenanceEntryModel`, and
+control-plane snapshot serializer already admit and persist all three values.
+Therefore the implementation must not version or regenerate the public schema,
+add another provenance enum, or create a sidecar persistence channel.
+
+The canonical classifier resolves the wording overlap in SEM-218 I5:
+parameter substitution is `PROCESSOR_DERIVED`, whether the selected parameter
+value came from a caller binding or an SDL default. `AUTHOR_DECLARED` is
+reserved for a value that survives instantiation without substitution. This
+follows `derive_instantiated_explicitness()` and the issue contract; runtime
+code must not infer origin from equality, explicitness class, plan presence, or
+backend success.
+
+## Existing Boundaries To Reuse
+
+- Classification and validation: `aces_sdl.explicitness`,
+  `derive_instantiated_explicitness()`, and the closed SDL/Pydantic admission
+  path remain the only origin authority.
+- Compilation and planning: `_compile_realization_requirements()`,
+  `RuntimeModel.realization_requirements`, `CompiledRealizationRequirement`,
+  and `realization_support_diagnostics()` remain the single typed path. The
+  added carrier is metadata and must not enter backend `resource_payload()`.
+- Runtime enforcement: `realization_disclosure()` and
+  `aces_runtime.backend_calls._call_backend_apply()` remain the fail-closed
+  adapter boundary. Existing `runtime.backend-contract-invalid` diagnostics,
+  rollback behavior, and snapshot acceptance order do not change.
+- Observation and persistence: `RealizationProvenanceEntry`,
+  `RuntimeSnapshot.realization_provenance`, `RealizationProvenanceEntryModel`,
+  `RuntimeSnapshotEnvelopeModel`, `_snapshot_payload()`, and
+  `_snapshot_from_payload()` remain the only disclosure and persistence path.
+- Verification: extend the existing SEM-218 differential/compiler and runtime
+  tests. The decisive case instantiates a realization concern through a
+  parameter/default substitution, compiles it, has the backend honour it, and
+  observes `PROCESSOR_DERIVED` in the runtime ledger.
+
+## Cross-Cutting Guardrails
+
+- Security and exposure: provenance is an enum label, not the realized value.
+  Do not add authored or realized values to diagnostics, logs, audit details,
+  fixtures, environment variables, process arguments, or error envelopes.
+  No authentication, secret, configuration, subprocess, or OS interface is
+  introduced by this repair.
+- Validation: reuse enum typing at the dataclass and published Pydantic contract
+  boundaries. Do not add duplicate string validation or a new exception type.
+  Compiled-address validation in `CompiledRealizationRequirement.__post_init__`
+  remains unchanged.
+- Errors and observability: an invalid backend result still uses the existing
+  structured `Diagnostic` path. Provenance preservation itself is not a new
+  warning, metric, log event, or exception surface.
+- Schema and compatibility: because `processor-derived` is already a valid
+  published enum member, no schema-publication manifest entry, fixture-shape
+  change, contract version bump, or downstream compatibility shim is required.
+- Persistence: the existing control-plane round trip already serializes enum
+  values. Do not introduce repository, database, migration, metadata-map, or
+  generic-details storage for compiled provenance.
+
+## Extension Seam
+
+The seam is the provenance field on the existing compiled requirement, keyed
+with the already parameterized `field_path`, `address`, `domain`, and
+`requirement_kind`. Future realization concerns can flow through that carrier
+and the existing concern-path/kind mappings. They must not require a
+backend-specific provenance vocabulary or another runtime gate.
+
+## Non-Goals And Anti-Patterns
+
+- Do not change explicitness classification, parameter binding semantics,
+  realization-support matching, exactness/non-approximation behavior, concern
+  coverage, backend manifests, SDL syntax, or public contract shapes.
+- Do not treat `PROCESSOR_DERIVED` as backend realization, or infer provenance
+  from whether the backend honoured a value. Honouring answers whether the
+  backend substituted; the compiled provenance answers where the honoured
+  value originated.
+- Do not reclassify SDL at runtime, inspect `record.variables` outside the
+  classifier, use a boolean such as `authored`, or duplicate the three-value
+  enum in processor/runtime packages.
+- Do not place provenance in backend payloads, snapshot `metadata`, apply-result
+  `details`, logs, or a private APTL-facing contract.
+- Do not alter accepted ADRs. The existing SEM-218 authority and issue #491
+  architecture are sufficient; this defect does not justify a new abstraction
+  or ADR.

--- a/implementations/python/packages/aces_processor/compiler.py
+++ b/implementations/python/packages/aces_processor/compiler.py
@@ -2441,6 +2441,7 @@ def _compile_realization_requirements(
                 domain=REALIZATION_DOMAIN,
                 requirement_kind=concern_kind,
                 explicitness=record.classification,
+                provenance=record.provenance,
             )
         )
     return tuple(requirements)

--- a/implementations/python/packages/aces_processor/semantics/realization.py
+++ b/implementations/python/packages/aces_processor/semantics/realization.py
@@ -92,6 +92,7 @@ class CompiledRealizationRequirement:
     domain: str
     requirement_kind: str
     explicitness: ExplicitnessClass
+    provenance: ExplicitnessProvenance
 
     def __post_init__(self) -> None:
         require_compiled_address(self.address)
@@ -281,7 +282,7 @@ def _realization_provenance_entry(
         domain=requirement.domain,
         requirement_kind=requirement.requirement_kind,
         explicitness=requirement.explicitness,
-        provenance=(ExplicitnessProvenance.AUTHOR_DECLARED if honoured else ExplicitnessProvenance.BACKEND_REALIZED),
+        provenance=(requirement.provenance if honoured else ExplicitnessProvenance.BACKEND_REALIZED),
     )
 
 

--- a/implementations/python/tests/test_sem_218_realization.py
+++ b/implementations/python/tests/test_sem_218_realization.py
@@ -15,7 +15,7 @@ import textwrap
 
 from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.vocabulary import RealizationSupportMode
-from aces_sdl.explicitness import ExplicitnessClass
+from aces_sdl.explicitness import ExplicitnessClass, ExplicitnessProvenance
 
 from aces.backends.stubs import create_stub_manifest
 from aces.core.runtime.capabilities import BackendManifest, ProvisionerCapabilities
@@ -100,6 +100,18 @@ def test_compiled_class_matches_scenario_classifier_output():
     for req in model.realization_requirements:
         assert req.field_path in classified
         assert req.explicitness is classified[req.field_path].classification
+
+
+def test_compiled_provenance_matches_scenario_classifier_output():
+    """Differential: compilation preserves the classifier's origin authority."""
+
+    classified = instantiate_scenario(_scenario(_CONSTRAINED_SCENARIO)).explicitness
+    model = compile_runtime_model(_scenario(_CONSTRAINED_SCENARIO))
+
+    by_field = {req.field_path: req for req in model.realization_requirements}
+    assert by_field["nodes.web.os"].provenance is ExplicitnessProvenance.PROCESSOR_DERIVED
+    assert by_field["nodes.web.os"].provenance is classified["nodes.web.os"].provenance
+    assert by_field["nodes.web.type"].provenance is ExplicitnessProvenance.AUTHOR_DECLARED
 
 
 def test_planner_rejects_unrealizable_exact_declaration():

--- a/implementations/python/tests/test_sem_218_runtime_realization.py
+++ b/implementations/python/tests/test_sem_218_runtime_realization.py
@@ -44,6 +44,17 @@ nodes:
     resources: {ram: 1 gib, cpu: 1}
 """
 
+_PARAMETERIZED_SCENARIO = """
+name: sem-218-runtime-parameterized
+variables:
+  os_choice: {type: string, default: linux, allowed_values: [linux, windows]}
+nodes:
+  web:
+    type: vm
+    os: ${os_choice}
+    resources: {ram: 1 gib, cpu: 1}
+"""
+
 
 def _plan_exact(manager: RuntimeManager):
     return manager.plan(parse_sdl(textwrap.dedent(_EXACT_SCENARIO)))
@@ -166,6 +177,20 @@ def test_honest_apply_records_realization_provenance():
     assert by_field["nodes.web.os"].requirement_kind == "os-family"
     assert by_field["nodes.web.type"].provenance is ExplicitnessProvenance.AUTHOR_DECLARED
     assert by_field["nodes.web.type"].explicitness is ExplicitnessClass.EXACT
+
+
+def test_honoured_parameter_substitution_records_processor_derived_provenance():
+    """I5: an honoured substituted value retains its processor-derived origin."""
+
+    manager = RuntimeManager(create_stub_target())
+    plan = manager.plan(parse_sdl(textwrap.dedent(_PARAMETERIZED_SCENARIO)))
+
+    result = manager.apply(plan)
+
+    assert result.success
+    by_field = {entry.field_path: entry for entry in result.snapshot.realization_provenance}
+    assert by_field["nodes.web.os"].provenance is ExplicitnessProvenance.PROCESSOR_DERIVED
+    assert by_field["nodes.web.os"].provenance is not ExplicitnessProvenance.AUTHOR_DECLARED
 
 
 def test_realization_provenance_round_trips_through_control_plane_store():

--- a/specs/formal/realization/explicitness-and-realization.md
+++ b/specs/formal/realization/explicitness-and-realization.md
@@ -229,12 +229,13 @@ history, or evidence envelopes MUST be recorded with provenance
 distinguishing three origins:
 
 - **author-declared** — the value is exactly as the author wrote it in
-  the SDL (or as the author's parameter input resolved at
-  instantiation);
+  the SDL and survives instantiation without parameter or default
+  substitution;
 - **processor-derived** — the value was produced by deterministic
   processor activity that does NOT constitute realization: parameter
-  substitution, defaulting permitted by the SDL schema, canonical
-  identity normalization, and compilation transformations. The
+  substitution (whether the selected value is caller-bound or comes from an
+  SDL default), defaulting permitted by the SDL schema, canonical identity
+  normalization, and compilation transformations. The
   processor does not realize underspecified concerns; "processor-derived"
   is the provenance label for deterministic processing of declared
   input.


### PR DESCRIPTION
## Summary

Preserves the classifier's authored-versus-processor-derived provenance through compilation so honoured runtime realization disclosures report the true origin instead of attributing substituted values to the author.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #760

## ADR Impact

- ADR-021
- ADR-008
- ADR-009
- ADR-070

## Changes

- Add required provenance metadata to compiled realization requirements and populate it from the classifier.
- Use compiled provenance for honoured values while retaining backend-realized provenance for backend substitutions.
- Add compiler differential and end-to-end runtime regression coverage, plus clarify the SEM-218 invariant.

## Test Plan

- [x] Focused SEM-218 tests pass (14 tests)
- [x] `uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify` passes
- [x] Repository policy, requirement governance, and `tools/verify_all.py` pass with `ACES_REQUIREMENT_UID=SEM-218`

## Ground Control Checks

- [x] Repository policy checks pass
- [x] `gc_assert_quality_gates` passes
- [x] Codex and test-quality pre-push reviews are clean

## Traceability

- IMPLEMENTS: issue #760 ← implementations/python/packages/aces_processor/compiler.py, issue #760 ← implementations/python/packages/aces_processor/semantics/realization.py
- TESTS: issue #760 ← implementations/python/tests/test_sem_218_realization.py, issue #760 ← implementations/python/tests/test_sem_218_runtime_realization.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Release-please derives the changelog from the Conventional Commit PR title
- [x] Architectural docs updated if stack, package structure, or key behaviors changed