### PR TITLE
fix: define node service reachability semantics

### DIFF
--- a/contracts/schema-publication-manifest.json
+++ b/contracts/schema-publication-manifest.json
@@ -180,20 +180,20 @@
       "contract_id": "instantiated-scenario-snapshot-v1",
       "schema_path": "contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json",
       "stability": "draft",
-      "content_hash": "2b17c6c70899c17c46649c5de8724c2f8529641155b03777e7437265b2559e0a",
+      "content_hash": "15998ab101e41f0b87a7a661b959f6ebfcd7cc4c94041e1a1b20ab2573b08b4b",
       "last_change": {
-        "summary": "Removed observation-only health results, generated network identity, scanner findings, and scanner capture provenance from instantiated runtime contract snapshots.",
-        "content_hash": "2b17c6c70899c17c46649c5de8724c2f8529641155b03777e7437265b2559e0a"
+        "summary": "Clarified that Node.services entries identify node-local transport bindings without granting reachability or host publication (issue #748).",
+        "content_hash": "15998ab101e41f0b87a7a661b959f6ebfcd7cc4c94041e1a1b20ab2573b08b4b"
       }
     },
     {
       "contract_id": "instantiated-scenario-v1",
       "schema_path": "contracts/schemas/sdl/instantiated-scenario-v1.json",
       "stability": "draft",
-      "content_hash": "11f87bec135c48910ce7c48c6f64a807e2fa305ae0855d96238c744e80d5fc2a",
+      "content_hash": "c46feef54bde3cfe238cb1949386e5d726ef7319c2414bc307651e12a991b6e8",
       "last_change": {
-        "summary": "Removed observation-only health results, generated network identity, scanner findings, and scanner capture provenance from instantiated runtime contracts.",
-        "content_hash": "11f87bec135c48910ce7c48c6f64a807e2fa305ae0855d96238c744e80d5fc2a"
+        "summary": "Clarified that Node.services entries identify node-local transport bindings without granting reachability or host publication (issue #748).",
+        "content_hash": "c46feef54bde3cfe238cb1949386e5d726ef7319c2414bc307651e12a991b6e8"
       }
     },
     {
@@ -446,10 +446,10 @@
       "contract_id": "sdl-authoring-input-v1",
       "schema_path": "contracts/schemas/sdl/sdl-authoring-input-v1.json",
       "stability": "draft",
-      "content_hash": "271972c3a991cfb98b19950d2c33bf53f3aca4c9f0cae275f3b191ebcf8152e9",
+      "content_hash": "9e9b402a1a1505054bc555f19b674d798e092667d3da54f1a8561369e26191e3",
       "last_change": {
-        "summary": "Removed observation-only health results, generated network identity, scanner findings, and scanner capture provenance from authored runtime contracts.",
-        "content_hash": "271972c3a991cfb98b19950d2c33bf53f3aca4c9f0cae275f3b191ebcf8152e9"
+        "summary": "Clarified that Node.services entries identify node-local transport bindings without granting reachability or host publication (issue #748).",
+        "content_hash": "9e9b402a1a1505054bc555f19b674d798e092667d3da54f1a8561369e26191e3"
       }
     },
     {

--- a/contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-snapshot-v1.json
@@ -21588,7 +21588,7 @@
     },
     "ServicePort": {
       "additionalProperties": false,
-      "description": "A network service exposed by a node. From OCSF NetworkEndpoint.",
+      "description": "Authored identity of a node-local transport binding.\n\nA service declaration does not authorize traffic, prove a live listener,\npublish a host port, or classify an internal/external audience. Traffic\nauthorization belongs to infrastructure ACLs; observed bind state and host\npublication belong to their dedicated runtime surfaces.",
       "properties": {
         "description": {
           "default": "",

--- a/contracts/schemas/sdl/instantiated-scenario-v1.json
+++ b/contracts/schemas/sdl/instantiated-scenario-v1.json
@@ -21137,7 +21137,7 @@
     },
     "ServicePort": {
       "additionalProperties": false,
-      "description": "A network service exposed by a node. From OCSF NetworkEndpoint.",
+      "description": "Authored identity of a node-local transport binding.\n\nA service declaration does not authorize traffic, prove a live listener,\npublish a host port, or classify an internal/external audience. Traffic\nauthorization belongs to infrastructure ACLs; observed bind state and host\npublication belong to their dedicated runtime surfaces.",
       "properties": {
         "description": {
           "default": "",

--- a/contracts/schemas/sdl/sdl-authoring-input-v1.json
+++ b/contracts/schemas/sdl/sdl-authoring-input-v1.json
@@ -16617,7 +16617,7 @@
     },
     "ServicePort": {
       "additionalProperties": false,
-      "description": "A network service exposed by a node. From OCSF NetworkEndpoint.",
+      "description": "Authored identity of a node-local transport binding.\n\nA service declaration does not authorize traffic, prove a live listener,\npublish a host port, or classify an internal/external audience. Traffic\nauthorization belongs to infrastructure ACLs; observed bind state and host\npublication belong to their dedicated runtime surfaces.",
       "properties": {
         "description": {
           "default": "",

--- a/docs/decisions/issue-748-node-services-reachability-preflight.md
+++ b/docs/decisions/issue-748-node-services-reachability-preflight.md
@@ -1,0 +1,205 @@
+# Issue 748 Node Services Reachability Preflight
+
+Date: 2026-07-13
+
+Issue: #748. Requirement: none; the issue is the delivery contract.
+
+This note records the repository-wide architecture boundary for authored node
+services, traffic authorization, and backend realization. It does not implement
+the SDL, processor, backend, or conformance changes.
+
+## Decision
+
+`Node.services[]` is the positive authored or curated identity of a node-local
+transport binding: optional service name, container/node-side port, and
+transport protocol. A declaration can be a realization concern for a backend
+that supports or synthesizes services, but it is not by itself:
+
+- permission for any source to reach the port;
+- a bind address, listener-scope observation, or proof that a daemon is live;
+- a host-published port, NAT rule, image `EXPOSE` declaration, or firewall rule;
+- an `internal` / `external` audience classification.
+
+Consequently, a backend MUST NOT derive ingress, host publication, or an ACL
+allow rule merely because a service is declared. Traffic authorization must be
+authored through the existing `infrastructure.*.acls` policy surface, or a
+future separately governed traffic-policy surface. The current ACL model does
+not yet specify a portable default action, rule-order calculus, or end-to-end
+reachability proof, so this issue must not claim that an ACL list alone proves
+identical reachability across backends. The portable invariant for this issue
+is narrower and fail-closed: a service declaration never grants reachability.
+
+Do not add `ServicePort.role`. In the current canonical implementation,
+`SDLModel(extra="forbid")` and both published SDL schemas reject that key; it is
+not silently dropped. A free-form `role: internal` would conflate transport
+identity, topology, participant or login roles, protocol-local roles, and
+traffic authorization while still failing to identify an allowed source. If a
+later requirement needs audience policy, it belongs on the authorization
+surface as a typed source selector with defined evaluation and defaults, not as
+a descriptive service label.
+
+## Existing Authority And Incumbents
+
+- ADR-025 keeps container-side `Node.services`, image exposed ports, and
+  `runtime.network.published_ports` distinct. ADR-033 keeps transport bindings,
+  runtime state, delivery mechanics, and evidence distinct. ADR-043 keeps
+  authored service identity, observed `runtime.service_listeners`, and host
+  publication distinct. These decisions already own the semantic boundary; a
+  new ADR or competing endpoint schema is not justified.
+- `aces_sdl.nodes.ServicePort`, `Node.validate_unique_service_ports()`, the
+  shared `parse_int_or_var()` helper, `SDLModel`, `parse_sdl()`,
+  `SemanticValidator`, and `instantiate_scenario()` are the canonical
+  authoring, shape, semantic, and concrete-revalidation path.
+- `aces_processor.compiler._compile_node_runtimes()` already carries the full
+  node and matching infrastructure declarations in the existing node resource
+  payload. Named services already participate in canonical aliases. Do not add
+  a second service resource, DTO at the compiler boundary, or parallel plan.
+- `RealizationConcern.SERVICE`, `RealizationConcern.ACL`,
+  `ConcernDisposition`, `ObservationStrength`, and
+  `TransformationKind.SERVICE_SYNTHESIS` already provide the backend claim
+  vocabulary. `ProvisionerCapabilities.supports_acls`,
+  `RealizationSupportDeclaration`, `BackendRealizationEnvelopeModel`, and
+  `backend_manifest_payload()` are the existing capability/configuration
+  surfaces. Do not add a standalone `supports_services` dialect.
+- `aces_reference_backend.realization`, its existing `NetworkSpec` /
+  `ContainerSpec` driver boundary, `ReferenceProvisioner`, and
+  `DeploymentDriver` are the reference-backend seams. The libvirt
+  `ServiceSpec` and fail-closed ACL translator are useful behavioral precedent,
+  but they are backend-owned types and must not be imported to create a
+  cross-backend dependency.
+- `Diagnostic`, `ApplyResult`, `OperationReceipt`, `OperationStatus`, and
+  `RuntimeSnapshot` are the error, result, and observation envelopes. Snapshot
+  payload preservation proves carriage only; it is not evidence that a service
+  listened or an ACL was enforced.
+
+Two current gaps must not be hidden by the change. The reference manifest says
+`supports_acls=True` although neither reference interpreter nor driver realizes
+ACLs. That claim must either become false or be backed by real fail-closed
+enforcement. Also, the planner's coarse ACL capability check currently inspects
+network resources only, while `InfraNode.acls` and the libvirt backend support
+node-attached ACLs. The canonical capability gate must cover every materialized
+infrastructure entry rather than duplicating location-specific checks.
+
+## Cross-Cutting Gates
+
+- **Source and parser gate:** retain `_source_validation.py` UTF-8, byte,
+  scalar, alias, depth, node, tag, and directive limits. Unknown service fields
+  continue through `SDLParseError` and bounded, source-anchored
+  `sdl.model.invalid` diagnostics; do not add a permissive YAML preprocessor or
+  silently delete `role`.
+- **SDL model and semantic gate:** retain closed-world Pydantic models, shared
+  port bounds, protocol-plus-port and name uniqueness, ACL action/port parsing,
+  and `SemanticValidator` network-reference checks. Authoring errors remain
+  `SDLParseError` or `SDLValidationError`; do not add duplicate validators or a
+  service exception hierarchy. Description text must never be parsed as
+  policy.
+- **Instantiation and contract gate:** concrete scenarios revalidate through
+  `instantiate_scenario()`. The hand-governed schemas under
+  `contracts/schemas/` remain normative; `schema_bundle()` is the reference
+  implementation's compatibility proof, not authority to change them. Any
+  future public model change must update the Python SDL model and every affected
+  authoring/instantiated schema together, record the change in
+  `contracts/schema-publication-manifest.json`, and keep
+  `tools/check_generated_schemas.py` passing. Never update only the generator,
+  one published phase, or one copy of `ServicePort`.
+- **Compiler and planner gate:** use the existing node resource payload and
+  canonical addresses. A required or claimed service/ACL runtime effect that a
+  selected backend cannot honor must fail before side effects through the
+  existing realization-support / capability `Diagnostic` path. Descriptor-only
+  carriage may succeed only when the selected backend configuration discloses
+  that disposition and claims no runtime effect. Merely echoing the authored
+  payload into a snapshot must not satisfy realization or non-approximation
+  evidence.
+- **Manifest and configuration gate:** machine-readable claims remain bound to
+  the selected backend configuration and rendered by
+  `backend_manifest_payload()`. If a realization envelope is published, its
+  existing configuration and envelope digests plus complete service/ACL concern
+  disclosures are authoritative. Do not create an environment-variable flag,
+  unvalidated config dictionary, or backend-local capability vocabulary.
+- **Interpreter and error-envelope gate:** reference interpretation stays pure
+  and driver-neutral, shape-checks plan mappings, and returns stable redacted
+  `Diagnostic` values. `aces_runtime.backend_calls` remains the exception and
+  return-contract boundary. Driver failures preserve the baseline snapshot and
+  use `ApplyResult`; do not expose native exceptions, tracebacks, runtime ids,
+  or raw rule payloads.
+- **Host / OS gate:** the OCI driver retains its closed Docker/Podman runtime
+  allowlist, fixed argv lists, bounded timeout, image trust policy, private
+  stdout/stderr handling, ownership labels, and rollback. `Node.services` must
+  never produce `--publish` / `-p` arguments. Firewall or namespace mutation is
+  privileged host behavior and is outside this issue; a future implementation
+  would need an explicit, ownership-checked, reversible driver mechanism rather
+  than shell fragments or host-global rules assembled from free-form input.
+- **HTTP, auth, and secret gate:** this change needs no new API, credential,
+  secret, environment binding, or process argument. If plans traverse the
+  remote control plane, reuse `ControlPlaneSecurityConfig.strict_defaults()`,
+  request-size guards, identity and role authorization, target binding,
+  idempotency, audit, and the redacted FastAPI exception handler unchanged.
+- **Persistence and observability gate:** use the existing control-plane store,
+  runtime snapshot, operation status, realization provenance, and evidence
+  surfaces. Do not add a repository, migration, sidecar ledger, logger, or raw
+  backend-output field. Structured diagnostics and observation strength are the
+  observability surface.
+
+## Conformance Boundary
+
+Conformance must distinguish four claims instead of treating them as one:
+
+1. parsing and compilation preserve a service declaration;
+2. a backend interpreter extracts or explicitly rejects it;
+3. a driver realizes the declared listener or ACL effect;
+4. an independent daemon/guest/network probe observes the claimed effect.
+
+A snapshot that repeats the provisioning payload proves only the first claim.
+Service and ACL remain separate realization concerns, so a service-positive
+probe cannot certify traffic authorization and an ACL-positive probe cannot
+certify that a daemon is listening. Any backend claim of reachability needs a
+positive authorized path and a negative unauthorized path, ordinary
+`OperationStatus` / `Diagnostic` refusal without state mutation, and evidence at
+the observation strength it declares. Backends that disclose service or ACL as
+`descriptor-only` or `unsupported` are conformant only when they do not claim
+the corresponding runtime effect.
+
+Reuse the existing conformance scenario parameter while it remains the active
+bridge; the realization-envelope witness seam is its governed replacement.
+Tests belong in the existing SDL model/parser/schema, processor, pure backend
+realization, OCI argv/redaction, libvirt ACL enforcement, and target-conformance
+families rather than a second service-specific harness.
+
+## Extension Seam
+
+The immediate seam is the existing node resource's `spec.node.services`
+collection paired with independent service and ACL realization-concern
+disclosures for the selected backend configuration. Preserve every concrete
+entry, including unnamed services, and preserve or reject the authored
+protocol; never coerce an unknown protocol to TCP or discard an unnamed entry.
+
+The next reasonable extension is richer source selection. Its parameter belongs
+on a typed traffic-authorization rule and should identify governed network,
+CIDR, zone, or principal selectors with explicit default and evaluation
+semantics. That allows a future same-range, cross-range, or externally sourced
+policy without reinterpreting `Node.services` or baking one backend's topology
+choice into the portable service contract.
+
+## Non-Goals And Anti-Patterns
+
+- Do not implement shifter's same-range-derived firewall policy as the ACES
+  default, infer audience from `internal`, topology membership, node roles, or
+  service names, or auto-generate allow rules from services.
+- Do not turn `Node.services` into observed listener state, host publication,
+  image metadata, daemon configuration, an ACL container, or a reachability
+  result. Do not move ACL fields onto `ServicePort`.
+- Do not add `role`, `audience`, or a free-form policy bag without a separately
+  specified source-selector and evaluation contract.
+- Do not silently drop unnamed services, unsupported protocols, unresolved
+  CIDRs, invalid ACL rules, or unsupported backend concerns. In particular, do
+  not copy libvirt's current unknown-protocol-to-TCP fallback.
+- Do not claim ACL support from extraction, snapshot carriage, labels, or test
+  doubles. Do not claim service realization from a declared port or container
+  metadata alone.
+- Do not redesign ACL ordering/default semantics, backend privilege management,
+  control-plane APIs, persistence, logging, runtime listener inventory,
+  published-port semantics, image build metadata, or protocol-specific runtime
+  inventories in this issue.
+- Do not add implementation under `implementations/python/src/aces/`, hand-edit
+  generated schemas, fork diagnostics/exceptions, or introduce a second
+  compiler/backend workflow.

--- a/docs/explain/reference/reference-emulation-backend.md
+++ b/docs/explain/reference/reference-emulation-backend.md
@@ -58,6 +58,21 @@ ignores extras it does not use.
   (a partial failure rolls back what succeeded), and containers are attached to
   every network their plan declares.
 
+### Service and ACL boundary
+
+The interpreter preserves each authored `Node.services[]` entry as a typed
+service descriptor on the portable container specification, including unnamed
+services and non-TCP protocols. Both bundled drivers treat those descriptors as
+descriptor-only: they do not publish host ports, configure daemons, synthesize
+allow rules, or claim that a listener exists. Reachability therefore never
+follows from a service declaration.
+
+Traffic authorization remains the separate `infrastructure.*.acls` concern.
+The reference backend declares `supports_acls=false` because neither bundled
+driver enforces ACLs; the planner rejects such a plan before apply. A future
+driver that realizes services or ACLs must use the existing realization-concern
+and diagnostic surfaces and provide evidence for the runtime effect it claims.
+
 ```python
 from aces_reference_backend import create_reference_backend_target
 from aces_reference_backend.drivers.oci import OciDeploymentDriver

--- a/docs/explain/sdl/sections.md
+++ b/docs/explain/sdl/sections.md
@@ -88,7 +88,7 @@ nodes:
       operator:                         # longhand
         username: ops
         entities: [blue-team.alice]     # binds to entity
-    services:                           # exposed network services
+    services:                           # authored node-local transport bindings
       - port: 80
         protocol: tcp
         name: http
@@ -723,6 +723,15 @@ For **VM** nodes, `resources` remain optional at the SDL layer to preserve abstr
 When `features`, `conditions`, or `injects` use the `{name: role}` form, the role must be declared in the node's `roles` map.
 
 Concrete service bindings on a VM must be unique by `protocol` + `port`. Reusing `53/tcp` and `53/udp` is valid; declaring `443/tcp` twice on the same node is rejected. If a service binding also has a `name`, that `name` must be unique within the node and can be targeted directly as `nodes.<node>.services.<service_name>`.
+
+A `services` entry identifies an authored node-local transport binding. It does
+not authorize any source to reach the port, prove a live listener, publish a
+host port, or classify an `internal`/`external` audience. Traffic authorization
+is declared separately through `infrastructure.*.acls`; observed bind state is
+recorded in `runtime.service_listeners`, and host publication is recorded in
+`runtime.network.published_ports`. Service entries are closed-world objects, so
+an unmodeled field such as `role` is rejected rather than interpreted as policy
+or silently dropped.
 
 `runtime` is authored declarative contract state for VM/container nodes. Every
 field present there requires exact state, constrains acceptable state, or marks

--- a/implementations/python/packages/aces_processor/planner.py
+++ b/implementations/python/packages/aces_processor/planner.py
@@ -344,6 +344,17 @@ def _validate_manifest(model: RuntimeModel, manifest: BackendManifest) -> list[D
     diagnostics: list[Diagnostic] = []
     provisioner = manifest.provisioner
 
+    for resource in [*model.networks.values(), *model.node_deployments.values()]:
+        if resource.spec.get("infrastructure", {}).get("acls") and not provisioner.supports_acls:
+            diagnostics.append(
+                Diagnostic(
+                    code="provisioner.acls-unsupported",
+                    domain="provisioning",
+                    address=resource.address,
+                    message="Provisioner does not support ACL declarations.",
+                )
+            )
+
     for network in model.networks.values():
         if "switch" not in provisioner.supported_node_types:
             diagnostics.append(
@@ -354,16 +365,6 @@ def _validate_manifest(model: RuntimeModel, manifest: BackendManifest) -> list[D
                     message="Provisioner does not support switch/network nodes.",
                 )
             )
-        if network.spec.get("infrastructure", {}).get("acls") and not provisioner.supports_acls:
-            diagnostics.append(
-                Diagnostic(
-                    code="provisioner.acls-unsupported",
-                    domain="provisioning",
-                    address=network.address,
-                    message="Provisioner does not support ACL declarations.",
-                )
-            )
-
     for node in model.node_deployments.values():
         if node.node_type and node.node_type not in provisioner.supported_node_types:
             diagnostics.append(

--- a/implementations/python/packages/aces_reference_backend/__init__.py
+++ b/implementations/python/packages/aces_reference_backend/__init__.py
@@ -21,6 +21,7 @@ from .driver import (
     DeploymentDriver,
     NetworkHandle,
     NetworkSpec,
+    ServiceSpec,
 )
 from .manifest import REFERENCE_BACKEND_NAME, create_reference_backend_manifest
 from .realization import Realization, interpret_provisioning_plan
@@ -37,6 +38,7 @@ __all__ = [
     "DeploymentDriver",
     "NetworkHandle",
     "NetworkSpec",
+    "ServiceSpec",
     "Realization",
     "create_reference_backend_components",
     "create_reference_backend_manifest",

--- a/implementations/python/packages/aces_reference_backend/driver.py
+++ b/implementations/python/packages/aces_reference_backend/driver.py
@@ -35,12 +35,29 @@ class NetworkSpec:
 
 
 @dataclass(frozen=True)
+class ServiceSpec:
+    """Portable authored service descriptor carried to a deployment driver.
+
+    The descriptor identifies a node-local transport binding. Its presence
+    does not authorize traffic, publish a host port, or prove that a listener
+    exists. Drivers may inspect it when declaring service support, but must not
+    infer reachability from it.
+    """
+
+    port: int
+    protocol: str
+    name: str = ""
+
+
+@dataclass(frozen=True)
 class ContainerSpec:
     """Portable description of a container to realize.
 
     ``image_ref`` is a portable image reference (a name/tag or digest), not
     a pulled local image id. ``networks`` are ACES network resource
-    addresses. ``labels`` carries only non-sensitive classification labels.
+    addresses. ``services`` preserves authored node-local transport binding
+    descriptors without granting reachability or host publication. ``labels``
+    carries only non-sensitive classification labels.
     """
 
     address: str
@@ -48,6 +65,7 @@ class ContainerSpec:
     image_ref: str
     networks: tuple[str, ...] = ()
     labels: dict[str, str] = field(default_factory=dict)
+    services: tuple[ServiceSpec, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/implementations/python/packages/aces_reference_backend/manifest.py
+++ b/implementations/python/packages/aces_reference_backend/manifest.py
@@ -125,7 +125,7 @@ def _capabilities() -> BackendCapabilitySet:
             supported_content_types=frozenset({"file", "dataset", "directory"}),
             supported_account_features=frozenset({"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}),
             max_total_nodes=None,
-            supports_acls=True,
+            supports_acls=False,
             supports_accounts=True,
         ),
         orchestrator=OrchestratorCapabilities(

--- a/implementations/python/packages/aces_reference_backend/realization.py
+++ b/implementations/python/packages/aces_reference_backend/realization.py
@@ -17,7 +17,7 @@ from aces_backend_protocols.naming import provider_resource_name
 from aces_contracts.diagnostics import Diagnostic, Severity
 from aces_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
 
-from .driver import ContainerSpec, NetworkSpec
+from .driver import ContainerSpec, NetworkSpec, ServiceSpec
 
 _DOMAIN = "runtime"
 
@@ -81,7 +81,11 @@ def interpret_provisioning_plan(plan: ProvisioningPlan) -> Realization:
 
     networks = [_network_spec(resource, payload) for resource, payload in network_resources]
     network_lookup = _network_address_lookup(networks)
-    containers = [_container_spec(resource, payload, network_lookup) for resource, payload in node_resources]
+    containers: list[ContainerSpec] = []
+    for resource, payload in node_resources:
+        container, service_diagnostics = _container_spec(resource, payload, network_lookup)
+        containers.append(container)
+        diagnostics.extend(service_diagnostics)
     placements = [_placement(resource, payload) for resource, payload in placement_resources]
 
     return Realization(
@@ -135,7 +139,7 @@ def _container_spec(
     resource: PlannedResource,
     payload: Mapping[str, object],
     network_lookup: dict[str, str],
-) -> ContainerSpec:
+) -> tuple[ContainerSpec, tuple[Diagnostic, ...]]:
     infrastructure = _infrastructure_spec(payload)
     networks = infrastructure.get("networks")
     references: tuple[str, ...] = ()
@@ -146,12 +150,51 @@ def _container_spec(
     # contract stays total even when a node names a network not in this plan.
     network_addresses = tuple(network_lookup.get(ref, ref) for ref in references)
     image_ref = _image_ref(payload)
-    return ContainerSpec(
-        address=resource.address,
-        name=_resource_name(resource, payload),
-        image_ref=image_ref,
-        networks=network_addresses,
+    services, diagnostics = _service_specs(resource, payload)
+    return (
+        ContainerSpec(
+            address=resource.address,
+            name=_resource_name(resource, payload),
+            image_ref=image_ref,
+            networks=network_addresses,
+            services=services,
+        ),
+        diagnostics,
     )
+
+
+def _service_specs(
+    resource: PlannedResource,
+    payload: Mapping[str, object],
+) -> tuple[tuple[ServiceSpec, ...], tuple[Diagnostic, ...]]:
+    spec = payload.get("spec")
+    node = spec.get("node") if isinstance(spec, Mapping) else None
+    raw_services = node.get("services") if isinstance(node, Mapping) else None
+    if raw_services is None:
+        return (), ()
+    if not isinstance(raw_services, (list, tuple)):
+        return (), (_invalid_services(resource),)
+
+    services: list[ServiceSpec] = []
+    diagnostics: list[Diagnostic] = []
+    for index, raw_service in enumerate(raw_services):
+        if not isinstance(raw_service, Mapping):
+            diagnostics.append(_invalid_service(resource, index))
+            continue
+        port = raw_service.get("port")
+        protocol = raw_service.get("protocol", "tcp")
+        name = raw_service.get("name", "")
+        if (
+            not isinstance(port, int)
+            or isinstance(port, bool)
+            or not 1 <= port <= 65535
+            or not isinstance(protocol, str)
+            or not isinstance(name, str)
+        ):
+            diagnostics.append(_invalid_service(resource, index))
+            continue
+        services.append(ServiceSpec(port=port, protocol=protocol, name=name))
+    return tuple(services), tuple(diagnostics)
 
 
 def _image_ref(payload: Mapping[str, object]) -> str:
@@ -211,6 +254,30 @@ def _invalid_payload(resource: PlannedResource) -> Diagnostic:
         message=(
             f"Reference backend expected provisioning resource '{resource.address}' "
             f"of type '{resource.resource_type}' to carry a mapping payload."
+        ),
+        severity=Severity.ERROR,
+    )
+
+
+def _invalid_services(resource: PlannedResource) -> Diagnostic:
+    return Diagnostic(
+        code="reference-backend.realization.services-invalid",
+        domain=_DOMAIN,
+        address=resource.address,
+        message=(f"Reference backend expected provisioning node '{resource.address}' to carry services as a sequence."),
+        severity=Severity.ERROR,
+    )
+
+
+def _invalid_service(resource: PlannedResource, index: int) -> Diagnostic:
+    return Diagnostic(
+        code="reference-backend.realization.service-invalid",
+        domain=_DOMAIN,
+        address=resource.address,
+        message=(
+            f"Reference backend expected service entry {index} on provisioning "
+            f"node '{resource.address}' to contain a concrete port, protocol, "
+            "and optional name."
         ),
         severity=Severity.ERROR,
     )

--- a/implementations/python/packages/aces_reference_backend/realization.py
+++ b/implementations/python/packages/aces_reference_backend/realization.py
@@ -178,23 +178,31 @@ def _service_specs(
     services: list[ServiceSpec] = []
     diagnostics: list[Diagnostic] = []
     for index, raw_service in enumerate(raw_services):
-        if not isinstance(raw_service, Mapping):
+        service = _service_spec(raw_service)
+        if service is None:
             diagnostics.append(_invalid_service(resource, index))
             continue
-        port = raw_service.get("port")
-        protocol = raw_service.get("protocol", "tcp")
-        name = raw_service.get("name", "")
-        if (
-            not isinstance(port, int)
-            or isinstance(port, bool)
-            or not 1 <= port <= 65535
-            or not isinstance(protocol, str)
-            or not isinstance(name, str)
-        ):
-            diagnostics.append(_invalid_service(resource, index))
-            continue
-        services.append(ServiceSpec(port=port, protocol=protocol, name=name))
+        services.append(service)
     return tuple(services), tuple(diagnostics)
+
+
+def _service_spec(raw_service: object) -> ServiceSpec | None:
+    if not isinstance(raw_service, Mapping):
+        return None
+    port = raw_service.get("port")
+    if not _valid_service_port(port):
+        return None
+    protocol = raw_service.get("protocol", "tcp")
+    if not isinstance(protocol, str):
+        return None
+    name = raw_service.get("name", "")
+    if not isinstance(name, str):
+        return None
+    return ServiceSpec(port=port, protocol=protocol, name=name)
+
+
+def _valid_service_port(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 65535
 
 
 def _image_ref(payload: Mapping[str, object]) -> str:

--- a/implementations/python/packages/aces_reference_backend/realization.py
+++ b/implementations/python/packages/aces_reference_backend/realization.py
@@ -190,13 +190,9 @@ def _service_spec(raw_service: object) -> ServiceSpec | None:
     if not isinstance(raw_service, Mapping):
         return None
     port = raw_service.get("port")
-    if not _valid_service_port(port):
-        return None
     protocol = raw_service.get("protocol", "tcp")
-    if not isinstance(protocol, str):
-        return None
     name = raw_service.get("name", "")
-    if not isinstance(name, str):
+    if not _valid_service_port(port) or not isinstance(protocol, str) or not isinstance(name, str):
         return None
     return ServiceSpec(port=port, protocol=protocol, name=name)
 

--- a/implementations/python/packages/aces_sdl/nodes.py
+++ b/implementations/python/packages/aces_sdl/nodes.py
@@ -239,7 +239,13 @@ class AssetValue(SDLModel):
 
 
 class ServicePort(SDLModel):
-    """A network service exposed by a node. From OCSF NetworkEndpoint."""
+    """Authored identity of a node-local transport binding.
+
+    A service declaration does not authorize traffic, prove a live listener,
+    publish a host port, or classify an internal/external audience. Traffic
+    authorization belongs to infrastructure ACLs; observed bind state and host
+    publication belong to their dedicated runtime surfaces.
+    """
 
     port: int | str
     protocol: str = "tcp"

--- a/implementations/python/tests/test_reference_backend_manifest.py
+++ b/implementations/python/tests/test_reference_backend_manifest.py
@@ -36,6 +36,12 @@ def test_manifest_declares_orchestrator_evaluator_participant_runtime_and_observ
     assert manifest.has_observation
 
 
+def test_manifest_does_not_claim_unimplemented_acl_enforcement():
+    manifest = create_reference_backend_manifest()
+
+    assert manifest.provisioner.supports_acls is False
+
+
 def test_manifest_accepts_and_ignores_extra_config_kwargs():
     # Config kwargs flow to both factories; the manifest factory must accept
     # and ignore extras such as ``driver``.

--- a/implementations/python/tests/test_reference_backend_oci_driver.py
+++ b/implementations/python/tests/test_reference_backend_oci_driver.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 from aces_backend_protocols.naming import provider_resource_name
-from aces_reference_backend.driver import ContainerSpec, NetworkSpec
+from aces_reference_backend.driver import ContainerSpec, NetworkSpec, ServiceSpec
 from aces_reference_backend.drivers.oci import ImageTrustPolicy, OciDeploymentDriver
 
 
@@ -38,6 +38,15 @@ def _driver(recorder: _Recorder) -> OciDeploymentDriver:
         runner=recorder,
         image_policy=ImageTrustPolicy(allowed_images=("img", "aces-reference/linux", "pinned-img")),
     )
+
+
+def test_container_spec_preserves_legacy_positional_labels_argument():
+    labels = {"environment": "test"}
+
+    spec = ContainerSpec("provision.node.web", "web", "img", (), labels)
+
+    assert spec.labels is labels
+    assert spec.services == ()
 
 
 def test_oci_realize_uses_fixed_argv_list_never_shell():
@@ -199,6 +208,28 @@ def test_oci_attaches_container_to_requested_networks():
     run_argv = next(call["argv"] for call in recorder.calls if "run" in call["argv"])
     assert "--network" in run_argv
     assert run_argv[run_argv.index("--network") + 1] == provider_resource_name("provision.network.lan", prefix="aces")
+
+
+def test_oci_service_descriptors_do_not_publish_host_ports():
+    recorder = _Recorder(stdout="id\n")
+    driver = _driver(recorder)
+
+    driver.realize(
+        networks=(),
+        containers=(
+            ContainerSpec(
+                address="provision.node.web",
+                name="web",
+                image_ref="img",
+                services=(ServiceSpec(port=8443, protocol="tcp", name="https"),),
+            ),
+        ),
+    )
+
+    run_argv = next(call["argv"] for call in recorder.calls if "run" in call["argv"])
+    assert "--publish" not in run_argv
+    assert "-p" not in run_argv
+    assert "8443" not in run_argv
 
 
 def test_oci_rejects_plan_pinned_image_without_allowlist():

--- a/implementations/python/tests/test_reference_backend_realization.py
+++ b/implementations/python/tests/test_reference_backend_realization.py
@@ -11,10 +11,17 @@ from aces_contracts.planning import (
     RuntimeDomain,
 )
 from aces_reference_backend import interpret_provisioning_plan
+from aces_reference_backend.driver import ServiceSpec
 from aces_reference_backend.realization import Realization
 
 
-def _node_resource(address: str, name: str, os_family: str = "linux") -> PlannedResource:
+def _node_resource(
+    address: str,
+    name: str,
+    os_family: str = "linux",
+    *,
+    services: list[dict[str, object]] | None = None,
+) -> PlannedResource:
     return PlannedResource(
         address=address,
         domain=RuntimeDomain.PROVISIONING,
@@ -24,7 +31,10 @@ def _node_resource(address: str, name: str, os_family: str = "linux") -> Planned
             "node_name": name,
             "node_type": "vm",
             "os_family": os_family,
-            "spec": {"node": {}, "infrastructure": {"networks": ["lan"]}},
+            "spec": {
+                "node": {"services": services or []},
+                "infrastructure": {"networks": ["lan"]},
+            },
         },
     )
 
@@ -62,6 +72,44 @@ def test_interpret_maps_nodes_to_container_specs():
     assert [spec.address for spec in realization.containers] == ["provision.node.web"]
     assert realization.containers[0].name == "web"
     assert not realization.diagnostics
+
+
+def test_interpret_preserves_named_and_unnamed_service_descriptors():
+    plan = _plan(
+        _node_resource(
+            "provision.node.web",
+            "web",
+            services=[
+                {"port": 80, "protocol": "tcp", "name": "http"},
+                {"port": 5000, "protocol": "sctp", "name": ""},
+            ],
+        )
+    )
+
+    realization = interpret_provisioning_plan(plan)
+
+    assert realization.containers[0].services == (
+        ServiceSpec(port=80, protocol="tcp", name="http"),
+        ServiceSpec(port=5000, protocol="sctp", name=""),
+    )
+    assert not realization.diagnostics
+
+
+def test_interpret_rejects_malformed_service_without_leaking_payload():
+    sentinel = "TOKEN-LEAK-SENTINEL-XYZ"
+    plan = _plan(
+        _node_resource(
+            "provision.node.web",
+            "web",
+            services=[{"port": sentinel, "protocol": "tcp", "name": "http"}],
+        )
+    )
+
+    realization = interpret_provisioning_plan(plan)
+
+    codes = {diagnostic.code for diagnostic in realization.diagnostics}
+    assert "reference-backend.realization.service-invalid" in codes
+    assert all(sentinel not in diagnostic.message for diagnostic in realization.diagnostics)
 
 
 def test_interpret_maps_networks_to_network_specs():

--- a/implementations/python/tests/test_runtime_planner.py
+++ b/implementations/python/tests/test_runtime_planner.py
@@ -1078,6 +1078,40 @@ workflows:
         assert "evaluator.objectives-unsupported" in codes
         assert not execution_plan.is_valid
 
+    def test_acl_capability_validation_covers_node_attached_rules(self):
+        limited = _limited_backend_manifest(
+            name="limited",
+            provisioner=ProvisionerCapabilities(
+                name="limited-provisioner",
+                supported_node_types=frozenset({"vm"}),
+                supported_os_families=frozenset({"linux"}),
+                supports_acls=False,
+            ),
+        )
+        model = compile_runtime_model(
+            _scenario("""
+name: node-acl
+nodes:
+  web:
+    type: vm
+    os: linux
+    resources: {ram: 1 gib, cpu: 1}
+infrastructure:
+  web:
+    count: 1
+    acls:
+      - {direction: in, protocol: tcp, ports: [443], action: allow}
+""")
+        )
+
+        execution_plan = plan(model, limited)
+
+        acl_diagnostics = [
+            diagnostic for diagnostic in execution_plan.diagnostics if diagnostic.code == "provisioner.acls-unsupported"
+        ]
+        assert [diagnostic.address for diagnostic in acl_diagnostics] == ["provision.node.web"]
+        assert not execution_plan.is_valid
+
     def test_variable_backed_os_allowed_values_pass_when_all_supported(self):
         manifest = _limited_backend_manifest(
             name="limited",

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -2551,6 +2551,10 @@ class TestServicePort:
         sp = ServicePort(port="${service_port}", name="https")
         assert sp.port == "${service_port}"
 
+    def test_rejects_unmodeled_role_as_reachability_policy(self):
+        with pytest.raises(ValidationError, match="role"):
+            ServicePort.model_validate({"port": 80, "protocol": "tcp", "name": "http", "role": "internal"})
+
 
 class TestConditionExtensions:
     def test_timeout_and_retries(self):

--- a/specs/sdl/runtime-inventory.md
+++ b/specs/sdl/runtime-inventory.md
@@ -23,6 +23,13 @@ sequence.
    nested runtime-family reference form
    ([references.md §1](references.md)):
    `nodes.<node>.runtime.<collection>.<id>[.<child-collection>.<child-id>…]`.
+4. `Node.services[]` is adjacent authored identity, not runtime inventory. Each
+   entry identifies a node-local transport binding by port, protocol, and
+   optional name; it does not authorize traffic, prove a live listener, publish
+   a host port, or classify an audience. Authorization remains in
+   `infrastructure.*.acls`, observed bind state in
+   `runtime.service_listeners`, and host publication in
+   `runtime.network.published_ports`.
 
 ## 2. Family index
 


### PR DESCRIPTION
## Summary

Defines and enforces the non-reachability semantics of authored node services, preserves those declarations through the reference backend without host publication, and makes ACL capability admission fail closed for every attachment point.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #748

## ADR Impact

- ADR-021
- ADR-063

## Changes

- Define `Node.services` as authored node-local transport-binding identity, explicitly separate from reachability, publication, ACLs, audience, and observed listeners, with regenerated public schemas and documentation.
- Carry named and unnamed service descriptors through the reference-backend realization boundary without publishing host ports; reject malformed service payloads with stable redacted diagnostics.
- Correct the reference backend's ACL capability declaration and make planner admission reject both network- and node-attached ACLs before side effects while preserving the legacy positional `ContainerSpec` constructor.

## Test Plan

- [x] Relevant unit tests pass
- [x] Canonical `nox -f noxfile.py -s verify` passes
- [x] Integration tests and documentation build pass
- [x] No coverage regression (92% total coverage)

Validated with 3,670 core tests, 34 integration tests, focused reference-backend tests, repository policy checks, pre-commit, production-readiness/security review, and test-quality review.

## Ground Control Checks

- [x] Repository policy and requirement-governance checks pass
- [x] Ground Control quality gates evaluated (no enabled project gates)
- [x] Completion, production-readiness/security, and test-quality gates completed

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — issue-scoped bug run with repository-local regression coverage)

## Checklist

- [x] Code follows project coding standards (`docs/explain/reference/coding-standards.md`)
- [x] FM level classified for the semantic change
- [x] Published contract schemas regenerated and publication hashes updated
- [x] PR title is a Conventional Commit
- [x] Architectural and user-facing documentation updated
- [x] Changelog fragment is not applicable; release-please owns `CHANGELOG.md` and this repository forbids `changelog.d/`

## Documentation

Updated: authored service semantics, reference-backend behavior, runtime inventory, and the issue-specific architecture preflight decision.
