### PR TITLE
feat: add realization honesty conformance

### DIFF
--- a/docs/conformance/libvirt-qemu.provisioning-only.report.json
+++ b/docs/conformance/libvirt-qemu.provisioning-only.report.json
@@ -1,6 +1,6 @@
 {
   "profile": "provisioning-only",
-  "passed": true,
+  "passed": false,
   "cases": [
     {
       "name": "feature-support-bounded",
@@ -241,18 +241,14 @@
       "diagnostic_codes": []
     },
     {
-      "name": "target-provisioning",
-      "contract_name": "operation-status-v1",
+      "name": "realization-envelope-constructive",
+      "contract_name": "realization-envelope-v1",
       "valid": true,
-      "passed": true,
-      "diagnostic_codes": []
-    },
-    {
-      "name": "target-snapshot",
-      "contract_name": "runtime-snapshot-v1",
-      "valid": true,
-      "passed": true,
-      "diagnostic_codes": []
+      "passed": false,
+      "diagnostic_codes": [
+        "realization-envelope.negative-probe.no-witness",
+        "realization-envelope.positive-probe.no-witness"
+      ]
     }
   ],
   "unsupported_contract_gaps": [],

--- a/docs/decisions/issue-716-asr-519-realization-honesty-conformance-preflight.md
+++ b/docs/decisions/issue-716-asr-519-realization-honesty-conformance-preflight.md
@@ -1,0 +1,456 @@
+# Issue 716 / ASR-519 Realization Honesty Conformance Preflight
+
+Date: 2026-07-14
+
+Requirement source: Ground Control requirement ASR-519, selected by GitHub
+issue #716.
+
+This note records repository-wide guardrails for the realization-honesty
+conformance work. It is guidance only: it does not implement the runner, alter
+an envelope, add probes or fixtures, certify a backend, or define an
+implementation plan.
+
+No new ADR is required. ADR-021, ADR-036, ADR-066, and ADR-070 already own the
+claim-evidence, package-boundary, evidence-plane, and realization-envelope
+decisions. This issue must close the executable conformance gap without creating
+parallel authority.
+
+## Binding Sources And Canonical Incumbents
+
+- ADR-070 and `specs/formal/realization/envelope-semantics.md` own the shared
+  envelope language and the `member()`, `subsumes()`, `witness()`, and
+  `generate_negative_probes()` relation in
+  `aces_sdl.realization_envelope`. Conformance must extend that relation's
+  deterministic probe coverage when necessary; it must not interpret domains,
+  closure, or paths again.
+- The issue #100 preflight and the published
+  `BackendRealizationEnvelopeModel` own configuration/envelope identity,
+  `RealizationConcern`, `ConcernDisposition`, `TransformationKind`, and
+  `ObservationStrength`. The selected artifact under
+  `contracts/realization-envelopes/` is the value/disclosure authority;
+  `realization_support` and `ProvisionerCapabilities` remain separate coarse
+  gates.
+- The issue #714 and #715 preflights own exact-or-reject admission, one
+  field-addressed concern inventory, daemon/guest observation, freshness,
+  rollback, and cleanup. `RealizationObservation`, `DriverResult`, the TechVault
+  concern validators, the guest observer, and the validated scenario-evidence
+  workflow are incumbents, not examples to copy.
+- `run_fixture_suite()`, `run_target_conformance()`,
+  `ConformanceCaseResult`, `BackendConformanceReport`, and the existing
+  `bounded-probe-success` `BehavioralClaimBindingModel` are the conformance and
+  report family. Issue #716 evolves this family; it does not add an honesty-only
+  runner, claim relation, report schema, profile, or exception hierarchy.
+- `RuntimeManager`, `RuntimeControlPlane`, `_call_backend_diagnostics()`,
+  `_call_backend_apply()`, `OperationReceipt`, `OperationStatus`, `ApplyResult`,
+  `RuntimeSnapshot`, `ControlPlaneStore`, and the closed plan/snapshot models are
+  the execution, validation, error, and portable persistence path.
+- `interpret_provisioning_plan()`, `Realization`, `DomainSpec`, `NetworkSpec`,
+  and `Realization.placement_targets` are the libvirt plan interpretation and
+  aggregation seam. Conformance must account for the original plan operations;
+  a domain-level spec or handle cannot erase placement/binding obligations.
+- `aces_operations.libvirt_evidence_run`,
+  `validate_libvirt_evidence_run_artifact()`, `redaction_violations()`,
+  `cleanup_native_snapshot()`, `run_artifact_path()`, and
+  `atomic_write_json_artifact()` are the native proof, redaction, cleanup, and
+  explicit report-output incumbents.
+- ADR-009/ADR-061, `ContractModel`, `schema_bundle()`, the packaged corpus,
+  `contracts/schema-publication-manifest.json`, and
+  `specs/authority/authority-boundary.yaml` govern any unavoidable published
+  contract change. A local conformance report does not become a published
+  contract merely because it is JSON.
+
+## Architectural Diagnosis
+
+The current target probe proves only that a control-plane apply returned a
+successful operation, non-empty changed addresses, and a schema-valid mutated
+snapshot. Its libvirt test uses a daemon-free recording driver. That is useful
+**hermetic target-adapter evidence**, but it is neither native-live nor evidence
+that each realization concern was observed at its declared strength.
+
+Four existing shapes are insufficient by themselves:
+
+1. `SnapshotEntry.payload` is planned reconciliation state and can echo a plan
+   that the backend ignored.
+2. `DomainHandle`, `NetworkHandle`, `changed_addresses`, and
+   `realized_addresses()` are completion/accounting receipts, not concern
+   observations.
+3. `BackendConformanceReport` currently records a boolean per case but no
+   execution basis, envelope/configuration binding, observation inventory,
+   negative-probe mutation proof, or cleanup result.
+4. The three published libvirt envelopes currently contain empty/open
+   expressions. `witness()` cannot derive a complete valid scenario from those
+   expressions. Conformance must fail visibly until an authoritative envelope
+   is sufficiently constructive; it must not fall back to
+   `_DEFAULT_CONFORMANCE_SCENARIO`, a caller-selected happy path, or a
+   libvirt-specific witness table.
+
+The existing `reference_scenario` bridge is therefore not an acceptable ASR-519
+certification path. It may remain for legacy adapter conformance, but its result
+must be labelled `hermetic-live` and bounded to that supplied scenario, never
+promoted to realization-envelope or native conformance.
+
+## Architecture Decisions And Guardrails
+
+### Keep one conformance runner and one report family
+
+- Extend `run_target_conformance()` (or a narrowly named helper it owns) and
+  `BackendConformanceReport`; keep fixture, target, realization, and cleanup
+  cases in one machine-readable report. Do not create `HonestyReport`, a
+  libvirt report DTO, or a second serializer.
+- Keep `aces_conformance` backend-neutral. It may depend on neutral contracts,
+  SDL relations, processor planning, and runtime control, but it must not import
+  `aces_backend_libvirt`, `aces_operations`, or inspect driver classes.
+- Native/backend-specific construction and observation remain behind an
+  injected, conformance-only harness assembled by operations code (and by test
+  fixtures for hermetic runs). The minimal harness supplies an already validated
+  `RuntimeTarget`, execution basis, addressed observations, an independent
+  mutation/state ledger, and cleanup/residual results. It is not a new runtime
+  role, manifest capability, `RuntimeTarget` component, control-plane endpoint,
+  or general backend protocol.
+- `aces_backend_libvirt.driver.RealizationObservation` is a backend-local
+  readback DTO, not the backend-neutral evidence contract: it lacks probe,
+  operation, envelope/configuration, freshness, and cleanup binding.
+  `RealizationProvenanceEntry` is also not that contract; it records SEM-218
+  origin without observed values or observation strength. Keep both meanings
+  intact. If the injected harness must pass evidence between
+  `aces_operations` and `aces_conformance`, ADR-036 puts the minimum neutral,
+  typed observation-evidence DTO in `aces_contracts`; the backend/operations
+  adapter maps its local readback into that DTO and the existing
+  `BackendConformanceReport` projects it. Do not copy the libvirt dataclass into
+  each backend, re-export it as if backend-local fields were neutral, or overload
+  runtime provenance. A neutral internal DTO does not by itself authorize a
+  published JSON Schema.
+- Preserve the enforced import graph. `aces_conformance` must not import
+  `aces_operations` or `aces_backend_libvirt`, and `aces_operations` must not
+  import `aces_conformance`. The `aces_cli` composition root may wire the
+  structurally compatible operations harness into the conformance runner while
+  both sides exchange only `aces_contracts` DTOs. Any new public module prefix
+  must be added narrowly to `tools/policy/adr_policy.yaml`; do not evade the
+  policy with private-module imports or `Any` payloads.
+
+### Derive the probe set from the selected envelope
+
+- Load and validate the configuration-selected
+  `BackendRealizationEnvelopeModel` through the packaged corpus loader. Require
+  exact equality among manifest identity, offered artifact identity, plan
+  identity, target configuration, observer binding, and report binding before
+  any probe executes.
+- Generate positive witnesses and negative variants through the shared envelope
+  relation. If one deterministic base witness does not cover a finite enum,
+  boolean, bounded interval boundary, governed reference, exact omission, or
+  closed child dimension, extend the shared generator over the same
+  `effective_constraints()`/domain engine. Do not put sampling logic in
+  `aces_conformance` or a backend.
+- Every positive candidate must pass the normal closed SDL model,
+  instantiation, `SemanticValidator`, and `member()` checks before planning.
+  Every negative candidate must remain structurally/semantically safe and be
+  proven outside the offered envelope for exactly one reported variation. A
+  malformed request rejected by Pydantic is not evidence that the backend
+  enforces its envelope.
+- Probe generation is deterministic and reportable: policy/seed, dimension,
+  path, variation, and a secret-free canonical probe digest are recorded. Raw
+  secret-capable values are not report identity.
+- A dimension for which no safe, ordinary-contract-valid probe can be generated
+  is `unsupported`, not passed. Skipped and unsupported probes prevent the
+  corresponding claim from certifying. Open or genuinely unbounded dimensions
+  remain explicit nonclaims rather than silently increasing the denominator.
+
+### Require total operation and concern accounting
+
+- For each positive witness, derive the expected operation inventory from the
+  canonical `ProvisioningPlan`, not from driver handles or the post-apply
+  snapshot. Every non-`UNCHANGED` operation has exactly one terminal accounting
+  result: independently observed at the envelope-required strength, rejected
+  before mutation, or failed with an addressed diagnostic.
+- Preserve both levels when the backend aggregates: a node/domain observation
+  may account for the node operation, but account/content/feature/service/ACL
+  placements and bindings require their own addressed concern observations.
+  Missing aggregated placements/bindings fail even when the parent domain and
+  every `changed_address` exist.
+- `UNCHANGED` means no fresh mutation and supplies no fresh observation claim.
+  `DELETE` requires ownership-checked observed absence and complete cleanup; a
+  false absence handle is not enough.
+- Compare authored/planned requirements with independently observed facts. An
+  exact value is equal or rejected. A transformed value passes only when the
+  selected envelope names the transformation, the input and output are both
+  admitted by an executable governed rule, and the report discloses it. The
+  current transformation-name enum is disclosure, not executable permission;
+  absent such a rule, use exact-or-reject.
+- Missing disclosure, image substitution, resource clamping/defaulting,
+  descriptor substitution, synthesized services, planned-as-observed facts,
+  fabricated handles, duplicate/missing observations, stale evidence, and
+  unexpected augmentation are distinct failures with stable diagnostic codes.
+
+### Observation strength is a per-concern evidence requirement
+
+- Treat envelope observation strength as a required terminal level, not a label
+  copied onto a report. Driver-reported concerns require a fresh addressed
+  `RealizationObservation`, not merely a handle. Daemon-observed concerns require
+  ownership-correlated post-operation readback. Guest-observed concerns require
+  the issue #715 challenge-bound concern probe and its daemon correlation.
+- Strength is ordered evidence, not interchangeable provenance. SEM-218
+  `backend-realized`, SEM-225 augmentation, report execution basis, and
+  `driver`/`daemon`/`guest` observation are four different classifications.
+- A guest terminal claim does not erase its prerequisite daemon binding. Reports
+  enumerate both layers and never upgrade driver/daemon evidence because the
+  overall run used a guest-capable or native driver.
+- Every observation is bound to the current operation/probe, safe ACES address
+  and field path, concern, source, selected envelope/configuration digests,
+  observer/probe-policy version, and freshness evidence. A prior driver snapshot,
+  reused challenge, cross-operation fact, or unbound timestamp fails.
+
+### Negative probes prove refusal without mutation
+
+- Submit plan-valid negative probes through the ordinary planning/control-plane
+  boundary far enough to exercise the target's envelope/admission gate. They
+  must fail before `driver.realize()`, `driver.destroy()`, libvirt connection,
+  artifact creation, or any native mutation.
+- Prove non-mutation in both planes: byte-equivalent portable baseline snapshot
+  (including envelope/provenance and persisted store round-trip where used) and
+  an independent harness ledger showing no driver/native mutation call and no
+  change in the owned native inventory. Backend self-report alone is not proof.
+- Wrong-envelope tests pair each libvirt configuration with another published
+  envelope identity and assert refusal before IO. Generic,
+  `techvault-appliance`, and any selectable guest-certified configuration remain
+  separate target instances and reports; success in one must not certify the
+  abstract `libvirt-qemu` name or another configuration.
+
+### Execution basis, outcome, and certification scope stay distinct
+
+- Use exactly these execution-basis statuses in conformance results:
+  `fixture-only` (published corpus only), `hermetic-live` (real
+  processor/control-plane/provisioner path with injected hermetic driver and
+  observer), and `native-live` (real daemon/native mutation and verified
+  teardown). Only `native-live` may support a native-conformance claim.
+- `guest-certified` is an observation capability/mode inside a `native-live`
+  run, not a fourth conformance basis. Existing evidence-source modes such as
+  `deterministic` also do not substitute for these statuses.
+- Probe outcomes are `passed`, `failed`, `skipped`, or `unsupported`; only
+  `passed` contributes to an overall pass. ADR-021 evidence status
+  (`untested`/`partial`/`demonstrated`/`refuted`) and the behavioral relation
+  claim remain separate fields.
+- Rename remaining user/report-facing “live provisioning” descriptions that
+  refer to a recording/fake driver to “hermetic target provisioning” or
+  equivalent. Historical function names may remain private only if they cannot
+  be mistaken for real-daemon evidence.
+
+### Claims and reports are configuration-bound
+
+- Bind every claim to backend implementation name and version, target instance,
+  profile, driver/configuration mode, envelope id/digest, configuration digest,
+  probe-set digest, execution basis, observer/probe-policy version, and evidence
+  artifact refs. `backend-target:libvirt-qemu` alone is too broad.
+- Reuse `bounded-probe-success`; finite probes never establish universal
+  realizability, backend equivalence, or a broader abstract backend name.
+- Extend the existing report projection so it enumerates each envelope concern,
+  generated probe, expected observation level, actual observations, operation
+  accounting, outcome, stable diagnostics, pre/post state proof, cleanup, and
+  residual category. Preserve failed and unsupported results; no serializer may
+  filter them from the claim's evidence boundary. Keep one canonical report
+  finalizer/serializer and validate its cross-field invariants before rendering;
+  do not create a parallel operations-only or libvirt-only report validator.
+- Durable native evidence is written only after full report validation and the
+  shared redaction gate, using the existing safe run-id/root confinement and
+  atomic writer. A cleanup failure may produce a failed redacted report, never a
+  passing one. Fixture-only output remains stdout unless explicit output was
+  requested.
+
+## Dishonest Backend And Falsification Boundary
+
+- Model prohibited behaviors as a table-driven dishonest **test fixture** behind
+  the same `RuntimeTarget`/provisioner/harness boundary. Do not add dishonest
+  modes to the production reference backend or monkeypatch the conformance gate
+  under test.
+- Each behavior is independently selectable and must fail for its expected
+  stable reason: schema-valid no-op/snapshot echo, omitted or mutated placement,
+  silent transformation, clamp/default, image substitution, missing disclosure,
+  planned-as-observed evidence, fabricated handle/observation, stale evidence,
+  wrong envelope/configuration, partial cleanup, and residual state.
+- Assertions cover failed operation/probe outcome, empty changed addresses where
+  admission failed, unchanged portable and native baselines, expected diagnostic
+  code/address, no passing claim, and cleanup/residual result. A single
+  multi-fault fixture cannot prove diagnostic specificity.
+- Hermetic mutation tests are mandatory in the default verification graph. Real
+  libvirt proof is separate and opt-in, but it is not allowed to self-skip and
+  then publish a passing native report.
+
+## Required Cross-Cutting Reuse
+
+- **SDL and envelope validation:** `Scenario`, `parse_sdl()`/`parse_sdl_file()`,
+  `instantiate_scenario()`, `SemanticValidator`, `member()`, `subsumes()`,
+  `witness()`, `generate_negative_probes()`, and their existing diagnostic
+  model.
+- **Contract and corpus authority:** `BackendRealizationEnvelopeModel`,
+  `RealizationEnvelopeIdentityModel`, closed `ContractModel` descendants,
+  `schema_bundle()`, `corpus_family_root()`, schema/fixture/profile publication
+  rules, and canonical digest helpers.
+- **Manifest and planning:** `backend_manifest_payload()`,
+  `BackendManifestV2Model`, supported-contract and controlled-vocabulary gates,
+  `realization_support_diagnostics()`, `realization_disclosure()`,
+  `RuntimeManager.plan()`, and the typed provisioning plan.
+- **Execution and persistence:** `RuntimeControlPlane`, backend call guards,
+  operation receipt/status, `ApplyResult`, snapshot transition validation,
+  `RuntimeSnapshotEnvelopeModel`, `ControlPlaneStore`, and atomic store behavior.
+- **Backend observation:** the existing plan interpreter, recording drivers,
+  `RealizationObservation`, TechVault daemon/guest observers, operation binding,
+  ownership stamps, safe absence detection, rollback, and cleanup helpers.
+- **Errors and observability:** `Diagnostic`, `Severity`, audit events, stable
+  package-local codes, `BehavioralClaimBindingModel`, `SessionReporter`, and the
+  shared artifact redaction validator. Logs and nox stage summaries are
+  supplemental and never count as probe evidence.
+- **Workflow:** the canonical Typer `aces conformance` family, explicit
+  destructive confirmation and noncredential URI validation for native runs,
+  the hermetic `nox verify` graph, separate real-daemon workflow, and repository
+  policy/governance checks from `.ground-control.yaml` and `.gc/plan-rules.md`.
+
+## Security And Whole-Path Gates
+
+- **Corpus/config shape:** envelope/profile ids resolve only through grammar-
+  checked, root-confined packaged corpus loaders. Payloads pass closed Pydantic
+  models, canonical digest checks, manifest/config/mode consistency, and
+  allowlisted `_validate_config_keys()` before target or observer construction.
+  Do not accept caller-supplied envelope paths or remote envelope URLs.
+- **SDL/plan shape:** generated probes pass ordinary SDL structure, semantics,
+  envelope relation, compiler/planner, `ProvisioningPlanModel`, capability, and
+  target identity gates. A conformance shortcut must not instantiate backend
+  specs directly.
+- **Authentication/authorization:** no new HTTP route is required; prefer the
+  in-process runner, whose result makes no authentication claim. If conformance
+  is ever driven through the existing HTTP submission route, retain
+  `ControlPlaneSecurityConfig.strict_defaults()`, verified bearer/proxy identity,
+  backend/operator role authorization, request-size limits, idempotency
+  fingerprints, and audit events. The current
+  `_ControlPlaneApiAuth._authenticate_request()` applies `identity.target_name`
+  only in the proxy-header branch because a valid bearer returns early. That
+  must be factored into one post-authentication scope check for both mechanisms
+  before an HTTP-driven result can count; issue #716 must not add a second auth
+  path or claim the current bearer path is target-scoped.
+- **Secrets and environment binding:** credentials, bearer tokens, keys,
+  cloud-init/account material, environment dumps, connector/transport reprs,
+  host paths, native ids, and raw configuration never enter probes, digests,
+  diagnostics, snapshots, reports, or logs. The CLI's
+  `_noncredential_connection_uri()` check must become one shared library/config
+  validator used by both `TechVaultNativeLibvirtDriver` and the generic
+  `LibvirtDeploymentDriver`; Typer validation alone does not protect Python
+  callers, and the generic driver currently checks only non-emptiness. The
+  opt-in `ACES_REAL_LIBVIRT_URI` test input must pass that same validator before
+  driver or direct `libvirt.open()` construction; unset/invalid native input is
+  blocked or unsupported, never a passing `native-live` result. Do not add a
+  dotenv or generic environment-to-config binder. Never hash a
+  credential-bearing URI as a safe substitute and never place secrets in
+  process argv. Use injected connection/credential handles if a future
+  transport requires authentication.
+- **Host/OS exposure:** fixture-only and hermetic-live are pure with respect to
+  libvirt/QEMU. Native-live remains opt-in, uses lazy libvirt import, structured
+  XML, fixed argv/no `shell=True`, bounded stage and overall deadlines,
+  ownership-confined workspaces, safe file modes/symlink checks, and no ambient
+  privilege escalation. Guest probing remains a fixed read-only fact channel,
+  never a general command runner.
+- **Error envelope:** public failures carry stable code, safe address/path,
+  concern/observation level, and generic redacted message. Do not concatenate
+  backend diagnostic messages or `str(exc)`. Existing conformance paths that
+  render raw Pydantic/backend exception text (`_validate_payload()`, event
+  validation, participant probe handling, and target provisioning status
+  aggregation) must be sanitized if reused by the new report. The HTTP routes'
+  `HTTPException(detail=str(exc))` conflict responses are likewise not a safe
+  conformance error carrier. Apply the shared redaction gate to the complete
+  report before persistence and discard raw stdout/stderr, XML, probe details,
+  and tracebacks.
+- **Portable persistence:** conformance does not add fields to
+  `RuntimeSnapshot.metadata` or `ApplyResult.details`, and it does not add a
+  native-state database. Runtime state continues through typed snapshots/store;
+  captured observation and cleanup proof live in the validated report/evidence
+  artifact. Rejected work writes no successful operation, snapshot mutation, or
+  realization claim.
+
+## Whole-Repository Surfaces In Scope
+
+- Normative: realization-envelope formal semantics; published realization
+  envelope, backend manifest, provisioning plan, operation status, and runtime
+  snapshot schemas/artifacts; backend profile and fixture corpora; authority and
+  schema-publication manifests if any published shape changes.
+- Implementation: `aces_sdl.realization_envelope`, `aces_contracts` envelope and
+  runtime DTOs, `aces_conformance`, processor planning/realization disclosure,
+  runtime control plane/backend calls/store, libvirt target/provisioner/driver
+  observers, operations evidence/cleanup/writer, and the canonical CLI wiring.
+- Verification: relation/property tests, contract/fixture tests, target and
+  control-plane tests, dishonest-backend mutation corpus, generic and TechVault
+  wrong-envelope tests, libvirt daemon/guest evidence validation, report drift
+  tests, redaction/security tests, and the opt-in reproducible real-daemon proof.
+- Governance: repo policy, requirement governance/traceability, generated-schema
+  parity, schema publication, authority boundaries, ADR-036 module-boundary
+  policy, docs build, and full verify.
+
+## Extensibility Seam
+
+The required seam is a backend-neutral conformance engine parameterized by:
+
+- one validated target and configuration-bound envelope;
+- deterministic probe policy/seed;
+- execution basis (`fixture-only`, `hermetic-live`, `native-live`);
+- one source-specific addressed observer;
+- one independent mutation/state ledger; and
+- one cleanup/residual verifier.
+
+A future backend, libvirt image family, remote libvirt policy, architecture,
+guest transport, or stronger observation source supplies another target/harness
+configuration. It must not require edits to the envelope relation, concern or
+observation vocabularies, planner action model, runtime control plane, diagnostic
+hierarchy, store, claim relation, or report writer. The probe policy is the seam
+for future deterministic coverage strengthening; backend names and driver
+classes are not dispatch keys in the conformance engine.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- treating the current empty/open libvirt envelope expressions as constructive,
+  or silently substituting the old default/reference scenario;
+- accepting one in-envelope witness as proof of a bounded dimension;
+- counting a skipped, unsupported, unsafe, malformed, or unexecuted probe as
+  passed;
+- using schema validity, receipt acceptance, snapshot mutation, changed
+  addresses, handles, or a planned payload echo as realization evidence;
+- letting parent domain accounting hide aggregated placement/binding omissions;
+- letting a claimed transformation name authorize clamp/default/substitution
+  without a governed executable rule and explicit report record;
+- treating `backend-realized`, `native-live`, `guest-certified`, and
+  `guest-observed` as synonyms;
+- trusting a backend's own “no mutation” or cleanup assertion without an
+  independent call/native-state ledger;
+- allowing a fake/recording driver report to certify native conformance;
+- treating an integration-test self-skip or an unset/invalid
+  `ACES_REAL_LIBVIRT_URI` as a passing native-conformance result;
+- certifying `libvirt-qemu` broadly from one mode, envelope, driver,
+  configuration, or witness;
+- importing libvirt/operations code into `aces_conformance`, adding conformance
+  to the universal runtime protocols, or duplicating the observation DTO;
+- adding a conformance schema, profile, capability language, exception tree,
+  logger, store, endpoint, report writer, or secret/config parser when the
+  incumbents already exist;
+- mutating canonical fixtures in place, monkeypatching the gate under test, or
+  putting dishonest behavior in a production backend;
+- exposing credential-bearing URIs in argv or accepting them through unvalidated
+  library calls; and
+- persisting a passing report before cleanup and full redaction/report
+  validation succeed.
+
+## Non-Goals And Implementation Boundaries
+
+- No implementation of issue #716 in this preflight and no certification result.
+- No new SDL syntax, envelope language, solver, backend profile, universal
+  observation service, runtime role, HTTP route, persistence service, or public
+  report schema.
+- No redesign of the planner, control plane, backend protocol, runtime snapshot,
+  experiment-core evidence contracts, or participant-observation semantics.
+- No implementation of additional guest applications, OS/image families,
+  services, ACL mechanisms, or broader libvirt realizability merely to make a
+  probe pass. Unsupported concerns stay unsupported.
+- No claim of universal envelope subsumption, backend equivalence, all-driver
+  conformance, all-configuration conformance, or final reference-scenario
+  certification (issue #717).
+- No requirement that the hermetic verification graph install libvirt/QEMU,
+  access a daemon, hold credentials, use network access, or gain host privileges.
+- No compatibility fallback for missing/stale/mismatched identity, incomplete
+  operation accounting, absent required observation, failed cleanup, or
+  residual native state.

--- a/docs/explain/reference/backend-conformance.md
+++ b/docs/explain/reference/backend-conformance.md
@@ -206,10 +206,30 @@ facts to daemon- or guest-observed evidence.
 Issue #100 publishes configuration-bound realization envelopes using the shared
 parameterized SDL semantics from #667 and the membership/subsumption relation
 from #668. Manifests, provisioning plans, and snapshots carry one immutable
-envelope/configuration identity. Replacing the temporary
-`reference_scenario` bridge with generated positive and negative probes remains
-tracked by #716; contract, adapter, native-daemon, and guest conformance remain
-distinct reportable dimensions.
+envelope/configuration identity. For an envelope-bound target, target
+conformance now derives deterministic positive witnesses and safe negative
+probes through that shared relation. It does not fall back to
+`_DEFAULT_CONFORMANCE_SCENARIO` when an envelope is non-constructive.
+
+Each realization case records its `fixture-only`, `hermetic-live`, or
+`native-live` execution basis, probe and probe-set digests, exact envelope and
+configuration digests, operation accounting, declared and observed strength,
+state-mutation checks, cleanup status, residual state, evidence references,
+outcome, and diagnostics. Skipped and unsupported cases are gating failures;
+only a passing `native-live` run can set `native_conformance`.
+
+The execution seam is an injected operations-owned harness. It must supply an
+independent expected-observation inventory and fresh addressed observations;
+planned values, unbound or fabricated handles, stale samples, missing operation
+results, silent transformations, and incomplete cleanup all fail closed.
+Machine-readable reports are written only through the redaction-gated atomic
+artifact path. The currently published open libvirt envelopes are deliberately
+reported as non-constructive until the configuration-specific envelopes are
+made executable; a caller-selected happy path cannot substitute for them.
+
+Contract, adapter, native-daemon, and guest conformance remain distinct
+reportable dimensions. The repository-wide guardrails for this work are recorded in the
+[`issue #716 realization-honesty preflight`](../../decisions/issue-716-asr-519-realization-honesty-conformance-preflight.md).
 
 ## Non-Goals
 

--- a/implementations/python/packages/aces_backend_libvirt/driver.py
+++ b/implementations/python/packages/aces_backend_libvirt/driver.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.realization_envelope import ObservationStrength, RealizationConcern
+from aces_contracts.realization_observation import RealizationObservation
 
 from .cloudinit import CloudInitSpec
 
@@ -76,17 +76,6 @@ class DomainHandle:
 
     address: str
     realized: bool = True
-
-
-@dataclass(frozen=True)
-class RealizationObservation:
-    """Bounded typed readback for one realized concern field."""
-
-    address: str
-    field_path: str
-    concern: RealizationConcern
-    source: ObservationStrength
-    value: object
 
 
 @dataclass(frozen=True)

--- a/implementations/python/packages/aces_cli/conformance.py
+++ b/implementations/python/packages/aces_cli/conformance.py
@@ -15,9 +15,9 @@ import typer
 from aces_conformance.conformance import (
     BackendCapabilityProfile,
     BackendConformanceReport,
+    backend_conformance_report_payload,
     run_fixture_suite,
 )
-from aces_contracts.diagnostics import Diagnostic
 
 _DEFAULT_PROFILE_ID = BackendCapabilityProfile.ORCHESTRATION_EVALUATION.value
 _KNOWN_PROFILE_HINT = ", ".join(sorted(profile.value for profile in BackendCapabilityProfile))
@@ -25,41 +25,8 @@ _KNOWN_PROFILE_HINT = ", ".join(sorted(profile.value for profile in BackendCapab
 app = typer.Typer(help="Backend conformance suite and fixture corpus.")
 
 
-def _serialize_diagnostic(diag: Diagnostic) -> dict[str, object]:
-    """Serialize a :class:`Diagnostic` with its stable identifying fields.
-
-    CI gates wired to ``aces conformance backend`` need to distinguish
-    ``conformance.profile-load-failed`` from ``conformance.fixture-missing``
-    from a case-level schema failure; flattening to ``message`` would force
-    brittle string-matching. Preserve the structured envelope.
-    """
-
-    return {
-        "code": diag.code,
-        "domain": diag.domain,
-        "address": diag.address,
-        "severity": diag.severity.value if hasattr(diag.severity, "value") else str(diag.severity),
-        "message": diag.message,
-    }
-
-
 def _report_payload(report: BackendConformanceReport) -> dict[str, object]:
-    return {
-        "profile": report.profile,
-        "passed": report.passed,
-        "claim": report.claim.model_dump(mode="json"),
-        "cases": [
-            {
-                "name": case.name,
-                "contract_name": case.contract_name,
-                "valid": case.valid,
-                "passed": case.passed,
-                "diagnostics": [_serialize_diagnostic(diag) for diag in case.diagnostics],
-            }
-            for case in report.cases
-        ],
-        "diagnostics": [_serialize_diagnostic(diag) for diag in report.diagnostics],
-    }
+    return backend_conformance_report_payload(report)
 
 
 @app.command("backend")

--- a/implementations/python/packages/aces_conformance/_realization_models.py
+++ b/implementations/python/packages/aces_conformance/_realization_models.py
@@ -1,0 +1,132 @@
+"""Data contracts for backend-neutral realization conformance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.planning import ProvisioningPlan
+from aces_contracts.realization_envelope import RealizationConcern
+from aces_contracts.realization_observation import RealizationObservation
+
+
+class ExecutionBasis(str, Enum):
+    """Execution substrate used by one conformance case."""
+
+    FIXTURE_ONLY = "fixture-only"
+    HERMETIC_LIVE = "hermetic-live"
+    NATIVE_LIVE = "native-live"
+
+
+class ProbeOutcome(str, Enum):
+    """Closed outcome vocabulary for realization probes."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class ExpectedRealizationObservation:
+    """Independent expected fact projected by the injected harness."""
+
+    address: str
+    field_path: str
+    concern: RealizationConcern
+    value: object
+
+
+@dataclass(frozen=True)
+class RealizationTransformation:
+    """One material difference between planned and observed realization."""
+
+    address: str
+    concern: RealizationConcern
+    kind: str
+    disclosed: bool
+
+
+@dataclass(frozen=True)
+class RealizationProbeRequest:
+    """Validated probe request supplied to an independent execution harness."""
+
+    probe_digest: str
+    probe_kind: str
+    payload: dict[str, object]
+    negative: bool
+    provisioning_plan: ProvisioningPlan | None
+    envelope_digest: str
+    configuration_digest: str
+    observer_version: str
+
+
+@dataclass(frozen=True)
+class RealizationProbeEvidence:
+    """Evidence returned by a backend-specific but independently-owned harness."""
+
+    accepted: bool
+    accounted_operations: tuple[str, ...] = ()
+    changed_addresses: tuple[str, ...] = ()
+    expected_observations: tuple[ExpectedRealizationObservation, ...] = ()
+    observations: tuple[RealizationObservation, ...] = ()
+    transformations: tuple[RealizationTransformation, ...] = ()
+    driver_invoked: bool = False
+    native_mutated: bool = False
+    portable_state_before: str = ""
+    portable_state_after: str = ""
+    native_state_before: str = ""
+    native_state_after: str = ""
+    baseline_sequence: int = 0
+    cleanup_verified: bool = False
+    residual_state: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
+
+
+class RealizationConformanceHarness(Protocol):
+    """Narrow operations-owned execution, observation, ledger, and cleanup seam."""
+
+    def execute(self, request: RealizationProbeRequest) -> RealizationProbeEvidence:
+        """Execute one validated positive or negative probe."""
+        ...
+
+
+@dataclass(frozen=True)
+class RealizationProbeCase:
+    """One realization probe in the existing backend conformance report."""
+
+    name: str
+    contract_name: str
+    valid: bool
+    passed: bool
+    diagnostics: tuple[Diagnostic, ...] = ()
+    execution_basis: str = ExecutionBasis.FIXTURE_ONLY.value
+    outcome: str = ProbeOutcome.PASSED.value
+    probe_kind: str | None = None
+    probe_digest: str | None = None
+    probe_set_digest: str | None = None
+    envelope_digest: str | None = None
+    configuration_digest: str | None = None
+    target_binding: str | None = None
+    expected_operations: tuple[str, ...] = ()
+    accounted_operations: tuple[str, ...] = ()
+    expected_observation_strengths: tuple[str, ...] = ()
+    actual_observation_strengths: tuple[str, ...] = ()
+    portable_state_unchanged: bool | None = None
+    native_state_unchanged: bool | None = None
+    cleanup_verified: bool | None = None
+    residual_state: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RealizationConformanceRun:
+    """Internal aggregate returned to ``run_target_conformance``."""
+
+    cases: tuple[RealizationProbeCase, ...] = ()
+    probe_set_digest: str | None = None
+    target_binding: str | None = None
+    native_conformance: bool = False

--- a/implementations/python/packages/aces_conformance/_realization_validation.py
+++ b/implementations/python/packages/aces_conformance/_realization_validation.py
@@ -145,15 +145,7 @@ def _expected_observation_diagnostics(
                 "The realization observation is weaker than the configuration requires.",
             )
         )
-    binding = (
-        item.operation_id == address
-        and item.probe_digest == request.probe_digest
-        and item.envelope_digest == request.envelope_digest
-        and item.configuration_digest == request.configuration_digest
-        and item.observer_version == request.observer_version
-        and item.binding_verified
-    )
-    if not binding:
+    if not _observation_binding_valid(item, address, request):
         diagnostics.append(
             diagnostic(
                 "conformance.observation-binding-invalid",
@@ -178,6 +170,21 @@ def _expected_observation_diagnostics(
             )
         )
     return diagnostics
+
+
+def _observation_binding_valid(
+    item: RealizationObservation,
+    address: str,
+    request: RealizationProbeRequest,
+) -> bool:
+    return (
+        item.operation_id == address
+        and item.probe_digest == request.probe_digest
+        and item.envelope_digest == request.envelope_digest
+        and item.configuration_digest == request.configuration_digest
+        and item.observer_version == request.observer_version
+        and item.binding_verified
+    )
 
 
 def transformation_diagnostics(evidence: RealizationProbeEvidence) -> list[Diagnostic]:

--- a/implementations/python/packages/aces_conformance/_realization_validation.py
+++ b/implementations/python/packages/aces_conformance/_realization_validation.py
@@ -12,7 +12,11 @@ from aces_contracts.realization_envelope import (
 )
 from aces_contracts.realization_observation import RealizationObservation
 
-from ._realization_models import RealizationProbeEvidence, RealizationProbeRequest
+from ._realization_models import (
+    ExpectedRealizationObservation,
+    RealizationProbeEvidence,
+    RealizationProbeRequest,
+)
 
 _DOMAIN = "conformance"
 _RESOURCE_CONCERNS: dict[str, frozenset[RealizationConcern]] = {
@@ -102,59 +106,77 @@ def observation_diagnostics(
         observed.setdefault((item.address, item.field_path, item.concern), []).append(item)
     diagnostics: list[Diagnostic] = []
     for expected in evidence.expected_observations:
-        key = (expected.address, expected.field_path, expected.concern)
-        candidates = observed.get(key, [])
-        if len(candidates) != 1 or candidates[0].value != expected.value:
-            diagnostics.append(
-                diagnostic(
-                    "conformance.observation-missing",
-                    expected.address,
-                    "A required addressed realization observation is missing, duplicated, or mismatched.",
-                )
+        diagnostics.extend(
+            _expected_observation_diagnostics(
+                expected,
+                observed.get((expected.address, expected.field_path, expected.concern), []),
+                request,
+                evidence.baseline_sequence,
+                strengths,
             )
-            continue
-        item = candidates[0]
-        required = strengths.get(expected.concern, ObservationStrength.NONE)
-        if _STRENGTH_RANK[item.source] < _STRENGTH_RANK[required]:
-            diagnostics.append(
-                diagnostic(
-                    "conformance.observation-strength-insufficient",
-                    expected.address,
-                    "The realization observation is weaker than the configuration requires.",
-                )
-            )
-        binding = (
-            item.operation_id == expected.address
-            and item.probe_digest == request.probe_digest
-            and item.envelope_digest == request.envelope_digest
-            and item.configuration_digest == request.configuration_digest
-            and item.observer_version == request.observer_version
-            and item.binding_verified
         )
-        if not binding:
-            diagnostics.append(
-                diagnostic(
-                    "conformance.observation-binding-invalid",
-                    expected.address,
-                    "The realization observation is not bound to this operation, probe, envelope, and observer.",
-                )
+    return diagnostics
+
+
+def _expected_observation_diagnostics(
+    expected: ExpectedRealizationObservation,
+    candidates: list[RealizationObservation],
+    request: RealizationProbeRequest,
+    baseline_sequence: int,
+    strengths: dict[RealizationConcern, ObservationStrength],
+) -> list[Diagnostic]:
+    address = expected.address
+    if len(candidates) != 1 or candidates[0].value != expected.value:
+        return [
+            diagnostic(
+                "conformance.observation-missing",
+                address,
+                "A required addressed realization observation is missing, duplicated, or mismatched.",
             )
-        if item.origin != "observed":
-            diagnostics.append(
-                diagnostic(
-                    "conformance.observation-not-independent",
-                    expected.address,
-                    "Planned or echoed state cannot satisfy an independent realization observation.",
-                )
+        ]
+    item = candidates[0]
+    diagnostics: list[Diagnostic] = []
+    required = strengths.get(expected.concern, ObservationStrength.NONE)
+    if _STRENGTH_RANK[item.source] < _STRENGTH_RANK[required]:
+        diagnostics.append(
+            diagnostic(
+                "conformance.observation-strength-insufficient",
+                address,
+                "The realization observation is weaker than the configuration requires.",
             )
-        if item.sequence is None or item.sequence <= evidence.baseline_sequence:
-            diagnostics.append(
-                diagnostic(
-                    "conformance.observation-stale",
-                    expected.address,
-                    "The realization observation is not fresh for this probe execution.",
-                )
+        )
+    binding = (
+        item.operation_id == address
+        and item.probe_digest == request.probe_digest
+        and item.envelope_digest == request.envelope_digest
+        and item.configuration_digest == request.configuration_digest
+        and item.observer_version == request.observer_version
+        and item.binding_verified
+    )
+    if not binding:
+        diagnostics.append(
+            diagnostic(
+                "conformance.observation-binding-invalid",
+                address,
+                "The realization observation is not bound to this operation, probe, envelope, and observer.",
             )
+        )
+    if item.origin != "observed":
+        diagnostics.append(
+            diagnostic(
+                "conformance.observation-not-independent",
+                address,
+                "Planned or echoed state cannot satisfy an independent realization observation.",
+            )
+        )
+    if item.sequence is None or item.sequence <= baseline_sequence:
+        diagnostics.append(
+            diagnostic(
+                "conformance.observation-stale",
+                address,
+                "The realization observation is not fresh for this probe execution.",
+            )
+        )
     return diagnostics
 
 

--- a/implementations/python/packages/aces_conformance/_realization_validation.py
+++ b/implementations/python/packages/aces_conformance/_realization_validation.py
@@ -1,0 +1,178 @@
+"""Validation helpers for realization-honesty evidence."""
+
+from __future__ import annotations
+
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.planning import ProvisioningPlan
+from aces_contracts.realization_envelope import (
+    BackendRealizationEnvelopeModel,
+    ConcernDisposition,
+    ObservationStrength,
+    RealizationConcern,
+)
+from aces_contracts.realization_observation import RealizationObservation
+
+from ._realization_models import RealizationProbeEvidence, RealizationProbeRequest
+
+_DOMAIN = "conformance"
+_RESOURCE_CONCERNS: dict[str, frozenset[RealizationConcern]] = {
+    "network": frozenset({RealizationConcern.TOPOLOGY, RealizationConcern.NETWORK}),
+    "node": frozenset(
+        {
+            RealizationConcern.TOPOLOGY,
+            RealizationConcern.ARCHITECTURE,
+            RealizationConcern.IMAGE,
+            RealizationConcern.RESOURCE_ALLOCATION,
+            RealizationConcern.NETWORK,
+            RealizationConcern.SERVICE,
+            RealizationConcern.ACL,
+        }
+    ),
+    "content-placement": frozenset({RealizationConcern.CONTENT_PLACEMENT}),
+    "account-placement": frozenset({RealizationConcern.ACCOUNT_PLACEMENT}),
+    "feature-binding": frozenset({RealizationConcern.FEATURE_BINDING}),
+}
+_STRENGTH_RANK = {
+    ObservationStrength.NONE: 0,
+    ObservationStrength.DRIVER_REPORTED: 1,
+    ObservationStrength.DAEMON_OBSERVED: 2,
+    ObservationStrength.GUEST_OBSERVED: 3,
+}
+
+
+def diagnostic(code: str, address: str, message: str) -> Diagnostic:
+    """Return a sanitized conformance error diagnostic."""
+
+    return Diagnostic(code=code, domain=_DOMAIN, address=address, message=message, severity=Severity.ERROR)
+
+
+def required_strengths(
+    envelope: BackendRealizationEnvelopeModel,
+) -> dict[RealizationConcern, ObservationStrength]:
+    """Return required observation strength by supported concern."""
+
+    return {
+        disclosure.concern: disclosure.observation_strength
+        for disclosure in envelope.concerns
+        if disclosure.disposition is not ConcernDisposition.UNSUPPORTED
+    }
+
+
+def operation_inventory_diagnostics(
+    plan: ProvisioningPlan,
+    evidence: RealizationProbeEvidence,
+    strengths: dict[RealizationConcern, ObservationStrength],
+) -> list[Diagnostic]:
+    """Check exact operation accounting and expected-observation coverage."""
+
+    expected_operations = {operation.address for operation in plan.actionable_operations}
+    accounted = set(evidence.accounted_operations)
+    diagnostics: list[Diagnostic] = []
+    if accounted != expected_operations or set(evidence.changed_addresses) != expected_operations:
+        diagnostics.append(
+            diagnostic(
+                "conformance.operation-accounting-incomplete",
+                "runtime.provisioning.operations",
+                "Every actionable provisioning operation must have exactly one terminal accounting result.",
+            )
+        )
+    inventory = {(item.address, item.concern) for item in evidence.expected_observations}
+    for operation in plan.actionable_operations:
+        required = _RESOURCE_CONCERNS.get(operation.resource_type, frozenset()) & strengths.keys()
+        if any((operation.address, concern) not in inventory for concern in required):
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-inventory-incomplete",
+                    operation.address,
+                    "The independent expected-observation inventory omits a required realization concern.",
+                )
+            )
+    return diagnostics
+
+
+def observation_diagnostics(
+    request: RealizationProbeRequest,
+    evidence: RealizationProbeEvidence,
+    strengths: dict[RealizationConcern, ObservationStrength],
+) -> list[Diagnostic]:
+    """Check observation value, strength, binding, provenance, and freshness."""
+
+    observed: dict[tuple[str, str, RealizationConcern], list[RealizationObservation]] = {}
+    for item in evidence.observations:
+        observed.setdefault((item.address, item.field_path, item.concern), []).append(item)
+    diagnostics: list[Diagnostic] = []
+    for expected in evidence.expected_observations:
+        key = (expected.address, expected.field_path, expected.concern)
+        candidates = observed.get(key, [])
+        if len(candidates) != 1 or candidates[0].value != expected.value:
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-missing",
+                    expected.address,
+                    "A required addressed realization observation is missing, duplicated, or mismatched.",
+                )
+            )
+            continue
+        item = candidates[0]
+        required = strengths.get(expected.concern, ObservationStrength.NONE)
+        if _STRENGTH_RANK[item.source] < _STRENGTH_RANK[required]:
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-strength-insufficient",
+                    expected.address,
+                    "The realization observation is weaker than the configuration requires.",
+                )
+            )
+        binding = (
+            item.operation_id == expected.address
+            and item.probe_digest == request.probe_digest
+            and item.envelope_digest == request.envelope_digest
+            and item.configuration_digest == request.configuration_digest
+            and item.observer_version == request.observer_version
+            and item.binding_verified
+        )
+        if not binding:
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-binding-invalid",
+                    expected.address,
+                    "The realization observation is not bound to this operation, probe, envelope, and observer.",
+                )
+            )
+        if item.origin != "observed":
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-not-independent",
+                    expected.address,
+                    "Planned or echoed state cannot satisfy an independent realization observation.",
+                )
+            )
+        if item.sequence is None or item.sequence <= evidence.baseline_sequence:
+            diagnostics.append(
+                diagnostic(
+                    "conformance.observation-stale",
+                    expected.address,
+                    "The realization observation is not fresh for this probe execution.",
+                )
+            )
+    return diagnostics
+
+
+def transformation_diagnostics(evidence: RealizationProbeEvidence) -> list[Diagnostic]:
+    """Reject all material transformations lacking executable governed evidence."""
+
+    diagnostics: list[Diagnostic] = []
+    for transformation in evidence.transformations:
+        code = (
+            "conformance.transformation-undisclosed"
+            if not transformation.disclosed
+            else "conformance.transformation-unverified"
+        )
+        diagnostics.append(
+            diagnostic(
+                code,
+                transformation.address,
+                "A material realization transformation lacks a governed executable rule and exact evidence.",
+            )
+        )
+    return diagnostics

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
@@ -92,6 +92,13 @@ from aces_runtime.result_contracts import (
     workflow_result_contract_diagnostics,
 )
 from pydantic import ValidationError
+
+from aces_conformance.realization import (
+    ExecutionBasis,
+    RealizationConformanceHarness,
+    RealizationProbeCase,
+    run_realization_conformance,
+)
 
 _SEMANTIC_INVALID_DIAGNOSTIC_CODE = "conformance.semantic-invalid"
 _OBSERVABILITY_EVIDENCE_INVALID_DIAGNOSTIC_CODE = "conformance.observability-evidence-invalid"
@@ -222,6 +229,29 @@ class ConformanceCaseResult:
     valid: bool
     passed: bool
     diagnostics: tuple[Diagnostic, ...] = ()
+    execution_basis: str = ExecutionBasis.FIXTURE_ONLY.value
+    outcome: str = "passed"
+    probe_kind: str | None = None
+    probe_digest: str | None = None
+    probe_set_digest: str | None = None
+    envelope_digest: str | None = None
+    configuration_digest: str | None = None
+    target_binding: str | None = None
+    expected_operations: tuple[str, ...] = ()
+    accounted_operations: tuple[str, ...] = ()
+    expected_observation_strengths: tuple[str, ...] = ()
+    actual_observation_strengths: tuple[str, ...] = ()
+    portable_state_unchanged: bool | None = None
+    native_state_unchanged: bool | None = None
+    cleanup_verified: bool | None = None
+    residual_state: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Keep the closed outcome vocabulary aligned with the gating boolean."""
+
+        if self.outcome == "passed" and not self.passed:
+            object.__setattr__(self, "outcome", "failed")
 
 
 @dataclass(frozen=True)
@@ -243,6 +273,61 @@ class BackendConformanceReport:
     unsupported_contract_gaps: tuple[str, ...] = ()
     unsupported_capability_gaps: tuple[str, ...] = ()
     diagnostics: tuple[Diagnostic, ...] = ()
+    probe_set_digest: str | None = None
+    native_conformance: bool = False
+
+
+def _diagnostic_payload(diag: Diagnostic) -> dict[str, object]:
+    return {
+        "code": diag.code,
+        "domain": diag.domain,
+        "address": diag.address,
+        "severity": diag.severity.value if hasattr(diag.severity, "value") else str(diag.severity),
+        "message": diag.message,
+    }
+
+
+def backend_conformance_report_payload(report: BackendConformanceReport) -> dict[str, object]:
+    """Render the single machine-readable backend conformance report projection."""
+
+    return {
+        "profile": report.profile,
+        "passed": report.passed,
+        "native_conformance": report.native_conformance,
+        "probe_set_digest": report.probe_set_digest,
+        "claim": report.claim.model_dump(mode="json"),
+        "contract_versions": dict(report.contract_versions),
+        "unsupported_contract_gaps": list(report.unsupported_contract_gaps),
+        "unsupported_capability_gaps": list(report.unsupported_capability_gaps),
+        "cases": [
+            {
+                "name": case.name,
+                "contract_name": case.contract_name,
+                "valid": case.valid,
+                "passed": case.passed,
+                "execution_basis": case.execution_basis,
+                "outcome": case.outcome,
+                "probe_kind": case.probe_kind,
+                "probe_digest": case.probe_digest,
+                "probe_set_digest": case.probe_set_digest,
+                "envelope_digest": case.envelope_digest,
+                "configuration_digest": case.configuration_digest,
+                "target_binding": case.target_binding,
+                "expected_operations": list(case.expected_operations),
+                "accounted_operations": list(case.accounted_operations),
+                "expected_observation_strengths": list(case.expected_observation_strengths),
+                "actual_observation_strengths": list(case.actual_observation_strengths),
+                "portable_state_unchanged": case.portable_state_unchanged,
+                "native_state_unchanged": case.native_state_unchanged,
+                "cleanup_verified": case.cleanup_verified,
+                "residual_state": list(case.residual_state),
+                "evidence_refs": list(case.evidence_refs),
+                "diagnostics": [_diagnostic_payload(diag) for diag in case.diagnostics],
+            }
+            for case in report.cases
+        ],
+        "diagnostics": [_diagnostic_payload(diag) for diag in report.diagnostics],
+    }
 
 
 def _bounded_conformance_claim(
@@ -277,6 +362,8 @@ def _bounded_conformance_claim(
         explicit_non_claims=[
             "Does not establish trace equivalence or bisimulation.",
             "Does not establish strategic, epistemic, probabilistic, timed, or partial-order equivalence.",
+            "Finite generated probes do not establish universal realizability outside the recorded envelope dimensions.",
+            "Fixture-only and hermetic-live execution do not establish native-daemon conformance.",
         ],
     )
     return validate_behavioral_claim_binding(binding)
@@ -1269,14 +1356,19 @@ def run_target_conformance(
     root: Path | None = None,
     profiles_root: Path | None = None,
     reference_scenario: ScenarioInput | None = None,
+    realization_harness: RealizationConformanceHarness | None = None,
+    execution_basis: ExecutionBasis = ExecutionBasis.HERMETIC_LIVE,
+    realization_envelope: BackendRealizationEnvelopeModel | None = None,
+    observer_version: str = "aces-realization-observer/v1",
+    native_conformance: bool = False,
 ) -> BackendConformanceReport:
     """Run fixture conformance for a target's declared runtime surface.
 
     ``root`` overrides the fixtures tree and ``profiles_root`` overrides the
     backend profile tree; both default to the canonical published roots.
 
-    ``reference_scenario`` selects the scenario the live provisioning/snapshot
-    probes drive (issue #663). It defaults to a generic linux-vm scenario
+    ``reference_scenario`` selects the scenario the hermetic target-adapter
+    provisioning/snapshot probes drive (issue #663). It defaults to a generic linux-vm scenario
     (``_DEFAULT_CONFORMANCE_SCENARIO``). A fixed-topology emulation or bounded
     simulation backend that cannot realize the generic default supplies a
     scenario it *can* realize here, instead of being wrongly failed for not
@@ -1368,23 +1460,46 @@ def run_target_conformance(
                 + "; ".join(claim_gaps),
             )
         )
-    target_cases = _target_adapter_cases(target, effective_profile, reference_scenario=reference_scenario)
-    cases = (*fixture_report.cases, *target_cases)
-    passed = passed and all(case.passed for case in target_cases)
+    adapter_cases = _target_adapter_cases(target, effective_profile, reference_scenario=reference_scenario)
+    if target.manifest.realization_envelope is not None:
+        # Envelope-bound targets use the generated honesty probes below. The
+        # historic caller-supplied/default reference scenario remains only for
+        # targets that do not yet carry the governed envelope contract.
+        adapter_cases = adapter_cases[:1]
+    target_cases = tuple(replace(case, execution_basis=execution_basis.value) for case in adapter_cases)
+    realization_run = run_realization_conformance(
+        target,
+        harness=realization_harness,
+        execution_basis=execution_basis,
+        envelope=realization_envelope,
+        observer_version=observer_version,
+        native_conformance=native_conformance,
+    )
+    realization_cases = tuple(_realization_case_result(case) for case in realization_run.cases)
+    cases = (*fixture_report.cases, *target_cases, *realization_cases)
+    passed = passed and all(case.passed for case in (*target_cases, *realization_cases))
     return BackendConformanceReport(
         profile=_to_profile_id(effective_profile),
         passed=passed,
         claim=_bounded_conformance_claim(
             profile=_to_profile_id(effective_profile),
             cases=cases,
-            left_carrier_ref=f"backend-target:{target.name}",
+            left_carrier_ref=realization_run.target_binding or f"backend-target:{target.name}",
         ),
         cases=cases,
         contract_versions=dict(fixture_report.contract_versions),
         unsupported_contract_gaps=contract_gaps,
         unsupported_capability_gaps=capability_gaps,
         diagnostics=tuple(diagnostics),
+        probe_set_digest=realization_run.probe_set_digest,
+        native_conformance=passed and realization_run.native_conformance,
     )
+
+
+def _realization_case_result(case: RealizationProbeCase) -> ConformanceCaseResult:
+    """Project the internal realization case into the one report case family."""
+
+    return ConformanceCaseResult(**case.__dict__)
 
 
 def _drive_participant_episode_probe(
@@ -1518,7 +1633,7 @@ def _provisioning_probe_case(
     control_plane: RuntimeControlPlane,
     provisioning_plan: ProvisioningPlan,
 ) -> ConformanceCaseResult:
-    """Drive live provisioning and prove the operation genuinely realized state.
+    """Drive hermetic target-adapter provisioning and prove portable mutation.
 
     Backend-neutral (issue #606): every known profile requires a provisioner,
     so target conformance always submits the reference scenario's provisioning
@@ -1570,8 +1685,8 @@ def _provisioning_probe_case(
     )
 
 
-def _live_snapshot_payload(control_plane: RuntimeControlPlane) -> dict[str, Any]:
-    """Serialize the live control-plane snapshot to its portable envelope shape."""
+def _hermetic_snapshot_payload(control_plane: RuntimeControlPlane) -> dict[str, Any]:
+    """Serialize the hermetic control-plane snapshot to its portable envelope shape."""
 
     return {
         "schema_version": RuntimeSnapshotEnvelope().schema_version,
@@ -1611,16 +1726,16 @@ def _live_snapshot_payload(control_plane: RuntimeControlPlane) -> dict[str, Any]
     }
 
 
-def _live_snapshot_case(control_plane: RuntimeControlPlane) -> ConformanceCaseResult:
+def _hermetic_snapshot_case(control_plane: RuntimeControlPlane) -> ConformanceCaseResult:
     """Validate the post-provisioning snapshot and prove it was mutated.
 
-    Runs the ``runtime-snapshot-v1`` schema + semantic checks on the live
+    Runs the ``runtime-snapshot-v1`` schema + semantic checks on the hermetic
     snapshot and additionally requires at least one provisioning-domain entry
     (issue #606), so a target cannot pass with a schema-valid but empty
     (unmutated) snapshot.
     """
 
-    snapshot_payload = _live_snapshot_payload(control_plane)
+    snapshot_payload = _hermetic_snapshot_payload(control_plane)
     diagnostics = [
         *_validate_payload("runtime-snapshot-v1", snapshot_payload),
         *_semantic_diagnostics("runtime-snapshot-v1", snapshot_payload),
@@ -1634,7 +1749,7 @@ def _live_snapshot_case(control_plane: RuntimeControlPlane) -> ConformanceCaseRe
                 "conformance.snapshot-not-mutated",
                 "runtime.snapshot.entries",
                 (
-                    "Live snapshot carries no provisioning-domain entry after the provisioning "
+                    "Hermetic snapshot carries no provisioning-domain entry after the provisioning "
                     "probe; the backend validated contracts without realizing runtime state."
                 ),
             )
@@ -1705,5 +1820,5 @@ def _target_adapter_cases(
                     participant_address="participant.conformance",
                 )
             )
-    cases.append(_live_snapshot_case(control_plane))
+    cases.append(_hermetic_snapshot_case(control_plane))
     return tuple(cases)

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -362,7 +362,10 @@ def _bounded_conformance_claim(
         explicit_non_claims=[
             "Does not establish trace equivalence or bisimulation.",
             "Does not establish strategic, epistemic, probabilistic, timed, or partial-order equivalence.",
-            "Finite generated probes do not establish universal realizability outside the recorded envelope dimensions.",
+            (
+                "Finite generated probes do not establish universal realizability "
+                "outside the recorded envelope dimensions."
+            ),
             "Fixture-only and hermetic-live execution do not establish native-daemon conformance.",
         ],
     )
@@ -1349,19 +1352,20 @@ def _declared_contract_gaps(
     return tuple(sorted(required - manifest.supported_contract_versions))
 
 
-def run_target_conformance(
-    target: RuntimeTarget,
-    *,
-    profile: BackendProfileSelector | None = None,
-    root: Path | None = None,
-    profiles_root: Path | None = None,
-    reference_scenario: ScenarioInput | None = None,
-    realization_harness: RealizationConformanceHarness | None = None,
-    execution_basis: ExecutionBasis = ExecutionBasis.HERMETIC_LIVE,
-    realization_envelope: BackendRealizationEnvelopeModel | None = None,
-    observer_version: str = "aces-realization-observer/v1",
-    native_conformance: bool = False,
-) -> BackendConformanceReport:
+@dataclass(frozen=True)
+class _TargetConformanceOptions:
+    profile: BackendProfileSelector | None = None
+    root: Path | None = None
+    profiles_root: Path | None = None
+    reference_scenario: ScenarioInput | None = None
+    realization_harness: RealizationConformanceHarness | None = None
+    execution_basis: ExecutionBasis = ExecutionBasis.HERMETIC_LIVE
+    realization_envelope: BackendRealizationEnvelopeModel | None = None
+    observer_version: str = "aces-realization-observer/v1"
+    native_conformance: bool = False
+
+
+def run_target_conformance(target: RuntimeTarget, **option_values: Any) -> BackendConformanceReport:
     """Run fixture conformance for a target's declared runtime surface.
 
     ``root`` overrides the fixtures tree and ``profiles_root`` overrides the
@@ -1378,8 +1382,13 @@ def run_target_conformance(
     realizability-envelope design (#667/#668).
     """
 
-    effective_profile = profile or profile_for_manifest(target.manifest)
-    fixture_report = run_fixture_suite(profile=effective_profile, root=root, profiles_root=profiles_root)
+    options = _TargetConformanceOptions(**option_values)
+    effective_profile = options.profile or profile_for_manifest(target.manifest)
+    fixture_report = run_fixture_suite(
+        profile=effective_profile,
+        root=options.root,
+        profiles_root=options.profiles_root,
+    )
     if any(diag.code == "conformance.profile-load-failed" for diag in fixture_report.diagnostics):
         # The published profile is the contract set we are supposed to validate
         # against. With no profile loaded we must NOT mutate the backend via
@@ -1427,7 +1436,11 @@ def run_target_conformance(
             contract_versions=dict(fixture_report.contract_versions),
             diagnostics=diagnostics,
         )
-    contract_gaps = _declared_contract_gaps(effective_profile, target.manifest, profiles_root=profiles_root)
+    contract_gaps = _declared_contract_gaps(
+        effective_profile,
+        target.manifest,
+        profiles_root=options.profiles_root,
+    )
     surface_gaps = _capability_gaps(effective_profile, target)
     participant_claim_gaps = participant_runtime_capability_contract_gaps(target.manifest)
     observation_claim_gaps = observation_capability_contract_gaps(target.manifest)
@@ -1460,20 +1473,24 @@ def run_target_conformance(
                 + "; ".join(claim_gaps),
             )
         )
-    adapter_cases = _target_adapter_cases(target, effective_profile, reference_scenario=reference_scenario)
+    adapter_cases = _target_adapter_cases(
+        target,
+        effective_profile,
+        reference_scenario=options.reference_scenario,
+    )
     if target.manifest.realization_envelope is not None:
         # Envelope-bound targets use the generated honesty probes below. The
         # historic caller-supplied/default reference scenario remains only for
         # targets that do not yet carry the governed envelope contract.
         adapter_cases = adapter_cases[:1]
-    target_cases = tuple(replace(case, execution_basis=execution_basis.value) for case in adapter_cases)
+    target_cases = tuple(replace(case, execution_basis=options.execution_basis.value) for case in adapter_cases)
     realization_run = run_realization_conformance(
         target,
-        harness=realization_harness,
-        execution_basis=execution_basis,
-        envelope=realization_envelope,
-        observer_version=observer_version,
-        native_conformance=native_conformance,
+        harness=options.realization_harness,
+        execution_basis=options.execution_basis,
+        envelope=options.realization_envelope,
+        observer_version=options.observer_version,
+        native_conformance=options.native_conformance,
     )
     realization_cases = tuple(_realization_case_result(case) for case in realization_run.cases)
     cases = (*fixture_report.cases, *target_cases, *realization_cases)

--- a/implementations/python/packages/aces_conformance/conformance.py
+++ b/implementations/python/packages/aces_conformance/conformance.py
@@ -1365,6 +1365,137 @@ class _TargetConformanceOptions:
     native_conformance: bool = False
 
 
+def _unknown_profile_report(
+    target: RuntimeTarget,
+    profile: BackendProfileSelector,
+    fixture_report: BackendConformanceReport,
+) -> BackendConformanceReport:
+    profile_id = _to_profile_id(profile)
+    diagnostics = (
+        *fixture_report.diagnostics,
+        _diagnostic(
+            "conformance.profile-runtime-surface-unknown",
+            profile_id,
+            (
+                f"Target conformance cannot certify profile {profile_id!r}: this "
+                "implementation does not know the runtime-surface contract for the "
+                "profile. Known runtime surfaces: "
+                + ", ".join(sorted(item.value for item in BackendCapabilityProfile))
+                + ". Use run_fixture_suite() for fixture-only validation, or extend "
+                "BackendCapabilityProfile to declare this profile's runtime surfaces."
+            ),
+        ),
+    )
+    return BackendConformanceReport(
+        profile=profile_id,
+        passed=False,
+        claim=_bounded_conformance_claim(
+            profile=profile_id,
+            cases=fixture_report.cases,
+            left_carrier_ref=f"backend-target:{target.name}",
+        ),
+        cases=fixture_report.cases,
+        contract_versions=dict(fixture_report.contract_versions),
+        diagnostics=diagnostics,
+    )
+
+
+def _gap_diagnostics(
+    target: RuntimeTarget,
+    profile: BackendProfileSelector,
+    contract_gaps: tuple[str, ...],
+    surface_gaps: tuple[str, ...],
+    claim_gaps: tuple[str, ...],
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    if contract_gaps:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.unsupported-contract-declaration",
+                target.name,
+                f"Target does not declare required contracts for {_to_profile_id(profile)}: {', '.join(contract_gaps)}",
+            )
+        )
+    if surface_gaps:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.unsupported-surface",
+                target.name,
+                "Target is missing required runtime surfaces: " + ", ".join(surface_gaps),
+            )
+        )
+    if claim_gaps:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.unsupported-capability-claim",
+                target.name,
+                "Target declares participant capability claims without required contract surfaces: "
+                + "; ".join(claim_gaps),
+            )
+        )
+    return diagnostics
+
+
+def _known_profile_report(
+    target: RuntimeTarget,
+    profile: BackendProfileSelector,
+    fixture_report: BackendConformanceReport,
+    options: _TargetConformanceOptions,
+) -> BackendConformanceReport:
+    contract_gaps = _declared_contract_gaps(profile, target.manifest, profiles_root=options.profiles_root)
+    surface_gaps = _capability_gaps(profile, target)
+    claim_gaps = (
+        *participant_runtime_capability_contract_gaps(target.manifest),
+        *observation_capability_contract_gaps(target.manifest),
+    )
+    capability_gaps = (*surface_gaps, *claim_gaps)
+    diagnostics = [
+        *fixture_report.diagnostics,
+        *_gap_diagnostics(target, profile, contract_gaps, surface_gaps, claim_gaps),
+    ]
+    adapter_cases = _target_adapter_cases(
+        target,
+        profile,
+        reference_scenario=options.reference_scenario,
+    )
+    if target.manifest.realization_envelope is not None:
+        adapter_cases = adapter_cases[:1]
+    target_cases = tuple(replace(case, execution_basis=options.execution_basis.value) for case in adapter_cases)
+    realization_run = run_realization_conformance(
+        target,
+        harness=options.realization_harness,
+        execution_basis=options.execution_basis,
+        envelope=options.realization_envelope,
+        observer_version=options.observer_version,
+        native_conformance=options.native_conformance,
+    )
+    realization_cases = tuple(_realization_case_result(case) for case in realization_run.cases)
+    cases = (*fixture_report.cases, *target_cases, *realization_cases)
+    passed = (
+        fixture_report.passed
+        and not contract_gaps
+        and not capability_gaps
+        and all(case.passed for case in (*target_cases, *realization_cases))
+    )
+    profile_id = _to_profile_id(profile)
+    return BackendConformanceReport(
+        profile=profile_id,
+        passed=passed,
+        claim=_bounded_conformance_claim(
+            profile=profile_id,
+            cases=cases,
+            left_carrier_ref=realization_run.target_binding or f"backend-target:{target.name}",
+        ),
+        cases=cases,
+        contract_versions=dict(fixture_report.contract_versions),
+        unsupported_contract_gaps=contract_gaps,
+        unsupported_capability_gaps=capability_gaps,
+        diagnostics=tuple(diagnostics),
+        probe_set_digest=realization_run.probe_set_digest,
+        native_conformance=passed and realization_run.native_conformance,
+    )
+
+
 def run_target_conformance(target: RuntimeTarget, **option_values: Any) -> BackendConformanceReport:
     """Run fixture conformance for a target's declared runtime surface.
 
@@ -1390,127 +1521,10 @@ def run_target_conformance(target: RuntimeTarget, **option_values: Any) -> Backe
         profiles_root=options.profiles_root,
     )
     if any(diag.code == "conformance.profile-load-failed" for diag in fixture_report.diagnostics):
-        # The published profile is the contract set we are supposed to validate
-        # against. With no profile loaded we must NOT mutate the backend via
-        # ``_target_adapter_cases`` — there is nothing to validate against. The
-        # fixture report already carries the structured profile-load
-        # diagnostic and ``passed=False``; surface it as the conformance
-        # result for this target.
         return fixture_report
     if _to_known_profile(effective_profile) is None:
-        # Target conformance enforces runtime-surface gates (which capability
-        # roles the target must implement, which target probes to run). Those
-        # gates depend on knowing the profile's runtime surface contract. For
-        # an unknown profile id we have NO runtime-surface authority — letting
-        # the run continue would silently certify a target that's missing every
-        # required role (orchestrator/evaluator/participant_runtime) just
-        # because the diff added a profile JSON we don't yet understand.
-        # Refuse explicitly so the gap is visible to CI and the JSON corpus is
-        # forced to land its runtime-surface contract before target conformance
-        # can certify against it.
-        profile_id = _to_profile_id(effective_profile)
-        diagnostics = (
-            *fixture_report.diagnostics,
-            _diagnostic(
-                "conformance.profile-runtime-surface-unknown",
-                profile_id,
-                (
-                    f"Target conformance cannot certify profile {profile_id!r}: this "
-                    "implementation does not know the runtime-surface contract for the "
-                    "profile. Known runtime surfaces: "
-                    + ", ".join(sorted(p.value for p in BackendCapabilityProfile))
-                    + ". Use run_fixture_suite() for fixture-only validation, or extend "
-                    "BackendCapabilityProfile to declare this profile's runtime surfaces."
-                ),
-            ),
-        )
-        return BackendConformanceReport(
-            profile=profile_id,
-            passed=False,
-            claim=_bounded_conformance_claim(
-                profile=profile_id,
-                cases=fixture_report.cases,
-                left_carrier_ref=f"backend-target:{target.name}",
-            ),
-            cases=fixture_report.cases,
-            contract_versions=dict(fixture_report.contract_versions),
-            diagnostics=diagnostics,
-        )
-    contract_gaps = _declared_contract_gaps(
-        effective_profile,
-        target.manifest,
-        profiles_root=options.profiles_root,
-    )
-    surface_gaps = _capability_gaps(effective_profile, target)
-    participant_claim_gaps = participant_runtime_capability_contract_gaps(target.manifest)
-    observation_claim_gaps = observation_capability_contract_gaps(target.manifest)
-    claim_gaps = (*participant_claim_gaps, *observation_claim_gaps)
-    capability_gaps = (*surface_gaps, *claim_gaps)
-    passed = fixture_report.passed and not contract_gaps and not capability_gaps
-    diagnostics = list(fixture_report.diagnostics)
-    if contract_gaps:
-        diagnostics.append(
-            _diagnostic(
-                "conformance.unsupported-contract-declaration",
-                target.name,
-                f"Target does not declare required contracts for {_to_profile_id(effective_profile)}: {', '.join(contract_gaps)}",
-            )
-        )
-    if surface_gaps:
-        diagnostics.append(
-            _diagnostic(
-                "conformance.unsupported-surface",
-                target.name,
-                "Target is missing required runtime surfaces: " + ", ".join(surface_gaps),
-            )
-        )
-    if claim_gaps:
-        diagnostics.append(
-            _diagnostic(
-                "conformance.unsupported-capability-claim",
-                target.name,
-                "Target declares participant capability claims without required contract surfaces: "
-                + "; ".join(claim_gaps),
-            )
-        )
-    adapter_cases = _target_adapter_cases(
-        target,
-        effective_profile,
-        reference_scenario=options.reference_scenario,
-    )
-    if target.manifest.realization_envelope is not None:
-        # Envelope-bound targets use the generated honesty probes below. The
-        # historic caller-supplied/default reference scenario remains only for
-        # targets that do not yet carry the governed envelope contract.
-        adapter_cases = adapter_cases[:1]
-    target_cases = tuple(replace(case, execution_basis=options.execution_basis.value) for case in adapter_cases)
-    realization_run = run_realization_conformance(
-        target,
-        harness=options.realization_harness,
-        execution_basis=options.execution_basis,
-        envelope=options.realization_envelope,
-        observer_version=options.observer_version,
-        native_conformance=options.native_conformance,
-    )
-    realization_cases = tuple(_realization_case_result(case) for case in realization_run.cases)
-    cases = (*fixture_report.cases, *target_cases, *realization_cases)
-    passed = passed and all(case.passed for case in (*target_cases, *realization_cases))
-    return BackendConformanceReport(
-        profile=_to_profile_id(effective_profile),
-        passed=passed,
-        claim=_bounded_conformance_claim(
-            profile=_to_profile_id(effective_profile),
-            cases=cases,
-            left_carrier_ref=realization_run.target_binding or f"backend-target:{target.name}",
-        ),
-        cases=cases,
-        contract_versions=dict(fixture_report.contract_versions),
-        unsupported_contract_gaps=contract_gaps,
-        unsupported_capability_gaps=capability_gaps,
-        diagnostics=tuple(diagnostics),
-        probe_set_digest=realization_run.probe_set_digest,
-        native_conformance=passed and realization_run.native_conformance,
-    )
+        return _unknown_profile_report(target, effective_profile, fixture_report)
+    return _known_profile_report(target, effective_profile, fixture_report, options)
 
 
 def _realization_case_result(case: RealizationProbeCase) -> ConformanceCaseResult:

--- a/implementations/python/packages/aces_conformance/realization.py
+++ b/implementations/python/packages/aces_conformance/realization.py
@@ -1,0 +1,457 @@
+"""Backend-neutral realization-honesty cases for the conformance report family."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from aces_contracts.diagnostics import Diagnostic
+from aces_contracts.realization_envelope import (
+    BackendRealizationEnvelopeModel,
+)
+from aces_processor.reference import run_reference_processor
+from aces_runtime.registry import RuntimeTarget
+from aces_sdl.realization_envelope import (
+    NegativeProbe,
+    PositiveProbe,
+    generate_negative_probes,
+    generate_positive_probes,
+)
+from aces_sdl.scenario import Scenario
+
+from ._realization_models import (
+    ExecutionBasis,
+    ExpectedRealizationObservation,
+    ProbeOutcome,
+    RealizationConformanceHarness,
+    RealizationConformanceRun,
+    RealizationProbeCase,
+    RealizationProbeEvidence,
+    RealizationProbeRequest,
+    RealizationTransformation,
+)
+from ._realization_validation import (
+    diagnostic as _diagnostic,
+)
+from ._realization_validation import (
+    observation_diagnostics as _observation_diagnostics,
+)
+from ._realization_validation import (
+    operation_inventory_diagnostics as _operation_inventory_diagnostics,
+)
+from ._realization_validation import (
+    required_strengths as _required_strengths,
+)
+from ._realization_validation import (
+    transformation_diagnostics as _transformation_diagnostics,
+)
+
+
+def _payload_digest(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _probe_set_digest(positives: tuple[PositiveProbe, ...], negatives: tuple[NegativeProbe, ...]) -> str:
+    material = [probe.digest for probe in positives] + [_payload_digest(probe.payload) for probe in negatives]
+    return _payload_digest({"probe_digests": material})
+
+
+def _target_binding(target: RuntimeTarget, envelope: BackendRealizationEnvelopeModel) -> str:
+    return (
+        f"backend-target:{target.manifest.name}@{target.manifest.version};"
+        f"mode={envelope.configuration.mode};envelope={envelope.digest};"
+        f"configuration={envelope.configuration.configuration_digest}"
+    )
+
+
+def _base_case(
+    *,
+    name: str,
+    basis: ExecutionBasis,
+    outcome: ProbeOutcome,
+    passed: bool,
+    diagnostics: tuple[Diagnostic, ...],
+    envelope: BackendRealizationEnvelopeModel,
+    target_binding: str,
+    probe_set_digest: str | None = None,
+) -> RealizationProbeCase:
+    return RealizationProbeCase(
+        name=name,
+        contract_name="realization-envelope-v1",
+        valid=True,
+        passed=passed,
+        diagnostics=diagnostics,
+        execution_basis=basis.value,
+        outcome=outcome.value,
+        probe_set_digest=probe_set_digest,
+        envelope_digest=envelope.digest,
+        configuration_digest=envelope.configuration.configuration_digest,
+        target_binding=target_binding,
+    )
+
+
+def _mismatch_run(
+    target: RuntimeTarget,
+    offered: BackendRealizationEnvelopeModel,
+    selected: BackendRealizationEnvelopeModel,
+    basis: ExecutionBasis,
+) -> RealizationConformanceRun:
+    binding = _target_binding(target, offered)
+    case = _base_case(
+        name="realization-envelope-binding",
+        basis=basis,
+        outcome=ProbeOutcome.FAILED,
+        passed=False,
+        diagnostics=(
+            _diagnostic(
+                "conformance.realization-envelope-mismatch",
+                "runtime.target.realization-envelope",
+                "Selected realization envelope does not match the target configuration identity.",
+            ),
+        ),
+        envelope=selected,
+        target_binding=binding,
+    )
+    return RealizationConformanceRun(cases=(case,), target_binding=binding)
+
+
+def _constructive_failure(
+    target: RuntimeTarget,
+    envelope: BackendRealizationEnvelopeModel,
+    basis: ExecutionBasis,
+    diagnostics: tuple[Diagnostic, ...],
+) -> RealizationConformanceRun:
+    binding = _target_binding(target, envelope)
+    case = _base_case(
+        name="realization-envelope-constructive",
+        basis=basis,
+        outcome=ProbeOutcome.UNSUPPORTED,
+        passed=False,
+        diagnostics=diagnostics,
+        envelope=envelope,
+        target_binding=binding,
+    )
+    return RealizationConformanceRun(cases=(case,), target_binding=binding)
+
+
+def _positive_case(
+    *,
+    index: int,
+    probe: PositiveProbe,
+    probe_set_digest: str,
+    target: RuntimeTarget,
+    envelope: BackendRealizationEnvelopeModel,
+    harness: RealizationConformanceHarness,
+    basis: ExecutionBasis,
+    observer_version: str,
+) -> RealizationProbeCase:
+    binding = _target_binding(target, envelope)
+    try:
+        plan = run_reference_processor(
+            Scenario.model_validate(probe.payload), target.manifest
+        ).execution_plan.provisioning
+    except Exception:
+        return _base_case(
+            name=f"realization-positive-{index}",
+            basis=basis,
+            outcome=ProbeOutcome.FAILED,
+            passed=False,
+            diagnostics=(
+                _diagnostic(
+                    "conformance.positive-probe-plan-failed",
+                    probe.path,
+                    "The generated positive probe did not pass the ordinary processor and planning boundary.",
+                ),
+            ),
+            envelope=envelope,
+            target_binding=binding,
+            probe_set_digest=probe_set_digest,
+        )
+    request = RealizationProbeRequest(
+        probe_digest=probe.digest,
+        probe_kind="positive",
+        payload=probe.payload,
+        negative=False,
+        provisioning_plan=plan,
+        envelope_digest=envelope.digest,
+        configuration_digest=envelope.configuration.configuration_digest,
+        observer_version=observer_version,
+    )
+    evidence = harness.execute(request)
+    strengths = _required_strengths(envelope)
+    diagnostics = list(evidence.diagnostics)
+    if not evidence.accepted:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.positive-probe-rejected",
+                probe.path,
+                "The in-envelope positive probe was rejected.",
+            )
+        )
+    diagnostics.extend(_operation_inventory_diagnostics(plan, evidence, strengths))
+    diagnostics.extend(_observation_diagnostics(request, evidence, strengths))
+    diagnostics.extend(_transformation_diagnostics(evidence))
+    if plan.actionable_operations and evidence.portable_state_before == evidence.portable_state_after:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.positive-portable-state-unchanged",
+                "runtime.snapshot",
+                "A successful actionable positive probe did not mutate portable state.",
+            )
+        )
+    if not evidence.cleanup_verified:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.cleanup-unverified",
+                "runtime.cleanup",
+                "Probe cleanup was not independently verified.",
+            )
+        )
+    if evidence.residual_state:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.residual-state",
+                "runtime.cleanup",
+                "Probe cleanup left residual owned state.",
+            )
+        )
+    expected_operations = tuple(operation.address for operation in plan.actionable_operations)
+    return RealizationProbeCase(
+        name=f"realization-positive-{index}",
+        contract_name="realization-envelope-v1",
+        valid=True,
+        passed=not diagnostics,
+        diagnostics=tuple(diagnostics),
+        execution_basis=basis.value,
+        outcome=(ProbeOutcome.PASSED if not diagnostics else ProbeOutcome.FAILED).value,
+        probe_kind="positive",
+        probe_digest=probe.digest,
+        probe_set_digest=probe_set_digest,
+        envelope_digest=envelope.digest,
+        configuration_digest=envelope.configuration.configuration_digest,
+        target_binding=binding,
+        expected_operations=expected_operations,
+        accounted_operations=evidence.accounted_operations,
+        expected_observation_strengths=tuple(sorted({strength.value for strength in strengths.values()})),
+        actual_observation_strengths=tuple(sorted({item.source.value for item in evidence.observations})),
+        portable_state_unchanged=evidence.portable_state_before == evidence.portable_state_after,
+        native_state_unchanged=evidence.native_state_before == evidence.native_state_after,
+        cleanup_verified=evidence.cleanup_verified,
+        residual_state=evidence.residual_state,
+        evidence_refs=evidence.evidence_refs,
+    )
+
+
+def _negative_case(
+    *,
+    index: int,
+    probe: NegativeProbe,
+    probe_set_digest: str,
+    target: RuntimeTarget,
+    envelope: BackendRealizationEnvelopeModel,
+    harness: RealizationConformanceHarness,
+    basis: ExecutionBasis,
+    observer_version: str,
+) -> RealizationProbeCase:
+    digest = _payload_digest(probe.payload)
+    request = RealizationProbeRequest(
+        probe_digest=digest,
+        probe_kind="negative",
+        payload=probe.payload,
+        negative=True,
+        provisioning_plan=None,
+        envelope_digest=envelope.digest,
+        configuration_digest=envelope.configuration.configuration_digest,
+        observer_version=observer_version,
+    )
+    evidence = harness.execute(request)
+    diagnostics = list(evidence.diagnostics)
+    if evidence.accepted:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.negative-probe-accepted",
+                probe.path,
+                "The out-of-envelope probe was accepted.",
+            )
+        )
+    if evidence.driver_invoked:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.negative-driver-invoked",
+                probe.path,
+                "The out-of-envelope probe reached driver invocation.",
+            )
+        )
+    if evidence.native_mutated:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.negative-native-mutation",
+                probe.path,
+                "The out-of-envelope probe caused native mutation.",
+            )
+        )
+    portable_unchanged = evidence.portable_state_before == evidence.portable_state_after
+    native_unchanged = evidence.native_state_before == evidence.native_state_after
+    if not portable_unchanged:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.negative-portable-state-mutated",
+                probe.path,
+                "The out-of-envelope probe changed portable runtime state.",
+            )
+        )
+    if not native_unchanged:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.negative-native-state-mutated",
+                probe.path,
+                "The out-of-envelope probe changed independently inventoried native state.",
+            )
+        )
+    if not evidence.cleanup_verified:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.cleanup-unverified",
+                "runtime.cleanup",
+                "Negative-probe cleanup was not independently verified.",
+            )
+        )
+    if evidence.residual_state:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.residual-state",
+                "runtime.cleanup",
+                "Negative-probe cleanup left residual owned state.",
+            )
+        )
+    binding = _target_binding(target, envelope)
+    return RealizationProbeCase(
+        name=f"realization-negative-{index}",
+        contract_name="realization-envelope-v1",
+        valid=True,
+        passed=not diagnostics,
+        diagnostics=tuple(diagnostics),
+        execution_basis=basis.value,
+        outcome=(ProbeOutcome.PASSED if not diagnostics else ProbeOutcome.FAILED).value,
+        probe_kind="negative",
+        probe_digest=digest,
+        probe_set_digest=probe_set_digest,
+        envelope_digest=envelope.digest,
+        configuration_digest=envelope.configuration.configuration_digest,
+        target_binding=binding,
+        portable_state_unchanged=portable_unchanged,
+        native_state_unchanged=native_unchanged,
+        cleanup_verified=evidence.cleanup_verified,
+        residual_state=evidence.residual_state,
+        evidence_refs=evidence.evidence_refs,
+    )
+
+
+def run_realization_conformance(
+    target: RuntimeTarget,
+    *,
+    harness: RealizationConformanceHarness | None,
+    execution_basis: ExecutionBasis,
+    envelope: BackendRealizationEnvelopeModel | None = None,
+    observer_version: str = "aces-realization-observer/v1",
+    native_conformance: bool = False,
+) -> RealizationConformanceRun:
+    """Return realization-honesty cases for one exact target configuration."""
+
+    offered = target.manifest.realization_envelope
+    if offered is None:
+        return RealizationConformanceRun()
+    selected = envelope or offered
+    if selected.identity != offered.identity:
+        return _mismatch_run(target, offered, selected, execution_basis)
+    positive, positive_diagnostics = generate_positive_probes(selected.expression)
+    negative, negative_diagnostics = generate_negative_probes(selected.expression)
+    if positive_diagnostics or negative_diagnostics or not positive:
+        diagnostics = tuple((*positive_diagnostics, *negative_diagnostics))
+        return _constructive_failure(target, selected, execution_basis, diagnostics)
+    probe_digest = _probe_set_digest(positive, negative)
+    binding = _target_binding(target, selected)
+    if harness is None:
+        case = _base_case(
+            name="realization-harness-required",
+            basis=execution_basis,
+            outcome=ProbeOutcome.UNSUPPORTED,
+            passed=False,
+            diagnostics=(
+                _diagnostic(
+                    "conformance.realization-harness-missing",
+                    "runtime.target.realization-conformance",
+                    "Realization certification requires an independent execution and observation harness.",
+                ),
+            ),
+            envelope=selected,
+            target_binding=binding,
+            probe_set_digest=probe_digest,
+        )
+        return RealizationConformanceRun(cases=(case,), probe_set_digest=probe_digest, target_binding=binding)
+    cases = [
+        _positive_case(
+            index=index,
+            probe=probe,
+            probe_set_digest=probe_digest,
+            target=target,
+            envelope=selected,
+            harness=harness,
+            basis=execution_basis,
+            observer_version=observer_version,
+        )
+        for index, probe in enumerate(positive, start=1)
+    ]
+    cases.extend(
+        _negative_case(
+            index=index,
+            probe=probe,
+            probe_set_digest=probe_digest,
+            target=target,
+            envelope=selected,
+            harness=harness,
+            basis=execution_basis,
+            observer_version=observer_version,
+        )
+        for index, probe in enumerate(negative, start=1)
+    )
+    if native_conformance and execution_basis is not ExecutionBasis.NATIVE_LIVE:
+        cases.append(
+            _base_case(
+                name="native-conformance-basis",
+                basis=execution_basis,
+                outcome=ProbeOutcome.FAILED,
+                passed=False,
+                diagnostics=(
+                    _diagnostic(
+                        "conformance.native-basis-required",
+                        "runtime.target.execution-basis",
+                        "Only native-live execution may support a native conformance claim.",
+                    ),
+                ),
+                envelope=selected,
+                target_binding=binding,
+                probe_set_digest=probe_digest,
+            )
+        )
+    passed = all(case.passed for case in cases)
+    return RealizationConformanceRun(
+        cases=tuple(cases),
+        probe_set_digest=probe_digest,
+        target_binding=binding,
+        native_conformance=native_conformance and execution_basis is ExecutionBasis.NATIVE_LIVE and passed,
+    )
+
+
+__all__ = [
+    "ExecutionBasis",
+    "ExpectedRealizationObservation",
+    "ProbeOutcome",
+    "RealizationConformanceHarness",
+    "RealizationProbeCase",
+    "RealizationProbeEvidence",
+    "RealizationProbeRequest",
+    "RealizationTransformation",
+    "run_realization_conformance",
+]

