### PR TITLE
feat: add DSL evaluation evidence gate

### DIFF
--- a/docs/decisions/issue-346-dsl-language-evaluation-preflight.md
+++ b/docs/decisions/issue-346-dsl-language-evaluation-preflight.md
@@ -1,0 +1,350 @@
+# Issue 346 DSL Language-Evaluation Preflight
+
+Date: 2026-07-15
+
+Issue: #346. Requirement: ASR-530.
+
+ASR-530 supplies the claim-evidence rule. The issue body supplies this
+protocol's research question, dimensions, tasks, and pass/fail criteria.
+
+This note fixes architecture guardrails for evaluating ACES as a language. It
+does not run the study, select study subjects, author its task corpus, change
+SDL, or implement gaps found by the evaluation. No new ADR is needed: the existing
+authority, claim-evidence, participant-semantics, validation-strength,
+evolution, phase-contract, and source-provenance decisions already govern this
+work.
+
+## Decision Boundary
+
+Issue #346 is a falsification/evidence bundle, not a language feature or a new
+kind of SDL validity. Keep three independently revisioned concerns, following
+the established related-work research bundle:
+
+1. **Preregistered protocol:** dimensions, constructs, personas, sampling and
+   experience bands, tasks and mutations, intended semantics, assistance and
+   tooling conditions, artifact stages, measures, thresholds, missing-data and
+   disagreement rules, validity threats, source pins, and amendments.
+2. **Execution snapshot:** the exact ACES revision and public-document/tool
+   surface, pseudonymous attempts, bounded observations, submitted SDL,
+   production-stage outputs and diagnostics, reviewer judgments, deviations,
+   withdrawals or abandoned attempts, and preserved disagreements.
+3. **Analysis and claim record:** recomputed measures, pass/fail disposition,
+   limitations, and ADR-021 evidence status with exact protocol and snapshot
+   references.
+
+Keep the non-normative bundle under the existing `docs/research/` convention,
+in a dedicated language-evaluation directory. Do not publish it as an SDL JSON
+Schema, add it to `aces_contracts`, or place research state in a runtime store.
+If machine-readable records are used, one focused offline checker owns their
+closed shape and cross-record invariants. It should reuse, or extract for reuse,
+the bounded duplicate-key JSON-loading and safe-path idiom already used by
+`tools/check_related_work_comparison.py`; it must not copy a second generic
+schema/exception/logging framework.
+
+The following constructs remain separate. A result in one column is not a
+proxy for another.
+
+| Dimension | Boundary |
+| --- | --- |
+| Expressiveness | Whether the declared experimental meaning is representable, not whether parsing succeeds or every possible field exists. |
+| Comprehension/usability | Whether a stated persona can understand and use the public surface under a declared assistance condition, not feature breadth or maintainer familiarity. |
+| Effectiveness/productivity | Task outcome, effort, error and rework measures against preregistered criteria, not elapsed time alone or a self-report alone. |
+| Maintainability/evolution | Whether a controlled change preserves, changes, or invalidates declared meaning with visible migration status, not mere editability. |
+| Ambiguity | Whether one artifact has more than one materially defensible meaning or two intended-equivalent authorings diverge undetected, not ordinary syntax flexibility. |
+| Diagnostic quality | Whether bounded public diagnostics locate and explain a defect and guide a valid repair, not merely whether an exception occurred. |
+| Reviewability | Whether an independent reviewer can identify meaning, changes, assumptions and information boundaries, not author-reviewer agreement by itself. |
+| Semantic traceability | Whether intent can be followed through authored, expanded, instantiated, compiled and planned artifacts without backend-private interpretation, not path or digest presence alone. |
+
+Scenario completeness profiles, validation/admission strength, semantic
+coverage, backend conformance, researcher accessibility, and language adequacy
+are related but distinct claims. In particular, `valid-sdl-fragment` or an
+implemented scientific-completeness row does not demonstrate language
+adequacy; issue #346 must not revise those profile meanings or store its result
+as a new profile status.
+
+ADR-021 evidence status is also not Ground Control requirement status, ADR
+status, task outcome, attempt completion, review/adjudication status, or
+validation strength. Store and report each axis independently. Likewise, call
+a human who authors or reviews study material a `subject` or `reviewer`; reserve
+`participant` for the SDL participant/agent concept. A study subject is not an
+ACES participant implementation or participant-semantics record.
+
+## Protocol And Evidence Guardrails
+
+- Freeze all six issue personas as stable ids: benchmark designer, scenario
+  author, participant-model author, backend implementer, evaluator/reviewer,
+  and assurance auditor. Record relevant experience and assistance as bounded
+  bands, not names, employers, free-form biographies, or a claim that one
+  maintainer represents a population.
+- Derive representative tasks from the already cited cyber-range/agent corpus,
+  the frozen tasks in `docs/research/related-work-comparison/protocol-v1.json`,
+  the participant-semantics obligations, and current non-trivial ACES examples.
+  Preserve a source locator and derivation rationale. Do not substitute a
+  hand-picked minimal example or the test-local `LanguageEvaluation` oracle for
+  the issue's task corpus.
+- Preregister positive, negative, unsupported, underspecified, and deliberately
+  ambiguous cases. A negative case has one injected defect. Record
+  `invalid`, `unsupported`, `underspecified`, and `profile-dependent` as
+  different outcomes; none may be rewritten as another after observing tool or
+  participant performance.
+- Separate the sealed intended-semantics record from material supplied to an
+  independent reviewer. Reviewers receive only the preregistered public
+  artifacts for their condition. Reveal intent for scoring/adjudication only
+  after the judgment is fixed, and preserve disagreement instead of replacing
+  it with consensus prose.
+- Predeclare the unit of analysis, denominators, thresholds, assistance,
+  repetitions, task order/counterbalancing, time/error/rework capture,
+  exclusion and missing-data handling, and stopping rule. Missing, abandoned,
+  withdrawn, or tool-failed attempts remain in the denominator according to
+  that rule; post-hoc task or threshold selection is a failed protocol.
+- Actual human participation requires the applicable institutional ethics,
+  consent, privacy, and data-protection review before collection. Commit only
+  the public projection authorized by that review: normally aggregate records,
+  or specifically approved minimized study-local pseudonyms with no linkage
+  key in the repository. Pseudonymized data is not anonymous data. Names, email
+  addresses, recordings, raw chats/prompts, keystroke streams, and unrestricted
+  free text belong outside the repository in an approved controlled store, if
+  collected at all. Simulated personas, maintainers, or agent walkthroughs are
+  exploratory evidence and cannot support a generalized usability or
+  productivity claim.
+- Every tool-assisted attempt pins the ACES commit/release, source profile,
+  canonicalization profile, contract ids, public documentation paths, tool and
+  adapter, assistance condition, and parameters. Backend source, private
+  prompts, undocumented conventions, or manual repair after scoring cannot be
+  silent inputs.
+- Every public claim retains ADR-021 threats, falsification criteria, named
+  evidence, and one of `untested`, `partial`, `demonstrated`, or `refuted`.
+  A preregistered protocol without completed independent evidence remains
+  `untested` or `partial`.
+
+## Semantic Identity And Mutation Boundary
+
+Each task or mutation must declare the relation it expects and the artifact
+stage on which that relation is observed. Do not use a generic `equivalent`
+flag.
+
+- Source-format variants may be expected to converge only after explicit
+  migration and strict reparse.
+- Authoring-meaning equivalence may be checked with
+  `canonical_sdl_bytes()`/`canonical_sdl_digest()` only after expansion and
+  semantic validation.
+- Concrete equivalence after parameter binding uses admitted instantiated
+  snapshots and `canonical_instantiated_sdl_digest()`.
+- Processor-facing traceability uses canonical addresses and typed output from
+  `compile_runtime_model()` and `plan()`.
+- Reviewer equivalence is a separate observation with its own rubric and
+  disagreement record.
+
+Digest equality proves identity under the named canonicalization profile. It
+does not prove behavioral, observational, epistemic, strategic, backend, or
+scientific equivalence. Conversely, a source-byte or formatting difference is
+not automatically a semantic difference. A mutation that changes hidden
+assets, participant visibility, observations, outcomes, action meaning,
+realization posture, or experiment controls must be assessed at the owning
+semantic/artifact stage; it must not be hidden by comparing only a topology or
+plan summary.
+
+Maintenance exercises also pin source and target surface versions and the
+claimed compatibility dimension from ADR-075: structural, semantic,
+behavioral, or operational. A migration that parses is not thereby
+meaning-preserving. Preserve invalidation, lossy/ambiguous migration, and
+replacement status explicitly.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and required boundary |
+| --- | --- |
+| Authority and claims | ADR-009/019, `specs/authority/authority-boundary.yaml`, ADR-021, and the documentation style guide. Research reports evidence; it does not define SDL meaning or promote a claim from prose. |
+| Research bundle and sources | `docs/research/related-work-comparison/`, issue-728's protocol/snapshot/analysis split, `tools/check_related_work_comparison.py`, ADR-080, the SDL lineage ledger, and the source-audit/search-log patterns. Reuse source identities where they already exist; do not turn lineage into a study-results ledger. |
+| Study personas and SDL participant semantics | The issue's six study personas; ADR-022, `specs/formal/participant-semantics/`, participant information-boundary invariants, and the existing `LanguageEvaluation` test oracle only as prior evidence of the obligation. Keep human subjects/reviewers separate from SDL participants, and do not promote the test-local dataclass into a contract. |
+| Authoring corpus | `examples/scenarios/`, `examples/library/catalog.yaml`, `test_sdl_realworld.py`, `test_sdl_stress.py`, `enterprise-participant-evidence-loop.sdl.yaml`, and the related-work tasks. Reuse these by reference where suitable; invalid evaluation cases do not belong in the positive example corpus. |
+| Concrete syntax and shape | `sdl-yaml/v1`, `SDLParserLimits`, `_SDLSafeLoader`, mapping-key analysis, `parse_sdl()`/`parse_sdl_file()`, closed `Scenario`/`InstantiatedScenario` models, and the checked-in SDL schemas and source-profile fixtures. The normalized schema is not a raw-YAML validator. |
+| Static semantics | `SemanticValidator`, `specs/sdl/references.md`, `specs/sdl/diagnostics.md`, shared declaration/reference indexes, and fail-closed ambiguity/uniqueness/graph rules. Do not implement evaluation-only acceptance or reference resolution. |
+| Tools and diagnostics | SDL CLI formatting/import verification; MCP authoring, language-service, inspection, design-assessment and claims-assessment tools; `SDLParseDiagnostic`, `SDLParseError`, `SDLValidationError`, `SDLInstantiationError`, `Diagnostic`, and `Severity`. Record the exact public entrypoint and mode: parse-only summaries are not semantic validation, inspection tools deliberately skip semantic validation, prose authoring responses are not structured language-service diagnostics, and stub planning is not backend evidence. |
+| Phase traceability | `instantiate_scenario()`, `admit_instantiated_scenario()`, canonical SDL/snapshot profiles, `compile_runtime_model()`, the reference processor, `plan()`, canonical addresses, and pipeline-determinism tests. Compare typed artifacts, not raw dictionaries or backend labels. |
+| Evolution | ADR-053/075/078, module/import/lock/trust handling, `specs/evolution/`, migration diagnostics, deprecation records, and canonical phase identities. Do not add an evaluation-specific version or migration registry. |
+| Experiment method | ADR-055/064/065/068/074 and existing metric, evaluation-protocol, validity-note, factor, allocation, analysis, evidence, and study concepts. Reuse their meanings and validators when a record is genuinely an instance; do not mislabel a human authoring attempt as an `ExperimentRunModel` or weaken those contracts to fit this study. |
+| Workflow and reporting | `.ground-control.yaml`, `.gc/plan-rules.md`, `.pre-commit-config.yaml`, ADR-014, `noxfile.py`, `SessionReporter`, repository policy, contract checks, Sphinx, `tools/verify_all.py`, private-key detection, and gitleaks. Wire any focused checker once into the canonical graph consumed by `.github/workflows/ci.yml`; do not add a parallel CI workflow. |
+
+There is no new controller, HTTP DTO, service, runtime repository, or mutable
+persistence layer in the intended design. `RuntimeControlPlane`,
+`ControlPlaneStore`, runtime snapshots, audit events, and backend operation
+envelopes are not stores for author/reviewer study state.
+
+## Cross-Cutting Validation, Security, And Operational Layers
+
+1. **Research-file gate:** load fixed checked-in protocol/snapshot/analysis data
+   as inert content. Reject duplicate or unknown fields and ids, dangling refs,
+   duplicate attempts, missing required persona/task/mutation coverage, unsafe
+   paths, unpinned sources/toolchains, unbounded files/counts, stale derived
+   output, and secret-bearing URI userinfo or query parameters. Resolve every
+   repository path with `safe_repo_path`.
+2. **SDL source gate:** every authored attempt enters through the production
+   UTF-8 and `SDLParserLimits` checks, YAML 1.2 Core resolver, safe loader,
+   tag/directive rejection, scalar/input/depth/node/alias/composition limits,
+   duplicate and normalized-key collision checks, string-keyed JSON-domain
+   validation, and explicit source/migration profile. No pre-parse YAML
+   round-trip or evaluation-only loader is allowed.
+3. **Model/schema gate:** construct the existing closed SDL models and, where
+   schema conformance is claimed, validate the correctly phased JSON payload
+   against the checked-in published schema. Do not use generated schema output
+   as authority, create a study-specific SDL DTO, or treat schema acceptance as
+   semantic success.
+4. **Semantic/composition gate:** run `SemanticValidator` with collect-all,
+   fail-closed reference, ambiguity, uniqueness, graph, profile and redaction
+   rules. Imported scenarios additionally retain base confinement, lockfile,
+   registry allowlist, version, digest, signature, export, namespace, cycle and
+   composition-budget checks. The evaluation observes these results; it never
+   bypasses or reclassifies them.
+5. **Instantiation/processor gate:** when a task claims later-stage fidelity,
+   use existing instantiation/admission, canonicalization, compiler, reference
+   processor and planner entry points. Preserve diagnostics and unsupported or
+   degraded output. Never infer machine distinction from a filename, raw YAML
+   dictionary, backend-private field, or hand-built summary.
+6. **Tool-adapter/config gate:** public MCP authoring/language/inspection paths
+   retain their 64 KiB adapter limits; direct parser limits remain the library
+   bound. Source format, migration policy, task condition, and assistance level
+   are explicit protocol inputs, not ambient environment switches. Add no
+   runtime config, listener, daemon, profile selector, or auth bypass. The
+   exact public adapter response is evidence for that adapter condition; do not
+   inspect an internal exception or model to silently enrich, repair, or
+   reinterpret a public response.
+7. **Authentication and information-boundary gate:** the offline evaluation
+   adds no endpoint and traverses no control-plane authorization surface. If a
+   future service exposes results, it must reuse
+   `ControlPlaneSecurityConfig.strict_defaults()`, verified identity,
+   target-bound roles, request-size/idempotency/fingerprint guards, audit
+   events, and redacted internal errors. Reviewer blinding and hidden-intent
+   separation are study information boundaries, not bearer-token roles.
+8. **Secret and privacy gate:** use synthetic scenario facts or already
+   governed public examples. Authoritative SDL can legitimately contain
+   exercise credentials under ADR-057, but published study projections,
+   diagnostics, locations, task metadata, subject/reviewer records, and logs must
+   never contain real operator credentials, tokens, private keys, environment
+   dumps, absolute host paths, hidden answers, private prompts, raw backend
+   objects, or unrestricted subject text. Normalize public locations to
+   repository-relative paths or task artifact ids. Explicit
+   `redacted`/`operator_secret` omission rules remain enforced; a digest is not
+   redaction, and a pseudonymization linkage key never belongs in the bundle.
+9. **OS, network, and supply-chain gate:** the study checker and reproduction
+   path perform no live study-source or OCI import fetch, compared-project code
+   execution, backend deployment, shell evaluation, privileged host access, or
+   secret-bearing argv. Existing nox/CI may bootstrap its already-governed,
+   pinned tools; issue #346 adds no downloader or executable dependency. Any
+   separately approved behavioral execution uses a pinned, resource-bounded
+   isolated apparatus with no repository/operator secrets and records only
+   bounded, redacted evidence. It must not become a default CI dependency.
+10. **Error-envelope and observability gate:** preserve SDL diagnostic code,
+    stage, severity, bounded message, path/range and related locations when the
+    selected public entrypoint emits them; absence is a diagnostic-quality
+    observation, not permission to synthesize fields from internals. Preserve
+    every processor `Diagnostic` field that is emitted. Research-integrity
+    failures use bounded `PolicyFailure` records and `SessionReporter`. Do not
+    add an issue-specific exception hierarchy, logger or telemetry stream, and
+    do not dump source, parameter maps, raw responses, Pydantic input,
+    tracebacks or environment state.
+11. **Persistence and integrity gate:** Git-tracked protocol, sanitized
+    execution snapshot, analysis, source log and checksums are the durable
+    public record. Raw human-subject data, if any, follows its approved external
+    retention boundary. Add no database, mutable cache, object store, runtime
+    metadata field, audit blob, or result registry.
+
+## Whole-Repository Scope
+
+The implementation must review and, only where evidence requires it, reference
+the canonical SDL prose and contracts; source-profile and conformance fixtures;
+positive examples and test-only stress/real-world corpora; participant,
+information-boundary, observability and outcome semantics; phase identities,
+compiler/planner artifacts and determinism tests; language-service, CLI and MCP
+authoring/inspection surfaces; scientific-completeness and validation-strength
+profiles; evolution and deprecation policy; lineage/source records; research
+bundle conventions; and the `.ground-control.yaml` / `.gc/plan-rules.md` /
+`.pre-commit-config.yaml` / `noxfile.py` / `.github/workflows/ci.yml` canonical
+policy, contracts, tests, docs, private-key, and secret-scanning graph.
+
+It must not edit those owning surfaces merely to make the evaluation pass.
+Every ambiguity, unsupported expression, backend-private assumption,
+diagnostic failure, reviewer disagreement, migration failure, missing attempt,
+or information-boundary leak is an evidence gap. A product correction belongs
+to a separately scoped issue and the owning parser/spec/contract/test surface;
+the original failed observation remains in the frozen snapshot.
+
+## Extensibility Seam
+
+The stable observation join is:
+
+```text
+(protocol_revision, study_run_id, task_id, persona_id, subject_id,
+ tooling_condition_id, attempt_id, variant_id, artifact_stage)
+```
+
+`subject_id` is pseudonymous and local to the controlled study; it appears in a
+public snapshot only when the applicable review permits that minimized
+projection, and never with its linkage key. Dimensions, personas, tasks,
+tooling/assistance conditions, variants/mutations, artifact stages, and measures
+are protocol data with stable ids, not Python enums or table columns.
+The obvious next variation—a new persona, tool surface, SDL/profile revision,
+task, mutation family, or independent-review wave—adds catalog records and a
+new execution snapshot. A changed construct, rubric, threshold, sampling rule,
+or task meaning creates a protocol revision. A source/tool refresh creates a
+new snapshot. Neither requires editing SDL models, contracts, controllers,
+repositories, exception types, or the prior frozen evidence.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- inferring adequacy from schema completeness, successful parsing, accepted
+  ADRs, formal prose, example count, field count, or one author's success;
+- allowing `structural_only`, parse-only inspection, migration acceptance, or
+  stub-backend planning to masquerade as full semantic or behavioral evidence;
+- treating all author variation as ambiguity, or author-selectable specificity
+  as permission for materially different hidden semantics;
+- treating reviewer agreement as correctness, disagreement as documentation
+  debt, or adjudicated consensus as the original independent result;
+- treating canonical digest equality as behavioral equivalence, a changed
+  digest as proof of material change, or a stable plan summary as proof that
+  participant visibility/outcome meaning was preserved;
+- collapsing invalid, unsupported, underspecified, profile-dependent,
+  not-observed, not-applicable, missing and withdrawn outcomes;
+- collapsing ADR-021 evidence status with requirement, ADR, validation,
+  attempt, task-outcome, or review status, or treating a human study subject as
+  an SDL participant/participant implementation;
+- scoring diagnostics by message substring alone while ignoring stable code,
+  stage, severity, locator, repair outcome and leakage;
+- recording only successful attempts, allowing private source inspection,
+  changing assistance mid-task, or omitting learning/order effects;
+- committing identifiable participant data, raw recordings/chats/prompts,
+  pseudonym linkage keys, absolute host paths, hidden answer material, real
+  credentials, unrestricted third-party text, or source/backend dumps;
+- putting invalid study artifacts in `examples/scenarios/`, turning research
+  cases into normative fixtures, or using the research bundle as the only
+  regression for a discovered defect;
+- adding a DSL-evaluation schema to `contracts/`, extending experiment-core or
+  completeness contracts with study-local fields, or creating a second source
+  registry, parser, validator, exception tree, logger, persistence store, or CI
+  workflow;
+- allowing an imported task to perform a live OCI fetch during offline
+  reproduction, or bypassing a public tool adapter to improve its observed
+  diagnostics; and
+- silently repairing the language during the evidence run and replacing the
+  falsifying snapshot with post-fix results.
+
+## Non-Goals And Implementation Boundaries
+
+- Do not add or change SDL syntax, schemas, semantics, diagnostics, examples,
+  compiler/planner behavior, backends, profiles, or migration behavior in this
+  issue merely to improve the result.
+- Do not implement participant behavior, authoring specificity, formal
+  validation/reachability, standardized scenario coverage, or researcher
+  accessibility work owned by #71, #73, #168, #164, or #178.
+- Do not claim scientific adequacy, broad usability, productivity, domain
+  validity, backend independence, reproducibility, or maintainability beyond
+  the exact preregistered population, tasks, conditions, versions and evidence.
+- Do not deploy a range, execute participant actions, evaluate model quality,
+  recruit participants without applicable review/consent, or establish a
+  production telemetry/analytics service.
+- Do not create a new normative ADR, formal semantics, contract family, API,
+  controller, service, repository, database, UI, or migration system. A future
+  external interchange or hosted study service requires its own authority and
+  security decision.

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,7 @@ research/primary/index
 research/lineage/source-audit-2026-07-12
 research/behavioral-relations/conflation-audit-2026-07-13
 research/related-work-comparison/index