--- a/implementations/python/packages/aces_conformance/realization.py
+++ b/implementations/python/packages/aces_conformance/realization.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.realization_envelope import (
-    BackendRealizationEnvelopeModel,
-)
+from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel
 from aces_processor.reference import run_reference_processor
 from aces_runtime.registry import RuntimeTarget
 from aces_sdl.realization_envelope import (
@@ -46,6 +45,19 @@ from ._realization_validation import (
     transformation_diagnostics as _transformation_diagnostics,
 )
 
+_CLEANUP_ADDRESS = "runtime.cleanup"
+
+
+@dataclass(frozen=True)
+class _CaseContext:
+    target: RuntimeTarget
+    envelope: BackendRealizationEnvelopeModel
+    harness: RealizationConformanceHarness | None
+    basis: ExecutionBasis
+    observer_version: str
+    probe_set_digest: str
+    target_binding: str
+
 
 def _payload_digest(payload: dict[str, object]) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
@@ -55,6 +67,12 @@ def _payload_digest(payload: dict[str, object]) -> str:
 def _probe_set_digest(positives: tuple[PositiveProbe, ...], negatives: tuple[NegativeProbe, ...]) -> str:
     material = [probe.digest for probe in positives] + [_payload_digest(probe.payload) for probe in negatives]
     return _payload_digest({"probe_digests": material})
+
+
+def _execute(context: _CaseContext, request: RealizationProbeRequest) -> RealizationProbeEvidence:
+    if context.harness is None:
+        raise ValueError("realization conformance harness is required")
+    return context.harness.execute(request)
 
 
 def _target_binding(target: RuntimeTarget, envelope: BackendRealizationEnvelopeModel) -> str:
@@ -68,13 +86,10 @@ def _target_binding(target: RuntimeTarget, envelope: BackendRealizationEnvelopeM
 def _base_case(
     *,
     name: str,
-    basis: ExecutionBasis,
     outcome: ProbeOutcome,
     passed: bool,
     diagnostics: tuple[Diagnostic, ...],
-    envelope: BackendRealizationEnvelopeModel,
-    target_binding: str,
-    probe_set_digest: str | None = None,
+    context: _CaseContext,
 ) -> RealizationProbeCase:
     return RealizationProbeCase(
         name=name,
@@ -82,12 +97,12 @@ def _base_case(
         valid=True,
         passed=passed,
         diagnostics=diagnostics,
-        execution_basis=basis.value,
+        execution_basis=context.basis.value,
         outcome=outcome.value,
-        probe_set_digest=probe_set_digest,
-        envelope_digest=envelope.digest,
-        configuration_digest=envelope.configuration.configuration_digest,
-        target_binding=target_binding,
+        probe_set_digest=context.probe_set_digest,
+        envelope_digest=context.envelope.digest,
+        configuration_digest=context.envelope.configuration.configuration_digest,
+        target_binding=context.target_binding,
     )
 
 
@@ -98,9 +113,17 @@ def _mismatch_run(
     basis: ExecutionBasis,
 ) -> RealizationConformanceRun:
     binding = _target_binding(target, offered)
+    context = _CaseContext(
+        target=target,
+        envelope=selected,
+        harness=None,
+        basis=basis,
+        observer_version="",
+        probe_set_digest="",
+        target_binding=binding,
+    )
     case = _base_case(
         name="realization-envelope-binding",
-        basis=basis,
         outcome=ProbeOutcome.FAILED,
         passed=False,
         diagnostics=(
@@ -110,8 +133,7 @@ def _mismatch_run(
                 "Selected realization envelope does not match the target configuration identity.",
             ),
         ),
-        envelope=selected,
-        target_binding=binding,
+        context=context,
     )
     return RealizationConformanceRun(cases=(case,), target_binding=binding)
 
@@ -123,14 +145,21 @@ def _constructive_failure(
     diagnostics: tuple[Diagnostic, ...],
 ) -> RealizationConformanceRun:
     binding = _target_binding(target, envelope)
+    context = _CaseContext(
+        target=target,
+        envelope=envelope,
+        harness=None,
+        basis=basis,
+        observer_version="",
+        probe_set_digest="",
+        target_binding=binding,
+    )
     case = _base_case(
         name="realization-envelope-constructive",
-        basis=basis,
         outcome=ProbeOutcome.UNSUPPORTED,
         passed=False,
         diagnostics=diagnostics,
-        envelope=envelope,
-        target_binding=binding,
+        context=context,
     )
     return RealizationConformanceRun(cases=(case,), target_binding=binding)
 
@@ -139,22 +168,15 @@ def _positive_case(
     *,
     index: int,
     probe: PositiveProbe,
-    probe_set_digest: str,
-    target: RuntimeTarget,
-    envelope: BackendRealizationEnvelopeModel,
-    harness: RealizationConformanceHarness,
-    basis: ExecutionBasis,
-    observer_version: str,
+    context: _CaseContext,
 ) -> RealizationProbeCase:
-    binding = _target_binding(target, envelope)
     try:
         plan = run_reference_processor(
-            Scenario.model_validate(probe.payload), target.manifest
+            Scenario.model_validate(probe.payload), context.target.manifest
         ).execution_plan.provisioning
     except Exception:
         return _base_case(
             name=f"realization-positive-{index}",
-            basis=basis,
             outcome=ProbeOutcome.FAILED,
             passed=False,
             diagnostics=(
@@ -164,9 +186,7 @@ def _positive_case(
                     "The generated positive probe did not pass the ordinary processor and planning boundary.",
                 ),
             ),
-            envelope=envelope,
-            target_binding=binding,
-            probe_set_digest=probe_set_digest,
+            context=context,
         )
     request = RealizationProbeRequest(
         probe_digest=probe.digest,
@@ -174,12 +194,12 @@ def _positive_case(
         payload=probe.payload,
         negative=False,
         provisioning_plan=plan,
-        envelope_digest=envelope.digest,
-        configuration_digest=envelope.configuration.configuration_digest,
-        observer_version=observer_version,
+        envelope_digest=context.envelope.digest,
+        configuration_digest=context.envelope.configuration.configuration_digest,
+        observer_version=context.observer_version,
     )
-    evidence = harness.execute(request)
-    strengths = _required_strengths(envelope)
+    evidence = _execute(context, request)
+    strengths = _required_strengths(context.envelope)
     diagnostics = list(evidence.diagnostics)
     if not evidence.accepted:
         diagnostics.append(
@@ -204,7 +224,7 @@ def _positive_case(
         diagnostics.append(
             _diagnostic(
                 "conformance.cleanup-unverified",
-                "runtime.cleanup",
+                _CLEANUP_ADDRESS,
                 "Probe cleanup was not independently verified.",
             )
         )
@@ -212,7 +232,7 @@ def _positive_case(
         diagnostics.append(
             _diagnostic(
                 "conformance.residual-state",
-                "runtime.cleanup",
+                _CLEANUP_ADDRESS,
                 "Probe cleanup left residual owned state.",
             )
         )
@@ -223,14 +243,14 @@ def _positive_case(
         valid=True,
         passed=not diagnostics,
         diagnostics=tuple(diagnostics),
-        execution_basis=basis.value,
+        execution_basis=context.basis.value,
         outcome=(ProbeOutcome.PASSED if not diagnostics else ProbeOutcome.FAILED).value,
         probe_kind="positive",
         probe_digest=probe.digest,
-        probe_set_digest=probe_set_digest,
-        envelope_digest=envelope.digest,
-        configuration_digest=envelope.configuration.configuration_digest,
-        target_binding=binding,
+        probe_set_digest=context.probe_set_digest,
+        envelope_digest=context.envelope.digest,
+        configuration_digest=context.envelope.configuration.configuration_digest,
+        target_binding=context.target_binding,
         expected_operations=expected_operations,
         accounted_operations=evidence.accounted_operations,
         expected_observation_strengths=tuple(sorted({strength.value for strength in strengths.values()})),
@@ -247,12 +267,7 @@ def _negative_case(
     *,
     index: int,
     probe: NegativeProbe,
-    probe_set_digest: str,
-    target: RuntimeTarget,
-    envelope: BackendRealizationEnvelopeModel,
-    harness: RealizationConformanceHarness,
-    basis: ExecutionBasis,
-    observer_version: str,
+    context: _CaseContext,
 ) -> RealizationProbeCase:
     digest = _payload_digest(probe.payload)
     request = RealizationProbeRequest(
@@ -261,11 +276,11 @@ def _negative_case(
         payload=probe.payload,
         negative=True,
         provisioning_plan=None,
-        envelope_digest=envelope.digest,
-        configuration_digest=envelope.configuration.configuration_digest,
-        observer_version=observer_version,
+        envelope_digest=context.envelope.digest,
+        configuration_digest=context.envelope.configuration.configuration_digest,
+        observer_version=context.observer_version,
     )
-    evidence = harness.execute(request)
+    evidence = _execute(context, request)
     diagnostics = list(evidence.diagnostics)
     if evidence.accepted:
         diagnostics.append(
@@ -313,7 +328,7 @@ def _negative_case(
         diagnostics.append(
             _diagnostic(
                 "conformance.cleanup-unverified",
-                "runtime.cleanup",
+                _CLEANUP_ADDRESS,
                 "Negative-probe cleanup was not independently verified.",
             )
         )
@@ -321,30 +336,99 @@ def _negative_case(
         diagnostics.append(
             _diagnostic(
                 "conformance.residual-state",
-                "runtime.cleanup",
+                _CLEANUP_ADDRESS,
                 "Negative-probe cleanup left residual owned state.",
             )
         )
-    binding = _target_binding(target, envelope)
     return RealizationProbeCase(
         name=f"realization-negative-{index}",
         contract_name="realization-envelope-v1",
         valid=True,
         passed=not diagnostics,
         diagnostics=tuple(diagnostics),
-        execution_basis=basis.value,
+        execution_basis=context.basis.value,
         outcome=(ProbeOutcome.PASSED if not diagnostics else ProbeOutcome.FAILED).value,
         probe_kind="negative",
         probe_digest=digest,
-        probe_set_digest=probe_set_digest,
-        envelope_digest=envelope.digest,
-        configuration_digest=envelope.configuration.configuration_digest,
-        target_binding=binding,
+        probe_set_digest=context.probe_set_digest,
+        envelope_digest=context.envelope.digest,
+        configuration_digest=context.envelope.configuration.configuration_digest,
+        target_binding=context.target_binding,
         portable_state_unchanged=portable_unchanged,
         native_state_unchanged=native_unchanged,
         cleanup_verified=evidence.cleanup_verified,
         residual_state=evidence.residual_state,
         evidence_refs=evidence.evidence_refs,
+    )
+
+
+def _missing_harness_run(context: _CaseContext) -> RealizationConformanceRun:
+    case = _base_case(
+        name="realization-harness-required",
+        outcome=ProbeOutcome.UNSUPPORTED,
+        passed=False,
+        diagnostics=(
+            _diagnostic(
+                "conformance.realization-harness-missing",
+                "runtime.target.realization-conformance",
+                "Realization certification requires an independent execution and observation harness.",
+            ),
+        ),
+        context=context,
+    )
+    return RealizationConformanceRun(
+        cases=(case,),
+        probe_set_digest=context.probe_set_digest,
+        target_binding=context.target_binding,
+    )
+
+
+def _probe_cases(
+    context: _CaseContext,
+    positive: tuple[PositiveProbe, ...],
+    negative: tuple[NegativeProbe, ...],
+    *,
+    native_conformance: bool,
+) -> list[RealizationProbeCase]:
+    cases = [_positive_case(index=index, probe=probe, context=context) for index, probe in enumerate(positive, start=1)]
+    cases.extend(
+        _negative_case(index=index, probe=probe, context=context) for index, probe in enumerate(negative, start=1)
+    )
+    if native_conformance and context.basis is not ExecutionBasis.NATIVE_LIVE:
+        cases.append(
+            _base_case(
+                name="native-conformance-basis",
+                outcome=ProbeOutcome.FAILED,
+                passed=False,
+                diagnostics=(
+                    _diagnostic(
+                        "conformance.native-basis-required",
+                        "runtime.target.execution-basis",
+                        "Only native-live execution may support a native conformance claim.",
+                    ),
+                ),
+                context=context,
+            )
+        )
+    return cases
+
+
+def _constructive_run(
+    context: _CaseContext,
+    positive: tuple[PositiveProbe, ...],
+    negative: tuple[NegativeProbe, ...],
+    *,
+    native_conformance: bool,
+) -> RealizationConformanceRun:
+    if context.harness is None:
+        return _missing_harness_run(context)
+    cases = _probe_cases(context, positive, negative, native_conformance=native_conformance)
+    passed = all(case.passed for case in cases)
+    return RealizationConformanceRun(
+        cases=tuple(cases),
+        probe_set_digest=context.probe_set_digest,
+        target_binding=context.target_binding,
+        native_conformance=native_conformance and context.basis is ExecutionBasis.NATIVE_LIVE and passed,
     )
 
 
@@ -359,89 +443,35 @@ def run_realization_conformance(
 ) -> RealizationConformanceRun:
     """Return realization-honesty cases for one exact target configuration."""
 
+    result = RealizationConformanceRun()
     offered = target.manifest.realization_envelope
-    if offered is None:
-        return RealizationConformanceRun()
-    selected = envelope or offered
-    if selected.identity != offered.identity:
-        return _mismatch_run(target, offered, selected, execution_basis)
-    positive, positive_diagnostics = generate_positive_probes(selected.expression)
-    negative, negative_diagnostics = generate_negative_probes(selected.expression)
-    if positive_diagnostics or negative_diagnostics or not positive:
-        diagnostics = tuple((*positive_diagnostics, *negative_diagnostics))
-        return _constructive_failure(target, selected, execution_basis, diagnostics)
-    probe_digest = _probe_set_digest(positive, negative)
-    binding = _target_binding(target, selected)
-    if harness is None:
-        case = _base_case(
-            name="realization-harness-required",
-            basis=execution_basis,
-            outcome=ProbeOutcome.UNSUPPORTED,
-            passed=False,
-            diagnostics=(
-                _diagnostic(
-                    "conformance.realization-harness-missing",
-                    "runtime.target.realization-conformance",
-                    "Realization certification requires an independent execution and observation harness.",
-                ),
-            ),
-            envelope=selected,
-            target_binding=binding,
-            probe_set_digest=probe_digest,
-        )
-        return RealizationConformanceRun(cases=(case,), probe_set_digest=probe_digest, target_binding=binding)
-    cases = [
-        _positive_case(
-            index=index,
-            probe=probe,
-            probe_set_digest=probe_digest,
-            target=target,
-            envelope=selected,
-            harness=harness,
-            basis=execution_basis,
-            observer_version=observer_version,
-        )
-        for index, probe in enumerate(positive, start=1)
-    ]
-    cases.extend(
-        _negative_case(
-            index=index,
-            probe=probe,
-            probe_set_digest=probe_digest,
-            target=target,
-            envelope=selected,
-            harness=harness,
-            basis=execution_basis,
-            observer_version=observer_version,
-        )
-        for index, probe in enumerate(negative, start=1)
-    )
-    if native_conformance and execution_basis is not ExecutionBasis.NATIVE_LIVE:
-        cases.append(
-            _base_case(
-                name="native-conformance-basis",
-                basis=execution_basis,
-                outcome=ProbeOutcome.FAILED,
-                passed=False,
-                diagnostics=(
-                    _diagnostic(
-                        "conformance.native-basis-required",
-                        "runtime.target.execution-basis",
-                        "Only native-live execution may support a native conformance claim.",
-                    ),
-                ),
-                envelope=selected,
-                target_binding=binding,
-                probe_set_digest=probe_digest,
-            )
-        )
-    passed = all(case.passed for case in cases)
-    return RealizationConformanceRun(
-        cases=tuple(cases),
-        probe_set_digest=probe_digest,
-        target_binding=binding,
-        native_conformance=native_conformance and execution_basis is ExecutionBasis.NATIVE_LIVE and passed,
-    )
+    if offered is not None:
+        selected = envelope or offered
+        if selected.identity != offered.identity:
+            result = _mismatch_run(target, offered, selected, execution_basis)
+        else:
+            positive, positive_diagnostics = generate_positive_probes(selected.expression)
+            negative, negative_diagnostics = generate_negative_probes(selected.expression)
+            diagnostics = (*positive_diagnostics, *negative_diagnostics)
+            if diagnostics or not positive:
+                result = _constructive_failure(target, selected, execution_basis, diagnostics)
+            else:
+                context = _CaseContext(
+                    target=target,
+                    envelope=selected,
+                    harness=harness,
+                    basis=execution_basis,
+                    observer_version=observer_version,
+                    probe_set_digest=_probe_set_digest(positive, negative),
+                    target_binding=_target_binding(target, selected),
+                )
+                result = _constructive_run(
+                    context,
+                    positive,
+                    negative,
+                    native_conformance=native_conformance,
+                )
+    return result
 
 
 __all__ = [

--- a/implementations/python/packages/aces_contracts/realization_observation.py
+++ b/implementations/python/packages/aces_contracts/realization_observation.py
@@ -1,0 +1,34 @@
+"""Neutral addressed realization-observation evidence DTOs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aces_contracts.realization_envelope import ObservationStrength, RealizationConcern
+
+
+@dataclass(frozen=True)
+class RealizationObservation:
+    """One independently read realization fact with optional conformance binding.
+
+    Backend-local observers can keep using the five core fields. Conformance
+    requires every binding field below and rejects observations that omit them;
+    the defaults preserve the existing non-conformance driver boundary.
+    """
+
+    address: str
+    field_path: str
+    concern: RealizationConcern
+    source: ObservationStrength
+    value: object
+    operation_id: str | None = None
+    probe_digest: str | None = None
+    envelope_digest: str | None = None
+    configuration_digest: str | None = None
+    observer_version: str | None = None
+    sequence: int | None = None
+    origin: str = "observed"
+    binding_verified: bool = False
+
+
+__all__ = ["RealizationObservation"]

--- a/implementations/python/packages/aces_operations/realization_conformance.py
+++ b/implementations/python/packages/aces_operations/realization_conformance.py
@@ -1,0 +1,27 @@
+"""Validated persistence for machine-readable backend conformance evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from aces_operations._evidence_run_validation import redaction_violations
+from aces_operations.run_artifacts import atomic_write_json_artifact, run_artifact_path
+
+
+def write_backend_conformance_report(
+    payload: Mapping[str, object],
+    *,
+    output_dir: Path,
+    run_id: str,
+) -> Path:
+    """Redaction-check and atomically persist one conformance report."""
+
+    if redaction_violations(payload):
+        raise ValueError("backend conformance report failed the redaction gate")
+    target = run_artifact_path(output_dir, run_id, "conformance", "backend-conformance.json")
+    atomic_write_json_artifact(target, payload)
+    return target
+
+
+__all__ = ["write_backend_conformance_report"]

--- a/implementations/python/packages/aces_sdl/_realization_envelope_domains.py
+++ b/implementations/python/packages/aces_sdl/_realization_envelope_domains.py
@@ -11,6 +11,7 @@ parser dependency.
 from __future__ import annotations
 
 from collections.abc import Callable
+from enum import Enum
 
 from aces_contracts.realization_envelope import (
     BooleanDomain,
@@ -149,6 +150,32 @@ def default_witness_value(domain: DomainDescriptor) -> WitnessSelection:
     return selector(domain)
 
 
+def positive_probe_values(domain: DomainDescriptor) -> list[DomainScalar]:
+    """Deterministic safe values that cover one bounded scalar domain.
+
+    Finite domains enumerate every member. Numeric intervals contribute their
+    admissible boundaries; for an open real boundary, where no portable epsilon
+    exists, the deterministic witness supplies the safe interior representative.
+    """
+
+    members = finite_members(domain)
+    if members is not None:
+        return sorted(members, key=_enum_sort_key)
+    if not isinstance(domain, NumericIntervalDomain):
+        return []
+    if domain.numeric_type is NumericType.INTEGER:
+        lower = int(domain.lower) + (0 if domain.lower_closed else 1)
+        upper = int(domain.upper) - (0 if domain.upper_closed else 1)
+        return [lower] if lower == upper else [lower, upper]
+    values: list[DomainScalar] = []
+    if domain.lower_closed:
+        values.append(domain.lower)
+    values.append((domain.lower + domain.upper) / 2)
+    if domain.upper_closed:
+        values.append(domain.upper)
+    return list(dict.fromkeys(values))
+
+
 # --------------------------------------------------------------------------- #
 # Out-of-envelope variation (R6)                                             #
 # --------------------------------------------------------------------------- #
@@ -195,3 +222,21 @@ def out_of_domain_value(domain: DomainDescriptor) -> object:
 
     factory = _OUT_OF_DOMAIN.get(type(domain))
     return factory(domain) if factory is not None else _MISSING
+
+
+def out_of_domain_candidates(domain: DomainDescriptor, current: object) -> list[object]:
+    """Candidate scalars outside ``domain``, preferring SDL enum members.
+
+    A domain-blind synthetic string is not a safe negative probe when the SDL
+    field is itself a closed enum.  The instantiated witness exposes that enum
+    type, so enumerate its other legal members before falling back to the
+    domain-kind perturbation used for open scalar fields.
+    """
+
+    candidates: list[object] = []
+    if isinstance(current, Enum):
+        candidates.extend(member.value for member in type(current) if not scalar_in_domain(member.value, domain))
+    fallback = out_of_domain_value(domain)
+    if fallback is not _MISSING:
+        candidates.append(fallback)
+    return list(dict.fromkeys(candidates))

--- a/implementations/python/packages/aces_sdl/_realization_envelope_domains.py
+++ b/implementations/python/packages/aces_sdl/_realization_envelope_domains.py
@@ -160,19 +160,20 @@ def positive_probe_values(domain: DomainDescriptor) -> list[DomainScalar]:
 
     members = finite_members(domain)
     if members is not None:
-        return sorted(members, key=_enum_sort_key)
-    if not isinstance(domain, NumericIntervalDomain):
-        return []
-    if domain.numeric_type is NumericType.INTEGER:
+        values = sorted(members, key=_enum_sort_key)
+    elif not isinstance(domain, NumericIntervalDomain):
+        values = []
+    elif domain.numeric_type is NumericType.INTEGER:
         lower = int(domain.lower) + (0 if domain.lower_closed else 1)
         upper = int(domain.upper) - (0 if domain.upper_closed else 1)
-        return [lower] if lower == upper else [lower, upper]
-    values: list[DomainScalar] = []
-    if domain.lower_closed:
-        values.append(domain.lower)
-    values.append((domain.lower + domain.upper) / 2)
-    if domain.upper_closed:
-        values.append(domain.upper)
+        values = [lower] if lower == upper else [lower, upper]
+    else:
+        values = []
+        if domain.lower_closed:
+            values.append(domain.lower)
+        values.append((domain.lower + domain.upper) / 2)
+        if domain.upper_closed:
+            values.append(domain.upper)
     return list(dict.fromkeys(values))
 
 

--- a/implementations/python/packages/aces_sdl/_realization_envelope_probe_payloads.py
+++ b/implementations/python/packages/aces_sdl/_realization_envelope_probe_payloads.py
@@ -1,0 +1,125 @@
+"""Structurally plausible payload candidates for realization-envelope probes."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+
+from aces_contracts.realization_envelope import Posture
+from pydantic import BaseModel
+
+from ._realization_envelope_domains import out_of_domain_candidates
+from ._realization_envelope_engine import (
+    LeafConstraint,
+    assign_path,
+    fresh_extra_key,
+    navigate,
+    remove_path,
+    tokenize_path,
+)
+from .scenario import InstantiatedScenario
+
+
+@dataclass(frozen=True)
+class ProbePayloadCandidate:
+    """One not-yet-validated negative-probe payload."""
+
+    path: str
+    domain_kind: str
+    variation: str
+    payload: dict[str, object]
+
+
+def _minimal_discriminator_payload(
+    base_payload: dict[str, object], path: str, variation_value: object
+) -> dict[str, object] | None:
+    """Return a minimal variant for a nested ``type`` discriminator."""
+
+    tokens = tokenize_path(path)
+    if len(tokens) < 2 or tokens[-1] != "type":
+        return None
+    payload = deepcopy(base_payload)
+    if assign_path(payload, tokens[:-1], {"type": variation_value}) is not None:
+        return None
+    return payload
+
+
+def value_probe_payloads(
+    base_payload: dict[str, object],
+    base_scenario: InstantiatedScenario,
+    path: str,
+    constraint: LeafConstraint,
+) -> list[ProbePayloadCandidate]:
+    """Build candidates for one constrained scalar path."""
+
+    probes: list[ProbePayloadCandidate] = []
+    tokens = tokenize_path(path)
+    found, current = navigate(base_scenario, tokens)
+    for variation_value in out_of_domain_candidates(constraint.domain, current if found else None):
+        payload = deepcopy(base_payload)
+        if assign_path(payload, tokens, variation_value) is None:
+            probes.append(ProbePayloadCandidate(path, constraint.domain.kind, "value-outside-domain", payload))
+        minimal = _minimal_discriminator_payload(base_payload, path, variation_value)
+        if minimal is not None:
+            probes.append(ProbePayloadCandidate(path, constraint.domain.kind, "value-outside-domain", minimal))
+    if constraint.posture is Posture.EXACT:
+        omitted = deepcopy(base_payload)
+        if remove_path(omitted, tokens):
+            probes.append(ProbePayloadCandidate(path, constraint.domain.kind, "omitted-required-exact", omitted))
+    return probes
+
+
+def _extra_dimension_values(current: object) -> list[object]:
+    if isinstance(current, Enum):
+        return [member.value for member in type(current) if member is not current]
+    if isinstance(current, bool):
+        return [not current]
+    if isinstance(current, (int, float)):
+        return [current + 1]
+    if isinstance(current, str):
+        return ["out-of-envelope" if current != "out-of-envelope" else "out-of-envelope-x"]
+    if isinstance(current, dict):
+        return [{"out-of-envelope": "out-of-envelope"}]
+    if isinstance(current, list):
+        return [["out-of-envelope"]]
+    return []
+
+
+def _model_extra_dimension_payloads(
+    base_payload: dict[str, object],
+    scope_path: str,
+    scope_value: BaseModel,
+    admitted: set[str],
+) -> list[ProbePayloadCandidate]:
+    probes: list[ProbePayloadCandidate] = []
+    for field_name in sorted(set(type(scope_value).model_fields) - admitted):
+        for variation_value in _extra_dimension_values(getattr(scope_value, field_name)):
+            payload = deepcopy(base_payload)
+            tokens = tokenize_path(scope_path) + [field_name] if scope_path else [field_name]
+            if assign_path(payload, tokens, variation_value) is None:
+                address = f"{scope_path}.{field_name}" if scope_path else field_name
+                probes.append(ProbePayloadCandidate(address, "closed-scope", "extra-dimension", payload))
+    return probes
+
+
+def closed_scope_probe_payloads(
+    base_payload: dict[str, object],
+    base_scenario: InstantiatedScenario,
+    closed: dict[str, set[str]],
+) -> list[ProbePayloadCandidate]:
+    """Build candidates for SDL fields excluded by each closed scope."""
+
+    probes: list[ProbePayloadCandidate] = []
+    for scope_path in sorted(closed):
+        scope_value = base_scenario if not scope_path else navigate(base_scenario, tokenize_path(scope_path))[1]
+        if isinstance(scope_value, BaseModel):
+            probes.extend(_model_extra_dimension_payloads(base_payload, scope_path, scope_value, closed[scope_path]))
+            continue
+        extra_key = fresh_extra_key(closed[scope_path])
+        payload = deepcopy(base_payload)
+        tokens = tokenize_path(scope_path) + [extra_key] if scope_path else [extra_key]
+        if assign_path(payload, tokens, "out-of-envelope") is None:
+            address = f"{scope_path}.{extra_key}" if scope_path else extra_key
+            probes.append(ProbePayloadCandidate(address, "closed-scope", "extra-dimension", payload))
+    return probes

--- a/implementations/python/packages/aces_sdl/_realization_envelope_probe_payloads.py
+++ b/implementations/python/packages/aces_sdl/_realization_envelope_probe_payloads.py
@@ -72,18 +72,20 @@ def value_probe_payloads(
 
 def _extra_dimension_values(current: object) -> list[object]:
     if isinstance(current, Enum):
-        return [member.value for member in type(current) if member is not current]
-    if isinstance(current, bool):
-        return [not current]
-    if isinstance(current, (int, float)):
-        return [current + 1]
-    if isinstance(current, str):
-        return ["out-of-envelope" if current != "out-of-envelope" else "out-of-envelope-x"]
-    if isinstance(current, dict):
-        return [{"out-of-envelope": "out-of-envelope"}]
-    if isinstance(current, list):
-        return [["out-of-envelope"]]
-    return []
+        values: list[object] = [member.value for member in type(current) if member is not current]
+    elif isinstance(current, bool):
+        values = [not current]
+    elif isinstance(current, (int, float)):
+        values = [current + 1]
+    elif isinstance(current, str):
+        values = ["out-of-envelope" if current != "out-of-envelope" else "out-of-envelope-x"]
+    elif isinstance(current, dict):
+        values = [{"out-of-envelope": "out-of-envelope"}]
+    elif isinstance(current, list):
+        values = [["out-of-envelope"]]
+    else:
+        values = []
+    return values
 
 
 def _model_extra_dimension_payloads(

--- a/implementations/python/packages/aces_sdl/realization_envelope.py
+++ b/implementations/python/packages/aces_sdl/realization_envelope.py
@@ -30,38 +30,41 @@ raw sensitive values (R8 / ADR-070 §7).
 
 from __future__ import annotations
 
+import hashlib
+import json
 from copy import deepcopy
 from dataclasses import dataclass
 
 from aces_contracts.diagnostics import Diagnostic, Severity
-from aces_contracts.realization_envelope import Posture, RealizationEnvelopeModel, WitnessPolicy, scalar_in_domain
+from aces_contracts.realization_envelope import RealizationEnvelopeModel, WitnessPolicy, scalar_in_domain
 from pydantic import ValidationError
 
 from ._errors import SDLInstantiationError, SDLValidationError
-from ._realization_envelope_domains import _MISSING, domain_subset, out_of_domain_value
+from ._realization_envelope_domains import domain_subset, positive_probe_values
 from ._realization_envelope_engine import (
     LeafConstraint,
     assign_path,
     effective_constraints,
-    fresh_extra_key,
     navigate,
     normalize_scalar,
     overridability_violations,
     present_children,
-    remove_path,
     tokenize_path,
     witness_value,
 )
+from ._realization_envelope_probe_payloads import closed_scope_probe_payloads, value_probe_payloads
 from .instantiate import instantiate_scenario
 from .scenario import InstantiatedScenario, Scenario
 from .validator import SemanticValidator
 
 __all__ = [
     "NegativeProbe",
+    "PositiveProbe",
     "RelationKind",
     "RelationResult",
     "WitnessResult",
     "generate_negative_probes",
+    "generate_positive_probes",
     "effective_constraints",
     "member",
     "subsumes",
@@ -104,6 +107,17 @@ class NegativeProbe:
     path: str
     domain_kind: str
     variation: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PositiveProbe:
+    """A validated in-envelope witness covering one bounded variation."""
+
+    path: str
+    domain_kind: str
+    variation: str
+    digest: str
     payload: dict[str, object]
 
 
@@ -351,34 +365,77 @@ def witness(envelope: RealizationEnvelopeModel, policy: WitnessPolicy | None = N
 
 
 # --------------------------------------------------------------------------- #
-# Negative probes (R6)                                                        #
+# Positive probes (ASR-519)                                                    #
 # --------------------------------------------------------------------------- #
 
 
-def _value_probes_for(base_payload: dict[str, object], path: str, constraint: LeafConstraint) -> list[NegativeProbe]:
-    probes: list[NegativeProbe] = []
-    variation_value = out_of_domain_value(constraint.domain)
-    if variation_value is not _MISSING:
-        payload = deepcopy(base_payload)
-        if assign_path(payload, tokenize_path(path), variation_value) is None:
-            probes.append(NegativeProbe(path, constraint.domain.kind, "value-outside-domain", payload))
-    if constraint.posture is Posture.EXACT:
-        omitted = deepcopy(base_payload)
-        if remove_path(omitted, tokenize_path(path)):
-            probes.append(NegativeProbe(path, constraint.domain.kind, "omitted-required-exact", omitted))
-    return probes
+def _probe_digest(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
 
 
-def _closed_scope_probes(base_payload: dict[str, object], closed: dict[str, set[str]]) -> list[NegativeProbe]:
-    probes: list[NegativeProbe] = []
-    for scope_path in sorted(closed):
-        extra_key = fresh_extra_key(closed[scope_path])
-        payload = deepcopy(base_payload)
-        tokens = tokenize_path(scope_path) + [extra_key] if scope_path else [extra_key]
-        if assign_path(payload, tokens, "out-of-envelope") is None:
-            address = f"{scope_path}.{extra_key}" if scope_path else extra_key
-            probes.append(NegativeProbe(address, "closed-scope", "extra-dimension", payload))
-    return probes
+def _positive_probe(payload: dict[str, object], *, path: str, domain_kind: str, variation: str) -> PositiveProbe:
+    return PositiveProbe(path, domain_kind, variation, _probe_digest(payload), payload)
+
+
+def generate_positive_probes(
+    envelope: RealizationEnvelopeModel,
+) -> tuple[tuple[PositiveProbe, ...], tuple[Diagnostic, ...]]:
+    """Derive deterministic, structurally valid witnesses for bounded dimensions.
+
+    The base witness is always retained. Each finite member and safe numeric
+    boundary is substituted through the shared path engine, then revalidated by
+    the ordinary SDL and envelope-membership gates. Invalid candidates remain
+    explicit diagnostics rather than silently increasing conformance coverage.
+    """
+
+    base_payload, build_diagnostics = _build_witness_payload(envelope, None)
+    base = _validate_witness_payload(base_payload, envelope) if not build_diagnostics else WitnessResult(None)
+    if base.scenario is None:
+        return (), (
+            _diag(
+                "positive-probe.no-witness",
+                envelope.id,
+                "cannot derive positive probes from a non-constructive envelope",
+            ),
+        )
+    probes: dict[str, PositiveProbe] = {}
+    initial = _positive_probe(base_payload, path=envelope.id, domain_kind="witness", variation="base-witness")
+    probes[initial.digest] = initial
+    diagnostics: list[Diagnostic] = []
+    constraints, _closed = effective_constraints(envelope)
+    for path in sorted(constraints):
+        constraint = constraints[path]
+        for value in positive_probe_values(constraint.domain):
+            payload = deepcopy(base_payload)
+            if assign_path(payload, tokenize_path(path), value) is not None:
+                diagnostics.append(
+                    _diag("positive-probe.invalid-candidate", path, "bounded variation could not be assigned")
+                )
+                continue
+            candidate = _validate_witness_payload(payload, envelope)
+            if candidate.scenario is None or not member(candidate.scenario, envelope).holds:
+                diagnostics.append(
+                    _diag(
+                        "positive-probe.invalid-candidate",
+                        path,
+                        "bounded variation did not pass ordinary SDL and membership validation",
+                    )
+                )
+                continue
+            probe = _positive_probe(
+                payload,
+                path=path,
+                domain_kind=constraint.domain.kind,
+                variation="bounded-member",
+            )
+            probes.setdefault(probe.digest, probe)
+    return tuple(probes.values()), tuple(diagnostics)
+
+
+# --------------------------------------------------------------------------- #
+# Negative probes (R6)                                                        #
+# --------------------------------------------------------------------------- #
 
 
 def generate_negative_probes(
@@ -386,7 +443,8 @@ def generate_negative_probes(
 ) -> tuple[tuple[NegativeProbe, ...], tuple[Diagnostic, ...]]:
     """Derive out-of-envelope probes for the envelope's closed dimensions (R6)."""
 
-    base = witness(envelope)
+    base_payload, build_diagnostics = _build_witness_payload(envelope, None)
+    base = _validate_witness_payload(base_payload, envelope) if not build_diagnostics else WitnessResult(None)
     if base.scenario is None:
         return (), (
             _diag(
@@ -396,12 +454,17 @@ def generate_negative_probes(
             ),
         )
 
-    # ``mode="json"`` yields plain JSON scalars (enums as their string value), so
-    # each probe payload is a portable, re-parseable scenario request.
-    base_payload = base.scenario.model_dump(mode="json", by_alias=True)
     constraints, closed = effective_constraints(envelope)
-    probes: list[NegativeProbe] = []
+    probes = []
     for path in sorted(constraints):
-        probes.extend(_value_probes_for(base_payload, path, constraints[path]))
-    probes.extend(_closed_scope_probes(base_payload, closed))
-    return tuple(probes), ()
+        probes.extend(value_probe_payloads(base_payload, base.scenario, path, constraints[path]))
+    probes.extend(closed_scope_probe_payloads(base_payload, base.scenario, closed))
+    safe: list[NegativeProbe] = []
+    seen: set[tuple[str, str]] = set()
+    for probe in probes:
+        candidate = _validate_witness_payload(probe.payload, envelope)
+        key = (probe.path, _probe_digest(probe.payload))
+        if candidate.scenario is not None and not member(candidate.scenario, envelope).holds and key not in seen:
+            safe.append(NegativeProbe(probe.path, probe.domain_kind, probe.variation, probe.payload))
+            seen.add(key)
+    return tuple(safe), ()

--- a/implementations/python/tests/test_libvirt_backend_manifest_publication.py
+++ b/implementations/python/tests/test_libvirt_backend_manifest_publication.py
@@ -73,23 +73,25 @@ def test_libvirt_manifest_validates_against_published_schema():
     BackendManifestV2Model.model_validate(payload)
 
 
-def test_libvirt_target_passes_provisioning_only_conformance():
-    """AC1: the target conforms to the published provisioning-only profile, daemon-free.
+def test_libvirt_target_manifest_passes_but_realization_envelope_is_non_constructive():
+    """AC1: manifest validity does not silently certify realization, daemon-free.
 
-    The live provisioning probe (issue #606) is exercised through a daemon-free
-    recording driver that confirms realization, so conformance proves real
-    snapshot mutation without a libvirt/QEMU daemon.
+    The recording driver remains useful hermetic adapter evidence, but ASR-519
+    now fails closed because the published expression cannot generate complete
+    witnesses. Issue #717 owns final native certification.
     """
     report = run_target_conformance(create_libvirt_target(driver=RecordingLibvirtDriver()))
 
     assert report.profile == BackendCapabilityProfile.PROVISIONING_ONLY
-    assert report.passed is True, [diag.message for diag in report.diagnostics]
+    assert report.passed is False
     assert not report.unsupported_contract_gaps
     assert not report.unsupported_capability_gaps
 
     live_manifest = next((case for case in report.cases if case.name == "target-manifest"), None)
     assert live_manifest is not None, "conformance must run the target-manifest validation case"
     assert live_manifest.passed, [diag.message for diag in live_manifest.diagnostics]
+    constructive = next(case for case in report.cases if case.name == "realization-envelope-constructive")
+    assert constructive.outcome == "unsupported"
 
 
 def test_supported_contract_versions_cover_provisioning_only_profile():

--- a/implementations/python/tests/test_libvirt_conformance.py
+++ b/implementations/python/tests/test_libvirt_conformance.py
@@ -6,14 +6,14 @@ Acceptance bar:
    ``unsupported-capability-claim`` / ``unsupported-contract-declaration``
    diagnostics (covered by ``test_backend_conformance_cli.py`` /
    ``run_fixture_suite`` -- asserted green here for the libvirt-relevant profile).
-2. ``run_target_conformance`` against the libvirt target passes a target
-   *provisioning probe* and asserts *snapshot mutation* -- not manifest /
-   contract-surface only. This is adapter evidence, not daemon or guest proof.
+2. ``run_target_conformance`` refuses realization certification while the
+   published libvirt envelope is non-constructive. It never promotes the old
+   daemon-free reference scenario into envelope or native evidence.
 3. A conformance report is captured and committed (drift-guarded here).
 
-The target probe runs daemon-free through an injected ``RecordingLibvirtDriver``
-that confirms realization, so the real ``LibvirtProvisioner`` path is exercised
-without a libvirt/QEMU daemon.
+The direct control-plane tests still exercise the real ``LibvirtProvisioner``
+path through an injected recording driver without a libvirt/QEMU daemon. That
+is hermetic adapter evidence only.
 """
 
 from __future__ import annotations
@@ -105,25 +105,24 @@ def test_provisioning_only_fixture_suite_has_no_unsupported_diagnostics():
 
 
 # ---------------------------------------------------------------------------
-# AC2: target provisioning probe + snapshot mutation
+# AC2: non-constructive envelope refusal + hermetic adapter mutation
 # ---------------------------------------------------------------------------
 
 
-def test_provisioning_only_conformance_runs_live_provisioning_probe():
+def test_provisioning_only_conformance_refuses_non_constructive_envelope():
     report = _libvirt_conformance_report()
 
     assert report.profile == BackendCapabilityProfile.PROVISIONING_ONLY
-    assert report.passed is True, [diag.message for diag in report.diagnostics]
+    assert report.passed is False
     assert not report.unsupported_contract_gaps
     assert not report.unsupported_capability_gaps
 
     case_names = {case.name for case in report.cases}
-    # Not manifest/contract-surface only: the probe must actually provision and
-    # validate a mutated snapshot.
-    assert {"target-manifest", "target-provisioning", "target-snapshot"} <= case_names
-    for case in report.cases:
-        if case.name in {"target-manifest", "target-provisioning", "target-snapshot"}:
-            assert case.passed, [diag.message for diag in case.diagnostics]
+    assert "target-manifest" in case_names
+    assert "target-provisioning" not in case_names
+    constructive = next(case for case in report.cases if case.name == "realization-envelope-constructive")
+    assert constructive.outcome == "unsupported"
+    assert constructive.passed is False
 
 
 def test_libvirt_provisioning_mutates_snapshot():
@@ -149,18 +148,20 @@ def test_libvirt_provisioning_mutates_snapshot():
 
 
 def test_provisioning_only_conformance_requires_confirmed_realization():
-    """A driver that does not confirm realization must fail the target probe.
+    """A driver that does not confirm realization fails the ordinary adapter boundary.
 
-    Guards the backend-neutral anti-pattern: provisioning-only conformance must
-    not pass on ``target-manifest`` alone, and must not accept an empty snapshot.
+    This remains a direct hermetic adapter test; the realization-envelope
+    conformance path deliberately refuses to reuse it as certification evidence.
     """
 
-    report = run_target_conformance(create_libvirt_target(driver=NullLibvirtDriver()))
+    target = create_libvirt_target(driver=NullLibvirtDriver())
+    control_plane = RuntimeControlPlane(target)
+    receipt = control_plane.submit_provisioning(_provisioning_plan(target))
+    status = control_plane.get_operation(receipt.operation_id)
 
-    assert report.passed is False
-    live_provisioning = next((case for case in report.cases if case.name == "target-provisioning"), None)
-    assert live_provisioning is not None, "provisioning-only conformance must run a target-provisioning probe"
-    assert live_provisioning.passed is False
+    assert status is not None and status.state.value == "failed"
+    assert not status.changed_addresses
+    assert not any(entry.domain == RuntimeDomain.PROVISIONING for entry in control_plane.snapshot.entries.values())
 
 
 # ---------------------------------------------------------------------------
@@ -177,4 +178,4 @@ def test_committed_conformance_report_is_current():
         "committed libvirt conformance report is stale; regenerate "
         f"{COMMITTED_REPORT.relative_to(REPO_ROOT)} from run_target_conformance"
     )
-    assert committed["passed"] is True
+    assert committed["passed"] is False

--- a/implementations/python/tests/test_libvirt_participant_runtime.py
+++ b/implementations/python/tests/test_libvirt_participant_runtime.py
@@ -91,29 +91,27 @@ def test_ac1_manifest_default_is_provisioning_only():
 
 
 # ---------------------------------------------------------------------------
-# AC-2: run_target_conformance passes for libvirt target with participant_runtime
+# AC-2: participant runtime remains valid while realization certification fails closed
 # ---------------------------------------------------------------------------
 
 
-def test_ac2_conformance_passes_with_participant_runtime_manifest():
-    # The live provisioning probe (issue #606) now runs for provisioning-only
-    # targets too, so exercise it through a daemon-free recording driver that
-    # confirms realization.
+def test_ac2_conformance_requires_constructive_envelope_with_participant_runtime_manifest():
+    # The participant capability surface remains valid, but the published open
+    # libvirt envelope cannot produce ASR-519 probes and must not fall back to a
+    # caller-selected hermetic target-adapter scenario.
     target = _libvirt_target_with_participant_runtime(driver=RecordingLibvirtDriver())
     report = run_target_conformance(target)
 
-    assert report.passed is True, f"conformance failed: {report.diagnostics}"
+    assert report.passed is False
     assert report.unsupported_contract_gaps == ()
     assert report.unsupported_capability_gaps == ()
 
-    # report.passed is vacuously True on an empty case set, so assert the live
-    # pipeline actually ran end-to-end for the participant-runtime manifest:
-    # the provisioning probe + snapshot-mutation cases must be present and green.
-    case_names = {case.name for case in report.cases}
-    assert {"target-manifest", "target-provisioning", "target-snapshot"} <= case_names
-    for case in report.cases:
-        if case.name in {"target-manifest", "target-provisioning", "target-snapshot"}:
-            assert case.passed, [diag.message for diag in case.diagnostics]
+    cases = {case.name: case for case in report.cases}
+    assert cases["target-manifest"].passed is True
+    assert cases["realization-envelope-constructive"].passed is False
+    assert cases["realization-envelope-constructive"].outcome == "unsupported"
+    assert "target-provisioning" not in cases
+    assert "target-snapshot" not in cases
 
 
 # ---------------------------------------------------------------------------

--- a/implementations/python/tests/test_realization_envelope_relation.py
+++ b/implementations/python/tests/test_realization_envelope_relation.py
@@ -38,7 +38,7 @@ from aces_sdl import (
 )
 from aces_sdl._realization_envelope_domains import _MISSING, default_witness_value, out_of_domain_value
 from aces_sdl._realization_envelope_engine import effective_constraints
-from aces_sdl.realization_envelope import generate_negative_probes, member, subsumes, witness
+from aces_sdl.realization_envelope import generate_negative_probes, generate_positive_probes, member, subsumes, witness
 from aces_sdl.scenario import InstantiatedScenario, Scenario
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -343,6 +343,62 @@ def test_witness_rejects_list_indexed_path() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Positive probes (ASR-519)                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_positive_probes_cover_every_finite_member_deterministically() -> None:
+    env = _web_envelope(os_values=("windows", "linux"))
+
+    first, diagnostics = generate_positive_probes(env)
+    second, second_diagnostics = generate_positive_probes(env)
+
+    assert diagnostics == second_diagnostics == ()
+    assert [probe.digest for probe in first] == [probe.digest for probe in second]
+    assert {probe.payload["nodes"]["web"]["os"] for probe in first} == {"linux", "windows"}
+    for probe in first:
+        scenario = instantiate_scenario(Scenario.model_validate(probe.payload))
+        assert member(scenario, env).holds
+
+
+def test_positive_probes_cover_safe_integer_interval_boundaries() -> None:
+    env = RealizationEnvelopeModel(
+        id="bounded-cpu",
+        scope=EnvelopeScope.SCENARIO,
+        domains={
+            "name": ExactDomain(value="bounded"),
+            "vm": ExactDomain(value="vm"),
+            "linux": ExactDomain(value="linux"),
+            "ram": ExactDomain(value=1024),
+            "cpu": NumericIntervalDomain(numeric_type=NumericType.INTEGER, lower=1, upper=4),
+        },
+        bindings=[
+            EnvelopeBinding(path="name", scope=EnvelopeScope.SCENARIO, posture=Posture.EXACT, domain="name"),
+            EnvelopeBinding(path="nodes.vm.type", scope=EnvelopeScope.NODE, posture=Posture.EXACT, domain="vm"),
+            EnvelopeBinding(path="nodes.vm.os", scope=EnvelopeScope.FIELD, posture=Posture.EXACT, domain="linux"),
+            EnvelopeBinding(
+                path="nodes.vm.resources.ram", scope=EnvelopeScope.FIELD, posture=Posture.EXACT, domain="ram"
+            ),
+            EnvelopeBinding(
+                path="nodes.vm.resources.cpu", scope=EnvelopeScope.FIELD, posture=Posture.CONSTRAINED, domain="cpu"
+            ),
+        ],
+    )
+
+    probes, diagnostics = generate_positive_probes(env)
+
+    assert not diagnostics
+    assert {probe.payload["nodes"]["vm"]["resources"]["cpu"] for probe in probes} == {1, 4}
+
+
+def test_positive_probes_fail_closed_for_non_constructive_envelope() -> None:
+    probes, diagnostics = generate_positive_probes(RealizationEnvelopeModel(id="open", scope=EnvelopeScope.SCENARIO))
+
+    assert probes == ()
+    assert any(diag.code == "realization-envelope.positive-probe.no-witness" for diag in diagnostics)
+
+
+# --------------------------------------------------------------------------- #
 # Negative probes (R6)                                                        #
 # --------------------------------------------------------------------------- #
 
@@ -364,9 +420,17 @@ def test_negative_probes_are_all_out_of_envelope() -> None:
     variations = {p.variation for p in probes}
     assert "value-outside-domain" in variations
     assert "extra-dimension" in variations
-    assert "omitted-required-exact" in variations
+    assert {"name", "nodes.web.type", "nodes.web.os"} <= {p.path for p in probes}
     for probe in probes:
-        assert _probe_is_out_of_envelope(probe.payload, env), probe.path
+        instance = instantiate_scenario(Scenario.model_validate(probe.payload))
+        assert not member(instance, env).holds, probe.path
+
+
+def test_negative_probes_exclude_malformed_exact_omissions() -> None:
+    probes, diagnostics = generate_negative_probes(_web_envelope())
+
+    assert not diagnostics
+    assert all(probe.variation != "omitted-required-exact" for probe in probes)
 
 
 def test_negative_probes_without_witness_report_diagnostic() -> None:
@@ -437,6 +501,7 @@ def test_property_negative_probes_out_of_envelope(os_values: set[str]) -> None:
     env = _web_envelope(os_values=tuple(sorted(os_values)), closed=True)
     probes, diagnostics = generate_negative_probes(env)
     assert not diagnostics
+    assert any(probe.path == "nodes.web.os" for probe in probes)
     for probe in probes:
         assert _probe_is_out_of_envelope(probe.payload, env), probe.path
 

--- a/implementations/python/tests/test_realization_honesty_conformance.py
+++ b/implementations/python/tests/test_realization_honesty_conformance.py
@@ -1,0 +1,446 @@
+"""ASR-519 falsification tests for realization-honesty conformance."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+from aces_backend_libvirt.envelopes import LibvirtDriverMode, load_libvirt_realization_envelope
+from aces_backend_libvirt.manifest import create_libvirt_manifest
+from aces_backend_libvirt.target import create_libvirt_target
+from aces_backend_protocols.capabilities import BackendManifest
+from aces_backend_stubs.stubs import StubProvisioner
+from aces_conformance.conformance import (
+    BackendCapabilityProfile,
+    backend_conformance_report_payload,
+    run_target_conformance,
+)
+from aces_conformance.realization import (
+    ExecutionBasis,
+    ExpectedRealizationObservation,
+    RealizationProbeEvidence,
+    RealizationProbeRequest,
+    RealizationTransformation,
+)
+from aces_contracts.realization_envelope import (
+    BackendRealizationEnvelopeModel,
+    ConcernDisposition,
+    EnumDomain,
+    EnvelopeBinding,
+    EnvelopeScope,
+    ExactDomain,
+    ObservationStrength,
+    Posture,
+    RealizationConcern,
+    RealizationEnvelopeModel,
+    realization_envelope_digest,
+)
+from aces_contracts.realization_observation import RealizationObservation
+from aces_operations.realization_conformance import write_backend_conformance_report
+from aces_runtime.registry import RuntimeTarget
+
+_SCENARIO = """\
+name: honesty
+nodes:
+  vm:
+    type: vm
+    os: linux
+"""
+
+
+def _constructive_expression() -> RealizationEnvelopeModel:
+    return RealizationEnvelopeModel(
+        id="honesty.expression.v1",
+        scope=EnvelopeScope.SCENARIO,
+        domains={
+            "name": ExactDomain(value="honesty"),
+            "type": ExactDomain(value="vm"),
+            "os": EnumDomain(values=["linux"]),
+        },
+        bindings=[
+            EnvelopeBinding(path="name", scope=EnvelopeScope.SCENARIO, posture=Posture.EXACT, domain="name"),
+            EnvelopeBinding(path="nodes.vm.type", scope=EnvelopeScope.NODE, posture=Posture.EXACT, domain="type"),
+            EnvelopeBinding(path="nodes.vm.os", scope=EnvelopeScope.FIELD, posture=Posture.CONSTRAINED, domain="os"),
+        ],
+    )
+
+
+def _constructive_envelope(
+    mode: LibvirtDriverMode = LibvirtDriverMode.GENERIC,
+    strength: ObservationStrength = ObservationStrength.DRIVER_REPORTED,
+) -> BackendRealizationEnvelopeModel:
+    base = load_libvirt_realization_envelope(mode)
+    payload = base.model_dump(mode="json")
+    payload["id"] = f"libvirt-qemu.{mode.value}.honesty-test.v1"
+    payload["expression"] = _constructive_expression().model_dump(mode="json")
+    for disclosure in payload["concerns"]:
+        if disclosure["concern"] == RealizationConcern.TOPOLOGY.value:
+            disclosure.update(
+                disposition=ConcernDisposition.REALIZED.value,
+                observation_strength=strength.value,
+                mechanism="test-addressed-observer",
+                transformations=[],
+            )
+        else:
+            disclosure.update(
+                disposition=ConcernDisposition.UNSUPPORTED.value,
+                observation_strength=ObservationStrength.NONE.value,
+                mechanism=None,
+                transformations=[],
+            )
+    payload["digest"] = realization_envelope_digest(payload)
+    return BackendRealizationEnvelopeModel.model_validate(payload)
+
+
+def _manifest_with_envelope(envelope: BackendRealizationEnvelopeModel) -> BackendManifest:
+    base = create_libvirt_manifest(driver_mode=envelope.configuration.mode)
+    return BackendManifest(
+        identity=base.identity,
+        supported_contract_versions=base.supported_contract_versions,
+        compatibility=base.compatibility,
+        realization_support=base.realization_support,
+        concept_bindings=base.concept_bindings,
+        constraints=base.constraints,
+        capabilities=base.capabilities,
+        realization_envelope=envelope,
+    )
+
+
+def _target(envelope: BackendRealizationEnvelopeModel | None = None) -> RuntimeTarget:
+    selected = envelope or _constructive_envelope()
+    return RuntimeTarget(
+        name="libvirt-qemu",
+        manifest=_manifest_with_envelope(selected),
+        provisioner=StubProvisioner(),
+    )
+
+
+def _mode_target(mode: LibvirtDriverMode) -> RuntimeTarget:
+    return RuntimeTarget(
+        name="libvirt-qemu",
+        manifest=create_libvirt_manifest(driver_mode=mode.value),
+        provisioner=StubProvisioner(),
+    )
+
+
+class _ScriptedHarness:
+    def __init__(
+        self,
+        fault: str | None = None,
+        observation_strength: ObservationStrength = ObservationStrength.DRIVER_REPORTED,
+    ) -> None:
+        self.fault = fault
+        self.observation_strength = observation_strength
+        self.calls: list[RealizationProbeRequest] = []
+
+    def execute(self, request: RealizationProbeRequest) -> RealizationProbeEvidence:
+        self.calls.append(request)
+        if request.negative:
+            return self._negative(request)
+        return self._positive(request)
+
+    def _positive(self, request: RealizationProbeRequest) -> RealizationProbeEvidence:
+        operations = tuple(operation.address for operation in request.provisioning_plan.actionable_operations)
+        expected = tuple(
+            ExpectedRealizationObservation(
+                address=address,
+                field_path="exists",
+                concern=RealizationConcern.TOPOLOGY,
+                value=True,
+            )
+            for address in operations
+        )
+        observations = tuple(
+            RealizationObservation(
+                address=item.address,
+                field_path=item.field_path,
+                concern=item.concern,
+                source=self.observation_strength,
+                value=item.value,
+                operation_id=item.address,
+                probe_digest=request.probe_digest,
+                envelope_digest=request.envelope_digest,
+                configuration_digest=request.configuration_digest,
+                observer_version=request.observer_version,
+                sequence=2,
+                origin="observed",
+                binding_verified=True,
+            )
+            for item in expected
+        )
+        evidence = RealizationProbeEvidence(
+            accepted=True,
+            accounted_operations=operations,
+            changed_addresses=operations,
+            expected_observations=expected,
+            observations=observations,
+            driver_invoked=True,
+            native_mutated=True,
+            portable_state_before="sha256:" + "0" * 64,
+            portable_state_after="sha256:" + "1" * 64,
+            native_state_before="sha256:" + "2" * 64,
+            native_state_after="sha256:" + "3" * 64,
+            baseline_sequence=1,
+            cleanup_verified=True,
+        )
+        fault = self.fault
+        if fault == "missing-operation":
+            return replace(evidence, accounted_operations=())
+        if fault == "schema-valid-noop":
+            return replace(evidence, portable_state_after=evidence.portable_state_before)
+        if fault == "missing-disclosure":
+            return replace(evidence, expected_observations=(), observations=())
+        if fault == "missing-observation":
+            return replace(evidence, observations=())
+        if fault == "stale-observation":
+            return replace(evidence, observations=tuple(replace(item, sequence=1) for item in observations))
+        if fault == "planned-as-observed":
+            return replace(evidence, observations=tuple(replace(item, origin="planned") for item in observations))
+        if fault == "fabricated-observation":
+            return replace(
+                evidence,
+                observations=tuple(replace(item, binding_verified=False) for item in observations),
+            )
+        if fault in {"silent-transform", "resource-clamp", "image-substitution"}:
+            kind = {
+                "silent-transform": "default-substitution",
+                "resource-clamp": "bounded-normalization",
+                "image-substitution": "image-substitution",
+            }[fault]
+            concern = (
+                RealizationConcern.IMAGE if fault == "image-substitution" else RealizationConcern.RESOURCE_ALLOCATION
+            )
+            return replace(
+                evidence,
+                transformations=(
+                    RealizationTransformation(
+                        address=operations[0], concern=concern, kind=kind, disclosed=fault != "silent-transform"
+                    ),
+                ),
+            )
+        if fault == "cleanup":
+            return replace(evidence, cleanup_verified=False)
+        if fault == "residual":
+            return replace(evidence, residual_state=(operations[0],))
+        return evidence
+
+    def _negative(self, request: RealizationProbeRequest) -> RealizationProbeEvidence:
+        evidence = RealizationProbeEvidence(
+            accepted=False,
+            driver_invoked=False,
+            native_mutated=False,
+            portable_state_before="sha256:" + "4" * 64,
+            portable_state_after="sha256:" + "4" * 64,
+            native_state_before="sha256:" + "5" * 64,
+            native_state_after="sha256:" + "5" * 64,
+            cleanup_verified=True,
+        )
+        if self.fault == "negative-driver":
+            return replace(evidence, driver_invoked=True)
+        if self.fault == "negative-native":
+            return replace(evidence, native_mutated=True)
+        if self.fault == "negative-portable-state":
+            return replace(evidence, portable_state_after="sha256:" + "6" * 64)
+        if self.fault == "negative-native-state":
+            return replace(evidence, native_state_after="sha256:" + "7" * 64)
+        if self.fault == "negative-cleanup":
+            return replace(evidence, cleanup_verified=False, residual_state=("node.vm",))
+        return evidence
+
+
+def _run(
+    harness: _ScriptedHarness,
+    envelope: BackendRealizationEnvelopeModel | None = None,
+    **kwargs,
+):
+    return run_target_conformance(
+        _target(envelope),
+        reference_scenario=_SCENARIO,
+        realization_harness=harness,
+        execution_basis=ExecutionBasis.HERMETIC_LIVE,
+        **kwargs,
+    )
+
+
+def test_constructive_envelope_runs_positive_and_negative_honesty_probes() -> None:
+    harness = _ScriptedHarness()
+
+    report = _run(harness)
+
+    assert report.passed is True, [diag.code for case in report.cases for diag in case.diagnostics]
+    honesty = [case for case in report.cases if case.probe_kind is not None]
+    assert {case.probe_kind for case in honesty} == {"positive", "negative"}
+    assert all(case.execution_basis == "hermetic-live" for case in honesty)
+    assert all(case.envelope_digest == _constructive_envelope().digest for case in honesty)
+    assert all(case.probe_set_digest for case in honesty)
+    assert report.native_conformance is False
+    assert report.claim.left_carrier_ref != "backend-target:libvirt-qemu"
+    assert _constructive_envelope().configuration.mode in report.claim.left_carrier_ref
+
+
+@pytest.mark.parametrize(
+    "required_strength",
+    [ObservationStrength.DAEMON_OBSERVED, ObservationStrength.GUEST_OBSERVED],
+)
+def test_positive_probe_enforces_declared_daemon_or_guest_strength(
+    required_strength: ObservationStrength,
+) -> None:
+    envelope = _constructive_envelope(strength=required_strength)
+
+    weak = _run(_ScriptedHarness(), envelope=envelope)
+    strong = _run(
+        _ScriptedHarness(observation_strength=required_strength),
+        envelope=envelope,
+    )
+
+    assert weak.passed is False
+    assert "conformance.observation-strength-insufficient" in {
+        diag.code for case in weak.cases for diag in case.diagnostics
+    }
+    assert strong.passed is True
+
+
+@pytest.mark.parametrize(
+    ("fault", "code"),
+    [
+        ("missing-operation", "conformance.operation-accounting-incomplete"),
+        ("schema-valid-noop", "conformance.positive-portable-state-unchanged"),
+        ("missing-disclosure", "conformance.observation-inventory-incomplete"),
+        ("missing-observation", "conformance.observation-missing"),
+        ("stale-observation", "conformance.observation-stale"),
+        ("planned-as-observed", "conformance.observation-not-independent"),
+        ("fabricated-observation", "conformance.observation-binding-invalid"),
+        ("silent-transform", "conformance.transformation-undisclosed"),
+        ("resource-clamp", "conformance.transformation-unverified"),
+        ("image-substitution", "conformance.transformation-unverified"),
+        ("cleanup", "conformance.cleanup-unverified"),
+        ("residual", "conformance.residual-state"),
+    ],
+)
+def test_dishonest_positive_behaviors_fail_for_stable_reason(fault: str, code: str) -> None:
+    report = _run(_ScriptedHarness(fault))
+
+    assert report.passed is False
+    assert code in {diag.code for case in report.cases for diag in case.diagnostics}
+
+
+@pytest.mark.parametrize(
+    ("fault", "code"),
+    [
+        ("negative-driver", "conformance.negative-driver-invoked"),
+        ("negative-native", "conformance.negative-native-mutation"),
+        ("negative-portable-state", "conformance.negative-portable-state-mutated"),
+        ("negative-native-state", "conformance.negative-native-state-mutated"),
+        ("negative-cleanup", "conformance.cleanup-unverified"),
+    ],
+)
+def test_negative_probe_requires_rejection_without_mutation(fault: str, code: str) -> None:
+    report = _run(_ScriptedHarness(fault))
+
+    assert report.passed is False
+    assert code in {diag.code for case in report.cases for diag in case.diagnostics}
+
+
+def test_current_open_libvirt_envelope_fails_as_non_constructive_without_fallback() -> None:
+    harness = _ScriptedHarness()
+    report = run_target_conformance(
+        create_libvirt_target(driver_mode="generic"),
+        reference_scenario=_SCENARIO,
+        realization_harness=harness,
+        execution_basis=ExecutionBasis.HERMETIC_LIVE,
+    )
+
+    assert report.passed is False
+    case = next(case for case in report.cases if case.name == "realization-envelope-constructive")
+    assert case.outcome == "unsupported"
+    assert not harness.calls
+
+
+@pytest.mark.parametrize(
+    ("target_mode", "wrong_mode"),
+    [
+        (LibvirtDriverMode.GENERIC, LibvirtDriverMode.TECHVAULT_APPLIANCE),
+        (LibvirtDriverMode.TECHVAULT_APPLIANCE, LibvirtDriverMode.GENERIC),
+    ],
+)
+def test_libvirt_modes_refuse_wrong_configuration_envelope_before_execution(
+    target_mode: LibvirtDriverMode,
+    wrong_mode: LibvirtDriverMode,
+) -> None:
+    harness = _ScriptedHarness()
+    report = run_target_conformance(
+        _mode_target(target_mode),
+        realization_harness=harness,
+        realization_envelope=load_libvirt_realization_envelope(wrong_mode),
+        execution_basis=ExecutionBasis.HERMETIC_LIVE,
+    )
+
+    assert report.passed is False
+    assert not harness.calls
+    assert "conformance.realization-envelope-mismatch" in {
+        diag.code for case in report.cases for diag in case.diagnostics
+    }
+
+
+def test_only_native_live_can_support_native_conformance() -> None:
+    hermetic = _run(_ScriptedHarness(), native_conformance=True)
+    native = run_target_conformance(
+        _target(),
+        reference_scenario=_SCENARIO,
+        realization_harness=_ScriptedHarness(),
+        execution_basis=ExecutionBasis.NATIVE_LIVE,
+        native_conformance=True,
+    )
+
+    assert hermetic.passed is False
+    assert hermetic.native_conformance is False
+    assert native.passed is True
+    assert native.native_conformance is True
+
+
+def test_failed_report_cannot_claim_native_conformance() -> None:
+    report = run_target_conformance(
+        _target(),
+        profile=BackendCapabilityProfile.FULL_REMOTE_CONTROL_PLANE,
+        reference_scenario=_SCENARIO,
+        realization_harness=_ScriptedHarness(),
+        execution_basis=ExecutionBasis.NATIVE_LIVE,
+        native_conformance=True,
+    )
+
+    assert report.passed is False
+    assert report.native_conformance is False
+
+
+def test_report_payload_enumerates_probe_evidence_without_raw_values() -> None:
+    report = _run(_ScriptedHarness())
+
+    payload = backend_conformance_report_payload(report)
+    honesty = [case for case in payload["cases"] if case["probe_kind"] is not None]
+
+    assert honesty
+    assert all(case["outcome"] == "passed" for case in honesty)
+    assert all(case["probe_digest"].startswith("sha256:") for case in honesty)
+    assert all("expected_operations" in case for case in honesty)
+    assert all("cleanup_verified" in case for case in honesty)
+    assert "honesty" not in json.dumps(honesty)
+
+
+def test_machine_readable_report_write_is_redaction_gated(tmp_path) -> None:
+    report = _run(_ScriptedHarness())
+
+    path = write_backend_conformance_report(
+        backend_conformance_report_payload(report), output_dir=tmp_path, run_id="honesty-native-1"
+    )
+
+    assert json.loads(path.read_text(encoding="utf-8")) == backend_conformance_report_payload(report)
+
+    cases = list(report.cases)
+    index = next(index for index, case in enumerate(cases) if case.probe_kind == "positive")
+    cases[index] = replace(cases[index], residual_state=("/home/operator/private",))
+    leaking = replace(report, cases=tuple(cases))
+    with pytest.raises(ValueError, match="redaction"):
+        write_backend_conformance_report(
+            backend_conformance_report_payload(leaking), output_dir=tmp_path, run_id="honesty-native-2"
+        )

--- a/implementations/python/tests/test_realization_honesty_conformance.py
+++ b/implementations/python/tests/test_realization_honesty_conformance.py
@@ -440,7 +440,10 @@ def test_machine_readable_report_write_is_redaction_gated(tmp_path) -> None:
     index = next(index for index, case in enumerate(cases) if case.probe_kind == "positive")
     cases[index] = replace(cases[index], residual_state=("/home/operator/private",))
     leaking = replace(report, cases=tuple(cases))
+    leaking_payload = backend_conformance_report_payload(leaking)
     with pytest.raises(ValueError, match="redaction"):
         write_backend_conformance_report(
-            backend_conformance_report_payload(leaking), output_dir=tmp_path, run_id="honesty-native-2"
+            leaking_payload,
+            output_dir=tmp_path,
+            run_id="honesty-native-2",
         )


### PR DESCRIPTION
## Summary

Add executable realization-honesty conformance so backend capability claims are checked against generated positive and negative envelope probes, bound observations, cleanup outcomes, and reproducible reports.

## Requirement UIDs

- `ASR-519`

## Related Issues

Closes #716

## ADR Impact

- No ADR required

## Changes

- Generate deterministic positive and negative probes from declared realization envelopes, including constrained enum dimensions and closed scopes.
- Add neutral observation contracts plus conformance models and validation for operation coverage, binding, freshness, transformations, state, and cleanup.
- Extend backend reports, CLI serialization, and redaction-gated atomic persistence with explicit execution-basis and nonclaim metadata.
- Document the conformance model and update the committed libvirt report to fail when its current envelope is nonconstructive.

## Test Plan

- [x] Focused conformance tests pass (82 tests)
- [x] Full `nox -s verify` passes (3,804 unit tests; 34 integration tests)
- [x] Repository policy and all-files pre-commit gates pass
- [x] Coverage and documentation build pass

Focused conformance tests passed (82 tests). Full verification passed with 3,804 unit tests, 1 skipped, 34 integration tests, policy checks, coverage, and documentation build. The all-files pre-commit gate also passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-519 ← implementations/python/packages/aces_sdl/realization_envelope.py, ASR-519 ← implementations/python/packages/aces_conformance/realization.py, ASR-519 ← implementations/python/packages/aces_conformance/_realization_validation.py, ASR-519 ← implementations/python/packages/aces_conformance/conformance.py, ASR-519 ← implementations/python/packages/aces_operations/realization_conformance.py
- TESTS: ASR-519 ← implementations/python/tests/test_realization_envelope_relation.py, ASR-519 ← implementations/python/tests/test_realization_honesty_conformance.py, ASR-519 ← implementations/python/tests/test_libvirt_conformance.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Release notes are managed by release-please; repository policy forbids changelog fragments
- [x] Architectural docs updated if stack, package structure, or key behaviors changed