+research/dsl-language-evaluation/index
 research/participant-backend-contracts/index
 ```
 

--- a/docs/research/dsl-language-evaluation/analysis-v1.json
+++ b/docs/research/dsl-language-evaluation/analysis-v1.json
@@ -1,0 +1,58 @@
+{
+  "analysis_id": "aces-dsl-language-evaluation-analysis-v1",
+  "protocol_revision": "1.0.0",
+  "snapshot_id": "aces-dsl-language-evaluation-not-started-v1",
+  "generated_at": "2026-07-15",
+  "execution_status": "not_started",
+  "measure_results": [
+    {"measure_id": "semantic-elements-correct", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "task-completion", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "critical-semantic-errors", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "semantic-rework-cycles", "status": "not_evaluated", "statistic": "median", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "relation-classification-accuracy", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "diagnostic-localization", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "diagnostic-repair", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "critical-review-items", "status": "not_evaluated", "statistic": "proportion", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "critical-silent-omissions", "status": "not_evaluated", "statistic": "count", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "silent-lossy-migrations", "status": "not_evaluated", "statistic": "count", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "critical-silent-ambiguities", "status": "not_evaluated", "statistic": "count", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "majority-missed-critical-items", "status": "not_evaluated", "statistic": "count", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []},
+    {"measure_id": "untraced-critical-changes", "status": "not_evaluated", "statistic": "count", "numerator": null, "denominator": 0, "opportunity_count": 0, "observed_count": 0, "missing_count": 0, "abandoned_count": 0, "tool_failed_count": 0, "withdrawn_count": 0, "value": null, "supporting_observation_ids": []}
+  ],
+  "dimension_results": [
+    {"dimension_id": "expressiveness", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "usability-comprehension", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "effectiveness-productivity", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "maintainability-evolution", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "ambiguity", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "diagnostic-quality", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "reviewability", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
+    {"dimension_id": "semantic-traceability", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []}
+  ],
+  "evidence_status": "untested",
+  "claim": {
+    "claim_id": "aces-dsl-language-adequacy",
+    "statement": "ACES SDL is experimentally adequate for the preregistered cyber-agent author and reviewer population, tasks, tooling conditions, and artifact stages.",
+    "threats_to_validity": [
+      "No study observations have been collected.",
+      "The preregistered sample and tasks would support only bounded, not universal, conclusions.",
+      "Results would apply only to the pinned ACES revision and public surfaces."
+    ],
+    "falsification_protocol": "docs/research/dsl-language-evaluation/protocol-v1.json",
+    "objective_pass_criteria": "Every dimension passes its preregistered threshold with complete required persona/task/condition coverage, no unresolved critical disagreement, and no invalidating protocol deviation.",
+    "objective_fail_criteria": "Any dimension meets its preregistered failure threshold, a critical semantic ambiguity or silent loss is observed, or reviewers/tools cannot recover meaning without backend-private interpretation.",
+    "allowed_evidence": ["sanitized attempt observations", "production tool outputs", "blinded reviewer judgments", "pinned public documentation", "recomputed aggregate measures"],
+    "disallowed_evidence": ["schema or parser success alone", "formal prose alone", "maintainer confidence", "backend-private interpretation", "private prompts", "post-hoc thresholds or exclusions", "fabricated or simulated human evidence"],
+    "evidence_artifacts": [
+      "docs/research/dsl-language-evaluation/protocol-v1.json",
+      "docs/research/dsl-language-evaluation/execution-snapshot-v1.json",
+      "docs/research/dsl-language-evaluation/analysis-v1.json"
+    ]
+  },
+  "plain_language_outcome": "The evaluation method is preregistered, but no human/domain-expert or independent-review observations exist yet. ACES language adequacy therefore remains untested.",
+  "limitations": [
+    "This record validates the protocol and evidence boundary, not ACES language adequacy.",
+    "The snapshot intentionally contains no subjects, attempts, reviews, deviations, withdrawals, or disagreements.",
+    "A later executed study must use a new immutable snapshot and recomputed analysis rather than editing this not-started record."
+  ]
+}

--- a/docs/research/dsl-language-evaluation/bundle-manifest.json
+++ b/docs/research/dsl-language-evaluation/bundle-manifest.json
@@ -1,0 +1,7 @@
+{
+  "bundle_id": "aces-dsl-language-evaluation",
+  "revision": "1.0.0",
+  "protocol_path": "docs/research/dsl-language-evaluation/protocol-v1.json",
+  "snapshot_path": "docs/research/dsl-language-evaluation/execution-snapshot-v1.json",
+  "analysis_path": "docs/research/dsl-language-evaluation/analysis-v1.json"
+}

--- a/docs/research/dsl-language-evaluation/execution-snapshot-v1.json
+++ b/docs/research/dsl-language-evaluation/execution-snapshot-v1.json
@@ -1,0 +1,85 @@
+{
+  "snapshot_id": "aces-dsl-language-evaluation-not-started-v1",
+  "protocol_revision": "1.0.0",
+  "captured_at": "2026-07-15",
+  "execution_status": "not_started",
+  "aces_revision": "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+  "public_surface": [
+    {
+      "surface_id": "sdl-source-profile",
+      "kind": "documentation",
+      "artifact": "docs/explain/sdl/parser.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "sdl-yaml/v1; explicit strict or migration mode per task"
+    },
+    {
+      "surface_id": "sdl-references",
+      "kind": "documentation",
+      "artifact": "specs/sdl/references.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "fail-closed resolution and ambiguity rules"
+    },
+    {
+      "surface_id": "sdl-diagnostics",
+      "kind": "documentation",
+      "artifact": "specs/sdl/diagnostics.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "public diagnostic codes, stages, severities, and locations"
+    },
+    {
+      "surface_id": "participant-semantics",
+      "kind": "documentation",
+      "artifact": "specs/formal/participant-semantics/README.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "participant information-boundary and outcome obligations"
+    },
+    {
+      "surface_id": "parser-validator",
+      "kind": "library",
+      "artifact": "implementations/python/packages/aces_sdl",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "production parse_sdl()/parse_sdl_file(), SDLParserLimits, and SemanticValidator; no evaluation-only loader"
+    },
+    {
+      "surface_id": "canonical-authored-sdl",
+      "kind": "library",
+      "artifact": "implementations/python/packages/aces_sdl",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "canonical_sdl_bytes()/canonical_sdl_digest() after expansion and validation"
+    },
+    {
+      "surface_id": "instantiation-admission",
+      "kind": "library",
+      "artifact": "implementations/python/packages/aces_sdl",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "instantiate_scenario(), admit_instantiated_scenario(), and canonical_instantiated_sdl_digest()"
+    },
+    {
+      "surface_id": "compiler-planner",
+      "kind": "library",
+      "artifact": "implementations/python/packages",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "compile_runtime_model(), the reference processor, and plan(); stub mode explicitly labeled"
+    },
+    {
+      "surface_id": "public-authoring-tools",
+      "kind": "tool",
+      "artifact": "implementations/python/packages/aces_cli",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "parameters": "selected CLI or MCP adapter and mode recorded per attempt; adapter input remains bounded"
+    }
+  ],
+  "ethics_review": {
+    "status": "pending",
+    "protocol_identifier": null,
+    "approved_population": null,
+    "approved_data_boundary": null
+  },
+  "subjects": [],
+  "attempts": [],
+  "observations": [],
+  "reviews": [],
+  "deviations": [],
+  "withdrawals": [],
+  "disagreements": []
+}

--- a/docs/research/dsl-language-evaluation/index.md
+++ b/docs/research/dsl-language-evaluation/index.md
@@ -1,0 +1,124 @@
+# ACES SDL Language Evaluation
+
+This directory is the evidence gate for issue #346 and requirement ASR-530.
+It does **not** claim that ACES is already an experimentally adequate language.
+It preregisters how that claim can be tested and pins a sanitized, not-started
+execution snapshot so architecture, parsing, or schema completeness cannot be
+mistaken for study evidence.
+
+The protocol follows the concern raised by Gabriel, Goulão, and Amaral that a
+domain-specific language is not validated merely by using domain concepts:
+expressiveness, usability, effectiveness, maintainability, and domain-expert
+productivity require explicit evaluation. Mernik, Heering, and Sloane provide
+the DSL-development boundary; Kosar, Bohra, and Mernik provide the systematic
+mapping context; VSDL supplies a cyber-range-language comparison point with
+constraint/solver semantics. Exact source identities are frozen in the
+protocol.
+
+## Bundle
+
+- [`bundle-manifest.json`](bundle-manifest.json) selects the exact active
+  artifacts without making a mutable branch name part of evidence identity.
+- [`protocol-v1.json`](protocol-v1.json) freezes constructs, personas, tasks,
+  variants, artifact stages, tooling conditions, measures, thresholds,
+  sampling, missing-data rules, stopping rules, privacy boundaries, and
+  validity threats before observations exist.
+- [`execution-snapshot-v1.json`](execution-snapshot-v1.json) pins ACES commit
+  `38ba081714b12a4dcc7a5c527e2f1250d80a4d1b` and the public documentation and
+  production entrypoints under evaluation. Its status is `not_started`, its
+  ethics state is `pending`, and it contains no subjects or observations.
+- [`analysis-v1.json`](analysis-v1.json) names the ADR-021 claim, allowed and
+  disallowed evidence, objective pass/fail criteria, and recomputable measure
+  slots. Its evidence status is `untested`.
+
+Protocol, snapshot, and analysis are independently revisioned. An executed
+study creates a new immutable snapshot and analysis. It does not edit the
+not-started record or silently change protocol thresholds. A changed construct,
+rubric, threshold, sampling rule, task meaning, or exclusion rule creates a new
+protocol revision and amendment entry.
+
+## What is evaluated
+
+The protocol keeps eight dimensions separate:
+
+1. expressiveness;
+2. usability and comprehension;
+3. effectiveness and productivity;
+4. maintainability and evolution;
+5. ambiguity;
+6. diagnostic quality;
+7. reviewability; and
+8. semantic traceability.
+
+It includes all six issue personas and representative positive, negative,
+underspecified, ambiguous, round-trip, non-equivalent mutation, maintenance,
+diagnostic-repair, and blinded independent-review tasks. Each relation-bearing
+task declares the artifact stage on which equivalence, non-equivalence,
+invalidity, profile dependence, or loss is expected. Canonical digest equality
+is used only for identity under the named canonicalization profile; it is not
+treated as proof of behavioral or scientific equivalence.
+
+Human study subjects are not SDL participants. Actual recruitment and data
+collection require applicable ethics, consent, privacy, and data-protection
+review. Only minimized pseudonymous observations or aggregates may be
+committed. Names, addresses, recordings, raw chats/prompts, keystroke streams,
+free-form biographies, credentials, private backend output, and pseudonym
+linkage keys are prohibited from the repository bundle.
+
+## Execution and reproduction
+
+Before execution:
+
+1. obtain and record the applicable ethics/privacy approval;
+2. freeze task materials, sealed intended semantics, reviewer rubrics, balanced
+   task order, recruitment deadline, and pseudonym handling outside the public
+   reviewer packet;
+3. verify the ACES revision and every public surface named by the snapshot;
+4. assign tooling and assistance conditions without environment-selected
+   semantics; and
+5. run the integrity gate.
+
+During execution, preserve missing, abandoned, tool-failed, and withdrawn
+attempts according to the preregistered denominator rules. Every active subject
+must receive the two structured workload groups in the execution plan: at least
+one constructive or underspecified task and at least one challenge or independent
+review task appropriate to that subject's persona. Every measure declares its
+applicable task, variant, and artifact stages. Each non-withdrawn attempt must
+contain exactly one observation for every resulting attempt-measure-stage
+opportunity; measures are aggregated only after that stage coverage is closed.
+Missing, abandoned, and tool-failed opportunities remain explicit rows;
+withdrawn opportunities are derived from the matching withdrawal and attempt
+records and are excluded from the denominator. Fix each independent review
+judgment before revealing intended semantics. Adjudication adds a new record and
+never replaces the original disagreement. Diagnostics are captured exactly as
+the selected public entrypoint emits them; missing structure is a finding, not
+permission to inspect source or rewrite the response.
+
+Run the focused integrity gate with:
+
+```bash
+implementations/python/.venv/bin/python tools/check_dsl_language_evaluation.py
+```
+
+The checker validates bounded duplicate-safe JSON, closed shapes, stable IDs,
+catalog and cross-artifact joins, source pins, repository path containment,
+secret-safe locators, the closed subject-attempt-observation-review graph,
+per-subject workload assignment, the protocol-derived task-variant-stage
+opportunity matrix, recomputed measure results with outcome counts, complete
+execution coverage, preserved disagreements, and ADR-021 evidence-status
+promotion. It performs no network access, backend deployment, shell evaluation,
+or private-data lookup. The same check runs once in the canonical nox contracts
+graph.
+
+## Interpretation boundary
+
+`demonstrated` is permitted only for the exact preregistered population, tasks,
+conditions, ACES revision, and public surfaces after every dimension passes and
+coverage is complete. `partial` preserves incomplete but relevant evidence.
+Any objective fail criterion yields `refuted`; absent execution remains
+`untested`.
+
+Failed observations are evidence. Product fixes belong to separately scoped
+issues and owning SDL/specification/test surfaces. A later correction may be
+evaluated in a new snapshot, but it must not overwrite the frozen falsifying
+record.

--- a/docs/research/dsl-language-evaluation/protocol-v1.json
+++ b/docs/research/dsl-language-evaluation/protocol-v1.json
@@ -1,0 +1,440 @@
+{
+  "protocol_id": "aces-dsl-language-evaluation",
+  "revision": "1.0.0",
+  "registered_at": "2026-07-15",
+  "title": "ACES SDL language-evaluation and adequacy protocol",
+  "claim": "Target ACES authors and reviewers can express, inspect, maintain, and critique representative cyber-agent evaluation scenarios with sufficiently low ambiguity and sufficiently high semantic fidelity for reviewable and reproducible research without backend-private interpretation.",
+  "research_question": "Can each preregistered study persona recover intended experimental meaning from the declared public ACES surface, create or review the required SDL artifacts, and distinguish meaning-preserving from meaning-changing variants under the declared thresholds?",
+  "evidence_status_values": [
+    "untested",
+    "partial",
+    "demonstrated",
+    "refuted"
+  ],
+  "dimensions": [
+    {
+      "dimension_id": "expressiveness",
+      "label": "Expressiveness",
+      "construct": "Whether every experimental concern in a task brief has a native representation or an explicit unsupported, underspecified, or profile-dependent disposition.",
+      "pass_rule": "At least 90 percent of required semantic elements are represented or explicitly dispositioned, with no silent loss of a critical element.",
+      "fail_rule": "A critical element is silently omitted or represented only by backend-private convention, or aggregate coverage is below 90 percent."
+    },
+    {
+      "dimension_id": "usability-comprehension",
+      "label": "Usability and comprehension",
+      "construct": "Whether qualified subjects complete assigned authoring or review tasks using only the declared public surface and assistance condition.",
+      "pass_rule": "At least 80 percent of scored attempts complete without prohibited assistance and the critical semantic-error rate is at most 10 percent.",
+      "fail_rule": "Completion is below 80 percent, critical semantic errors exceed 10 percent, or success depends on backend/source inspection."
+    },
+    {
+      "dimension_id": "effectiveness-productivity",
+      "label": "Effectiveness and productivity",
+      "construct": "Task correctness, bounded effort, diagnostic repair, and rework under a fixed task and assistance condition rather than elapsed time or self-report alone.",
+      "pass_rule": "At least 80 percent of attempts meet the task outcome and median rework is no more than two semantic repair cycles; timing is reported descriptively by persona and task.",
+      "fail_rule": "Outcome success is below 80 percent or median semantic rework exceeds two cycles; no universal speed claim is permitted."
+    },
+    {
+      "dimension_id": "maintainability-evolution",
+      "label": "Maintainability and evolution",
+      "construct": "Whether controlled edits and migrations preserve, change, invalidate, or replace declared meaning with visible status.",
+      "pass_rule": "At least 90 percent of maintenance attempts produce the preregistered semantic relation and every lossy or invalid migration is surfaced.",
+      "fail_rule": "A meaning-changing edit is reported as preserving meaning, a lossy migration is silent, or relation accuracy is below 90 percent."
+    },
+    {
+      "dimension_id": "ambiguity",
+      "label": "Ambiguity",
+      "construct": "Whether one artifact admits multiple materially defensible meanings or intended-equivalent authorings diverge without an explicit disposition.",
+      "pass_rule": "No critical ambiguity is accepted silently and at least 90 percent of preregistered ambiguous or relation-bearing variants receive the expected disposition.",
+      "fail_rule": "Any critical ambiguity is silently accepted or expected relation classification falls below 90 percent."
+    },
+    {
+      "dimension_id": "diagnostic-quality",
+      "label": "Diagnostic quality",
+      "construct": "Whether the selected public entrypoint reports a bounded code, stage, severity, location, explanation, and repair direction sufficient for a valid correction.",
+      "pass_rule": "At least 80 percent of negative attempts locate the injected defect and at least 75 percent are repaired without prohibited assistance.",
+      "fail_rule": "Defect localization is below 80 percent, repair success is below 75 percent, or resolution requires implementation-source inspection."
+    },
+    {
+      "dimension_id": "reviewability",
+      "label": "Reviewability",
+      "construct": "Whether an independent reviewer identifies intended meaning, material changes, hidden assumptions, and information boundaries before intent is revealed.",
+      "pass_rule": "At least 80 percent of critical rubric items are identified and no critical hidden-assumption or information-boundary change is missed by a majority of reviewers.",
+      "fail_rule": "Critical-item recall is below 80 percent or a majority miss a critical assumption or boundary change."
+    },
+    {
+      "dimension_id": "semantic-traceability",
+      "label": "Semantic traceability",
+      "construct": "Whether intent can be followed across authored, expanded, instantiated, compiled, and planned artifacts through canonical public identities.",
+      "pass_rule": "At least 90 percent of required intent-to-artifact links resolve at the owning stage and no critical change disappears from all machine artifacts.",
+      "fail_rule": "A critical intent element cannot be traced, a meaning change collapses at every observed stage, or link coverage is below 90 percent."
+    }
+  ],
+  "personas": [
+    {
+      "persona_id": "benchmark-designer",
+      "label": "Benchmark designer",
+      "qualification": "Has designed or evaluated at least one cyber, agent, or security benchmark and can state tasks, measures, and validity limits.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "scenario-author",
+      "label": "Scenario author",
+      "qualification": "Has authored cyber-range, infrastructure, exercise, or security-scenario material but need not know ACES internals.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "participant-model-author",
+      "label": "Participant-model author",
+      "qualification": "Has modeled agent or human actions, observations, information boundaries, episodes, or outcomes.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "backend-implementer",
+      "label": "Backend implementer",
+      "qualification": "Has implemented or integrated a cyber range, simulator, orchestration backend, or execution adapter.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "evaluator-reviewer",
+      "label": "Evaluator or reviewer",
+      "qualification": "Has independently reviewed experimental protocols, scenario specifications, or agent-evaluation artifacts.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "assurance-auditor",
+      "label": "Assurance auditor",
+      "qualification": "Has assessed traceability, evidence, security controls, reproducibility, or compliance claims.",
+      "minimum_completed_subjects": 5
+    }
+  ],
+  "tooling_conditions": [
+    {
+      "condition_id": "public-docs-only",
+      "label": "Public documentation only",
+      "allowed_surface": "Pinned public documentation and task materials; no source, backend internals, or private prompts.",
+      "assistance": "Search within the pinned documentation is allowed; maintainers and generative assistants are not."
+    },
+    {
+      "condition_id": "public-tools",
+      "label": "Public documentation and production tools",
+      "allowed_surface": "Pinned public documentation plus the selected production parser, validator, canonicalizer, compiler, planner, CLI, or MCP adapter named by the task.",
+      "assistance": "Tool diagnostics may be used; implementation-source inspection, backend-private interpretation, and manual artifact repair after scoring are prohibited."
+    }
+  ],
+  "artifact_stages": [
+    {
+      "stage_id": "authored",
+      "label": "Authored SDL",
+      "canonical_entrypoint": "parse_sdl() or parse_sdl_file() using sdl-yaml/v1 and the task's explicit source/migration profile"
+    },
+    {
+      "stage_id": "validated",
+      "label": "Semantically validated SDL",
+      "canonical_entrypoint": "SemanticValidator in collect-all fail-closed mode"
+    },
+    {
+      "stage_id": "canonical-authored",
+      "label": "Canonical authored SDL",
+      "canonical_entrypoint": "canonical_sdl_bytes() and canonical_sdl_digest() after expansion and semantic validation"
+    },
+    {
+      "stage_id": "instantiated",
+      "label": "Admitted instantiated SDL",
+      "canonical_entrypoint": "instantiate_scenario(), admit_instantiated_scenario(), and canonical_instantiated_sdl_digest()"
+    },
+    {
+      "stage_id": "compiled",
+      "label": "Compiled runtime model",
+      "canonical_entrypoint": "compile_runtime_model() with canonical SDL addresses"
+    },
+    {
+      "stage_id": "planned",
+      "label": "Processor plan",
+      "canonical_entrypoint": "the reference processor and plan(); stub planning must be labeled as such"
+    },
+    {
+      "stage_id": "review-judgment",
+      "label": "Independent review judgment",
+      "canonical_entrypoint": "a blinded rubric response fixed before intended semantics are revealed"
+    }
+  ],
+  "sources": [
+    {
+      "source_id": "gabriel-language-evaluation",
+      "kind": "publication",
+      "title": "Do Software Languages Engineers Evaluate their Languages?",
+      "authors": "Pedro Gabriel; Miguel Goulao; Vasco Amaral",
+      "year": 2011,
+      "locator": "https://arxiv.org/abs/1109.6794v1",
+      "version": "arXiv:1109.6794v1",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "mernik-dsl-method",
+      "kind": "publication",
+      "title": "When and How to Develop Domain-Specific Languages",
+      "authors": "Marjan Mernik; Jan Heering; Anthony M. Sloane",
+      "year": 2005,
+      "locator": "https://doi.org/10.1145/1118890.1118892",
+      "version": "ACM Computing Surveys 37(4)",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "kosar-dsl-mapping",
+      "kind": "publication",
+      "title": "Domain-Specific Languages: A Systematic Mapping Study",
+      "authors": "Tomaž Kosar; Sudev Bohra; Marjan Mernik",
+      "year": 2016,
+      "locator": "https://doi.org/10.1016/j.infsof.2015.11.001",
+      "version": "Information and Software Technology 71",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "vsdl",
+      "kind": "publication",
+      "title": "Automating the Generation of Cyber Range Virtual Scenarios with VSDL",
+      "authors": "Gabriele Costa; Enrico Russo; Alessandro Armando",
+      "year": 2023,
+      "locator": "https://arxiv.org/abs/2001.06681v2",
+      "version": "arXiv:2001.06681v2",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "aces-participant-semantics",
+      "kind": "repository-internal",
+      "title": "ACES participant behavior and interaction semantics",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/38ba081714b12a4dcc7a5c527e2f1250d80a4d1b/specs/formal/participant-semantics/README.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "revision": "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "artifact_path": "specs/formal/participant-semantics/README.md",
+      "primary": true
+    },
+    {
+      "source_id": "aces-related-work-protocol",
+      "kind": "repository-internal",
+      "title": "ACES reproducible related-work comparison protocol",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/38ba081714b12a4dcc7a5c527e2f1250d80a4d1b/docs/research/related-work-comparison/protocol-v1.json",
+      "version": "protocol 1.0.0 at ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "revision": "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "artifact_path": "docs/research/related-work-comparison/protocol-v1.json",
+      "primary": true
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "author-multihost-experiment",
+      "title": "Author a multi-host participant experiment",
+      "kind": "positive",
+      "persona_ids": ["benchmark-designer", "scenario-author", "participant-model-author"],
+      "dimension_ids": ["expressiveness", "usability-comprehension", "effectiveness-productivity", "semantic-traceability"],
+      "source_refs": ["aces-related-work-protocol", "aces-participant-semantics", "vsdl"],
+      "intended_semantics_ref": "sealed-intent/author-multihost-experiment-v1",
+      "artifact_stage_ids": ["authored", "validated", "instantiated", "compiled", "planned"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["multihost-reference"],
+      "success_rule": "The artifact expresses topology, participant views/actions, an objective, evidence, and declared external obligations without implementation-specific credentials or private conventions.",
+      "failure_rule": "A critical concern is omitted, silently externalized, or only recoverable from backend or implementation source."
+    },
+    {
+      "task_id": "author-information-boundary",
+      "title": "Author participant visibility and outcome boundaries",
+      "kind": "positive",
+      "persona_ids": ["participant-model-author", "assurance-auditor"],
+      "dimension_ids": ["expressiveness", "reviewability", "semantic-traceability"],
+      "source_refs": ["aces-participant-semantics"],
+      "intended_semantics_ref": "sealed-intent/author-information-boundary-v1",
+      "artifact_stage_ids": ["authored", "validated", "compiled", "review-judgment"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["visibility-boundary-change"],
+      "success_rule": "World truth, participant-visible projection, action applicability, observation, and outcome meaning remain distinguishable to tools and reviewers.",
+      "failure_rule": "A reviewer cannot determine what the participant can observe or a machine artifact collapses hidden truth into the visible projection."
+    },
+    {
+      "task_id": "reject-dangling-reference",
+      "title": "Reject one dangling authored reference",
+      "kind": "negative",
+      "persona_ids": ["scenario-author", "backend-implementer"],
+      "dimension_ids": ["diagnostic-quality", "usability-comprehension", "effectiveness-productivity"],
+      "source_refs": ["aces-related-work-protocol"],
+      "intended_semantics_ref": "sealed-intent/reject-dangling-reference-v1",
+      "artifact_stage_ids": ["authored", "validated"],
+      "tooling_condition_ids": ["public-tools"],
+      "variant_ids": ["dangling-reference-single-defect"],
+      "success_rule": "The production semantic boundary rejects the single defect with a bounded, located diagnostic and the subject repairs it without source inspection.",
+      "failure_rule": "The defect is accepted, mislocated, only reported by a private path, or cannot be repaired from the declared public output."
+    },
+    {
+      "task_id": "classify-underspecified-realization",
+      "title": "Classify underspecified or profile-dependent realization",
+      "kind": "underspecified",
+      "persona_ids": ["scenario-author", "backend-implementer", "evaluator-reviewer"],
+      "dimension_ids": ["expressiveness", "ambiguity", "reviewability"],
+      "source_refs": ["aces-participant-semantics", "vsdl"],
+      "intended_semantics_ref": "sealed-intent/classify-underspecified-realization-v1",
+      "artifact_stage_ids": ["validated", "compiled", "planned", "review-judgment"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["profile-dependent-realization"],
+      "success_rule": "The artifact and reviewer classify the concern as underspecified or profile-dependent at the owning stage rather than inventing backend meaning.",
+      "failure_rule": "The concern is reported as fully specified, silently defaulted, or resolved only through private backend assumptions."
+    },
+    {
+      "task_id": "reject-normalized-key-ambiguity",
+      "title": "Reject a deliberately ambiguous mapping key",
+      "kind": "ambiguous",
+      "persona_ids": ["scenario-author", "backend-implementer"],
+      "dimension_ids": ["ambiguity", "diagnostic-quality", "effectiveness-productivity"],
+      "source_refs": ["gabriel-language-evaluation", "aces-related-work-protocol"],
+      "intended_semantics_ref": "sealed-intent/reject-normalized-key-ambiguity-v1",
+      "artifact_stage_ids": ["authored"],
+      "tooling_condition_ids": ["public-tools"],
+      "variant_ids": ["normalized-key-collision"],
+      "success_rule": "The production parser fails closed before construction, identifies the collision, and supports a valid repair.",
+      "failure_rule": "One key silently wins, the ambiguity reaches later stages, or the diagnostic cannot support repair."
+    },
+    {
+      "task_id": "round-trip-format-equivalence",
+      "title": "Preserve meaning across source-format variation",
+      "kind": "round-trip",
+      "persona_ids": ["scenario-author", "evaluator-reviewer"],
+      "dimension_ids": ["ambiguity", "maintainability-evolution", "semantic-traceability"],
+      "source_refs": ["mernik-dsl-method", "kosar-dsl-mapping"],
+      "intended_semantics_ref": "sealed-intent/round-trip-format-equivalence-v1",
+      "artifact_stage_ids": ["authored", "canonical-authored", "review-judgment"],
+      "tooling_condition_ids": ["public-tools"],
+      "variant_ids": ["format-only-equivalent", "field-order-equivalent"],
+      "success_rule": "Strict reparse and canonical authored identity converge for both variants while reviewers classify the change as non-material.",
+      "failure_rule": "Equivalent source variants diverge semantically, a tool reports false material change, or a reviewer must rely on hidden conventions."
+    },
+    {
+      "task_id": "distinguish-hidden-asset-mutation",
+      "title": "Distinguish a non-equivalent hidden-asset mutation",
+      "kind": "mutation",
+      "persona_ids": ["participant-model-author", "evaluator-reviewer", "assurance-auditor"],
+      "dimension_ids": ["ambiguity", "reviewability", "semantic-traceability"],
+      "source_refs": ["aces-participant-semantics"],
+      "intended_semantics_ref": "sealed-intent/distinguish-hidden-asset-mutation-v1",
+      "artifact_stage_ids": ["authored", "instantiated", "compiled", "planned", "review-judgment"],
+      "tooling_condition_ids": ["public-tools"],
+      "variant_ids": ["hidden-asset-non-equivalent"],
+      "success_rule": "At least one owning machine artifact and the independent review distinguish the declared information-boundary change.",
+      "failure_rule": "All observed machine stages collapse the change or reviewers classify it as equivalent because the boundary is not public."
+    },
+    {
+      "task_id": "maintain-versioned-import",
+      "title": "Maintain a versioned imported scenario",
+      "kind": "maintenance",
+      "persona_ids": ["scenario-author", "backend-implementer", "assurance-auditor"],
+      "dimension_ids": ["maintainability-evolution", "diagnostic-quality", "semantic-traceability"],
+      "source_refs": ["mernik-dsl-method", "aces-related-work-protocol"],
+      "intended_semantics_ref": "sealed-intent/maintain-versioned-import-v1",
+      "artifact_stage_ids": ["authored", "validated", "canonical-authored", "instantiated"],
+      "tooling_condition_ids": ["public-tools"],
+      "variant_ids": ["compatible-import-update", "lossy-import-update"],
+      "success_rule": "The compatible update preserves the declared relation and the lossy update reports invalidation, migration, or replacement status.",
+      "failure_rule": "A lossy update is accepted as meaning-preserving, identity silently drifts, or repair requires private registry/source knowledge."
+    },
+    {
+      "task_id": "independent-review-change",
+      "title": "Review a blinded semantic change",
+      "kind": "independent-review",
+      "persona_ids": ["benchmark-designer", "evaluator-reviewer", "assurance-auditor"],
+      "dimension_ids": ["reviewability", "ambiguity", "semantic-traceability"],
+      "source_refs": ["gabriel-language-evaluation", "kosar-dsl-mapping"],
+      "intended_semantics_ref": "sealed-intent/independent-review-change-v1",
+      "artifact_stage_ids": ["authored", "compiled", "planned", "review-judgment"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["review-hidden-assumption-change"],
+      "success_rule": "The blinded reviewer identifies the material change, hidden assumption, affected artifact stage, and information boundary before intent is revealed.",
+      "failure_rule": "The critical change or assumption is missed by a majority or can be explained only after backend-private intent is disclosed."
+    }
+  ],
+  "variants": [
+    {"variant_id": "multihost-reference", "task_id": "author-multihost-experiment", "kind": "reference", "expected_relation": "reference", "description": "The sealed reference meaning for the positive task."},
+    {"variant_id": "visibility-boundary-change", "task_id": "author-information-boundary", "kind": "non-equivalent", "expected_relation": "non-equivalent", "description": "Changes one participant-visible fact while retaining topology."},
+    {"variant_id": "dangling-reference-single-defect", "task_id": "reject-dangling-reference", "kind": "invalid", "expected_relation": "invalid", "description": "Introduces exactly one undeclared reference."},
+    {"variant_id": "profile-dependent-realization", "task_id": "classify-underspecified-realization", "kind": "profile-dependent", "expected_relation": "profile-dependent", "description": "Leaves one realization choice outside portable SDL meaning."},
+    {"variant_id": "normalized-key-collision", "task_id": "reject-normalized-key-ambiguity", "kind": "ambiguous", "expected_relation": "invalid", "description": "Introduces two mapping keys that collide under the source profile."},
+    {"variant_id": "format-only-equivalent", "task_id": "round-trip-format-equivalence", "kind": "equivalent", "expected_relation": "equivalent", "description": "Changes comments and formatting only."},
+    {"variant_id": "field-order-equivalent", "task_id": "round-trip-format-equivalence", "kind": "equivalent", "expected_relation": "equivalent", "description": "Reorders mapping fields without changing values."},
+    {"variant_id": "hidden-asset-non-equivalent", "task_id": "distinguish-hidden-asset-mutation", "kind": "non-equivalent", "expected_relation": "non-equivalent", "description": "Changes whether one asset is visible to one participant."},
+    {"variant_id": "compatible-import-update", "task_id": "maintain-versioned-import", "kind": "equivalent", "expected_relation": "equivalent", "description": "Updates a versioned imported unit without changing declared semantics."},
+    {"variant_id": "lossy-import-update", "task_id": "maintain-versioned-import", "kind": "migration", "expected_relation": "lossy", "description": "Removes a referenced semantic element and requires explicit invalidation or migration status."},
+    {"variant_id": "review-hidden-assumption-change", "task_id": "independent-review-change", "kind": "non-equivalent", "expected_relation": "non-equivalent", "description": "Changes one hidden assumption without changing the high-level topology summary."}
+  ],
+  "measures": [
+    {"measure_id": "semantic-elements-correct", "task_ids": ["author-multihost-experiment", "author-information-boundary", "classify-underspecified-realization", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "maintain-versioned-import", "independent-review-change"], "dimension_ids": ["expressiveness", "semantic-traceability"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["authored", "validated", "instantiated", "compiled", "planned"]}, {"task_id": "author-information-boundary", "variant_ids": ["visibility-boundary-change"], "artifact_stage_ids": ["authored", "validated", "compiled", "review-judgment"]}, {"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["validated", "compiled", "planned", "review-judgment"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["authored", "canonical-authored", "review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["authored", "instantiated", "compiled", "planned", "review-judgment"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["authored", "validated", "canonical-authored", "instantiated"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["authored", "compiled", "planned", "review-judgment"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Score every declared task-variant-stage opportunity against the sealed intent after the attempt is fixed; a missing stage score leaves the aggregate incomplete."},
+    {"measure_id": "task-completion", "task_ids": ["author-multihost-experiment", "reject-dangling-reference", "reject-normalized-key-ambiguity"], "dimension_ids": ["usability-comprehension", "effectiveness-productivity"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["planned"]}, {"task_id": "reject-dangling-reference", "variant_ids": ["dangling-reference-single-defect"], "artifact_stage_ids": ["validated"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Count every assigned non-withdrawn attempt at its declared terminal decision stage; tool failures, missing records, and abandoned attempts are explicit zeroes unless the preregistered withdrawal rule applies."},
+    {"measure_id": "critical-semantic-errors", "task_ids": ["author-multihost-experiment", "reject-dangling-reference", "classify-underspecified-realization", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "independent-review-change"], "dimension_ids": ["usability-comprehension", "ambiguity"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["planned"]}, {"task_id": "reject-dangling-reference", "variant_ids": ["dangling-reference-single-defect"], "artifact_stage_ids": ["validated"]}, {"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["review-judgment"]}], "unit": "proportion", "aggregation": "proportion", "direction": "lower-is-better", "capture_rule": "Count attempts containing at least one preregistered critical meaning error at the declared decision stage; missing scores leave the aggregate incomplete."},
+    {"measure_id": "semantic-rework-cycles", "task_ids": ["author-multihost-experiment", "reject-dangling-reference", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "maintain-versioned-import"], "dimension_ids": ["effectiveness-productivity", "maintainability-evolution"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["authored"]}, {"task_id": "reject-dangling-reference", "variant_ids": ["dangling-reference-single-defect"], "artifact_stage_ids": ["authored"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["authored"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["authored"]}], "unit": "count", "aggregation": "median", "direction": "lower-is-better", "capture_rule": "Count submitted semantic repair cycles at each task's declared authored-stage opportunity; formatting-only edits do not count and missing scores leave the aggregate incomplete."},
+    {"measure_id": "relation-classification-accuracy", "task_ids": ["classify-underspecified-realization", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "maintain-versioned-import", "independent-review-change"], "dimension_ids": ["ambiguity", "maintainability-evolution"], "stage_applicability": [{"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["canonical-authored", "instantiated"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["review-judgment"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Compare each declared stage's fixed machine or reviewer relation judgment with the variant's preregistered expected relation; missing judgments leave the aggregate incomplete."},
+    {"measure_id": "diagnostic-localization", "task_ids": ["reject-dangling-reference", "reject-normalized-key-ambiguity", "maintain-versioned-import"], "dimension_ids": ["diagnostic-quality"], "stage_applicability": [{"task_id": "reject-dangling-reference", "variant_ids": ["dangling-reference-single-defect"], "artifact_stage_ids": ["validated"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["validated"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Count every declared diagnostic stage opportunity where the public diagnostic identifies the defect's owning stage and location; missing output leaves the aggregate incomplete."},
+    {"measure_id": "diagnostic-repair", "task_ids": ["reject-dangling-reference", "reject-normalized-key-ambiguity", "maintain-versioned-import"], "dimension_ids": ["diagnostic-quality", "effectiveness-productivity"], "stage_applicability": [{"task_id": "reject-dangling-reference", "variant_ids": ["dangling-reference-single-defect"], "artifact_stage_ids": ["validated"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["validated"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Count every declared repair stage opportunity achieved using only the assigned public surface before the stopping limit; missing output leaves the aggregate incomplete."},
+    {"measure_id": "critical-review-items", "task_ids": ["author-information-boundary", "classify-underspecified-realization", "distinguish-hidden-asset-mutation", "independent-review-change"], "dimension_ids": ["reviewability"], "stage_applicability": [{"task_id": "author-information-boundary", "variant_ids": ["visibility-boundary-change"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["review-judgment"]}], "unit": "proportion", "aggregation": "proportion", "direction": "higher-is-better", "capture_rule": "Score every blinded fixed review-judgment-stage rubric before intent reveal; missing judgments leave the aggregate incomplete and adjudication never overwrites the original judgment."},
+    {"measure_id": "critical-silent-omissions", "task_ids": ["author-multihost-experiment", "author-information-boundary", "classify-underspecified-realization"], "dimension_ids": ["expressiveness"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["authored", "validated", "instantiated", "compiled", "planned"]}, {"task_id": "author-information-boundary", "variant_ids": ["visibility-boundary-change"], "artifact_stage_ids": ["authored", "validated", "compiled"]}, {"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["validated", "compiled", "planned"]}], "unit": "count", "aggregation": "count", "direction": "lower-is-better", "capture_rule": "Count critical intended semantic elements silently omitted or recoverable only through backend-private convention at each declared machine stage."},
+    {"measure_id": "silent-lossy-migrations", "task_ids": ["round-trip-format-equivalence", "maintain-versioned-import"], "dimension_ids": ["maintainability-evolution"], "stage_applicability": [{"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["canonical-authored"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["canonical-authored", "instantiated"]}], "unit": "count", "aggregation": "count", "direction": "lower-is-better", "capture_rule": "Count lossy or invalid migrations accepted without visible invalidation, migration, or replacement status at each declared canonical or instantiated stage."},
+    {"measure_id": "critical-silent-ambiguities", "task_ids": ["classify-underspecified-realization", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "independent-review-change"], "dimension_ids": ["ambiguity"], "stage_applicability": [{"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["validated", "compiled", "planned", "review-judgment"]}, {"task_id": "reject-normalized-key-ambiguity", "variant_ids": ["normalized-key-collision"], "artifact_stage_ids": ["authored"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["authored", "canonical-authored", "review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["authored", "instantiated", "compiled", "planned", "review-judgment"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["authored", "compiled", "planned", "review-judgment"]}], "unit": "count", "aggregation": "count", "direction": "lower-is-better", "capture_rule": "Count critical ambiguities accepted without rejection or explicit underspecified/profile-dependent disposition at each declared stage."},
+    {"measure_id": "majority-missed-critical-items", "task_ids": ["author-information-boundary", "classify-underspecified-realization", "distinguish-hidden-asset-mutation", "independent-review-change"], "dimension_ids": ["reviewability"], "stage_applicability": [{"task_id": "author-information-boundary", "variant_ids": ["visibility-boundary-change"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "classify-underspecified-realization", "variant_ids": ["profile-dependent-realization"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["review-judgment"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["review-judgment"]}], "unit": "count", "aggregation": "count", "direction": "lower-is-better", "capture_rule": "Count critical hidden assumptions or information-boundary changes missed by a majority of assigned reviewers at each declared review-judgment stage."},
+    {"measure_id": "untraced-critical-changes", "task_ids": ["author-multihost-experiment", "author-information-boundary", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "maintain-versioned-import", "independent-review-change"], "dimension_ids": ["semantic-traceability"], "stage_applicability": [{"task_id": "author-multihost-experiment", "variant_ids": ["multihost-reference"], "artifact_stage_ids": ["authored", "validated", "instantiated", "compiled", "planned"]}, {"task_id": "author-information-boundary", "variant_ids": ["visibility-boundary-change"], "artifact_stage_ids": ["authored", "validated", "compiled"]}, {"task_id": "round-trip-format-equivalence", "variant_ids": ["format-only-equivalent", "field-order-equivalent"], "artifact_stage_ids": ["authored", "canonical-authored"]}, {"task_id": "distinguish-hidden-asset-mutation", "variant_ids": ["hidden-asset-non-equivalent"], "artifact_stage_ids": ["authored", "instantiated", "compiled", "planned"]}, {"task_id": "maintain-versioned-import", "variant_ids": ["compatible-import-update", "lossy-import-update"], "artifact_stage_ids": ["authored", "validated", "canonical-authored", "instantiated"]}, {"task_id": "independent-review-change", "variant_ids": ["review-hidden-assumption-change"], "artifact_stage_ids": ["authored", "compiled", "planned"]}], "unit": "count", "aggregation": "count", "direction": "lower-is-better", "capture_rule": "Count critical intended changes absent from each required owning machine artifact stage; every declared task-variant-stage opportunity is preserved before aggregation."}
+  ],
+  "sampling_plan": {
+    "target_total": 30,
+    "minimum_per_persona": 5,
+    "experience_bands": ["qualified-novice-to-aces", "prior-aces-user"],
+    "inclusion_rule": "Each subject satisfies the assigned persona qualification, completes consent where applicable, and has not seen sealed intent or adjudication material.",
+    "exclusion_rule": "Exclude only preregistered ineligibility, consent withdrawal, corrupted capture before task exposure, or duplicate enrollment; preserve all other failures in the denominator."
+  },
+  "execution_plan": {
+    "unit_of_analysis": "One subject-task-tooling-condition-attempt and its variant-stage observations.",
+    "attempts_per_subject": "Each subject completes at least one positive or underspecified task and one negative, ambiguity, mutation, maintenance, round-trip, or review task appropriate to the assigned persona.",
+    "subject_task_requirements": [
+      {"requirement_id": "constructive-or-underspecified", "minimum_assigned_attempts": 1, "task_kinds": ["positive", "underspecified"]},
+      {"requirement_id": "challenge-or-independent-review", "minimum_assigned_attempts": 1, "task_kinds": ["negative", "ambiguous", "round-trip", "mutation", "maintenance", "independent-review"]}
+    ],
+    "task_order": "Use a preregistered balanced order within persona and tooling condition; record the assigned order and learning exposure.",
+    "blinding": "Seal intended semantics and expected relations from independent reviewers until their judgments are fixed.",
+    "stopping_rule": "Stop at 30 completed subjects with at least five per persona, or at the approved recruitment deadline; do not extend or stop based on observed outcomes.",
+    "missing_data_rule": "Report denominator, missing, abandoned, tool-failed, and withdrawn counts separately for every measure; do not impute success.",
+    "withdrawal_rule": "Honor consent withdrawal and retain only the minimum aggregate count permitted by the approved protocol; never relabel withdrawal as task failure."
+  },
+  "thresholds": [
+    {"dimension_id": "expressiveness", "logic": "all", "conditions": [{"measure_id": "semantic-elements-correct", "operator": ">=", "target": 0.9}, {"measure_id": "critical-silent-omissions", "operator": "==", "target": 0}]},
+    {"dimension_id": "usability-comprehension", "logic": "all", "conditions": [{"measure_id": "task-completion", "operator": ">=", "target": 0.8}, {"measure_id": "critical-semantic-errors", "operator": "<=", "target": 0.1}]},
+    {"dimension_id": "effectiveness-productivity", "logic": "all", "conditions": [{"measure_id": "task-completion", "operator": ">=", "target": 0.8}, {"measure_id": "semantic-rework-cycles", "operator": "<=", "target": 2}]},
+    {"dimension_id": "maintainability-evolution", "logic": "all", "conditions": [{"measure_id": "relation-classification-accuracy", "operator": ">=", "target": 0.9}, {"measure_id": "silent-lossy-migrations", "operator": "==", "target": 0}]},
+    {"dimension_id": "ambiguity", "logic": "all", "conditions": [{"measure_id": "relation-classification-accuracy", "operator": ">=", "target": 0.9}, {"measure_id": "critical-silent-ambiguities", "operator": "==", "target": 0}]},
+    {"dimension_id": "diagnostic-quality", "logic": "all", "conditions": [{"measure_id": "diagnostic-localization", "operator": ">=", "target": 0.8}, {"measure_id": "diagnostic-repair", "operator": ">=", "target": 0.75}]},
+    {"dimension_id": "reviewability", "logic": "all", "conditions": [{"measure_id": "critical-review-items", "operator": ">=", "target": 0.8}, {"measure_id": "majority-missed-critical-items", "operator": "==", "target": 0}]},
+    {"dimension_id": "semantic-traceability", "logic": "all", "conditions": [{"measure_id": "semantic-elements-correct", "operator": ">=", "target": 0.9}, {"measure_id": "untraced-critical-changes", "operator": "==", "target": 0}]}
+  ],
+  "ethics_and_privacy": {
+    "review_status_required": "Obtain applicable institutional ethics, privacy, and data-protection review before recruiting or collecting from human subjects.",
+    "consent_required": true,
+    "committed_data_rule": "Commit only consented, minimized, pseudonymous observations or aggregates; keep the pseudonym linkage key outside the repository in an approved controlled store.",
+    "prohibited_data": ["names", "email addresses", "recordings", "raw chats or prompts", "keystroke streams", "free-form biographies", "pseudonym linkage keys", "credentials", "private backend output"]
+  },
+  "disagreement_policy": "Preserve every original reviewer judgment, confidence, rationale code, and disagreement. Adjudication adds a separate record after intent reveal and never replaces or edits the independent result.",
+  "validity_threats": [
+    "Construct validity: thresholds operationalize this protocol's bounded constructs and do not prove universal language quality.",
+    "Population validity: five subjects per persona is exploratory and supports only the recruited qualification bands.",
+    "Task validity: the selected corpus cannot represent every cyber-agent or cyber-range scenario.",
+    "Learning and order effects: repeated ACES exposure may improve later attempts despite balanced ordering.",
+    "Tooling effects: results apply only to pinned public entrypoints, modes, parameters, and documentation surfaces.",
+    "Reviewer reliability: agreement measures scoring consistency, not semantic correctness.",
+    "Implementation-version validity: later ACES changes require a new snapshot and cannot rewrite this run.",
+    "External validity: simulated personas, maintainers, or agents cannot support generalized human usability or productivity claims."
+  ],
+  "analysis_plan": "Compute every measure from frozen attempt and review records, publish numerators and denominators by persona, task, condition, and dimension, bootstrap descriptive 95 percent intervals where meaningful, apply the preregistered thresholds without post-hoc exclusions, preserve mixed pass/fail dimensions, and set the overall ADR-021 status to demonstrated only when every dimension passes with complete required coverage and no unresolved critical disagreement or protocol deviation. Any objective fail criterion sets refuted; incomplete coverage remains untested or partial.",
+  "amendment_log": []
+}

--- a/implementations/python/tests/test_dsl_language_evaluation.py
+++ b/implementations/python/tests/test_dsl_language_evaluation.py
@@ -1,0 +1,709 @@
+"""Integrity tests for the preregistered DSL language-evaluation bundle."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from tools.check_dsl_language_evaluation import (
+    REQUIRED_DIMENSION_IDS,
+    REQUIRED_PERSONA_IDS,
+    evaluate,
+    load_bundle,
+    recompute_dimension_results,
+    recompute_measure_results,
+    validate_bundle,
+)
+from tools.policy.common import load_bounded_json_object
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _rule_ids(failures: list[object]) -> set[str]:
+    return {failure.rule_id for failure in failures}
+
+
+def _bundle() -> tuple[dict, dict, dict, dict]:
+    manifest, protocol, snapshot, analysis = load_bundle(REPO_ROOT)
+    return (
+        deepcopy(manifest),
+        deepcopy(protocol),
+        deepcopy(snapshot),
+        deepcopy(analysis),
+    )
+
+
+def _refresh_analysis(
+    protocol: dict,
+    snapshot: dict,
+    analysis: dict,
+    evidence_status: str,
+) -> None:
+    measure_results = recompute_measure_results(protocol, snapshot)
+    analysis["measure_results"] = [
+        {
+            "measure_id": measure_id,
+            "status": (
+                "not_evaluated"
+                if result["denominator"] == 0
+                else "incomplete"
+                if result["observed_count"] != result["denominator"]
+                else "evaluated"
+            ),
+            **result,
+        }
+        for measure_id, result in measure_results.items()
+    ]
+    analysis["dimension_results"] = [
+        {"dimension_id": dimension_id, **result}
+        for dimension_id, result in recompute_dimension_results(protocol, measure_results).items()
+    ]
+    analysis["execution_status"] = snapshot["execution_status"]
+    analysis["evidence_status"] = evidence_status
+
+
+def _executed_bundle(*, failing: bool = False) -> tuple[dict, dict, dict]:
+    _, protocol, snapshot, analysis = _bundle()
+    snapshot["execution_status"] = "complete"
+    snapshot["ethics_review"] = {
+        "status": "approved",
+        "protocol_identifier": "ethics-approval-one",
+        "approved_population": "qualified ACES author and reviewer personas",
+        "approved_data_boundary": "minimized pseudonymous records",
+    }
+    subjects_by_persona: dict[str, list[dict]] = {}
+    for persona in protocol["personas"]:
+        persona_id = persona["persona_id"]
+        subjects_by_persona[persona_id] = []
+        for index in range(persona["minimum_completed_subjects"]):
+            subject = {
+                "subject_id": f"subject-{persona_id}-{index}",
+                "persona_id": persona_id,
+                "experience_band": "qualified",
+                "consent_status": "consented",
+            }
+            subjects_by_persona[persona_id].append(subject)
+            snapshot["subjects"].append(subject)
+
+    tasks_by_id = {task["task_id"]: task for task in protocol["tasks"]}
+    measures = protocol["measures"]
+
+    def append_attempt(subject: dict, task: dict, condition_id: str, variant_id: str) -> None:
+        attempt_number = len(snapshot["attempts"])
+        attempt_id = f"attempt-{attempt_number}"
+        observation_ids: list[str] = []
+        attempt_outcome = (
+            "failed"
+            if failing
+            and any(
+                measure["measure_id"] == "task-completion" and task["task_id"] in measure["task_ids"]
+                for measure in measures
+            )
+            else "completed"
+        )
+        attempt = {
+            "attempt_id": attempt_id,
+            "study_run_id": "study-run-one",
+            "task_id": task["task_id"],
+            "persona_id": subject["persona_id"],
+            "subject_id": subject["subject_id"],
+            "tooling_condition_id": condition_id,
+            "variant_id": variant_id,
+            "outcome": attempt_outcome,
+            "observation_ids": observation_ids,
+            "started_at": "2026-07-15T09:00:00Z",
+            "ended_at": "2026-07-15T10:00:00Z",
+        }
+        snapshot["attempts"].append(attempt)
+        for measure in measures:
+            if task["task_id"] not in measure["task_ids"]:
+                continue
+            declaration = next(
+                item
+                for item in measure["stage_applicability"]
+                if item["task_id"] == task["task_id"] and variant_id in item["variant_ids"]
+            )
+            for artifact_stage in declaration["artifact_stage_ids"]:
+                observation_id = f"observation-{attempt_number}-{measure['measure_id']}-{artifact_stage}"
+                observation_ids.append(observation_id)
+                value = 1 if measure["direction"] == "higher-is-better" else 0
+                if failing and measure["measure_id"] == "task-completion":
+                    value = 0
+                snapshot["observations"].append(
+                    {
+                        "observation_id": observation_id,
+                        "protocol_revision": protocol["revision"],
+                        "study_run_id": attempt["study_run_id"],
+                        "task_id": task["task_id"],
+                        "persona_id": subject["persona_id"],
+                        "subject_id": subject["subject_id"],
+                        "tooling_condition_id": condition_id,
+                        "attempt_id": attempt_id,
+                        "variant_id": variant_id,
+                        "artifact_stage": artifact_stage,
+                        "dimension_ids": [
+                            dimension_id
+                            for dimension_id in measure["dimension_ids"]
+                            if dimension_id in task["dimension_ids"]
+                        ],
+                        "measure_id": measure["measure_id"],
+                        "value": value,
+                        "outcome": attempt_outcome,
+                        "evidence_refs": [],
+                    }
+                )
+        if "review-judgment" in task["artifact_stage_ids"]:
+            reviewer = next(
+                candidate
+                for persona_id in task["persona_ids"]
+                for candidate in subjects_by_persona[persona_id]
+                if candidate["subject_id"] != subject["subject_id"]
+            )
+            snapshot["reviews"].append(
+                {
+                    "review_id": f"review-{attempt_number}",
+                    "attempt_id": attempt_id,
+                    "reviewer_subject_id": reviewer["subject_id"],
+                    "task_id": task["task_id"],
+                    "variant_id": variant_id,
+                    "judgment": "matches sealed intent",
+                    "confidence": 1.0,
+                    "rationale_code": "matches-intent",
+                    "fixed_at": "2026-07-15T10:30:00Z",
+                }
+            )
+
+    for subject in snapshot["subjects"]:
+        for requirement in protocol["execution_plan"]["subject_task_requirements"]:
+            task = next(
+                task
+                for task in protocol["tasks"]
+                if subject["persona_id"] in task["persona_ids"] and task["kind"] in requirement["task_kinds"]
+            )
+            append_attempt(
+                subject,
+                task,
+                task["tooling_condition_ids"][0],
+                task["variant_ids"][0],
+            )
+    for task in tasks_by_id.values():
+        subject = subjects_by_persona[task["persona_ids"][0]][0]
+        for condition_id in task["tooling_condition_ids"]:
+            for variant_id in task["variant_ids"]:
+                append_attempt(subject, task, condition_id, variant_id)
+
+    _refresh_analysis(protocol, snapshot, analysis, "refuted" if failing else "demonstrated")
+    return protocol, snapshot, analysis
+
+
+def _append_valid_disagreement(protocol: dict, snapshot: dict) -> dict:
+    """Add a second independent review and a valid disagreement record."""
+    first_review = snapshot["reviews"][0]
+    attempt = next(item for item in snapshot["attempts"] if item["attempt_id"] == first_review["attempt_id"])
+    task = next(item for item in protocol["tasks"] if item["task_id"] == attempt["task_id"])
+    second_reviewer = next(
+        subject
+        for subject in snapshot["subjects"]
+        if subject["subject_id"] not in {attempt["subject_id"], first_review["reviewer_subject_id"]}
+        and subject["persona_id"] in task["persona_ids"]
+    )
+    second_review = {
+        **first_review,
+        "review_id": f"{first_review['review_id']}-second",
+        "reviewer_subject_id": second_reviewer["subject_id"],
+        "judgment": "does not match sealed intent",
+        "rationale_code": "semantic-mismatch",
+    }
+    snapshot["reviews"].append(second_review)
+    disagreement = {
+        "disagreement_id": f"disagreement-{attempt['attempt_id']}",
+        "review_ids": [first_review["review_id"], second_review["review_id"]],
+        "status": "resolved",
+        "adjudication": "original fixed judgments retained with the adjudication",
+        "originals_preserved": True,
+    }
+    snapshot["disagreements"].append(disagreement)
+    return disagreement
+
+
+def test_current_bundle_passes_with_required_catalogs_and_an_honest_status() -> None:
+    assert evaluate(REPO_ROOT) == []
+
+    _, protocol, snapshot, analysis = _bundle()
+    assert {item["dimension_id"] for item in protocol["dimensions"]} == REQUIRED_DIMENSION_IDS
+    assert {item["persona_id"] for item in protocol["personas"]} == REQUIRED_PERSONA_IDS
+    assert snapshot["execution_status"] == "not_started"
+    assert snapshot["aces_revision"] == "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b"
+    assert analysis["evidence_status"] == "untested"
+
+
+def test_not_started_bundle_cannot_claim_observations_or_demonstration() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    snapshot["attempts"].append({"attempt_id": "fabricated"})
+    analysis["evidence_status"] = "demonstrated"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-not-started-observations",
+        "dsl-evaluation-evidence-status",
+    }.issubset(_rule_ids(failures))
+
+
+def test_protocol_gate_requires_every_issue_dimension_persona_and_task_kind() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["dimensions"] = [item for item in protocol["dimensions"] if item["dimension_id"] != "reviewability"]
+    protocol["thresholds"] = [item for item in protocol["thresholds"] if item["dimension_id"] != "reviewability"]
+    protocol["personas"] = [item for item in protocol["personas"] if item["persona_id"] != "assurance-auditor"]
+    protocol["tasks"] = [item for item in protocol["tasks"] if item["kind"] != "ambiguous"]
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-dimension-coverage",
+        "dsl-evaluation-persona-coverage",
+        "dsl-evaluation-task-kind-coverage",
+    }.issubset(_rule_ids(failures))
+
+
+def test_protocol_gate_rejects_unknown_fields_and_broken_catalog_joins() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["tasks"][0]["backend_hint"] = "private"
+    protocol["tasks"][1]["persona_ids"] = ["missing-persona"]
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-protocol-shape",
+        "dsl-evaluation-task-join",
+    }.issubset(_rule_ids(failures))
+
+
+def test_gate_rejects_unsafe_public_and_claim_evidence_paths() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    snapshot["public_surface"][0]["artifact"] = "../outside.md"
+    analysis["claim"]["evidence_artifacts"][0] = "../outside.json"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-public-surface-path",
+        "dsl-evaluation-claim-evidence-path",
+    }.issubset(_rule_ids(failures))
+
+
+def test_repository_source_locator_must_match_its_pinned_revision() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    source = next(item for item in protocol["sources"] if item["kind"] == "repository-internal")
+    source["locator"] = source["locator"].replace(source["revision"], "0" * 40)
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-source-pin" in _rule_ids(failures)
+
+
+def test_demonstrated_status_requires_preregistered_subject_and_task_coverage() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    snapshot["execution_status"] = "complete"
+    snapshot["ethics_review"]["status"] = "approved"
+    analysis["execution_status"] = "complete"
+    analysis["evidence_status"] = "demonstrated"
+    for result in analysis["dimension_results"]:
+        result.update(
+            {
+                "status": "evaluated",
+                "numerator": 1,
+                "denominator": 1,
+                "value": 1.0,
+                "threshold_result": "pass",
+            }
+        )
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-completion-coverage" in _rule_ids(failures)
+
+
+def test_shape_valid_complete_bundles_support_passing_and_failing_results() -> None:
+    passing_protocol, passing_snapshot, passing_analysis = _executed_bundle()
+    failing_protocol, failing_snapshot, failing_analysis = _executed_bundle(failing=True)
+
+    assert validate_bundle(REPO_ROOT, passing_protocol, passing_snapshot, passing_analysis) == []
+    assert passing_analysis["evidence_status"] == "demonstrated"
+    assert validate_bundle(REPO_ROOT, failing_protocol, failing_snapshot, failing_analysis) == []
+    assert failing_analysis["evidence_status"] == "refuted"
+
+
+def test_opportunity_matrix_rejects_a_self_selected_observation_subset() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    omitted = snapshot["observations"].pop()
+    parent = next(item for item in snapshot["attempts"] if item["attempt_id"] == omitted["attempt_id"])
+    parent["observation_ids"].remove(omitted["observation_id"])
+    _refresh_analysis(protocol, snapshot, analysis, "partial")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+    measure = next(result for result in analysis["measure_results"] if result["measure_id"] == omitted["measure_id"])
+
+    assert "dsl-evaluation-opportunity-coverage" in _rule_ids(failures)
+    assert measure["missing_count"] == 1
+    assert measure["observed_count"] + measure["missing_count"] == measure["denominator"]
+
+
+def test_stage_opportunity_matrix_requires_every_preregistered_artifact_stage() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    omitted = next(
+        observation
+        for observation in snapshot["observations"]
+        if observation["measure_id"] == "untraced-critical-changes"
+        and observation["task_id"] == "author-multihost-experiment"
+        and observation["artifact_stage"] == "compiled"
+    )
+    snapshot["observations"].remove(omitted)
+    parent = next(attempt for attempt in snapshot["attempts"] if attempt["attempt_id"] == omitted["attempt_id"])
+    parent["observation_ids"].remove(omitted["observation_id"])
+    _refresh_analysis(protocol, snapshot, analysis, "partial")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+    measure = next(
+        result for result in analysis["measure_results"] if result["measure_id"] == "untraced-critical-changes"
+    )
+
+    assert "dsl-evaluation-opportunity-coverage" in _rule_ids(failures)
+    assert measure["missing_count"] == 1
+    assert measure["observed_count"] + measure["missing_count"] == measure["denominator"]
+
+
+def test_observation_stage_must_match_measure_stage_applicability() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    observation = next(
+        item
+        for item in snapshot["observations"]
+        if item["measure_id"] == "task-completion" and item["task_id"] == "author-multihost-experiment"
+    )
+    observation["artifact_stage"] = "authored"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-observation-task-join",
+        "dsl-evaluation-opportunity-coverage",
+    }.issubset(_rule_ids(failures))
+
+
+def test_protocol_requires_closed_task_variant_stage_declarations() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["measures"][0]["stage_applicability"].pop()
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-measure-stage-coverage" in _rule_ids(failures)
+
+
+def test_complete_status_requires_each_subjects_preregistered_workload() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    subject = next(
+        item
+        for item in snapshot["subjects"]
+        if item["persona_id"] == "benchmark-designer" and item["subject_id"].endswith("-1")
+    )
+    challenge_kinds = set(protocol["execution_plan"]["subject_task_requirements"][1]["task_kinds"])
+    task_kinds = {task["task_id"]: task["kind"] for task in protocol["tasks"]}
+    removed_attempt_ids = {
+        attempt["attempt_id"]
+        for attempt in snapshot["attempts"]
+        if attempt["subject_id"] == subject["subject_id"] and task_kinds[attempt["task_id"]] in challenge_kinds
+    }
+    snapshot["attempts"] = [
+        attempt for attempt in snapshot["attempts"] if attempt["attempt_id"] not in removed_attempt_ids
+    ]
+    snapshot["observations"] = [
+        observation for observation in snapshot["observations"] if observation["attempt_id"] not in removed_attempt_ids
+    ]
+    snapshot["reviews"] = [review for review in snapshot["reviews"] if review["attempt_id"] not in removed_attempt_ids]
+    _refresh_analysis(protocol, snapshot, analysis, "demonstrated")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-subject-workload" in _rule_ids(failures)
+
+
+def test_protocol_requires_structured_per_subject_task_groups() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["execution_plan"]["subject_task_requirements"].pop()
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-subject-workload-plan" in _rule_ids(failures)
+
+
+def test_execution_graph_rejects_disconnected_parent_and_task_fields() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    observation = snapshot["observations"][0]
+    observation["persona_id"] = "assurance-auditor"
+    observation["artifact_stage"] = "review-judgment"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-observation-parent-join",
+        "dsl-evaluation-observation-task-join",
+    }.issubset(_rule_ids(failures))
+
+
+def test_independent_review_gate_rejects_every_ineligible_reviewer_path() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    baseline = (protocol, snapshot, analysis)
+
+    for case in (
+        "self-review",
+        "withdrawn-reviewer",
+        "ineligible-persona",
+        "task-without-review-stage",
+        "wrong-parent-task",
+        "wrong-parent-variant",
+        "unknown-reviewer",
+    ):
+        protocol, snapshot, analysis = deepcopy(baseline)
+        review = snapshot["reviews"][0]
+        attempt = next(item for item in snapshot["attempts"] if item["attempt_id"] == review["attempt_id"])
+        task = next(item for item in protocol["tasks"] if item["task_id"] == attempt["task_id"])
+
+        if case == "self-review":
+            review["reviewer_subject_id"] = attempt["subject_id"]
+        elif case == "withdrawn-reviewer":
+            reviewer = next(
+                item for item in snapshot["subjects"] if item["subject_id"] == review["reviewer_subject_id"]
+            )
+            reviewer["consent_status"] = "withdrawn"
+        elif case == "ineligible-persona":
+            review["reviewer_subject_id"] = next(
+                item["subject_id"]
+                for item in snapshot["subjects"]
+                if item["subject_id"] != attempt["subject_id"] and item["persona_id"] not in task["persona_ids"]
+            )
+        elif case == "task-without-review-stage":
+            task["artifact_stage_ids"].remove("review-judgment")
+        elif case == "wrong-parent-task":
+            review["task_id"] = next(
+                item["task_id"] for item in protocol["tasks"] if item["task_id"] != task["task_id"]
+            )
+        elif case == "wrong-parent-variant":
+            review["variant_id"] = "different-variant"
+        else:
+            review["reviewer_subject_id"] = "unknown-reviewer"
+
+        failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+        assert "dsl-evaluation-review-join" in _rule_ids(failures), case
+
+
+def test_independent_review_gate_rejects_every_malformed_fixed_judgment_path() -> None:
+    baseline = _executed_bundle()
+
+    for field, invalid_value in (
+        ("judgment", ""),
+        ("confidence", True),
+        ("confidence", "high"),
+        ("confidence", -0.1),
+        ("confidence", 1.1),
+        ("rationale_code", "not a valid rationale id"),
+        ("fixed_at", ""),
+    ):
+        protocol, snapshot, analysis = deepcopy(baseline)
+        snapshot["reviews"][0][field] = invalid_value
+
+        failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+        assert "dsl-evaluation-review-shape" in _rule_ids(failures), (field, invalid_value)
+
+
+def test_disagreements_must_join_distinct_reviews_of_one_parent_attempt() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    disagreement = _append_valid_disagreement(protocol, snapshot)
+    assert validate_bundle(REPO_ROOT, protocol, snapshot, analysis) == []
+
+    other_parent_review = next(
+        review for review in snapshot["reviews"] if review["attempt_id"] != snapshot["reviews"][0]["attempt_id"]
+    )
+    disagreement["review_ids"][1] = other_parent_review["review_id"]
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-disagreement-join" in _rule_ids(failures)
+
+
+def test_disagreement_adjudication_cannot_discard_original_judgments() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    disagreement = _append_valid_disagreement(protocol, snapshot)
+    disagreement["originals_preserved"] = False
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-disagreement-preservation" in _rule_ids(failures)
+
+
+def test_withdrawals_are_excluded_only_through_the_closed_parent_graph() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    withdrawn_subject = snapshot["subjects"][0]
+    withdrawn_subject["consent_status"] = "withdrawn"
+    snapshot["withdrawals"] = [
+        {
+            "subject_id": withdrawn_subject["subject_id"],
+            "recorded_at": "2026-07-15T11:00:00Z",
+            "retained_aggregate_only": True,
+        }
+    ]
+    withdrawn_attempt_ids = {
+        attempt["attempt_id"]
+        for attempt in snapshot["attempts"]
+        if attempt["subject_id"] == withdrawn_subject["subject_id"]
+    }
+    for attempt in snapshot["attempts"]:
+        if attempt["attempt_id"] in withdrawn_attempt_ids:
+            attempt["outcome"] = "withdrawn"
+            attempt["observation_ids"] = []
+    snapshot["observations"] = [
+        observation
+        for observation in snapshot["observations"]
+        if observation["attempt_id"] not in withdrawn_attempt_ids
+    ]
+    snapshot["reviews"] = [
+        review
+        for review in snapshot["reviews"]
+        if review["attempt_id"] not in withdrawn_attempt_ids
+        and review["reviewer_subject_id"] != withdrawn_subject["subject_id"]
+    ]
+    snapshot["execution_status"] = "in_progress"
+    _refresh_analysis(protocol, snapshot, analysis, "partial")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert failures == []
+    assert any(result["withdrawn_count"] > 0 for result in analysis["measure_results"])
+
+
+def test_complete_missing_outcomes_remain_explicit_partial_evidence() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    attempt = next(item for item in snapshot["attempts"] if item["task_id"] == "author-multihost-experiment")
+    attempt["outcome"] = "missing"
+    for observation in snapshot["observations"]:
+        if observation["attempt_id"] != attempt["attempt_id"]:
+            continue
+        observation["outcome"] = "missing"
+        observation["value"] = 0 if observation["measure_id"] == "task-completion" else None
+    _refresh_analysis(protocol, snapshot, analysis, "partial")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert failures == []
+    assert any(result["missing_count"] > 0 for result in analysis["measure_results"])
+    assert any(result["status"] == "incomplete" for result in analysis["measure_results"])
+
+
+def test_evidence_status_is_derived_from_recomputed_dimension_results() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    analysis["evidence_status"] = "refuted"
+    unsupported_refutation = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    snapshot["execution_status"] = "in_progress"
+    _refresh_analysis(protocol, snapshot, analysis, "partial")
+    supported_partial = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+    analysis["evidence_status"] = "untested"
+    unsupported_untested = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-evidence-status" in _rule_ids(unsupported_refutation)
+    assert supported_partial == []
+    assert "dsl-evaluation-evidence-status" in _rule_ids(unsupported_untested)
+
+
+def test_measure_results_are_recomputed_from_frozen_observations() -> None:
+    protocol, snapshot, _ = _executed_bundle()
+    completion_observations = [
+        observation for observation in snapshot["observations"] if observation["measure_id"] == "task-completion"
+    ]
+    for index, observation in enumerate(completion_observations):
+        observation["value"] = index % 2
+
+    results = recompute_measure_results(protocol, snapshot)
+
+    completion = results["task-completion"]
+    assert completion["denominator"] == len(completion_observations)
+    assert completion["observed_count"] == completion["opportunity_count"]
+    assert completion["numerator"] == sum(index % 2 for index in range(len(completion_observations)))
+    assert completion["value"] == completion["numerator"] / completion["denominator"]
+    assert results["semantic-rework-cycles"]["statistic"] == "median"
+    assert results["semantic-rework-cycles"]["value"] == 0.0
+
+
+def test_gate_rejects_stale_measure_results() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    recomputed = recompute_measure_results(protocol, snapshot)
+    analysis["measure_results"] = [
+        {"measure_id": measure_id, "status": "not_evaluated", **result} for measure_id, result in recomputed.items()
+    ]
+    analysis["measure_results"][0]["value"] = 1.0
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-analysis-measure-drift" in _rule_ids(failures)
+
+
+def test_gate_rejects_secret_bearing_source_locators() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["sources"][0]["locator"] = "https://example.test/paper?access_token=secret"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-source-secret" in _rule_ids(failures)
+
+
+def test_shared_json_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    artifact = tmp_path / "duplicate.json"
+    artifact.write_text('{"revision": 1, "revision": 2}\n', encoding="utf-8")
+
+    try:
+        load_bounded_json_object(tmp_path, "duplicate.json", max_bytes=1024)
+    except ValueError as exc:
+        assert "duplicate JSON key 'revision'" in str(exc)
+    else:
+        raise AssertionError("duplicate JSON keys must fail closed")
+
+
+def test_malformed_scalar_fields_fail_closed_without_crashing() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    protocol["sources"][-1]["locator"] = None
+    protocol["tasks"][0]["variant_ids"] = 1
+    snapshot["public_surface"][0]["artifact"] = {"path": "not-text"}
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert {
+        "dsl-evaluation-source-locator",
+        "dsl-evaluation-task-join",
+        "dsl-evaluation-public-surface-path",
+    }.issubset(_rule_ids(failures))
+
+
+def test_dimension_thresholds_are_recomputed_from_measure_results() -> None:
+    _, protocol, _, analysis = _bundle()
+    measure_results = {item["measure_id"]: deepcopy(item) for item in analysis["measure_results"]}
+    for result in measure_results.values():
+        result.update({"status": "evaluated", "denominator": 10, "value": 1.0})
+    measure_results["critical-semantic-errors"]["value"] = 0.0
+    measure_results["semantic-rework-cycles"]["value"] = 1.0
+    for measure_id in (
+        "critical-silent-omissions",
+        "silent-lossy-migrations",
+        "critical-silent-ambiguities",
+        "majority-missed-critical-items",
+        "untraced-critical-changes",
+    ):
+        measure_results[measure_id]["value"] = 0
+
+    passing = recompute_dimension_results(protocol, measure_results)
+    assert all(result["threshold_result"] == "pass" for result in passing.values())
+
+    measure_results["task-completion"]["value"] = 0.5
+    failing = recompute_dimension_results(protocol, measure_results)
+    assert failing["usability-comprehension"]["threshold_result"] == "fail"
+    assert failing["effectiveness-productivity"]["threshold_result"] == "fail"

--- a/noxfile.py
+++ b/noxfile.py
@@ -636,6 +636,10 @@ def _run_contracts(session: nox.Session, reporter: SessionReporter, *args: str) 
         lambda: _run_project_python(session, "tools/check_related_work_comparison.py"),
     )
     reporter.run(
+        "contracts / DSL language-evaluation evidence",
+        lambda: _run_project_python(session, "tools/check_dsl_language_evaluation.py"),
+    )
+    reporter.run(
         "contracts / json artifact validation",
         lambda: _run_project_python(session, "tools/check_json_artifacts.py", *json_artifact_args),
     )

--- a/tools/check_dsl_language_evaluation.py
+++ b/tools/check_dsl_language_evaluation.py
@@ -1,0 +1,2330 @@
+#!/usr/bin/env python3
+"""Validate the preregistered ACES SDL language-evaluation evidence bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from statistics import median
+from urllib.parse import parse_qsl, urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.policy.common import (  # noqa: E402
+    PolicyFailure,
+    load_bounded_json_object,
+    safe_repo_path,
+)
+
+MANIFEST_PATH = "docs/research/dsl-language-evaluation/bundle-manifest.json"
+_MAX_FILE_BYTES = 2 * 1024 * 1024
+_MAX_CATALOG_ITEMS = 128
+_MAX_EXECUTION_RECORDS = 20_000
+
+REQUIRED_DIMENSION_IDS = {
+    "expressiveness",
+    "usability-comprehension",
+    "effectiveness-productivity",
+    "maintainability-evolution",
+    "ambiguity",
+    "diagnostic-quality",
+    "reviewability",
+    "semantic-traceability",
+}
+REQUIRED_PERSONA_IDS = {
+    "benchmark-designer",
+    "scenario-author",
+    "participant-model-author",
+    "backend-implementer",
+    "evaluator-reviewer",
+    "assurance-auditor",
+}
+REQUIRED_TASK_KINDS = {
+    "positive",
+    "negative",
+    "underspecified",
+    "ambiguous",
+    "round-trip",
+    "mutation",
+    "maintenance",
+    "independent-review",
+}
+EVIDENCE_STATUSES = {"untested", "partial", "demonstrated", "refuted"}
+ATTEMPT_OUTCOMES = {"completed", "failed", "abandoned", "tool_failed", "missing", "withdrawn"}
+OBSERVATION_OUTCOMES = {"completed", "failed", "abandoned", "tool_failed", "missing"}
+
+_MANIFEST_KEYS = {
+    "bundle_id",
+    "revision",
+    "protocol_path",
+    "snapshot_path",
+    "analysis_path",
+}
+_PROTOCOL_KEYS = {
+    "protocol_id",
+    "revision",
+    "registered_at",
+    "title",
+    "claim",
+    "research_question",
+    "evidence_status_values",
+    "dimensions",
+    "personas",
+    "tooling_conditions",
+    "artifact_stages",
+    "sources",
+    "tasks",
+    "variants",
+    "measures",
+    "sampling_plan",
+    "execution_plan",
+    "thresholds",
+    "ethics_and_privacy",
+    "disagreement_policy",
+    "validity_threats",
+    "analysis_plan",
+    "amendment_log",
+}
+_DIMENSION_KEYS = {"dimension_id", "label", "construct", "pass_rule", "fail_rule"}
+_PERSONA_KEYS = {"persona_id", "label", "qualification", "minimum_completed_subjects"}
+_CONDITION_KEYS = {"condition_id", "label", "allowed_surface", "assistance"}
+_STAGE_KEYS = {"stage_id", "label", "canonical_entrypoint"}
+_SOURCE_KEYS = {
+    "source_id",
+    "kind",
+    "title",
+    "authors",
+    "year",
+    "locator",
+    "version",
+    "revision",
+    "artifact_path",
+    "primary",
+}
+_TASK_KEYS = {
+    "task_id",
+    "title",
+    "kind",
+    "persona_ids",
+    "dimension_ids",
+    "source_refs",
+    "intended_semantics_ref",
+    "artifact_stage_ids",
+    "tooling_condition_ids",
+    "variant_ids",
+    "success_rule",
+    "failure_rule",
+}
+_VARIANT_KEYS = {"variant_id", "task_id", "kind", "expected_relation", "description"}
+_MEASURE_KEYS = {
+    "measure_id",
+    "task_ids",
+    "dimension_ids",
+    "stage_applicability",
+    "unit",
+    "aggregation",
+    "direction",
+    "capture_rule",
+}
+_STAGE_APPLICABILITY_KEYS = {"task_id", "variant_ids", "artifact_stage_ids"}
+_SAMPLING_KEYS = {
+    "target_total",
+    "minimum_per_persona",
+    "experience_bands",
+    "inclusion_rule",
+    "exclusion_rule",
+}
+_EXECUTION_PLAN_KEYS = {
+    "unit_of_analysis",
+    "attempts_per_subject",
+    "subject_task_requirements",
+    "task_order",
+    "blinding",
+    "stopping_rule",
+    "missing_data_rule",
+    "withdrawal_rule",
+}
+_SUBJECT_TASK_REQUIREMENT_KEYS = {
+    "requirement_id",
+    "minimum_assigned_attempts",
+    "task_kinds",
+}
+_THRESHOLD_KEYS = {"dimension_id", "logic", "conditions"}
+_THRESHOLD_CONDITION_KEYS = {"measure_id", "operator", "target"}
+_ETHICS_KEYS = {
+    "review_status_required",
+    "consent_required",
+    "committed_data_rule",
+    "prohibited_data",
+}
+
+_SNAPSHOT_KEYS = {
+    "snapshot_id",
+    "protocol_revision",
+    "captured_at",
+    "execution_status",
+    "aces_revision",
+    "public_surface",
+    "ethics_review",
+    "subjects",
+    "attempts",
+    "observations",
+    "reviews",
+    "deviations",
+    "withdrawals",
+    "disagreements",
+}
+_SURFACE_KEYS = {"surface_id", "kind", "artifact", "version", "parameters"}
+_ETHICS_REVIEW_KEYS = {
+    "status",
+    "protocol_identifier",
+    "approved_population",
+    "approved_data_boundary",
+}
+_SUBJECT_KEYS = {"subject_id", "persona_id", "experience_band", "consent_status"}
+_ATTEMPT_KEYS = {
+    "attempt_id",
+    "study_run_id",
+    "task_id",
+    "persona_id",
+    "subject_id",
+    "tooling_condition_id",
+    "variant_id",
+    "outcome",
+    "observation_ids",
+    "started_at",
+    "ended_at",
+}
+_OBSERVATION_KEYS = {
+    "observation_id",
+    "protocol_revision",
+    "study_run_id",
+    "task_id",
+    "persona_id",
+    "subject_id",
+    "tooling_condition_id",
+    "attempt_id",
+    "variant_id",
+    "artifact_stage",
+    "dimension_ids",
+    "measure_id",
+    "value",
+    "outcome",
+    "evidence_refs",
+}
+_REVIEW_KEYS = {
+    "review_id",
+    "attempt_id",
+    "reviewer_subject_id",
+    "task_id",
+    "variant_id",
+    "judgment",
+    "confidence",
+    "rationale_code",
+    "fixed_at",
+}
+_DEVIATION_KEYS = {"deviation_id", "scope", "severity", "disposition", "rationale"}
+_WITHDRAWAL_KEYS = {"subject_id", "recorded_at", "retained_aggregate_only"}
+_DISAGREEMENT_KEYS = {
+    "disagreement_id",
+    "review_ids",
+    "status",
+    "adjudication",
+    "originals_preserved",
+}
+
+_ANALYSIS_KEYS = {
+    "analysis_id",
+    "protocol_revision",
+    "snapshot_id",
+    "generated_at",
+    "execution_status",
+    "measure_results",
+    "dimension_results",
+    "evidence_status",
+    "claim",
+    "plain_language_outcome",
+    "limitations",
+}
+_DIMENSION_RESULT_KEYS = {
+    "dimension_id",
+    "status",
+    "threshold_result",
+    "condition_results",
+    "supporting_observation_ids",
+}
+_MEASURE_RESULT_KEYS = {
+    "measure_id",
+    "status",
+    "statistic",
+    "numerator",
+    "denominator",
+    "opportunity_count",
+    "observed_count",
+    "missing_count",
+    "abandoned_count",
+    "tool_failed_count",
+    "withdrawn_count",
+    "value",
+    "supporting_observation_ids",
+}
+_CLAIM_KEYS = {
+    "claim_id",
+    "statement",
+    "threats_to_validity",
+    "falsification_protocol",
+    "objective_pass_criteria",
+    "objective_fail_criteria",
+    "allowed_evidence",
+    "disallowed_evidence",
+    "evidence_artifacts",
+}
+
+_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_SENSITIVE_QUERY_KEYS = {
+    "access_token",
+    "api_key",
+    "apikey",
+    "auth",
+    "authorization",
+    "client_secret",
+    "key",
+    "password",
+    "secret",
+    "sig",
+    "signature",
+    "token",
+}
+
+
+def _failure(rule_id: str, message: str, path: str | None = None) -> PolicyFailure:
+    return PolicyFailure(rule_id, message, path)
+
+
+def _exact_keys(
+    value: object,
+    expected: set[str],
+    failures: list[PolicyFailure],
+    *,
+    rule_id: str,
+    label: str,
+    path: str,
+) -> bool:
+    if not isinstance(value, dict):
+        failures.append(_failure(rule_id, f"{label} must be an object", path))
+        return False
+    actual = set(value)
+    if actual != expected:
+        failures.append(
+            _failure(
+                rule_id,
+                f"{label} fields must exactly match {sorted(expected)}; got {sorted(actual)}",
+                path,
+            )
+        )
+        return False
+    return True
+
+
+def _bounded_list(
+    value: object,
+    limit: int,
+    failures: list[PolicyFailure],
+    *,
+    rule_id: str,
+    label: str,
+    path: str,
+) -> list[object]:
+    if not isinstance(value, list):
+        failures.append(_failure(rule_id, f"{label} must be a list", path))
+        return []
+    if len(value) > limit:
+        failures.append(_failure(rule_id, f"{label} exceeds the {limit}-entry limit", path))
+        return []
+    return value
+
+
+def _valid_id(value: object) -> bool:
+    return isinstance(value, str) and bool(_ID_RE.fullmatch(value))
+
+
+def _bounded_text(value: object, *, maximum: int = 6000) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and len(value) <= maximum
+
+
+def _string_list(value: object, *, non_empty: bool = False) -> list[str] | None:
+    if not isinstance(value, list) or (non_empty and not value):
+        return None
+    if not all(isinstance(item, str) for item in value):
+        return None
+    return value
+
+
+def _record_ids(
+    records: Sequence[object],
+    field: str,
+    failures: list[PolicyFailure],
+    *,
+    rule_id: str,
+    label: str,
+    path: str,
+) -> set[str]:
+    result: set[str] = set()
+    duplicates: set[str] = set()
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        value = record.get(field)
+        if not _valid_id(value):
+            failures.append(_failure(rule_id, f"{label} has invalid {field} {value!r}", path))
+            continue
+        if value in result:
+            duplicates.add(value)
+        result.add(value)
+    if duplicates:
+        failures.append(_failure(rule_id, f"duplicate {label} ids: {sorted(duplicates)}", path))
+    return result
+
+
+def _validate_https_locator(locator: object, failures: list[PolicyFailure], source_id: object) -> None:
+    if not isinstance(locator, str):
+        failures.append(_failure("dsl-evaluation-source-locator", f"{source_id}: locator must be text"))
+        return
+    parsed = urlsplit(locator)
+    if parsed.scheme != "https" or not parsed.netloc:
+        failures.append(
+            _failure(
+                "dsl-evaluation-source-locator",
+                f"{source_id}: locator must be absolute HTTPS",
+            )
+        )
+    if parsed.username is not None or parsed.password is not None:
+        failures.append(
+            _failure(
+                "dsl-evaluation-source-secret",
+                f"{source_id}: locator contains URI userinfo",
+            )
+        )
+    query_keys = {key.casefold() for key, _ in parse_qsl(parsed.query, keep_blank_values=True)}
+    sensitive = sorted(query_keys & _SENSITIVE_QUERY_KEYS)
+    if sensitive:
+        failures.append(
+            _failure(
+                "dsl-evaluation-source-secret",
+                f"{source_id}: locator contains secret-bearing query keys {sensitive}",
+            )
+        )
+
+
+def _protocol_records_by_id(
+    protocol: Mapping[str, object],
+    field: str,
+    id_field: str,
+) -> dict[str, Mapping[str, object]]:
+    records = protocol.get(field, [])
+    if not isinstance(records, list):
+        return {}
+    return {
+        record[id_field]: record
+        for record in records
+        if isinstance(record, Mapping) and isinstance(record.get(id_field), str)
+    }
+
+
+def _measure_stage_ids(
+    measure: Mapping[str, object],
+    task_id: str,
+    variant_id: str,
+) -> list[str]:
+    """Return the single preregistered stage set for a task/variant/measure."""
+
+    declarations = measure.get("stage_applicability", [])
+    if not isinstance(declarations, list):
+        raise ValueError(f"{measure.get('measure_id')}: stage applicability must be a list")
+    matches: list[list[str]] = []
+    for declaration in declarations:
+        if not isinstance(declaration, Mapping) or declaration.get("task_id") != task_id:
+            continue
+        variant_ids = _string_list(declaration.get("variant_ids"), non_empty=True)
+        stage_ids = _string_list(declaration.get("artifact_stage_ids"), non_empty=True)
+        if variant_ids is not None and variant_id in variant_ids and stage_ids is not None:
+            matches.append(stage_ids)
+    if len(matches) != 1:
+        raise ValueError(f"{measure.get('measure_id')}: expected one stage declaration for {task_id}/{variant_id}")
+    return matches[0]
+
+
+def _measure_opportunities(
+    protocol: Mapping[str, object],
+    snapshot: Mapping[str, object],
+) -> tuple[
+    dict[str, Mapping[str, object]],
+    list[tuple[Mapping[str, object], Mapping[str, object], str, bool]],
+    dict[tuple[str, str, str], Mapping[str, object]],
+]:
+    """Derive every attempt-measure-stage opportunity and frozen observation."""
+
+    tasks = _protocol_records_by_id(protocol, "tasks", "task_id")
+    measures = _protocol_records_by_id(protocol, "measures", "measure_id")
+    attempts = snapshot.get("attempts", [])
+    observations = snapshot.get("observations", [])
+    withdrawals = snapshot.get("withdrawals", [])
+    if not isinstance(attempts, list) or not isinstance(observations, list) or not isinstance(withdrawals, list):
+        raise ValueError("snapshot execution records must be lists")
+
+    withdrawn_subjects = {
+        withdrawal["subject_id"]
+        for withdrawal in withdrawals
+        if isinstance(withdrawal, Mapping) and isinstance(withdrawal.get("subject_id"), str)
+    }
+    observation_by_opportunity: dict[tuple[str, str, str], Mapping[str, object]] = {}
+    for observation in observations:
+        if not isinstance(observation, Mapping):
+            continue
+        attempt_id = observation.get("attempt_id")
+        measure_id = observation.get("measure_id")
+        artifact_stage = observation.get("artifact_stage")
+        if not isinstance(attempt_id, str) or not isinstance(measure_id, str) or not isinstance(artifact_stage, str):
+            continue
+        key = (attempt_id, measure_id, artifact_stage)
+        if key in observation_by_opportunity:
+            raise ValueError(f"duplicate observation opportunity {attempt_id}/{measure_id}/{artifact_stage}")
+        observation_by_opportunity[key] = observation
+
+    opportunities: list[tuple[Mapping[str, object], Mapping[str, object], str, bool]] = []
+    expected_keys: set[tuple[str, str, str]] = set()
+    for attempt in attempts:
+        if not isinstance(attempt, Mapping):
+            continue
+        attempt_id = attempt.get("attempt_id")
+        task_id = attempt.get("task_id")
+        subject_id = attempt.get("subject_id")
+        variant_id = attempt.get("variant_id")
+        if not isinstance(attempt_id, str) or not isinstance(task_id, str) or not isinstance(variant_id, str):
+            continue
+        task = tasks.get(task_id)
+        if task is None:
+            continue
+        withdrawn = (isinstance(subject_id, str) and subject_id in withdrawn_subjects) or attempt.get(
+            "outcome"
+        ) == "withdrawn"
+        for measure in measures.values():
+            task_ids = _string_list(measure.get("task_ids"), non_empty=True)
+            if task_ids is None or task_id not in task_ids:
+                continue
+            measure_id = measure.get("measure_id")
+            if not isinstance(measure_id, str):
+                continue
+            for artifact_stage in _measure_stage_ids(measure, task_id, variant_id):
+                opportunities.append((attempt, measure, artifact_stage, withdrawn))
+                expected_keys.add((attempt_id, measure_id, artifact_stage))
+
+    extras = sorted(set(observation_by_opportunity) - expected_keys)
+    if extras:
+        raise ValueError(f"observations without protocol-declared opportunities: {extras[:5]}")
+    return measures, opportunities, observation_by_opportunity
+
+
+def recompute_measure_results(
+    protocol: Mapping[str, object],
+    snapshot: Mapping[str, object],
+) -> dict[str, dict[str, object]]:
+    """Recompute measures from the complete protocol-derived opportunity matrix."""
+
+    measures, opportunities, observation_by_opportunity = _measure_opportunities(protocol, snapshot)
+    results: dict[str, dict[str, object]] = {}
+    for measure_id, measure in measures.items():
+        aggregation = measure.get("aggregation")
+        if aggregation not in {"proportion", "median", "count"}:
+            raise ValueError(f"invalid measure aggregation for {measure_id!r}")
+
+        matching = [item for item in opportunities if item[1].get("measure_id") == measure_id]
+        opportunity_count = len(matching)
+        withdrawn_count = sum(withdrawn for _, _, _, withdrawn in matching)
+        eligible = [(attempt, artifact_stage) for attempt, _, artifact_stage, withdrawn in matching if not withdrawn]
+        denominator = len(eligible)
+        values: list[int | float] = []
+        supporting_ids: list[str] = []
+        missing_count = 0
+        abandoned_count = 0
+        tool_failed_count = 0
+
+        for attempt, artifact_stage in eligible:
+            attempt_id = attempt.get("attempt_id")
+            if not isinstance(attempt_id, str):
+                missing_count += 1
+                continue
+            observation = observation_by_opportunity.get((attempt_id, measure_id, artifact_stage))
+            if observation is None:
+                missing_count += 1
+                continue
+            observation_id = observation.get("observation_id")
+            if not isinstance(observation_id, str):
+                raise ValueError(f"{measure_id}: observations require ids")
+            supporting_ids.append(observation_id)
+            outcome = observation.get("outcome")
+            if outcome == "missing":
+                missing_count += 1
+            elif outcome == "abandoned":
+                abandoned_count += 1
+            elif outcome == "tool_failed":
+                tool_failed_count += 1
+            value = observation.get("value")
+            if value is None:
+                continue
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"{measure_id}: observation values must be numeric or null")
+            if aggregation == "proportion" and value not in {0, 1}:
+                raise ValueError(f"{measure_id}: proportion observations must be 0 or 1")
+            values.append(value)
+
+        observed_count = len(values)
+        numerator: int | float | None = None
+        value: int | float | None = None
+        if denominator > 0 and observed_count == denominator:
+            if aggregation == "proportion":
+                numerator = sum(values)
+                value = numerator / denominator
+            elif aggregation == "median":
+                value = float(median(values))
+            else:
+                numerator = sum(values)
+                value = numerator
+        results[measure_id] = {
+            "statistic": aggregation,
+            "numerator": numerator,
+            "denominator": denominator,
+            "opportunity_count": opportunity_count,
+            "observed_count": observed_count,
+            "missing_count": missing_count,
+            "abandoned_count": abandoned_count,
+            "tool_failed_count": tool_failed_count,
+            "withdrawn_count": withdrawn_count,
+            "value": value,
+            "supporting_observation_ids": supporting_ids,
+        }
+    return results
+
+
+def recompute_dimension_results(
+    protocol: Mapping[str, object],
+    measure_results: Mapping[str, Mapping[str, object]],
+) -> dict[str, dict[str, object]]:
+    """Apply protocol-declared threshold conditions to recomputed measures."""
+
+    operators = {
+        ">=": lambda actual, target: actual >= target,
+        "<=": lambda actual, target: actual <= target,
+        "==": lambda actual, target: actual == target,
+    }
+    results: dict[str, dict[str, object]] = {}
+    for threshold in protocol.get("thresholds", []):
+        if not isinstance(threshold, Mapping):
+            continue
+        dimension_id = threshold.get("dimension_id")
+        conditions = threshold.get("conditions")
+        if (
+            not isinstance(dimension_id, str)
+            or threshold.get("logic") != "all"
+            or not isinstance(conditions, list)
+            or not conditions
+        ):
+            raise ValueError(f"invalid threshold for {dimension_id!r}")
+        resolved: list[tuple[Mapping[str, object], Mapping[str, object]]] = []
+        for condition in conditions:
+            if not isinstance(condition, Mapping):
+                raise ValueError(f"{dimension_id}: threshold condition must be an object")
+            measure_id = condition.get("measure_id")
+            operator = condition.get("operator")
+            target = condition.get("target")
+            measure = measure_results.get(measure_id) if isinstance(measure_id, str) else None
+            if operator not in operators or isinstance(target, bool) or not isinstance(target, (int, float)):
+                raise ValueError(f"{dimension_id}: invalid threshold operator or target")
+            if measure is None:
+                raise ValueError(f"{dimension_id}: threshold references unknown measure {measure_id!r}")
+            resolved.append((condition, measure))
+        if any(measure.get("value") is None for _, measure in resolved):
+            results[dimension_id] = {
+                "status": "not_evaluated",
+                "threshold_result": "not_evaluated",
+                "condition_results": [],
+                "supporting_observation_ids": [],
+            }
+            continue
+        condition_results: list[dict[str, object]] = []
+        supporting_ids: list[str] = []
+        for condition, measure in resolved:
+            actual = measure["value"]
+            operator = condition["operator"]
+            target = condition["target"]
+            if isinstance(actual, bool) or not isinstance(actual, (int, float)):
+                raise ValueError(f"{dimension_id}: measure value must be numeric")
+            passed = operators[operator](actual, target)
+            condition_results.append(
+                {
+                    "measure_id": condition["measure_id"],
+                    "operator": operator,
+                    "target": target,
+                    "actual": actual,
+                    "passed": passed,
+                }
+            )
+            refs = measure.get("supporting_observation_ids", [])
+            if not isinstance(refs, list) or not all(isinstance(item, str) for item in refs):
+                raise ValueError(f"{dimension_id}: measure observation refs must be text ids")
+            for observation_id in refs:
+                if observation_id not in supporting_ids:
+                    supporting_ids.append(observation_id)
+        results[dimension_id] = {
+            "status": "evaluated",
+            "threshold_result": "pass" if all(item["passed"] for item in condition_results) else "fail",
+            "condition_results": condition_results,
+            "supporting_observation_ids": supporting_ids,
+        }
+    return results
+
+
+def _validate_protocol(
+    repo_root: Path,
+    protocol: dict[str, object],
+    failures: list[PolicyFailure],
+) -> dict[str, set[str]]:
+    path = "docs/research/dsl-language-evaluation/protocol-v1.json"
+    if not _exact_keys(
+        protocol,
+        _PROTOCOL_KEYS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="protocol",
+        path=path,
+    ):
+        return {}
+
+    dimensions = _bounded_list(
+        protocol["dimensions"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="dimensions",
+        path=path,
+    )
+    personas = _bounded_list(
+        protocol["personas"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="personas",
+        path=path,
+    )
+    conditions = _bounded_list(
+        protocol["tooling_conditions"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="tooling_conditions",
+        path=path,
+    )
+    stages = _bounded_list(
+        protocol["artifact_stages"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="artifact_stages",
+        path=path,
+    )
+    sources = _bounded_list(
+        protocol["sources"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="sources",
+        path=path,
+    )
+    tasks = _bounded_list(
+        protocol["tasks"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="tasks",
+        path=path,
+    )
+    variants = _bounded_list(
+        protocol["variants"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="variants",
+        path=path,
+    )
+    measures = _bounded_list(
+        protocol["measures"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="measures",
+        path=path,
+    )
+    thresholds = _bounded_list(
+        protocol["thresholds"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="thresholds",
+        path=path,
+    )
+
+    dimension_ids = _record_ids(
+        dimensions,
+        "dimension_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="dimension",
+        path=path,
+    )
+    persona_ids = _record_ids(
+        personas,
+        "persona_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="persona",
+        path=path,
+    )
+    condition_ids = _record_ids(
+        conditions,
+        "condition_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="tooling condition",
+        path=path,
+    )
+    stage_ids = _record_ids(
+        stages,
+        "stage_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="artifact stage",
+        path=path,
+    )
+    source_ids = _record_ids(
+        sources,
+        "source_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="source",
+        path=path,
+    )
+    task_ids = _record_ids(
+        tasks,
+        "task_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="task",
+        path=path,
+    )
+    variant_ids = _record_ids(
+        variants,
+        "variant_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="variant",
+        path=path,
+    )
+    measure_ids = _record_ids(
+        measures,
+        "measure_id",
+        failures,
+        rule_id="dsl-evaluation-protocol-id",
+        label="measure",
+        path=path,
+    )
+
+    if not REQUIRED_DIMENSION_IDS.issubset(dimension_ids):
+        failures.append(
+            _failure(
+                "dsl-evaluation-dimension-coverage",
+                f"missing required dimensions: {sorted(REQUIRED_DIMENSION_IDS - dimension_ids)}",
+                path,
+            )
+        )
+    if not REQUIRED_PERSONA_IDS.issubset(persona_ids):
+        failures.append(
+            _failure(
+                "dsl-evaluation-persona-coverage",
+                f"missing required personas: {sorted(REQUIRED_PERSONA_IDS - persona_ids)}",
+                path,
+            )
+        )
+    if protocol["evidence_status_values"] != [
+        "untested",
+        "partial",
+        "demonstrated",
+        "refuted",
+    ]:
+        failures.append(
+            _failure(
+                "dsl-evaluation-status-vocabulary",
+                "evidence statuses must preserve ADR-021 order and vocabulary",
+                path,
+            )
+        )
+
+    for index, record in enumerate(dimensions):
+        _exact_keys(
+            record,
+            _DIMENSION_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"dimensions[{index}]",
+            path=path,
+        )
+    for index, record in enumerate(personas):
+        if not _exact_keys(
+            record,
+            _PERSONA_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"personas[{index}]",
+            path=path,
+        ):
+            continue
+        if not isinstance(record["minimum_completed_subjects"], int) or record["minimum_completed_subjects"] < 1:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-sampling-plan",
+                    f"{record['persona_id']}: minimum_completed_subjects must be positive",
+                    path,
+                )
+            )
+    for index, record in enumerate(conditions):
+        _exact_keys(
+            record,
+            _CONDITION_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"tooling_conditions[{index}]",
+            path=path,
+        )
+    for index, record in enumerate(stages):
+        _exact_keys(
+            record,
+            _STAGE_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"artifact_stages[{index}]",
+            path=path,
+        )
+
+    for index, source in enumerate(sources):
+        if not _exact_keys(
+            source,
+            _SOURCE_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"sources[{index}]",
+            path=path,
+        ):
+            continue
+        source_id = source["source_id"]
+        _validate_https_locator(source["locator"], failures, source_id)
+        if source["primary"] is not True:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-source-primary",
+                    f"{source_id}: source must be primary",
+                    path,
+                )
+            )
+        if source["kind"] == "repository-internal":
+            revision = source["revision"]
+            artifact_path = source["artifact_path"]
+            if not isinstance(revision, str) or not _SHA_RE.fullmatch(revision):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-source-pin",
+                        f"{source_id}: invalid Git revision",
+                        path,
+                    )
+                )
+            elif isinstance(source["locator"], str) and revision not in source["locator"]:
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-source-pin",
+                        f"{source_id}: locator does not bind the declared Git revision",
+                        path,
+                    )
+                )
+            if not isinstance(artifact_path, str):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-source-path",
+                        f"{source_id}: missing artifact path",
+                        path,
+                    )
+                )
+            else:
+                resolved = safe_repo_path(repo_root, artifact_path)
+                if resolved is None or not resolved.exists():
+                    failures.append(
+                        _failure(
+                            "dsl-evaluation-source-path",
+                            f"{source_id}: unsafe or missing path",
+                            path,
+                        )
+                    )
+        elif source["revision"] is not None or source["artifact_path"] is not None:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-source-shape",
+                    f"{source_id}: publication must not claim a repository revision/path",
+                    path,
+                )
+            )
+
+    task_kinds: set[str] = set()
+    variants_by_task: dict[str, set[str]] = {task_id: set() for task_id in task_ids}
+    for index, variant in enumerate(variants):
+        if not _exact_keys(
+            variant,
+            _VARIANT_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"variants[{index}]",
+            path=path,
+        ):
+            continue
+        task_id = variant["task_id"]
+        if not isinstance(task_id, str) or task_id not in task_ids:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-variant-join",
+                    f"{variant['variant_id']}: unknown task",
+                    path,
+                )
+            )
+        else:
+            variant_id = variant["variant_id"]
+            if isinstance(variant_id, str):
+                variants_by_task[task_id].add(variant_id)
+    for index, task in enumerate(tasks):
+        if not _exact_keys(
+            task,
+            _TASK_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"tasks[{index}]",
+            path=path,
+        ):
+            continue
+        task_id = task["task_id"]
+        if not isinstance(task_id, str):
+            failures.append(_failure("dsl-evaluation-protocol-id", "task id must be text", path))
+            continue
+        task_kind = task["kind"]
+        if isinstance(task_kind, str):
+            task_kinds.add(task_kind)
+        else:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-task-kind-coverage",
+                    f"{task_id}: task kind must be text",
+                    path,
+                )
+            )
+        joins = (
+            ("persona_ids", persona_ids),
+            ("dimension_ids", dimension_ids),
+            ("source_refs", source_ids),
+            ("artifact_stage_ids", stage_ids),
+            ("tooling_condition_ids", condition_ids),
+            ("variant_ids", variant_ids),
+        )
+        for field, allowed in joins:
+            values = task[field]
+            value_ids = _string_list(values, non_empty=True)
+            if value_ids is None or not set(value_ids).issubset(allowed):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-task-join",
+                        f"{task_id}: invalid or empty {field}",
+                        path,
+                    )
+                )
+        task_variant_ids = task["variant_ids"]
+        valid_task_variant_ids = _string_list(task_variant_ids)
+        if valid_task_variant_ids is not None and set(valid_task_variant_ids) != variants_by_task.get(task_id, set()):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-task-variant-coverage",
+                    f"{task_id}: task and variant catalogs disagree",
+                    path,
+                )
+            )
+    if not REQUIRED_TASK_KINDS.issubset(task_kinds):
+        failures.append(
+            _failure(
+                "dsl-evaluation-task-kind-coverage",
+                f"missing required task kinds: {sorted(REQUIRED_TASK_KINDS - task_kinds)}",
+                path,
+            )
+        )
+
+    tasks_by_id = _protocol_records_by_id(protocol, "tasks", "task_id")
+    for index, measure in enumerate(measures):
+        if not _exact_keys(
+            measure,
+            _MEASURE_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"measures[{index}]",
+            path=path,
+        ):
+            continue
+        measure_dimensions = _string_list(measure["dimension_ids"], non_empty=True)
+        if measure_dimensions is None or not set(measure_dimensions).issubset(dimension_ids):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-measure-join",
+                    f"{measure['measure_id']}: invalid dimension ids",
+                    path,
+                )
+            )
+        measure_tasks = _string_list(measure["task_ids"], non_empty=True)
+        if measure_tasks is None or not set(measure_tasks).issubset(task_ids):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-measure-join",
+                    f"{measure['measure_id']}: invalid task ids",
+                    path,
+                )
+            )
+        elif not all(
+            set(measure_dimensions or []) & set(task["dimension_ids"])
+            for task in tasks
+            if isinstance(task, Mapping)
+            and task.get("task_id") in measure_tasks
+            and _string_list(task.get("dimension_ids"), non_empty=True) is not None
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-measure-join",
+                    f"{measure['measure_id']}: task applicability must share a measured dimension",
+                    path,
+                )
+            )
+        applicability = _bounded_list(
+            measure["stage_applicability"],
+            _MAX_CATALOG_ITEMS,
+            failures,
+            rule_id="dsl-evaluation-measure-stage-applicability",
+            label=f"measures[{index}].stage_applicability",
+            path=path,
+        )
+        actual_stage_pairs: set[tuple[str, str]] = set()
+        duplicate_stage_pairs: set[tuple[str, str]] = set()
+        for applicability_index, declaration in enumerate(applicability):
+            if not _exact_keys(
+                declaration,
+                _STAGE_APPLICABILITY_KEYS,
+                failures,
+                rule_id="dsl-evaluation-measure-stage-applicability",
+                label=(f"measures[{index}].stage_applicability[{applicability_index}]"),
+                path=path,
+            ):
+                continue
+            task_id = declaration["task_id"]
+            task = tasks_by_id.get(task_id) if isinstance(task_id, str) else None
+            declaration_variants = _string_list(declaration["variant_ids"], non_empty=True)
+            declaration_stages = _string_list(declaration["artifact_stage_ids"], non_empty=True)
+            task_variants = (
+                set(_string_list(task.get("variant_ids"), non_empty=True) or []) if task is not None else set()
+            )
+            task_stages = (
+                set(_string_list(task.get("artifact_stage_ids"), non_empty=True) or []) if task is not None else set()
+            )
+            if (
+                task is None
+                or measure_tasks is None
+                or task_id not in measure_tasks
+                or declaration_variants is None
+                or not set(declaration_variants).issubset(task_variants)
+                or declaration_stages is None
+                or not set(declaration_stages).issubset(task_stages)
+            ):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-measure-stage-applicability",
+                        f"{measure['measure_id']}: invalid task, variant, or stage applicability",
+                        path,
+                    )
+                )
+                continue
+            for variant_id in declaration_variants:
+                pair = (task_id, variant_id)
+                if pair in actual_stage_pairs:
+                    duplicate_stage_pairs.add(pair)
+                actual_stage_pairs.add(pair)
+        expected_stage_pairs = {
+            (task_id, variant_id)
+            for task_id in (measure_tasks or [])
+            for variant_id in (_string_list(tasks_by_id.get(task_id, {}).get("variant_ids"), non_empty=True) or [])
+        }
+        if actual_stage_pairs != expected_stage_pairs or duplicate_stage_pairs:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-measure-stage-coverage",
+                    f"{measure['measure_id']}: every task/variant requires one stage declaration",
+                    path,
+                )
+            )
+    threshold_ids = _record_ids(
+        thresholds,
+        "dimension_id",
+        failures,
+        rule_id="dsl-evaluation-threshold-id",
+        label="threshold",
+        path=path,
+    )
+    for index, threshold in enumerate(thresholds):
+        if not _exact_keys(
+            threshold,
+            _THRESHOLD_KEYS,
+            failures,
+            rule_id="dsl-evaluation-protocol-shape",
+            label=f"thresholds[{index}]",
+            path=path,
+        ):
+            continue
+        conditions = _bounded_list(
+            threshold["conditions"],
+            16,
+            failures,
+            rule_id="dsl-evaluation-threshold-shape",
+            label=f"thresholds[{index}].conditions",
+            path=path,
+        )
+        if threshold["logic"] != "all" or not conditions:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-threshold-shape",
+                    f"{threshold['dimension_id']}: threshold requires non-empty all conditions",
+                    path,
+                )
+            )
+        for condition_index, condition in enumerate(conditions):
+            if not _exact_keys(
+                condition,
+                _THRESHOLD_CONDITION_KEYS,
+                failures,
+                rule_id="dsl-evaluation-threshold-shape",
+                label=f"thresholds[{index}].conditions[{condition_index}]",
+                path=path,
+            ):
+                continue
+            if (
+                not isinstance(condition["measure_id"], str)
+                or condition["measure_id"] not in measure_ids
+                or not isinstance(condition["operator"], str)
+                or condition["operator"] not in {">=", "<=", "=="}
+                or isinstance(condition["target"], bool)
+                or not isinstance(condition["target"], (int, float))
+            ):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-threshold-join",
+                        f"{threshold['dimension_id']}: invalid measure, operator, or target",
+                        path,
+                    )
+                )
+    if threshold_ids != dimension_ids:
+        failures.append(
+            _failure(
+                "dsl-evaluation-threshold-coverage",
+                "every dimension requires exactly one preregistered threshold",
+                path,
+            )
+        )
+
+    if _exact_keys(
+        protocol["sampling_plan"],
+        _SAMPLING_KEYS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="sampling_plan",
+        path=path,
+    ):
+        sampling = protocol["sampling_plan"]
+        minimum = sampling["minimum_per_persona"]
+        target = sampling["target_total"]
+        if not isinstance(minimum, int) or minimum < 1 or not isinstance(target, int):
+            failures.append(_failure("dsl-evaluation-sampling-plan", "invalid sample sizes", path))
+        elif target < minimum * len(REQUIRED_PERSONA_IDS):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-sampling-plan",
+                    "target_total cannot cover the required per-persona minimum",
+                    path,
+                )
+            )
+    if _exact_keys(
+        protocol["execution_plan"],
+        _EXECUTION_PLAN_KEYS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="execution_plan",
+        path=path,
+    ):
+        execution_plan = protocol["execution_plan"]
+        requirements = _bounded_list(
+            execution_plan["subject_task_requirements"],
+            16,
+            failures,
+            rule_id="dsl-evaluation-subject-workload-plan",
+            label="execution_plan.subject_task_requirements",
+            path=path,
+        )
+        requirement_ids = _record_ids(
+            requirements,
+            "requirement_id",
+            failures,
+            rule_id="dsl-evaluation-subject-workload-plan",
+            label="subject task requirement",
+            path=path,
+        )
+        declared_kinds: set[str] = set()
+        duplicate_kinds: set[str] = set()
+        for index, requirement in enumerate(requirements):
+            if not _exact_keys(
+                requirement,
+                _SUBJECT_TASK_REQUIREMENT_KEYS,
+                failures,
+                rule_id="dsl-evaluation-subject-workload-plan",
+                label=f"execution_plan.subject_task_requirements[{index}]",
+                path=path,
+            ):
+                continue
+            task_kind_values = _string_list(requirement["task_kinds"], non_empty=True)
+            minimum = requirement["minimum_assigned_attempts"]
+            if (
+                task_kind_values is None
+                or not set(task_kind_values).issubset(REQUIRED_TASK_KINDS)
+                or isinstance(minimum, bool)
+                or not isinstance(minimum, int)
+                or minimum < 1
+            ):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-subject-workload-plan",
+                        f"{requirement['requirement_id']}: invalid task kinds or minimum",
+                        path,
+                    )
+                )
+                continue
+            overlap = declared_kinds & set(task_kind_values)
+            duplicate_kinds.update(overlap)
+            declared_kinds.update(task_kind_values)
+            for persona_id in persona_ids:
+                if not any(
+                    task.get("kind") in task_kind_values
+                    and persona_id in (_string_list(task.get("persona_ids"), non_empty=True) or [])
+                    for task in tasks_by_id.values()
+                ):
+                    failures.append(
+                        _failure(
+                            "dsl-evaluation-subject-workload-plan",
+                            f"{requirement['requirement_id']}: no eligible task for {persona_id}",
+                            path,
+                        )
+                    )
+        if not requirement_ids or declared_kinds != REQUIRED_TASK_KINDS or duplicate_kinds:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-subject-workload-plan",
+                    "subject task requirements must partition every required task kind",
+                    path,
+                )
+            )
+    _exact_keys(
+        protocol["ethics_and_privacy"],
+        _ETHICS_KEYS,
+        failures,
+        rule_id="dsl-evaluation-protocol-shape",
+        label="ethics_and_privacy",
+        path=path,
+    )
+    if not protocol["validity_threats"] or not protocol["analysis_plan"]:
+        failures.append(
+            _failure(
+                "dsl-evaluation-preregistration",
+                "validity threats and the analysis plan must be preregistered",
+                path,
+            )
+        )
+    if not isinstance(protocol["amendment_log"], list):
+        failures.append(_failure("dsl-evaluation-protocol-shape", "amendment_log must be a list", path))
+    return {
+        "dimension_ids": dimension_ids,
+        "persona_ids": persona_ids,
+        "condition_ids": condition_ids,
+        "stage_ids": stage_ids,
+        "task_ids": task_ids,
+        "variant_ids": variant_ids,
+        "measure_ids": measure_ids,
+    }
+
+
+def _validate_snapshot(
+    repo_root: Path,
+    protocol: Mapping[str, object],
+    snapshot: dict[str, object],
+    catalogs: Mapping[str, set[str]],
+    failures: list[PolicyFailure],
+) -> set[str]:
+    path = "docs/research/dsl-language-evaluation/execution-snapshot-v1.json"
+    if not _exact_keys(
+        snapshot,
+        _SNAPSHOT_KEYS,
+        failures,
+        rule_id="dsl-evaluation-snapshot-shape",
+        label="snapshot",
+        path=path,
+    ):
+        return set()
+    if snapshot["protocol_revision"] != protocol.get("revision"):
+        failures.append(_failure("dsl-evaluation-snapshot-join", "protocol revision mismatch", path))
+    if not isinstance(snapshot["aces_revision"], str) or not _SHA_RE.fullmatch(snapshot["aces_revision"]):
+        failures.append(
+            _failure(
+                "dsl-evaluation-snapshot-pin",
+                "ACES revision must be full Git SHA",
+                path,
+            )
+        )
+    if snapshot["execution_status"] not in {"not_started", "in_progress", "complete"}:
+        failures.append(_failure("dsl-evaluation-snapshot-status", "invalid execution status", path))
+
+    surfaces = _bounded_list(
+        snapshot["public_surface"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-snapshot-shape",
+        label="public_surface",
+        path=path,
+    )
+    _record_ids(
+        surfaces,
+        "surface_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="public surface",
+        path=path,
+    )
+    for index, surface in enumerate(surfaces):
+        if not _exact_keys(
+            surface,
+            _SURFACE_KEYS,
+            failures,
+            rule_id="dsl-evaluation-snapshot-shape",
+            label=f"public_surface[{index}]",
+            path=path,
+        ):
+            continue
+        artifact = surface["artifact"]
+        resolved = safe_repo_path(repo_root, artifact) if isinstance(artifact, str) else None
+        if resolved is None or not resolved.exists():
+            failures.append(
+                _failure(
+                    "dsl-evaluation-public-surface-path",
+                    f"{surface['surface_id']}: unsafe or missing artifact",
+                    path,
+                )
+            )
+    _exact_keys(
+        snapshot["ethics_review"],
+        _ETHICS_REVIEW_KEYS,
+        failures,
+        rule_id="dsl-evaluation-snapshot-shape",
+        label="ethics_review",
+        path=path,
+    )
+
+    record_fields = {
+        "subjects": _SUBJECT_KEYS,
+        "attempts": _ATTEMPT_KEYS,
+        "observations": _OBSERVATION_KEYS,
+        "reviews": _REVIEW_KEYS,
+        "deviations": _DEVIATION_KEYS,
+        "withdrawals": _WITHDRAWAL_KEYS,
+        "disagreements": _DISAGREEMENT_KEYS,
+    }
+    records: dict[str, list[object]] = {}
+    for field, keys in record_fields.items():
+        records[field] = _bounded_list(
+            snapshot[field],
+            _MAX_EXECUTION_RECORDS,
+            failures,
+            rule_id="dsl-evaluation-snapshot-shape",
+            label=field,
+            path=path,
+        )
+        for index, record in enumerate(records[field]):
+            _exact_keys(
+                record,
+                keys,
+                failures,
+                rule_id="dsl-evaluation-snapshot-shape",
+                label=f"{field}[{index}]",
+                path=path,
+            )
+    if snapshot["execution_status"] == "not_started":
+        populated = sorted(field for field, value in records.items() if value)
+        if populated:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-not-started-observations",
+                    f"not-started snapshot contains execution records: {populated}",
+                    path,
+                )
+            )
+        ethics = snapshot["ethics_review"]
+        if isinstance(ethics, Mapping) and ethics.get("status") not in {
+            "pending",
+            "not_required",
+        }:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-ethics-state",
+                    "not-started snapshot must remain pending or explicitly not-required",
+                    path,
+                )
+            )
+        return set()
+
+    subjects = records["subjects"]
+    attempts = records["attempts"]
+    observations = records["observations"]
+    reviews = records["reviews"]
+    withdrawals = records["withdrawals"]
+    tasks = _protocol_records_by_id(protocol, "tasks", "task_id")
+    variants = _protocol_records_by_id(protocol, "variants", "variant_id")
+    measures = _protocol_records_by_id(protocol, "measures", "measure_id")
+
+    _record_ids(
+        subjects,
+        "subject_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="subject",
+        path=path,
+    )
+    attempt_ids = _record_ids(
+        attempts,
+        "attempt_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="attempt",
+        path=path,
+    )
+    observation_ids = _record_ids(
+        observations,
+        "observation_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="observation",
+        path=path,
+    )
+    review_ids = _record_ids(
+        reviews,
+        "review_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="review",
+        path=path,
+    )
+    withdrawal_subject_ids = _record_ids(
+        withdrawals,
+        "subject_id",
+        failures,
+        rule_id="dsl-evaluation-snapshot-id",
+        label="withdrawal",
+        path=path,
+    )
+
+    subjects_by_id = {
+        subject["subject_id"]: subject
+        for subject in subjects
+        if isinstance(subject, Mapping) and set(subject) == _SUBJECT_KEYS and isinstance(subject.get("subject_id"), str)
+    }
+    for subject_id, subject in subjects_by_id.items():
+        if subject.get("persona_id") not in catalogs.get("persona_ids", set()):
+            failures.append(_failure("dsl-evaluation-subject-join", f"{subject_id}: unknown persona", path))
+        if subject.get("consent_status") not in {"consented", "withdrawn"}:
+            failures.append(_failure("dsl-evaluation-consent-status", f"{subject_id}: invalid consent status", path))
+        if not _bounded_text(subject.get("experience_band"), maximum=200):
+            failures.append(_failure("dsl-evaluation-subject-shape", f"{subject_id}: invalid experience band", path))
+    declared_withdrawn_subjects = {
+        subject_id for subject_id, subject in subjects_by_id.items() if subject.get("consent_status") == "withdrawn"
+    }
+    if withdrawal_subject_ids != declared_withdrawn_subjects:
+        failures.append(
+            _failure(
+                "dsl-evaluation-withdrawal-join",
+                "withdrawal records must exactly match subjects with withdrawn consent",
+                path,
+            )
+        )
+    for withdrawal in withdrawals:
+        if not isinstance(withdrawal, Mapping) or set(withdrawal) != _WITHDRAWAL_KEYS:
+            continue
+        if (
+            not _bounded_text(withdrawal.get("recorded_at"), maximum=100)
+            or withdrawal.get("retained_aggregate_only") is not True
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-withdrawal-shape",
+                    f"{withdrawal.get('subject_id')}: withdrawal must retain aggregate counts only",
+                    path,
+                )
+            )
+
+    attempts_by_id: dict[str, Mapping[str, object]] = {}
+    for attempt in attempts:
+        if not isinstance(attempt, Mapping) or set(attempt) != _ATTEMPT_KEYS:
+            continue
+        attempt_id = attempt.get("attempt_id")
+        if not isinstance(attempt_id, str):
+            continue
+        attempts_by_id[attempt_id] = attempt
+        task_id = attempt.get("task_id")
+        task = tasks.get(task_id) if isinstance(task_id, str) else None
+        subject_id = attempt.get("subject_id")
+        subject = subjects_by_id.get(subject_id) if isinstance(subject_id, str) else None
+        outcome = attempt.get("outcome")
+        if outcome not in ATTEMPT_OUTCOMES:
+            failures.append(_failure("dsl-evaluation-attempt-outcome", f"{attempt_id}: invalid outcome", path))
+        if task is None or subject is None:
+            failures.append(_failure("dsl-evaluation-attempt-join", f"{attempt_id}: unknown task or subject", path))
+            continue
+        task_personas = _string_list(task.get("persona_ids"), non_empty=True) or []
+        task_conditions = _string_list(task.get("tooling_condition_ids"), non_empty=True) or []
+        task_variants = _string_list(task.get("variant_ids"), non_empty=True) or []
+        if (
+            attempt.get("persona_id") != subject.get("persona_id")
+            or attempt.get("persona_id") not in task_personas
+            or attempt.get("tooling_condition_id") not in task_conditions
+            or attempt.get("variant_id") not in task_variants
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-attempt-join",
+                    f"{attempt_id}: subject, persona, task, condition, or variant mismatch",
+                    path,
+                )
+            )
+        variant = variants.get(attempt.get("variant_id"))
+        if variant is None or variant.get("task_id") != task_id:
+            failures.append(
+                _failure("dsl-evaluation-attempt-join", f"{attempt_id}: variant belongs to another task", path)
+            )
+        withdrawn = subject_id in withdrawal_subject_ids
+        if withdrawn != (outcome == "withdrawn"):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-withdrawal-join",
+                    f"{attempt_id}: withdrawn subject and attempt outcome disagree",
+                    path,
+                )
+            )
+        if not _valid_id(attempt.get("study_run_id")):
+            failures.append(_failure("dsl-evaluation-attempt-identity", f"{attempt_id}: invalid study run id", path))
+        if not _bounded_text(attempt.get("started_at"), maximum=100) or not _bounded_text(
+            attempt.get("ended_at"), maximum=100
+        ):
+            failures.append(_failure("dsl-evaluation-attempt-identity", f"{attempt_id}: timestamps must be text", path))
+        if _string_list(attempt.get("observation_ids")) is None:
+            failures.append(
+                _failure("dsl-evaluation-attempt-observation-join", f"{attempt_id}: invalid observation ids", path)
+            )
+
+    observations_by_opportunity: dict[tuple[str, str, str], Mapping[str, object]] = {}
+    child_observations: dict[str, set[str]] = {attempt_id: set() for attempt_id in attempt_ids}
+    for observation in observations:
+        if not isinstance(observation, Mapping) or set(observation) != _OBSERVATION_KEYS:
+            continue
+        observation_id = observation.get("observation_id")
+        attempt_id = observation.get("attempt_id")
+        measure_id = observation.get("measure_id")
+        artifact_stage = observation.get("artifact_stage")
+        if (
+            not isinstance(observation_id, str)
+            or not isinstance(attempt_id, str)
+            or not isinstance(measure_id, str)
+            or not isinstance(artifact_stage, str)
+        ):
+            failures.append(
+                _failure("dsl-evaluation-observation-identity", "observation identity fields must be text", path)
+            )
+            continue
+        opportunity = (attempt_id, measure_id, artifact_stage)
+        if opportunity in observations_by_opportunity:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-identity",
+                    f"duplicate attempt-measure-stage observation at {observation_id}",
+                    path,
+                )
+            )
+        observations_by_opportunity[opportunity] = observation
+        child_observations.setdefault(attempt_id, set()).add(observation_id)
+        attempt = attempts_by_id.get(attempt_id)
+        measure = measures.get(measure_id)
+        task = tasks.get(observation.get("task_id"))
+        if attempt is None or measure is None or task is None:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-join",
+                    f"{observation_id}: unknown parent attempt, task, or measure",
+                    path,
+                )
+            )
+            continue
+        parent_fields = (
+            "study_run_id",
+            "task_id",
+            "persona_id",
+            "subject_id",
+            "tooling_condition_id",
+            "variant_id",
+            "outcome",
+        )
+        if observation.get("protocol_revision") != protocol.get("revision") or any(
+            observation.get(field) != attempt.get(field) for field in parent_fields
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-parent-join",
+                    f"{observation_id}: observation does not match its parent attempt",
+                    path,
+                )
+            )
+        task_stages = _string_list(task.get("artifact_stage_ids"), non_empty=True) or []
+        measure_tasks = _string_list(measure.get("task_ids"), non_empty=True) or []
+        task_dimensions = set(_string_list(task.get("dimension_ids"), non_empty=True) or [])
+        measure_dimensions = set(_string_list(measure.get("dimension_ids"), non_empty=True) or [])
+        expected_dimensions = task_dimensions & measure_dimensions
+        observation_dimensions = _string_list(observation.get("dimension_ids"), non_empty=True)
+        parent_task_id = attempt.get("task_id")
+        parent_variant_id = attempt.get("variant_id")
+        try:
+            applicable_stages = (
+                _measure_stage_ids(measure, parent_task_id, parent_variant_id)
+                if isinstance(parent_task_id, str) and isinstance(parent_variant_id, str)
+                else []
+            )
+        except ValueError:
+            applicable_stages = []
+        if (
+            artifact_stage not in task_stages
+            or artifact_stage not in applicable_stages
+            or observation.get("task_id") not in measure_tasks
+            or observation_dimensions is None
+            or set(observation_dimensions) != expected_dimensions
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-task-join",
+                    f"{observation_id}: stage, measure, or dimensions are not declared for the task",
+                    path,
+                )
+            )
+        outcome = observation.get("outcome")
+        value = observation.get("value")
+        if outcome not in OBSERVATION_OUTCOMES:
+            failures.append(_failure("dsl-evaluation-observation-outcome", f"{observation_id}: invalid outcome", path))
+        if measure_id == "task-completion":
+            expected_value = 1 if outcome == "completed" else 0
+            valid_value = value == expected_value and not isinstance(value, bool)
+        elif outcome in {"completed", "failed"}:
+            valid_value = not isinstance(value, bool) and isinstance(value, (int, float))
+        else:
+            valid_value = value is None
+        if not valid_value:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-value",
+                    f"{observation_id}: value does not represent its attempt outcome",
+                    path,
+                )
+            )
+        refs = _string_list(observation.get("evidence_refs"))
+        if refs is None or any(safe_repo_path(repo_root, ref) is None for ref in refs):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-observation-evidence",
+                    f"{observation_id}: evidence refs must be repository-confined paths",
+                    path,
+                )
+            )
+
+    expected_opportunities: set[tuple[str, str, str]] = set()
+    withdrawn_opportunities: set[tuple[str, str, str]] = set()
+    for attempt_id, attempt in attempts_by_id.items():
+        task_id = attempt.get("task_id")
+        variant_id = attempt.get("variant_id")
+        for measure_id, measure in measures.items():
+            measure_tasks = _string_list(measure.get("task_ids"), non_empty=True) or []
+            if task_id not in measure_tasks or not isinstance(task_id, str) or not isinstance(variant_id, str):
+                continue
+            try:
+                applicable_stages = _measure_stage_ids(measure, task_id, variant_id)
+            except ValueError:
+                continue
+            for artifact_stage in applicable_stages:
+                opportunity = (attempt_id, measure_id, artifact_stage)
+                if attempt.get("outcome") == "withdrawn":
+                    withdrawn_opportunities.add(opportunity)
+                else:
+                    expected_opportunities.add(opportunity)
+    actual_opportunities = set(observations_by_opportunity)
+    if actual_opportunities != expected_opportunities or actual_opportunities & withdrawn_opportunities:
+        failures.append(
+            _failure(
+                "dsl-evaluation-opportunity-coverage",
+                "observations must exactly cover every non-withdrawn protocol-declared attempt-measure-stage opportunity",
+                path,
+            )
+        )
+    for attempt_id, attempt in attempts_by_id.items():
+        stored_ids = _string_list(attempt.get("observation_ids"))
+        if stored_ids is not None and set(stored_ids) != child_observations.get(attempt_id, set()):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-attempt-observation-join",
+                    f"{attempt_id}: observation ids do not match child records",
+                    path,
+                )
+            )
+
+    reviews_by_attempt: Counter[str] = Counter()
+    for review in reviews:
+        if not isinstance(review, Mapping) or set(review) != _REVIEW_KEYS:
+            continue
+        review_id = review.get("review_id")
+        attempt_id = review.get("attempt_id")
+        attempt = attempts_by_id.get(attempt_id) if isinstance(attempt_id, str) else None
+        reviewer_id = review.get("reviewer_subject_id")
+        reviewer = subjects_by_id.get(reviewer_id) if isinstance(reviewer_id, str) else None
+        if attempt is None or reviewer is None:
+            failures.append(_failure("dsl-evaluation-review-join", f"{review_id}: unknown attempt or reviewer", path))
+            continue
+        task = tasks.get(attempt.get("task_id"))
+        task_stages = _string_list(task.get("artifact_stage_ids"), non_empty=True) if task else None
+        task_personas = _string_list(task.get("persona_ids"), non_empty=True) if task else None
+        if (
+            review.get("task_id") != attempt.get("task_id")
+            or review.get("variant_id") != attempt.get("variant_id")
+            or reviewer_id == attempt.get("subject_id")
+            or reviewer.get("consent_status") != "consented"
+            or task_stages is None
+            or "review-judgment" not in task_stages
+            or task_personas is None
+            or reviewer.get("persona_id") not in task_personas
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-review-join",
+                    f"{review_id}: review does not match an eligible independent reviewer and parent task",
+                    path,
+                )
+            )
+        if (
+            not _bounded_text(review.get("judgment"), maximum=500)
+            or isinstance(review.get("confidence"), bool)
+            or not isinstance(review.get("confidence"), (int, float))
+            or not 0 <= review["confidence"] <= 1
+            or not _valid_id(review.get("rationale_code"))
+            or not _bounded_text(review.get("fixed_at"), maximum=100)
+        ):
+            failures.append(_failure("dsl-evaluation-review-shape", f"{review_id}: invalid fixed judgment", path))
+        reviews_by_attempt[attempt_id] += 1
+
+    for disagreement in records["disagreements"]:
+        if not isinstance(disagreement, Mapping) or set(disagreement) != _DISAGREEMENT_KEYS:
+            continue
+        disagreement_review_ids = _string_list(disagreement["review_ids"], non_empty=True)
+        linked_reviews = [
+            review
+            for review in reviews
+            if isinstance(review, Mapping)
+            and disagreement_review_ids is not None
+            and review.get("review_id") in disagreement_review_ids
+        ]
+        linked_attempts = {review.get("attempt_id") for review in linked_reviews}
+        if (
+            disagreement_review_ids is None
+            or len(disagreement_review_ids) < 2
+            or not set(disagreement_review_ids).issubset(review_ids)
+            or len(linked_attempts) != 1
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-disagreement-join",
+                    f"{disagreement['disagreement_id']}: reviews must share one parent attempt",
+                    path,
+                )
+            )
+        if disagreement["originals_preserved"] is not True:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-disagreement-preservation",
+                    f"{disagreement['disagreement_id']}: originals must be preserved",
+                    path,
+                )
+            )
+
+    if snapshot["execution_status"] == "complete":
+        nonwithdrawn_subject_ids = {
+            subject_id for subject_id, subject in subjects_by_id.items() if subject.get("consent_status") == "consented"
+        }
+        active_subject_ids = {
+            subject_id
+            for subject_id in nonwithdrawn_subject_ids
+            if any(
+                attempt.get("subject_id") == subject_id and attempt.get("outcome") != "withdrawn"
+                for attempt in attempts_by_id.values()
+            )
+        }
+        persona_minimums = {
+            item["persona_id"]: item["minimum_completed_subjects"]
+            for item in protocol.get("personas", [])
+            if isinstance(item, Mapping)
+            and isinstance(item.get("persona_id"), str)
+            and isinstance(item.get("minimum_completed_subjects"), int)
+        }
+        persona_counts = Counter(subjects_by_id[subject_id]["persona_id"] for subject_id in active_subject_ids)
+        missing_personas = sorted(
+            persona_id for persona_id, minimum in persona_minimums.items() if persona_counts[persona_id] < minimum
+        )
+        expected_task_shapes = {
+            (task["task_id"], condition_id, variant_id)
+            for task in tasks.values()
+            for condition_id in (_string_list(task.get("tooling_condition_ids"), non_empty=True) or [])
+            for variant_id in (_string_list(task.get("variant_ids"), non_empty=True) or [])
+        }
+        actual_task_shapes = {
+            (attempt.get("task_id"), attempt.get("tooling_condition_id"), attempt.get("variant_id"))
+            for attempt in attempts_by_id.values()
+            if attempt.get("outcome") != "withdrawn"
+        }
+        review_required_attempts = {
+            attempt_id
+            for attempt_id, attempt in attempts_by_id.items()
+            if "review-judgment"
+            in (_string_list(tasks.get(attempt.get("task_id"), {}).get("artifact_stage_ids"), non_empty=True) or [])
+            and attempt.get("outcome") != "withdrawn"
+        }
+        sampling_plan = protocol.get("sampling_plan", {})
+        target_total = sampling_plan.get("target_total") if isinstance(sampling_plan, Mapping) else None
+        ethics = snapshot["ethics_review"]
+        ethics_approved = isinstance(ethics, Mapping) and ethics.get("status") == "approved"
+        execution_plan = protocol.get("execution_plan", {})
+        subject_task_requirements = (
+            execution_plan.get("subject_task_requirements", []) if isinstance(execution_plan, Mapping) else []
+        )
+        missing_subject_workloads: list[tuple[str, str]] = []
+        if isinstance(subject_task_requirements, list):
+            for subject_id in nonwithdrawn_subject_ids:
+                subject_attempts = [
+                    attempt
+                    for attempt in attempts_by_id.values()
+                    if attempt.get("subject_id") == subject_id and attempt.get("outcome") != "withdrawn"
+                ]
+                for requirement in subject_task_requirements:
+                    if not isinstance(requirement, Mapping):
+                        continue
+                    task_kind_values = _string_list(requirement.get("task_kinds"), non_empty=True)
+                    minimum = requirement.get("minimum_assigned_attempts")
+                    requirement_id = requirement.get("requirement_id")
+                    if (
+                        task_kind_values is None
+                        or not isinstance(minimum, int)
+                        or isinstance(minimum, bool)
+                        or not isinstance(requirement_id, str)
+                    ):
+                        continue
+                    assigned = sum(
+                        tasks.get(attempt.get("task_id"), {}).get("kind") in task_kind_values
+                        for attempt in subject_attempts
+                    )
+                    if assigned < minimum:
+                        missing_subject_workloads.append((subject_id, requirement_id))
+        if missing_subject_workloads:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-subject-workload",
+                    "complete execution does not satisfy every active subject's assigned task groups",
+                    path,
+                )
+            )
+        if (
+            not ethics_approved
+            or missing_personas
+            or not isinstance(target_total, int)
+            or len(active_subject_ids) < target_total
+            or not expected_task_shapes.issubset(actual_task_shapes)
+            or any(reviews_by_attempt[attempt_id] == 0 for attempt_id in review_required_attempts)
+            or missing_subject_workloads
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-completion-coverage",
+                    "complete execution lacks approved ethics, subject workload/minima, task/condition/variant coverage, or required independent reviews",
+                    path,
+                )
+            )
+    return observation_ids
+
+
+def _validate_analysis(
+    repo_root: Path,
+    protocol: Mapping[str, object],
+    snapshot: Mapping[str, object],
+    analysis: dict[str, object],
+    catalogs: Mapping[str, set[str]],
+    observation_ids: set[str],
+    failures: list[PolicyFailure],
+) -> None:
+    path = "docs/research/dsl-language-evaluation/analysis-v1.json"
+    if not _exact_keys(
+        analysis,
+        _ANALYSIS_KEYS,
+        failures,
+        rule_id="dsl-evaluation-analysis-shape",
+        label="analysis",
+        path=path,
+    ):
+        return
+    if analysis["protocol_revision"] != protocol.get("revision"):
+        failures.append(_failure("dsl-evaluation-analysis-join", "protocol revision mismatch", path))
+    if analysis["snapshot_id"] != snapshot.get("snapshot_id"):
+        failures.append(_failure("dsl-evaluation-analysis-join", "snapshot id mismatch", path))
+    if analysis["execution_status"] != snapshot.get("execution_status"):
+        failures.append(_failure("dsl-evaluation-analysis-join", "execution status mismatch", path))
+    if analysis["evidence_status"] not in EVIDENCE_STATUSES:
+        failures.append(_failure("dsl-evaluation-evidence-status", "invalid evidence status", path))
+
+    measure_results = _bounded_list(
+        analysis["measure_results"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-analysis-shape",
+        label="measure_results",
+        path=path,
+    )
+    measure_result_ids = _record_ids(
+        measure_results,
+        "measure_id",
+        failures,
+        rule_id="dsl-evaluation-analysis-id",
+        label="measure result",
+        path=path,
+    )
+    if measure_result_ids != catalogs.get("measure_ids", set()):
+        failures.append(
+            _failure(
+                "dsl-evaluation-analysis-measure-coverage",
+                "analysis must contain one result for every protocol measure",
+                path,
+            )
+        )
+    try:
+        recomputed_measures = recompute_measure_results(protocol, snapshot)
+    except ValueError as exc:
+        failures.append(_failure("dsl-evaluation-observation-value", str(exc), path))
+        recomputed_measures = {}
+    for index, result in enumerate(measure_results):
+        if not _exact_keys(
+            result,
+            _MEASURE_RESULT_KEYS,
+            failures,
+            rule_id="dsl-evaluation-analysis-shape",
+            label=f"measure_results[{index}]",
+            path=path,
+        ):
+            continue
+        expected = recomputed_measures.get(result["measure_id"])
+        if expected and expected["denominator"] == 0:
+            expected_status = "not_evaluated"
+        elif expected and expected["observed_count"] != expected["denominator"]:
+            expected_status = "incomplete"
+        else:
+            expected_status = "evaluated"
+        if expected is None or result != {
+            "measure_id": result["measure_id"],
+            "status": expected_status,
+            **expected,
+        }:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-analysis-measure-drift",
+                    f"{result['measure_id']}: stored aggregate does not match frozen observations",
+                    path,
+                )
+            )
+
+    try:
+        recomputed_dimensions = recompute_dimension_results(protocol, recomputed_measures)
+    except ValueError as exc:
+        failures.append(_failure("dsl-evaluation-threshold-evaluation", str(exc), path))
+        recomputed_dimensions = {}
+
+    results = _bounded_list(
+        analysis["dimension_results"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-analysis-shape",
+        label="dimension_results",
+        path=path,
+    )
+    result_ids = _record_ids(
+        results,
+        "dimension_id",
+        failures,
+        rule_id="dsl-evaluation-analysis-id",
+        label="dimension result",
+        path=path,
+    )
+    if result_ids != catalogs.get("dimension_ids", set()):
+        failures.append(
+            _failure(
+                "dsl-evaluation-analysis-dimension-coverage",
+                "analysis must contain one result for every protocol dimension",
+                path,
+            )
+        )
+    for index, result in enumerate(results):
+        if not _exact_keys(
+            result,
+            _DIMENSION_RESULT_KEYS,
+            failures,
+            rule_id="dsl-evaluation-analysis-shape",
+            label=f"dimension_results[{index}]",
+            path=path,
+        ):
+            continue
+        refs = _string_list(result["supporting_observation_ids"])
+        if refs is None or not set(refs).issubset(observation_ids):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-analysis-observation-join",
+                    f"{result['dimension_id']}: unknown supporting observations",
+                    path,
+                )
+            )
+        expected_dimension = recomputed_dimensions.get(result["dimension_id"])
+        if expected_dimension is None or result != {
+            "dimension_id": result["dimension_id"],
+            **expected_dimension,
+        }:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-analysis-dimension-drift",
+                    f"{result['dimension_id']}: stored threshold result does not match recomputed measures",
+                    path,
+                )
+            )
+
+    claim = analysis["claim"]
+    if _exact_keys(
+        claim,
+        _CLAIM_KEYS,
+        failures,
+        rule_id="dsl-evaluation-analysis-shape",
+        label="claim",
+        path=path,
+    ):
+        evidence_artifacts = claim["evidence_artifacts"]
+        if not isinstance(evidence_artifacts, list) or len(evidence_artifacts) != 3:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-evidence",
+                    "claim must name protocol, snapshot, and analysis artifacts",
+                    path,
+                )
+            )
+        else:
+            for artifact in evidence_artifacts:
+                resolved = safe_repo_path(repo_root, artifact) if isinstance(artifact, str) else None
+                if resolved is None or not resolved.is_file():
+                    failures.append(
+                        _failure(
+                            "dsl-evaluation-claim-evidence-path",
+                            f"unsafe or missing claim evidence artifact {artifact!r}",
+                            path,
+                        )
+                    )
+    status = analysis["evidence_status"]
+    if snapshot.get("execution_status") == "not_started":
+        if status != "untested":
+            failures.append(
+                _failure(
+                    "dsl-evaluation-evidence-status",
+                    "not-started execution must remain untested",
+                    path,
+                )
+            )
+        for result in results:
+            if not isinstance(result, Mapping):
+                continue
+            expected = {
+                "status": "not_evaluated",
+                "threshold_result": "not_evaluated",
+                "condition_results": [],
+                "supporting_observation_ids": [],
+            }
+            if any(result.get(field) != value for field, value in expected.items()):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-not-started-analysis",
+                        f"{result.get('dimension_id')}: not-started result contains derived evidence",
+                        path,
+                    )
+                )
+    dimension_values = list(recomputed_dimensions.values())
+    all_pass = set(recomputed_dimensions) == catalogs.get("dimension_ids", set()) and all(
+        result.get("status") == "evaluated" and result.get("threshold_result") == "pass" for result in dimension_values
+    )
+    any_fail = any(
+        result.get("status") == "evaluated" and result.get("threshold_result") == "fail" for result in dimension_values
+    )
+    unresolved = any(
+        isinstance(item, Mapping) and item.get("status") == "unresolved" for item in snapshot.get("disagreements", [])
+    )
+    invalidating_deviation = any(
+        isinstance(item, Mapping) and item.get("severity") == "invalidating" for item in snapshot.get("deviations", [])
+    )
+    execution_complete = snapshot.get("execution_status") == "complete"
+    qualifies_demonstrated = execution_complete and all_pass and not unresolved and not invalidating_deviation
+    qualifies_refuted = execution_complete and any_fail
+    execution_records_present = any(
+        isinstance(snapshot.get(field), list) and bool(snapshot[field])
+        for field in ("subjects", "attempts", "observations", "reviews", "deviations", "withdrawals")
+    )
+    if status == "demonstrated" and not qualifies_demonstrated:
+        failures.append(
+            _failure(
+                "dsl-evaluation-evidence-status",
+                "demonstrated requires complete all-pass results without unresolved critical disagreement or invalidating deviation",
+                path,
+            )
+        )
+    elif status == "refuted" and not qualifies_refuted:
+        failures.append(
+            _failure(
+                "dsl-evaluation-evidence-status",
+                "refuted requires a complete execution with at least one recomputed dimension failure",
+                path,
+            )
+        )
+    elif status == "partial" and (
+        snapshot.get("execution_status") == "not_started"
+        or not execution_records_present
+        or qualifies_demonstrated
+        or qualifies_refuted
+    ):
+        failures.append(
+            _failure(
+                "dsl-evaluation-evidence-status",
+                "partial requires relevant execution evidence that is not yet a demonstrated or refuted result",
+                path,
+            )
+        )
+    elif status == "untested" and snapshot.get("execution_status") != "not_started":
+        failures.append(
+            _failure(
+                "dsl-evaluation-evidence-status",
+                "untested is reserved for a not-started execution without evidence records",
+                path,
+            )
+        )
+
+
+def validate_bundle(
+    repo_root: Path,
+    protocol: dict[str, object],
+    snapshot: dict[str, object],
+    analysis: dict[str, object],
+) -> list[PolicyFailure]:
+    """Validate closed shapes, preregistration, joins, and evidence-status honesty."""
+
+    failures: list[PolicyFailure] = []
+    catalogs = _validate_protocol(repo_root, protocol, failures)
+    observation_ids = _validate_snapshot(repo_root, protocol, snapshot, catalogs, failures)
+    _validate_analysis(repo_root, protocol, snapshot, analysis, catalogs, observation_ids, failures)
+    return failures
+
+
+def load_bundle(
+    repo_root: Path = REPO_ROOT,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object], dict[str, object]]:
+    manifest = load_bounded_json_object(repo_root, MANIFEST_PATH, max_bytes=_MAX_FILE_BYTES)
+    if set(manifest) != _MANIFEST_KEYS:
+        raise ValueError(
+            f"{MANIFEST_PATH!r} fields must exactly match {sorted(_MANIFEST_KEYS)}; got {sorted(manifest)}"
+        )
+    paths: list[str] = []
+    for field in ("protocol_path", "snapshot_path", "analysis_path"):
+        value = manifest[field]
+        if not isinstance(value, str) or safe_repo_path(repo_root, value) is None:
+            raise ValueError(f"{MANIFEST_PATH!r} contains unsafe {field}")
+        paths.append(value)
+    protocol, snapshot, analysis = (
+        load_bounded_json_object(repo_root, path, max_bytes=_MAX_FILE_BYTES) for path in paths
+    )
+    return manifest, protocol, snapshot, analysis
+
+
+def evaluate(repo_root: Path = REPO_ROOT) -> list[PolicyFailure]:
+    try:
+        _, protocol, snapshot, analysis = load_bundle(repo_root)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return [_failure("dsl-evaluation-bundle-invalid", str(exc), MANIFEST_PATH)]
+    return validate_bundle(repo_root, protocol, snapshot, analysis)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit failures as JSON")
+    args = parser.parse_args()
+    failures = evaluate(REPO_ROOT)
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "rule_id": failure.rule_id,
+                        "message": failure.message,
+                        "path": failure.path,
+                    }
+                    for failure in failures
+                ],
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for failure in failures:
+            print(failure.render())
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_related_work_comparison.py
+++ b/tools/check_related_work_comparison.py
@@ -15,7 +15,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.policy.common import PolicyFailure, safe_repo_path  # noqa: E402
+from tools.policy.common import (  # noqa: E402
+    PolicyFailure,
+    load_bounded_json_object,
+    safe_repo_path,
+)
 
 PROTOCOL_PATH = "docs/research/related-work-comparison/protocol-v1.json"
 SNAPSHOT_PATH = "docs/research/related-work-comparison/extraction-snapshot-2026-07-13.json"
@@ -226,33 +230,8 @@ _MAX_OBSERVATIONS = 4096
 _MEASURE_BY_SCORE = {0: "absent", 1: "limited", 2: "substantial", 3: "strong"}
 
 
-class _DuplicateKeyError(ValueError):
-    pass
-
-
 def _failure(rule_id: str, message: str, path: str | None = None) -> PolicyFailure:
     return PolicyFailure(rule_id, message, path)
-
-
-def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
-    result: dict[str, object] = {}
-    for key, value in pairs:
-        if key in result:
-            raise _DuplicateKeyError(f"duplicate JSON key {key!r}")
-        result[key] = value
-    return result
-
-
-def _load_json(repo_root: Path, rel_path: str) -> dict[str, object]:
-    path = safe_repo_path(repo_root, rel_path)
-    if path is None or not path.is_file():
-        raise ValueError(f"missing or unsafe repository artifact {rel_path!r}")
-    if path.stat().st_size > _MAX_FILE_BYTES:
-        raise ValueError(f"{rel_path!r} exceeds the {_MAX_FILE_BYTES}-byte limit")
-    payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_object_without_duplicates)
-    if not isinstance(payload, dict):
-        raise ValueError(f"{rel_path!r} must contain a JSON object")
-    return payload
 
 
 def load_bundle(
@@ -261,9 +240,9 @@ def load_bundle(
     """Load the three frozen bundle artifacts with strict duplicate-key handling."""
 
     return (
-        _load_json(repo_root, PROTOCOL_PATH),
-        _load_json(repo_root, SNAPSHOT_PATH),
-        _load_json(repo_root, ANALYSIS_PATH),
+        load_bounded_json_object(repo_root, PROTOCOL_PATH, max_bytes=_MAX_FILE_BYTES),
+        load_bounded_json_object(repo_root, SNAPSHOT_PATH, max_bytes=_MAX_FILE_BYTES),
+        load_bounded_json_object(repo_root, ANALYSIS_PATH, max_bytes=_MAX_FILE_BYTES),
     )
 
 

--- a/tools/policy/common.py
+++ b/tools/policy/common.py
@@ -52,6 +52,37 @@ def safe_repo_path(repo_root: Path, rel_path: str) -> Path | None:
     return resolved
 
 
+def load_bounded_json_object(
+    repo_root: Path,
+    rel_path: str,
+    *,
+    max_bytes: int,
+) -> dict[str, object]:
+    """Load one repository JSON object with containment, size, and duplicate-key checks."""
+
+    path = safe_repo_path(repo_root, rel_path)
+    if path is None or not path.is_file():
+        raise ValueError(f"missing or unsafe repository artifact {rel_path!r}")
+    if path.stat().st_size > max_bytes:
+        raise ValueError(f"{rel_path!r} exceeds the {max_bytes}-byte limit")
+
+    def object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key {key!r}")
+            result[key] = value
+        return result
+
+    payload = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=object_without_duplicates,
+    )
+    if not isinstance(payload, dict):
+        raise ValueError(f"{rel_path!r} must contain a JSON object")
+    return payload
+
+
 def run_git(args: list[str], repo_root: Path = REPO_ROOT) -> str:
     proc = subprocess.run(
         ["git", *args],
@@ -72,7 +103,10 @@ def changed_paths(
     if staged:
         output = run_git(["diff", "--name-only", "--diff-filter=d", "--cached"], repo_root=repo_root)
     elif base_rev:
-        output = run_git(["diff", "--name-only", "--diff-filter=d", base_rev, "HEAD"], repo_root=repo_root)
+        output = run_git(
+            ["diff", "--name-only", "--diff-filter=d", base_rev, "HEAD"],
+            repo_root=repo_root,
+        )
     else:
         output = run_git(["diff", "--name-only", "--diff-filter=d", "HEAD"], repo_root=repo_root)
     return [line.strip() for line in output.splitlines() if line.strip()]
@@ -123,7 +157,10 @@ def apply_exceptions(
                 continue
             if entry.get("rule_id") != failure.rule_id:
                 continue
-            if requirement_uid and entry.get("requirement_uid") not in {None, requirement_uid}:
+            if requirement_uid and entry.get("requirement_uid") not in {
+                None,
+                requirement_uid,
+            }:
                 continue
             match_paths = entry.get("paths") or []
             if failure.path and match_paths and not path_matches_any(failure.path, match_paths):
@@ -137,7 +174,14 @@ def apply_exceptions(
 
 def failures_to_json(failures: list[PolicyFailure]) -> str:
     return json.dumps(
-        [{"rule_id": failure.rule_id, "message": failure.message, "path": failure.path} for failure in failures],
+        [
+            {
+                "rule_id": failure.rule_id,
+                "message": failure.message,
+                "path": failure.path,
+            }
+            for failure in failures
+        ],
         indent=2,
         sort_keys=True,
     )


### PR DESCRIPTION
## Summary

Adds a preregistered, falsifiable DSL language-evaluation evidence bundle and an offline structural gate that prevents adequacy claims until the declared study graph, measures, thresholds, artifact stages, and status transitions are internally consistent.

## Requirement UIDs

- `ASR-530`

## Related Issues

Closes #346

## ADR Impact

- ADR-021

## Changes

- Add a versioned human-evaluation protocol, unstarted execution snapshot, analysis surface, and research index covering eight evaluation dimensions, six personas, task diversity, ethics, disagreement handling, and explicit pass/fail criteria.
- Add a bounded offline checker that closes the protocol and execution artifacts into a validated relational graph, recomputes measures and thresholds, enforces per-stage coverage, and blocks unsupported demonstrated claims.
- Add comprehensive positive and negative regression coverage, wire the checker into the Nox contracts phase, and reuse a shared bounded JSON loader in the related-work checker.
- Follow repository release-please policy: feature PRs do not add changelog fragments or edit CHANGELOG.md.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Passed the canonical Nox verify session (policy, lint, contracts, full pytest, integration tests, and Sphinx build), the 28-test focused DSL-evaluation suite, and all-files pre-commit.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-530 ← docs/research/dsl-language-evaluation/, ASR-530 ← tools/check_dsl_language_evaluation.py
- TESTS: ASR-530 ← implementations/python/tests/test_dsl_language_evaluation.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog is managed by release-please; no fragment added per `.gc/plan-rules.md`.
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.


