### PR TITLE
docs: design deterministic scenario trial realization

### DIFF
--- a/docs/decisions/adrs/README.md
+++ b/docs/decisions/adrs/README.md
@@ -128,6 +128,7 @@ adr-080-revision-pinned-sdl-lineage-and-provenance-ledger
 adr-081-behavioral-relation-taxonomy-and-claim-discipline
 adr-082-authored-identity-domain-topology
 adr-083-participant-tool-decision-surface-and-exposure-semantics
+adr-084-scenario-variation-and-deterministic-trial-realization
 ```
 
 | ADR | Title | Status | Date |
@@ -202,7 +203,7 @@ adr-083-participant-tool-decision-surface-and-exposure-semantics
 | [067](adr-067-participant-behavior-model.md) | Participant Behavior Model | proposed | 2026-06-23 |
 | [068](adr-068-experiment-trials-replication-and-replay-claims.md) | Experiment Trials, Replication, and Replay Claims | accepted | 2026-06-25 |
 | [069](adr-069-cage-2-replication-architecture.md) | CAGE-2 Replication Architecture | accepted | 2026-07-01 |
-| [070](adr-070-realization-envelope-semantics.md) | Realization Envelope Semantics | proposed | 2026-07-04 |
+| [070](adr-070-realization-envelope-semantics.md) | Realization Envelope Semantics | accepted | 2026-07-04 |
 | [071](adr-071-reusable-asset-trust-and-integrity-policy.md) | Reusable Asset Trust and Integrity Policy | accepted | 2026-07-05 |
 | [072](adr-072-validation-and-admission-profiles.md) | Validation and Admission Profiles | proposed | 2026-07-05 |
 | [073](adr-073-scoring-reward-language-scope.md) | Scoring and Reward Language Scope in the SDL | accepted | 2026-07-05 |
@@ -216,3 +217,4 @@ adr-083-participant-tool-decision-surface-and-exposure-semantics
 | [081](adr-081-behavioral-relation-taxonomy-and-claim-discipline.md) | Behavioral-Relation Taxonomy And Claim Discipline | accepted | 2026-07-13 |
 | [082](adr-082-authored-identity-domain-topology.md) | Authored Identity-Domain Topology | accepted | 2026-07-13 |
 | [083](adr-083-participant-tool-decision-surface-and-exposure-semantics.md) | Participant Tool, Decision-Surface, and Exposure Semantics | proposed | 2026-07-14 |
+| [084](adr-084-scenario-variation-and-deterministic-trial-realization.md) | Scenario Variation And Deterministic Trial Realization | accepted | 2026-07-15 |

--- a/docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
+++ b/docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
@@ -68,6 +68,20 @@ The existing task/run validator remains the semantic gate for task identity,
 scenario snapshot compatibility, apparatus constraints, declared metrics, and
 evidence requirements.
 
+### 2a. An admitted plan preallocates the archival run identity
+
+ADR-084 introduces an admitted trial plan as immutable pre-execution intent.
+Each plan entry deterministically preallocates the `run_id` that
+`experiment-run-v1` uses if execution starts. The plan entry is not a second
+trial or run record: it has no actual timestamps, observed apparatus, evidence,
+results, deviations, or execution status.
+
+An idempotent transport retry before execution reuses the preallocated id. A
+genuine re-execution uses a new explicit replicate/execution coordinate, is
+admitted again, and receives a distinct run id. Plan ids, scheduler job ids,
+operation ids, runtime snapshot ids, and backend-native ids remain distinct
+from run identity.
+
 ### 3. Replication and controlled variation are study allocation semantics
 
 Replication, cohort, benchmark, comparison, and controlled-variation claims
@@ -88,6 +102,12 @@ apparatus context, selected manifests, capability declarations, measurement
 channels, task or scenario snapshot identity, non-opaque parameters, and
 stochastic controls. It must not depend on free-form tags, opaque `other`
 parameters, runtime metadata, audit blobs, or backend-private logs.
+
+ADR-084 further clarifies the pre-run boundary: typed experiment selection and
+allocation policies choose members of an SDL scenario family and bind them to
+logical trial coordinates. The admitted plan preserves those selections and
+factor assignments. SDL family validity, experiment selection, backend
+realizability, and scheduler placement remain separate authorities.
 
 ### 4. Replay support is claim support, not replay execution
 
@@ -127,6 +147,8 @@ evidence content.
 ## Required Boundaries
 
 - Trial identity is run identity.
+- A plan entry may preallocate that run identity, but is not itself an archival
+  run or a second trial identity.
 - Repetition is a set of distinct run records, not a mutation of one run.
 - Replication and controlled variation are study allocation facts, not tags.
 - Replay support is the preserved claim-support graph, not guaranteed
@@ -148,6 +170,11 @@ Issue #105 is satisfied by this ADR, the experiment-core formal specification,
 the preflight guardrail notes for EXP-706 and EXP-712, and the
 EXP-706/EXP-712 clause matrix in
 `docs/research/experiment-core/traceability-matrix-exp-706-712.md`.
+
+ADR-084 and
+`specs/formal/scenario-variation-trial-realization/README.md` constrain future
+producers that preallocate run ids and preserve selection/plan lineage; they do
+not replace the existing executable run/study validators.
 
 Existing executable gates already enforce the load-bearing clauses:
 
@@ -224,3 +251,9 @@ recalculation require separate producer and control-plane work.
 - Study authors may try to infer replication from repeated operations without
   publishing run records and study allocation. Validators and review guidance
   must continue to reject those shortcuts.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-07-15 | #652 | Clarified that an admitted plan entry preallocates the existing archival run identity and preserves experiment-owned selection without becoming a second trial/run record. |

--- a/docs/decisions/adrs/adr-070-realization-envelope-semantics.md
+++ b/docs/decisions/adrs/adr-070-realization-envelope-semantics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Date
 
@@ -19,6 +19,23 @@ membership/subsumption helper, backend-manifest schema evolution, witness-based
 conformance probes, and replacement of the #663 `reference_scenario` bridge are
 downstream implementation work tracked by the blocked subsumption/conformance
 issues, including #668.
+
+## Acceptance Basis And Relationship To Scenario Variation
+
+Issue #652 accepts this decision after the envelope contract and relation
+(#668), configuration-bound carriage (#100), scoped posture semantics (#539),
+and realization-honesty conformance (#777) landed. Acceptance also closes an
+authority ambiguity exposed by the SCE-002 design:
+
+- a realization envelope governs which already-authored or already-selected
+  scenario instances a backend may realize;
+- an SCE-002 scenario-family declaration governs which variations are valid;
+  and
+- an experiment policy governs which valid variations are selected.
+
+These are distinct set and selection planes. Envelope witness generation is a
+conformance mechanism, not experiment allocation or randomization, and its
+`WitnessPolicy.seed` is not an experiment seed or random-stream input.
 
 ## Context
 
@@ -56,8 +73,14 @@ Adopt a **realization envelope** as a versioned SDL semantic expression that
 describes a set of scenario instances. The same expression model is used in both
 directions:
 
-- authored SDL uses it to describe acceptable variation in a scenario family;
+- authored SDL or apparatus intent uses it to describe acceptable realization
+  bounds for already-authored scenario instances; and
 - backend declarations use it to describe realizability.
+
+An envelope does not declare SCE-002 variation points, factors, allocation,
+sampling, or stochastic controls. A trial must first be selected from its
+scenario-family domain; only then may the envelope relation prove whether the
+selected instance or requested realization set fits the backend offer.
 
 The normative formal boundary is
 `specs/formal/realization/envelope-semantics.md`.
@@ -100,6 +123,9 @@ contract:
 
 Witness generation is not evidence of subsumption by itself. It is only the
 concrete instance conformance can execute after the set relation has passed.
+Its seed exists solely to make conformance witness choice repeatable within the
+accepted envelope profile. It never advances, derives, or replaces an
+experiment random stream.
 
 ### 3. The admitted fragment is intentionally small
 
@@ -238,3 +264,9 @@ within the backend's realizable set.
 - If manifest carriage embeds large envelopes directly, manifests could become
   noisy and hard to review. The reference-by-contract-id/digest mode exists to
   keep large envelopes governed as separate published artifacts.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-07-15 | #652 | Accepted after envelope contract, relation, carriage, posture, and honesty conformance landed; clarified that envelopes govern realizability, not SCE-002 experiment selection, and witness seeds are not experiment randomness. |

--- a/docs/decisions/adrs/adr-074-experiment-authoring-input-contract-boundary.md
+++ b/docs/decisions/adrs/adr-074-experiment-authoring-input-contract-boundary.md
@@ -108,6 +108,21 @@ count source, red-variant map-key equality, and blocking factors resolving to
 declared factors — are declared as `x-aces-invariants` and enforced by the ACES
 model validators, consistent with ADR-055's semantic-invariant profile.
 
+### 3a. The authoring input is not an admitted trial plan
+
+ADR-084 makes the downstream boundary explicit. The authoring input declares
+experiment intent. A separate processor-owned operation combines an admitted
+spec with the exact composed scenario family, task, apparatus
+manifests/envelopes, and accepted compiler/identity/random-stream profiles to
+produce an immutable admitted trial plan.
+
+Typed selection/allocation policies may extend the run plan under ADR-061, but
+existing free-text allocation/randomization fields and seeds do not become
+executable by convention. The admitted plan records concrete logical
+coordinates, selections, factor assignments, apparatus bindings, and
+preallocated archival run ids. It is neither this authoring document nor an
+`experiment-run-v1` / `experiment-study-v1` output.
+
 ### 4. Authoring surface parity with SDL
 
 The contract ships an authored-file convention (`examples/experiments/*.exp.yaml`),
@@ -122,8 +137,9 @@ SDL authoring surface and satisfying AUT-801's agent-facing authoring mandate.
 
 Like ADR-055, this decision publishes a contract, a formal spec, tooling, and
 examples. It does not schedule, execute, persist, or evaluate experiments. A
-future orchestration surface consumes an authored spec to produce the archival
-`experiment-run-v1` / `experiment-study-v1` records.
+future orchestration surface consumes an authored spec through ADR-084's
+trial-compilation/admission boundary, then produces the archival
+`experiment-run-v1` / `experiment-study-v1` records from actual executions.
 
 ## Guardrails
 
@@ -137,6 +153,9 @@ future orchestration surface consumes an authored spec to produce the archival
   regenerate.
 - Do not add a parallel experiment-authoring DSL or SDL section; the spec is a
   single nested contract document.
+- Do not treat descriptive stochastic fields or a seed as an executable
+  random-stream contract, and do not let a scheduler/backend create selections
+  that are absent from the admitted plan.
 
 ## Consequences
 
@@ -189,3 +208,9 @@ new root section, and an experiment is not scenario meaning.
 Rejected. The issue asks specifically for an authoring surface analogous to SDL;
 the contract + tooling can and should exist independently of execution, exactly
 as the SDL authoring surface predates full runtime realization.
+
+## Amendments
+
+| Date | Commit/PR | Summary |
+|------|-----------|---------|
+| 2026-07-15 | #652 | Clarified that experiment authoring input is consumed by a separate deterministic trial-compilation/admission boundary and that descriptive stochastic fields are not executable profiles. |

--- a/docs/decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md
+++ b/docs/decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md
@@ -1,0 +1,421 @@
+# ADR-084: Scenario Variation And Deterministic Trial Realization
+
+## Status
+
+accepted
+
+## Date
+
+2026-07-15
+
+## Classification
+
+Classification: FM2
+
+Required artifacts: primary-source research note, complete phase/authority
+design, formal invariant list, contract sketches, compatibility guidance, and
+requirement/follow-on trace map.
+
+Waivers: issue #652 is design-only and adds no schema, generated artifact,
+contract model, compiler, random generator, runtime behavior, scheduler, API,
+or scenario content. Executable unit, typed-contract, and
+property/differential evidence is tracked by #274 and #786 through #791 and is
+recorded in `specs/formal/assurance-fulfillment.yaml`.
+
+## Context
+
+ACES already has the parts on either side of scenario variation:
+
+- ADR-053 and ADR-078 define trusted deterministic module composition and
+  closed authored, expanded, instantiated, and snapshot phases.
+- SDL `Variable` declarations and `instantiate_scenario()` provide typed scalar
+  binding with portable instantiation provenance.
+- ADR-055, ADR-065, ADR-068, and ADR-074 define experiment tasks, authoring
+  input, factors, allocation, stochastic disclosures, archival runs, studies,
+  apparatus, and provenance.
+- ADR-070 defines accepted bounded realization-envelope domains and
+  deterministic membership/subsumption/witness relations for backend
+  feasibility.
+
+What is missing is one normative bridge between a composed family and those
+experiment/runtime artifacts. Existing experiment stochastic fields are
+descriptive: they do not select a generator, stream derivation, draw
+transformation, or schedule-independent trial compiler. A backend realization
+envelope can state what a backend can realize, but cannot choose an experimental
+treatment. A scheduler can order executions, but must not become a scenario
+randomizer. Runtime observations can fill operation inputs, but must not
+retroactively change trial identity or factors.
+
+Without a single decision, follow-on work could create parallel binders, run
+identities, randomizers, loaders, or persistence models in SDL, experiment,
+backend, runtime, and APTL code.
+
+The supporting
+[research note](../../research/scenario-variation-trial-realization/prior-art-and-design-criteria.md)
+compares typed configuration languages, simulation experiment standards,
+parallel random streams, cyber playbooks/CTI/range generation, and adaptive
+difficulty. The complete implementation-facing architecture is
+[Scenario Variation And Deterministic Trial Realization](../../explain/reference/scenario-variation-and-trial-realization.md).
+
+## Decision
+
+### 1. Use one one-way lifecycle with one authority per plane
+
+ACES adopts:
+
+```text
+authored scenario family
+  -> deterministic trusted composition
+  -> experiment selection and allocation
+  -> deterministic trial compilation and admission
+  -> explicit SDL instantiation
+  -> processor planning and runtime/backend execution
+  -> existing experiment run/study provenance
+```
+
+Package ownership follows ADR-036:
+
+- `aces_sdl` owns composition, scenario-family declarations, typed targets,
+  selection application, instantiation, and scenario semantic admission.
+- `aces_contracts` owns portable neutral DTOs and shared bounded value-domain
+  primitives.
+- `aces_processor` owns trial-set compilation/admission, run-id preallocation,
+  and orchestration over public SDL/planner APIs.
+- `aces_runtime` owns live execution and typed fact binding into compiled
+  late-bound sinks.
+- existing backend protocols own realization within selected manifests and
+  envelopes.
+- external schedulers own placement, isolation, bounded parallelism, timeouts,
+  and cleanup only.
+- experiment run/study/evidence contracts remain archival authority.
+
+Every transition is partial and fail-closed. A later plane cannot rewrite an
+artifact or identity from an earlier plane.
+
+SCE-002's campaign composition does not introduce a `Campaign` runtime root.
+ADR-053 remains the composition mechanism: reusable SDL modules contribute
+typed exports to one root and produce one expanded canonical `Scenario` before
+selection. A campaign across multiple executions is represented by the
+experiment design, admitted plan, and existing run/study records. Neither form
+permits nested scenario lifecycles or concatenation of mutable runtime state.
+
+### 2. Add named, stable, bounded SDL variation points
+
+SDL scenario-family authoring uses an optional keyed registry of variation
+points. A point's canonical id participates in module namespace rewriting and
+never depends on its selected value, source path, trial, worker, or backend.
+
+The first version is a closed union:
+
+- scalar parameter binding through existing SDL variables;
+- governed reference choice;
+- exactly-one typed structural alternative;
+- bounded subset of typed keyed members;
+- constrained order over stable semantic item ids; and
+- logical timing choice with an explicit time domain/unit.
+
+Accordingly, attack order uses an `order` point, target selection uses a bounded
+`subset` or `governed-reference` point, and scenario timing uses a
+`logical-timing` point. IP and typed path inputs reuse existing SDL variables;
+credential inputs carry governed secret references or declared late-bound
+secret-reference sinks and never expose raw secret values as selections.
+
+Targets are closed descriptors owned by the SDL model containing the target
+slot. Arbitrary JSON/YAML paths, patches, templates, expressions, callbacks,
+external queries, and author code are not admitted.
+
+Alternatives/members are locally well-typed and independently valid. Closed
+requires/excludes/cardinality/precedence relations may constrain combinations.
+Every selected whole scenario is revalidated during instantiation; the compiler
+emits no plan if any requested combination is invalid.
+
+### 3. Reuse bounded value-domain primitives, not backend authority
+
+Exact, finite-enum, boolean, bounded-numeric, governed-reference, and acyclic
+record/product semantics reuse the neutral `DomainDescriptor` foundation
+governed by accepted ADR-070.
+
+Scenario-family validity, experiment selection, and backend realizability are
+three separate authorities:
+
+1. SDL states which members belong to the authored family.
+2. The experiment states which members/coordinates are selected.
+3. The selected backend envelope states which selected instances it can
+   realize.
+
+`RealizationEnvelopeModel`, backend posture, `WitnessPolicy`, and envelope
+witness generation do not become the experiment randomizer. This change
+explicitly accepts ADR-070 after its contract, relation, carriage, posture, and
+honesty-conformance work landed. It clarifies, but does not broaden, the
+envelope expression fragment: envelopes govern backend realizability after
+experiment selection.
+
+### 4. Make selection, allocation, and stochastic intent experiment concepts
+
+`experiment-authoring-input-v1` remains the pre-run design artifact. Typed
+selection policies reference qualified variation-point ids and explicitly
+state enumeration, explicit values, zip/product, sampling, stratification,
+blocking, or coverage semantics, finite output/budget, factor/condition
+bindings, logical-coordinate profile, and stochastic-control reference.
+
+Free-text allocation/randomization fields and a seed are not executable by
+convention. They remain descriptive until migrated to accepted typed profiles.
+SDL does not gain study factors, allocation, apparatus intent, run count, or
+analysis semantics.
+
+### 5. Require versioned semantic random streams
+
+Every executable stochastic policy names exact versions for the generator,
+seed encoding, canonical semantic-address encoding, stream/key derivation,
+raw-bit interpretation, distribution/sampling transformations, and failure
+behavior.
+
+Every experiment stochastic control also declares a canonical root seed and a
+stable randomness namespace. The namespace is an explicit experiment-owned
+identifier, not the aggregate experiment-spec identity or digest. It remains
+stable across revisions only when the author intends common random numbers for
+unchanged semantic addresses; an independent randomization intentionally uses
+a new namespace or seed.
+
+Draw addresses derive only from the randomness namespace, logical trial
+coordinate, policy id, variation-point id, draw purpose, and stable local draw
+coordinate. They never include the aggregate experiment digest, scheduling,
+worker/process/thread/host identity, wall time, completion order, retry count,
+map/hash iteration order, or backend availability. The exact experiment digest
+remains sealed plan/run provenance but is not a stream-address input.
+
+Each concern receives an independent stream. Adding an unrelated draw cannot
+perturb another point or trial. For identical admitted inputs, serial,
+parallel, worker-reversed, differently batched, retried, cross-process, and
+different hash-order compilation must produce byte-identical plans.
+
+This ADR selects the profile boundary, not a concrete PRNG. #274 selects and
+publishes accepted generator/derivation/transformation profiles.
+
+### 6. Compile and admit one immutable trial plan atomically
+
+`aces_processor` compiles an admitted experiment spec, exact composed family,
+task, required artifacts, selected apparatus manifests/envelopes, and exact
+compiler/identity/RNG profiles into one closed content-addressed admitted trial
+plan.
+
+Every entry contains a unique logical coordinate, factor/condition/replicate
+assignments, structural selections, non-secret scalar/reference bindings,
+stochastic control/namespace/seed/profile/address/outcome provenance, pinned
+apparatus claims, and the expected selection-to-instantiation linkage.
+
+The compiler stages and validates every requested entry before sealing the
+plan. Empty/contradictory domains, budget exhaustion, duplicate coordinates or
+ids, invalid selected scenarios, artifact/profile drift, or apparatus-envelope
+mismatch produce deterministic bounded diagnostics and no plan. It never
+clamps, substitutes, drops, falls back, or resamples a failed coordinate.
+
+The plan is execution intent, not a scheduler queue, live operation record,
+runtime snapshot, run, study, result, or evidence store.
+
+### 7. Preallocate the existing archival run identity
+
+Each plan entry deterministically preallocates the `run_id` that
+`experiment-run-v1` will use if execution starts. The identity derives from
+admitted execution intent and the logical coordinate under a versioned
+identity profile.
+
+An idempotent transport retry before execution reuses the id. A genuine
+re-execution uses a new explicit replicate/execution ordinal, is admitted
+again, receives a new run id, and may link to its source run. ACES does not add
+`experiment-trial-v1` or a second archival trial identity.
+
+The plan has its own content identity for the group. Plan identity, scheduler
+job id, operation id, and runtime snapshot id are never run ids.
+
+### 8. Realize entries through public SDL phase APIs
+
+For one entry, `aces_processor` applies only its recorded structural selections
+and scalar bindings to the exact family it pins, then uses the public SDL
+instantiation/admission path. It performs no new draw, import, query, secret
+read, backend callback, or fallback.
+
+Instantiation provenance gains plan/run and canonical point-selection lineage
+at its owning implementation issue. The canonical snapshot commits to the
+selected concrete scenario and that derivation evidence. A private binder or
+deserialized unchecked object cannot mint an admitted result.
+
+### 9. Restrict runtime facts to typed late-bound sinks
+
+Compiled late-bound slots declare a stable id, target address/type, allowed
+source/scope, freshness, sensitivity, authorization/evidence expectations, and
+absence behavior. Runtime facts or secret references may fill only those
+run-local operation/action inputs.
+
+Facts cannot add/remove/rename topology, choose a variation point, alter a
+factor/condition, change plan/snapshot/run identity, select apparatus, or
+advance/replace random streams. Missing, stale, unauthorized, wrong-type, or
+wrong-scope facts produce explicit runtime dispositions, never fallback
+selection.
+
+Secret values are resolved only at authorized sinks. They are not factors,
+condition assignments, seeds, stream inputs, ids/digests, plan bindings,
+fixtures, diagnostics, argv, logs, or telemetry.
+
+### 10. Keep backend realization and scheduling subordinate to admission
+
+The selected scenario must first be a family member, then satisfy selected
+manifest/capability and realization-envelope evidence. Backend-open choices
+stay within the envelope and are disclosed as realized forms. Backend refusal
+or availability drift is failure/deviation, not permission to pick another
+trial or backend silently.
+
+A scheduler consumes sealed entries. It may place, delay, pause, cancel, retry
+transport idempotently, prove isolated bounded parallelism, enforce timeouts,
+and verify clean state/cleanup. It cannot compose, select, randomize,
+instantiate, allocate run ids, compare, or score. APTL uses this handoff rather
+than implementing a second scenario lifecycle.
+
+### 11. Treat adaptation and generation as governed consumers
+
+Adaptive difficulty preserves the admitted baseline. Interventions carry
+policy, observation, trigger, action, timing, and validity provenance; a
+derived follow-up trial requires a new admitted coordinate/run id.
+
+ATT&CK layers, STIX, playbooks, CTI reports, planning systems, and AI generators
+may produce revision-pinned candidate SDL and mappings. Candidates re-enter the
+ordinary authoring, trust, composition, semantic-validation, experiment, and
+admission gates. Candidate generation is not execution authority.
+
+## Required Boundaries
+
+- Composition is deterministic and complete before trial selection.
+- Canonical ids do not depend on selected values.
+- Structural alternatives are declared, bounded, typed, and independently
+  valid.
+- Scenario-family domains and experiment selection policies are distinct.
+- Experiment selection and backend realizability are distinct.
+- Trial-plan bytes and selected values are invariant under valid scheduling and
+  worker permutations.
+- No failure, retry, or backend rejection consumes a shared stream or triggers
+  resampling.
+- Runtime facts cannot retroactively change identity, factors, topology,
+  structural choices, snapshots, or streams.
+- Backend choices stay within the selected realization envelope and are
+  disclosed.
+- One started trial is one existing archival run record.
+- Schedulers consume plans without owning scenario meaning or experiment
+  analysis.
+
+## Compatibility And Migration
+
+- Existing static SDL denotes a singleton family and remains valid.
+- Existing variable-only SDL retains its substitution/binding semantics; scalar
+  variation targets the existing variable mechanism.
+- Existing module composition and canonical namespace behavior remain
+  unchanged.
+- Existing experiment authoring files remain valid. Descriptive stochastic
+  fields do not execute until an explicit typed migration/profile is present.
+- Existing task, run, study, apparatus, evidence, and measure contracts remain
+  authoritative. Future versions add plan/selection lineage under ADR-061
+  rather than weakening or duplicating those records.
+- Consumers that do not support a new structural variation/profile reject it
+  cleanly; they do not ignore it.
+
+## Alternatives Considered
+
+### Embed Jsonnet, Dhall, CUE, templates, or an expression language
+
+Rejected. These would add another evaluator, trust model, termination/budget
+surface, and diagnostic language and would allow computed unbounded structure.
+ACES adopts bounded typed declarations and ordinary SDL validation instead.
+
+### Use JSON Patch/YAML overlays for structural variants
+
+Rejected. Path-based mutation is not semantic target authorization, can edit
+identity-bearing fields, is fragile under schema evolution, and makes branch
+validity difficult to review.
+
+### Put randomization in SDL composition or instantiation
+
+Rejected. A scenario family states validity; an experiment states selection.
+Hidden draws during composition or instantiation make the selected artifact
+depend on invocation context and defeat explicit provenance.
+
+### Use one process-global or worker-local RNG
+
+Rejected. Draw order then depends on traversal, parallelism, failures, and
+retries. Semantic independently derived streams are required.
+
+### Let the backend choose/resample a realizable point
+
+Rejected. That makes apparatus feasibility the treatment selector and hides
+selection bias. An unrealizable selected point fails admission/execution.
+
+### Use a shared mutable parameter/fact store
+
+Rejected. Values become time-dependent, retries observe different state,
+authorization/redaction boundaries blur, and runtime discoveries can rewrite
+pre-run intent. Plans are sealed; facts fill declared run-local sinks only.
+
+### Add a trial root schema or use scheduler jobs as trials
+
+Rejected. ADR-065/068 already establish one execution as one archival run.
+Parallel roots would split identity and provenance.
+
+### Make the trial plan itself the archival run
+
+Rejected. A plan states admitted intent for zero or more future executions; a
+run states what happened, including actual apparatus, evidence, results, and
+deviations.
+
+## Consequences
+
+### Positive
+
+- Follow-on SDL, experiment, processor, runtime, backend, and APTL work shares
+  one lifecycle and identity model.
+- Parallelism and retries cannot change the selected trial set.
+- Existing composition, instantiation, run/study, apparatus, and provenance
+  incumbents are extended rather than duplicated.
+- Failed/unrealizable selections remain scientifically visible.
+- Static and variable-only SDL remain compatible.
+- Adaptive and generated scenarios enter through explicit validity/provenance
+  boundaries.
+
+### Costs
+
+- Authors and tools must use typed point and selection profiles instead of
+  arbitrary templates or free-text randomization.
+- Plans carry substantial input, profile, selection, apparatus, and admission
+  provenance.
+- Implementations need canonicalization, budget enforcement, cross-artifact
+  validation, and cross-process schedule-permutation tests.
+- True re-execution requires a new explicit coordinate rather than silently
+  reusing a run id.
+
+### Risks
+
+- Implementers may mistake ADR-070's witness seed for an RNG. The formal
+  invariants and #274 profile work forbid this.
+- A backend may silently substitute a realizable default. Admission and
+  realized-form/deviation tests must reject or disclose it.
+- “Deterministic plan” may be overstated as exact replay or backend equivalence.
+  Claim boundaries remain explicit in ADR-068 and the formal specification.
+- Large cross-products may exhaust resources. Every producer enforces point,
+  product, trial, plan, artifact, and diagnostic budgets.
+- Fact binding can leak secrets through errors or telemetry. Values remain on
+  authorized run-local carriers and secondary surfaces are redacted.
+
+## Verification And Follow-On Work
+
+The normative invariant set is
+`specs/formal/scenario-variation-trial-realization/README.md`.
+
+Implementation is sequenced by native GitHub dependencies:
+
+1. #656 and #786 publish bounded SDL family declarations and targets.
+2. #274 and #787 publish accepted RNG/selection/allocation profiles.
+3. #788 publishes the admitted trial-plan contract.
+4. #789 implements deterministic compilation/admission and schedule witnesses.
+5. #790 integrates public SDL instantiation and run/study provenance.
+6. #791 implements typed runtime fact bindings.
+7. #783, #784, #653, #654, and #785 consume the shared spine.
+
+SCE-002 remains DRAFT until executable contract, implementation, and test
+evidence is reconciled through those issues.

--- a/docs/decisions/adrs/adr-index.yaml
+++ b/docs/decisions/adrs/adr-index.yaml
@@ -315,7 +315,11 @@ adrs:
         summary: "Recorded SEM-225 run-level augmentation disclosure implementation coverage."
   - id: ADR-068
     path: docs/decisions/adrs/adr-068-experiment-trials-replication-and-replay-claims.md
-    pin: 2cd46b67fb86a8d5d5c089e2b2f492a94e6141470706f33a2bb14d7268c49d02
+    pin: 12e6d644f7a90d50956964d8f0608737f9b4d8c7627819419a69974184c2781f
+    amendments:
+      - date: 2026-07-15
+        ref: "#652"
+        summary: "Clarified that an admitted plan entry preallocates the existing archival run identity and preserves experiment-owned selection without becoming a second trial/run record."
   - id: ADR-069
     path: docs/decisions/adrs/adr-069-cage-2-replication-architecture.md
     pin: 305334e5558fb88d1f84317209f0e64d182714ba8e99cdeb5f6781bf3ee384f5
@@ -323,6 +327,13 @@ adrs:
       - date: 2026-07-08
         ref: "#675"
         summary: "ADR-074 adds experiment-authoring-input-v1, giving REP-003 a pre-run home for execution-control facts; it complements the SDL scenario authoring path and adds no CAGE-specific schema."
+  - id: ADR-070
+    path: docs/decisions/adrs/adr-070-realization-envelope-semantics.md
+    pin: e7480c4849234177b9e11594e56c3f2d9a82c2536c8c9a1cee7ff84d027f35bb
+    amendments:
+      - date: 2026-07-15
+        ref: "#652"
+        summary: "Accepted after envelope contract, relation, carriage, posture, and honesty conformance landed; clarified that envelopes govern realizability, not SCE-002 experiment selection, and witness seeds are not experiment randomness."
   - id: ADR-071
     path: docs/decisions/adrs/adr-071-reusable-asset-trust-and-integrity-policy.md
     pin: d0f0d15945a91e97870d794986d7c7453cea7fade5c74c673d271ceaf05a6b7e
@@ -338,7 +349,11 @@ adrs:
         summary: "Per ADR-079, corrected executable conditions from observable facts to probe realizations and moved objective truth to typed propositions/assertions."
   - id: ADR-074
     path: docs/decisions/adrs/adr-074-experiment-authoring-input-contract-boundary.md
-    pin: 74dd29e3e5f3a2b7bdf836bd40908c0840c51f46a1a89efbb191e6ce7f620ce5
+    pin: 415566d82cc3d3ac43687016532b06ef62de85eec7ab37a61d7be9f87f9c53ef
+    amendments:
+      - date: 2026-07-15
+        ref: "#652"
+        summary: "Clarified that experiment authoring input is consumed by a separate deterministic trial-compilation/admission boundary and that descriptive stochastic fields are not executable profiles."
   - id: ADR-076
     path: docs/decisions/adrs/adr-076-portable-sdl-identifiers-and-canonical-addresses.md
     pin: cd28329002c1befb1920f0037c07517adbe3811d15e4f559455d05b893c69203
@@ -364,3 +379,6 @@ adrs:
   - id: ADR-082
     path: docs/decisions/adrs/adr-082-authored-identity-domain-topology.md
     pin: 0d5d4997bb2e3abf2ddf2bf9d6d345429a99deef5f343c6ca1aba4b8ebc3a95c
+  - id: ADR-084
+    path: docs/decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md
+    pin: e4be391affc09e1f0db3c5004fb2dfa0c4138c5c2f98086b3a6b8d341b4fd9d8

--- a/docs/decisions/issue-652-sce-002-variation-trial-realization-preflight.md
+++ b/docs/decisions/issue-652-sce-002-variation-trial-realization-preflight.md
@@ -1,0 +1,302 @@
+# Issue 652 SCE-002 Variation And Trial-Realization Preflight
+
+Date: 2026-07-15
+
+Issue: #652.
+
+Requirement: SCE-002.
+
+This note fixes the architecture boundary for scenario-family variation and
+deterministic trial realization before implementation. It is guidance only: it
+does not add SDL syntax, contracts, schemas, generators, schedulers, runtime
+fact behavior, persistence, or scenario content.
+
+## Binding Authority And Current Gaps
+
+- ADR-036 owns package boundaries. `aces_sdl` owns SDL composition,
+  instantiation, and language semantics; `aces_processor` owns deterministic
+  compilation, admission, and planning; `aces_runtime` owns live execution;
+  `aces_contracts` owns portable cross-package DTOs. Authoring adapters and
+  backends must not acquire parallel semantics.
+- ADR-053 makes module composition typed, trusted, deterministic, and complete
+  before downstream selection. ADR-076 keeps canonical declaration identities
+  independent of source layout. ADR-078 requires closed, disjoint authoring,
+  expanded, instantiated, and snapshot forms.
+- SDL `Variable`, `${name}`, `instantiate_scenario()`,
+  `InstantiationProvenance`, and the instantiated snapshot already own scalar
+  parameter binding. SCE-002 must extend that path rather than add a template
+  language or a second binder.
+- ADR-055/068/074 and `ExperimentSpecModel`, `ExperimentRunPlanModel`,
+  `ExperimentRunAllocationPlanModel`, `ExperimentStudyFactorModel`,
+  `ExperimentParameterModel`, `ExperimentStochasticControlModel`,
+  `ExperimentRunModel`, and `ExperimentStudyModel` already own experiment
+  intent, factors, allocation, stochastic-control disclosure, archival runs,
+  and study analysis.
+- ADR-065 makes `experiment-run-v1` the archival provenance join point. One
+  executed trial is one run record; a planned-trial artifact must not become a
+  second archival run identity or provenance graph.
+- ADR-070 and `aces_contracts.realization_envelope` supply reusable bounded
+  domain descriptors and backend membership/subsumption semantics. A scenario
+  validity domain, an experiment selection policy, and a backend realizability
+  envelope are nevertheless three different authorities. ADR-070 remains
+  `proposed`; #652 must not silently treat its status as accepted or broaden its
+  expression fragment without an explicit decision.
+- The existing experiment fields are not yet an executable randomization
+  contract. `allocation_method`, `randomization_unit`, `replication_policy`,
+  and stopping rules are descriptive strings;
+  `ExperimentStochasticControlModel` does not define a generator, stream
+  derivation, or draw semantics. `WitnessPolicy.seed` explicitly records a
+  basis but introduces no randomness. None of these may be treated as a
+  schedule-independent trial compiler by convention.
+
+A focused #652 architecture decision must make the choices below normative
+before follow-on contract or implementation work. It should amend ADR-068 and
+ADR-074 where planned run identity and admitted-plan input semantics are
+clarified, and reconcile ADR-070's status rather than duplicate it.
+
+## One Pipeline And One Authority Per Boundary
+
+| Boundary | Named authority | Input | Immutable output | Provenance rule |
+| --- | --- | --- | --- | --- |
+| Module composition | `aces_sdl.composition` and `module_registry` | Root SDL plus locked/trusted imports | `ExpandedScenario` with typed expansion provenance | Preserve declared import order, namespaces, module identities, checkout-independent sources, digests, exports, signer identity, and resolved module bindings per ADR-078. |
+| Scenario-family declaration | SDL normative prose/schema/model and semantic validator | Composed authored scenario with named bounded variation points | Semantically valid expanded scenario family | Variation-point ids are stable canonical symbols; imported ids are namespace-qualified during composition; selected values never rename declarations. |
+| Experiment design | `experiment-authoring-input-v1` and existing experiment-core models | Task/scenario-family refs, factors, allocation, typed selection and stochastic policies | Closed `ExperimentSpecModel` authoring artifact | Bind every factor/policy target to a declared variation-point id and pin referenced artifact identities/versions/digests where the existing ref model permits. Do not copy SDL declarations into the experiment document. |
+| Trial-set compilation and admission | `aces_processor`, using neutral DTOs from `aces_contracts` | Admitted experiment spec, composed family, task, apparatus intent/manifests/envelopes, and explicit compiler/RNG profiles | One closed, canonical, immutable admitted trial-plan artifact | Record all input refs/digests, compiler profile, RNG/stream profile, logical trial coordinates, selected bindings, factor assignments, apparatus/envelope bindings, and bounded admission diagnostics. No plan is emitted when any entry is impossible, invalid, or unrealizable against its selected apparatus. |
+| Trial realization | `aces_processor` orchestration over public `aces_sdl` APIs | One admitted plan entry plus the exact composed family it pins | Admitted `InstantiatedScenario`, canonical snapshot, then existing compiled runtime model/plans | Apply only plan-recorded structural selections and scalar bindings, call ordinary `instantiate_scenario()`/`admit_instantiated_scenario()`, and preserve selection-to-instantiation provenance. No private binder or validation bypass may mint a result. |
+| Runtime fact binding | `aces_runtime` over typed neutral fact DTOs and compiled late-binding slots | Admitted compiled artifact, authorized observations/secret references | Run-local bound operation/action input plus fact-binding provenance | Facts may fill only explicitly declared late-bound sinks. Source, type, scope, freshness, sensitivity, and evidence/provenance refs are recorded; raw secrets are not. Facts cannot alter plan identity, factors, topology, structural choice, or stochastic streams. |
+| Backend realization and scheduling | Existing planner/runtime/backend protocols; scheduler is an external consumer | Admitted per-trial compiled plans and selected apparatus bindings | Existing operation receipts/status, runtime snapshots, and realization disclosures | Planner applies realization-envelope membership and manifest capability checks. A scheduler may place, delay, pause, or retry admitted work under policy, but cannot select or resample scenario meaning. Backend refusal or availability change is a failure/deviation, not permission to choose another trial. |
+| Archival provenance | `ExperimentRunModel`, `ExperimentStudyModel`, and existing cross-artifact validators | Sealed execution/evidence plus the admitted plan/snapshot refs | One run per executed trial and one study/allocation record | The planned run id becomes the archival `run_id` if execution starts. Runs carry actual parameter/stochastic/apparatus facts, snapshot identity, realized-form disclosures, evidence, deviations, and lineage to the plan/spec. Studies retain factor/allocation meaning. |
+
+The admitted trial plan is an execution-intent artifact, not a scheduler queue,
+live operation record, run, study, or apparatus observation. Its per-entry id is
+a preallocated run identity under a versioned identity profile, not a second
+kind of archival trial id. An idempotent transport retry before execution may
+reuse it; a genuine re-execution after execution starts requires a newly
+admitted run identity and produces a distinct run record.
+
+## Variation And Reproducibility Guardrails
+
+- Reuse the closed `DomainDescriptor` primitives where their value semantics
+  fit: exact values, finite enums, booleans, bounded numeric intervals,
+  governed references, and acyclic products. Keep SDL `Variable` as the scalar
+  substitution carrier. Do not fork value typing or membership rules.
+- Scenario-family structure needs a closed discriminated variation-point
+  family, not JSON Patch or callbacks. The admitted kinds may cover one-of
+  alternatives, bounded subsets, constrained order, and logical timing in
+  addition to scalar/reference binding. Every alternative is declared,
+  bounded, addressable, and independently semantically valid when selected.
+- Composition resolves the complete declaration graph before selection.
+  Selection may choose among declared members but may not import a new module,
+  query an external catalog, execute code, create declaration keys from values,
+  or mutate arbitrary JSON paths.
+- Logical attack order and scenario timing are scenario/trial semantics.
+  Worker launch order, queue latency, host wall time, retry backoff, and batch
+  placement are scheduler/apparatus facts and cannot satisfy those variation
+  points.
+- Backend realizability cannot take authority from experiment selection. First
+  validate a selection against the scenario-family domain; then prove the
+  selected instance/requested family is within the selected backend envelope.
+  An unrealizable point fails admission. Do not silently clamp, substitute,
+  drop, or resample it.
+- A mandatory random-stream profile must name the generator algorithm and
+  version, seed encoding, canonical input encoding, semantic stream-address
+  derivation, and distribution/sampling transformations. A seed alone is not a
+  replay claim.
+- Stream addresses derive from immutable semantic coordinates such as the
+  experiment/spec identity, logical trial coordinate, variation-point or
+  policy id, and draw purpose. They must never include worker id, process id,
+  thread id, host, wall time, map iteration order, completion order, or retry
+  count.
+- Each concern receives an independent derived stream. Adding a draw for one
+  variation point must not perturb another point's result. Serial, parallel,
+  reversed-worker, and different-batch executions of the same admitted inputs
+  must produce byte-identical trial plans.
+- Canonical map traversal is by canonical identifier. Semantically ordered SDL
+  lists retain their declared/selected order; a serializer must not sort away a
+  meaningful order to manufacture determinism.
+- Failure is deterministic and fail-closed. Constraint exhaustion, empty
+  subset/order domains, invalid alternatives, duplicate coordinates, and
+  apparatus mismatch produce bounded diagnostics and no admitted plan. A
+  concurrency race or retry must not advance or replace a stream.
+
+## Required Incumbents And Cross-Cutting Reuse
+
+- **Normative authority and publication:** ADR-009/019/061,
+  `specs/authority/authority-boundary.yaml`, `contracts/schemas/`,
+  `contracts/fixtures/`, `contracts/schema-publication-manifest.json`,
+  `schema_bundle()`, `tools/generate_contract_schemas.py`,
+  `tools/check_schema_publication.py`, `tools/check_generated_schemas.py`, and
+  `tools/check_json_artifacts.py`. Portable trial-plan or fact contracts use
+  `ContractModel(extra="forbid")`, generated parity, positive/negative fixtures,
+  and `x-aces-invariants` for cross-artifact rules.
+- **SDL ingress and phases:** `load_sdl_yaml`, source and composition budgets,
+  duplicate/mapping-key checks, `Scenario`, `ExpandedScenario`,
+  `InstantiatedScenario`, `SemanticValidator`, `instantiate_scenario()`,
+  `admit_instantiated_scenario()`, `InstantiationProvenance`, RFC 8785/JCS
+  snapshot canonicalization, and `SDLParseError` / `SDLValidationError` /
+  `SDLInstantiationError`.
+- **Composition supply chain:** `ImportDecl`, `ModuleDescriptor`,
+  `resolve_import()`, path confinement, cycle/collision checks, lock and digest
+  pins, export hashes, trust policy, signature verification, and bounded OCI
+  extraction. A trial compiler consumes verified expansion provenance; it does
+  not resolve imports itself.
+- **Experiment semantics:** the existing authoring-input, task, apparatus,
+  parameter, stochastic-control, factor, allocation, run, study, traceability,
+  evidence, and realized-form models plus
+  `validate_experiment_run_against_task()` and
+  `validate_experiment_study_against_tasks_and_runs()`. Extend these owning
+  contracts with typed children where needed; do not add parallel task,
+  allocation, parameter, run, or study DTOs.
+- **Processing and realization:** `aces_processor.compiler`, planner capability
+  checks, manifests, `RuntimeModel`, typed plan DTOs, `Diagnostic`/`Severity`,
+  and realization-envelope `member()`/`subsumes()`. The conformance
+  `witness()` helper may share domain primitives but is not the experiment RNG
+  or allocation engine.
+- **Runtime, persistence, and observation:** existing backend protocols,
+  `OperationReceipt`, `OperationStatus`, `RuntimeSnapshot`,
+  `ControlPlaneStore`, audit events, experiment evidence records, and run
+  provenance. Live snapshots/operation details remain mutable control state;
+  they are not a trial-plan store or archival fact ledger.
+- **Workflow and tests:** ADR-014, `.ground-control.yaml`,
+  `.gc/plan-rules.md`, `noxfile.py`, `SessionReporter`, package-boundary policy,
+  `test_pipeline_determinism.py`, realization-envelope Hypothesis properties,
+  SDL phase/schema fixtures, experiment-contract fixtures, runtime contract
+  tests, and control-plane security tests. Add schedule-permutation and
+  cross-process/hash-seed witnesses to these canonical suites rather than a
+  second CI workflow.
+
+## Security And Whole-Path Gates
+
+1. **SDL source and composition gate.** Family input passes bounded
+   `sdl-yaml/v1` decoding, safe YAML construction, duplicate/canonical-key and
+   JSON-domain checks, closed models, module trust/lock/digest/signature checks,
+   namespace rewriting, whole-scenario semantic validation, selection,
+   instantiation, and concrete semantic revalidation. No later layer may accept
+   raw SDL dictionaries or skip these gates.
+2. **Experiment/config shape gate.** Experiment and admitted-plan inputs pass
+   closed `ContractModel`/published-schema validation plus owning cross-artifact
+   validators. `parse_experiment_spec()` currently uses `yaml.safe_load`, and
+   the MCP wrapper adds a 64 KiB limit, but the loader has no SDL-equivalent
+   duplicate-key/source-profile gate and renders raw Pydantic/YAML error text.
+   New remote or execution-facing SCE ingress must not inherit that leakage;
+   either admit JSON/model artifacts after a bounded parser or harden the one
+   canonical experiment loader rather than add another loader.
+3. **Authentication and authorization gate.** No new HTTP endpoint is required
+   for these contracts. Any later compile/admit/execute or fact-read endpoint
+   must reuse `ControlPlaneSecurityConfig.strict_defaults()`, bearer or
+   verified-proxy identity, operator/backend/auditor role checks, target scope,
+   request-size guards, idempotency keys/fingerprints, and append-only audit
+   events. Artifact dereference and secret resolution are separately authorized
+   reads, not implied by permission to read a plan summary.
+4. **Secret-handling gate.** Reuse `ExperimentParameterModel` redaction rules,
+   SDL `redacted`/`operator_secret` omission validators, ADR-056/057, artifact
+   sensitivity, and evidence redaction/loss disclosure. Secret variation values
+   are references only and cannot be factor levels, condition-assignment values,
+   random seeds, identity material, canonical digests, portable binding values,
+   plan entries, fixtures, or diagnostics. Resolve a secret reference only at
+   its authorized run-local sink.
+5. **Environment/config binding gate.** No ambient environment variable,
+   process-global RNG, worker-local config, backend default, mutable parameter
+   store, or hidden fact source may affect selection. If an environment value is
+   desired scenario state, it uses the existing typed runtime-environment shape
+   and sensitivity/origin validators; if discovered at runtime, it uses an
+   explicit typed late-binding slot and cannot enter scenario identity.
+6. **OS/process exposure gate.** Keep selection and binding in-process over
+   typed DTOs or bounded files/stdin. Never put credentials, parameter maps,
+   fact values, tokens, raw plans, or secret refs in process argv; never use
+   `shell=True` or interpolation. Fixed-argv determinism witnesses may expose
+   only safe paths/profile ids and canonical digests.
+7. **Backend admission gate.** Existing manifest authority, processor/backend
+   compatibility, capability profiles, realization-envelope membership or
+   subsumption, typed planning diagnostics, and target conformance all remain
+   mandatory. A successful SDL selection is not proof of deployability, and a
+   backend default is not an experiment selection.
+8. **Error-envelope gate.** Structural failures remain at their owning parser
+   or contract boundary; SDL binding failures use the existing SDL exceptions;
+   processor admission/planning uses addressed `Diagnostic` values; HTTP keeps
+   its redacted 500 envelope. Report codes, stages, safe canonical paths, ids,
+   counts, and domain kinds only. Never render supplied/selected values,
+   allowed domains, parameter/fact maps, rejected documents, raw Pydantic
+   inputs, backend objects, environment dumps, or tracebacks.
+9. **Logging/observability gate.** Reuse module-local logging and existing
+   operation/audit reporting. Log only safe ids, digests, profile versions,
+   counts, stage outcomes, and durations. Random draws, secret/fact values, raw
+   bindings, scenarios, plans, and evidence bodies are not telemetry. A run's
+   inspectable scientific record remains the experiment provenance/evidence
+   graph, not logs.
+10. **Persistence/distribution gate.** The admitted plan is a sealed portable
+    artifact identified by canonical digest. Do not place it or its bindings in
+    `RuntimeSnapshot.metadata`, `ControlPlaneOperationRecord.details`, an audit
+    blob, tags, or a new mutable parameter database. Runtime state uses
+    `ControlPlaneStore`; archival outcomes use run/study/evidence contracts. A
+    future artifact service must preserve immutable bytes/digests and reuse the
+    control-plane security patterns without turning the per-target store into an
+    experiment repository.
+
+## Extensibility Seam
+
+The required seam is a versioned pair of closed profiles:
+
+- a variation-point/selection-policy discriminated union whose domain members
+  are addressed by stable canonical ids; and
+- a random-stream profile whose semantic address and generator/draw versions
+  are explicit inputs to trial-set compilation.
+
+A new bounded variation kind, allocation policy, or generator version extends
+one owning union/profile and its validator/fixture/property-test dispatch. It
+does not require editing every scenario, backend, scheduler, or run schema.
+Generator changes mint a new profile and provenance value; they never silently
+change the output of an existing profile. Runtime facts have a separate seam:
+typed source and sink kinds with sensitivity/freshness/evidence metadata. Adding
+a new fact source must not widen which compiled sinks are late-bindable.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- calling `random`, `secrets`, UUID, wall time, hash iteration, or a backend
+  callback during semantic trial selection without the governed stream profile;
+- treating a common seed as sufficient replay provenance or sharing one mutable
+  RNG across trials/variation points;
+- using `WitnessPolicy.seed` or realization-envelope witness generation as the
+  trial randomizer;
+- free-text allocation/randomization fields driving execution directly;
+- resampling after backend rejection, worker failure, timeout, or resource
+  contention;
+- arbitrary templates, JSON/YAML patches, callbacks, expressions, external
+  queries, unbounded distributions, or a shared mutable parameter/fact store;
+- generating declaration ids from selected values or putting selections in
+  source paths, namespaces, compiled addresses, or task identity;
+- letting runtime observations retroactively alter a trial's factors, run id,
+  scenario snapshot, compiled topology, structural alternatives, or streams;
+- putting experiment concepts in a new SDL root object, or SDL declarations in
+  a duplicate experiment schema;
+- treating trial plans as runs, scheduler jobs, operation receipts, runtime
+  snapshots, studies, or replay guarantees;
+- adding a duplicate schema registry, loader, validator, exception hierarchy,
+  diagnostic envelope, persistence repository, logger, audit stream, or CI
+  workflow; and
+- exposing raw parameters/facts through current `ExperimentSpecValidationError`
+  rendering, MCP summaries, HTTP errors, logs, fixtures, argv, or provenance.
+
+## Non-Goals And Implementation Boundaries
+
+- This preflight does not implement SCE-002, modify schemas/models, choose a
+  concrete PRNG, define scenario content, or publish an implementation plan.
+- SCE-002 does not create an experiment scheduler, batch executor, worker pool,
+  persistence service, HTTP API, secret manager, general expression language,
+  optimizer, adaptive-difficulty policy, CTI generator, or analysis engine.
+- Adaptive interventions are later run events with their own policy and
+  provenance. They do not rewrite the admitted baseline trial. A derived
+  follow-up trial requires a new admitted identity linked to its source run.
+- SCE-004 may consume typed late-bound facts and goal/tool contracts, but it
+  cannot make tool choice or observations a hidden scenario-family selector.
+- SCE-001/SCE-005 may propose bounded candidate scenarios or coverage targets;
+  candidates enter through ordinary authoring, trust, validation, and admission
+  gates. CTI is not runtime selection authority.
+- SCE-006/APTL may consume admitted plans and schedule isolated executions; it
+  does not own composition, randomization, instantiation, trial identity, or
+  archival run/study semantics.
+- Exact replay from a seed alone, behavioral equivalence across backends,
+  artifact availability, and recreation of hidden backend state remain
+  explicitly unsupported claims.

--- a/docs/explain/reference/README.md
+++ b/docs/explain/reference/README.md
@@ -27,3 +27,6 @@ themselves normative specifications or ADRs.
   - Implementer-facing reference for `SEM-207` declarative-objective semantics
 - [explicitness-realization-semantics.md](explicitness-realization-semantics.md)
   - Architecture guardrails for `SEM-218` explicitness and realization work
+- [scenario-variation-and-trial-realization.md](scenario-variation-and-trial-realization.md)
+  - Complete SCE-002 phase, ownership, identity, random-stream, trial-plan,
+    runtime-fact, migration, and follow-on architecture

--- a/docs/explain/reference/canonical-reference-map.md
+++ b/docs/explain/reference/canonical-reference-map.md
@@ -40,6 +40,7 @@ material. It is an index, not a replacement for the linked artifacts.
 | Testing notes | [`docs/explain/sdl/testing.md`](../sdl/testing.md) |
 | Design precedents | [`docs/explain/sdl/precedents.md`](../sdl/precedents.md) |
 | Academic lineage | [`docs/explain/sdl/lineage.md`](../sdl/lineage.md) |
+| Scenario variation and trial realization design | [`scenario-variation-and-trial-realization.md`](scenario-variation-and-trial-realization.md), [ADR-084](../../decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md) |
 
 ## Contracts And Processing
 
@@ -65,6 +66,7 @@ material. It is an index, not a replacement for the linked artifacts.
 | Assessment semantics | `specs/formal/assessment/`, [`assessment-semantics.md`](assessment-semantics.md) |
 | Participant semantics | `specs/formal/participant-semantics/README.md` |
 | Realization semantics | `specs/formal/realization/`, [`explicitness-realization-semantics.md`](explicitness-realization-semantics.md) |
+| Scenario variation and trial realization invariants | `specs/formal/scenario-variation-trial-realization/` |
 | Planner semantics | `specs/formal/planner/` |
 
 ## Current Materialization Notes

--- a/docs/explain/reference/scenario-variation-and-trial-realization.md
+++ b/docs/explain/reference/scenario-variation-and-trial-realization.md
@@ -1,0 +1,848 @@
+# Scenario Variation And Deterministic Trial Realization
+
+This reference defines the cohesive ACES path from an authored scenario family
+to archival experiment provenance. It applies ADR-084 to the package and
+artifact boundaries already established by ADR-036, ADR-053, ADR-055, ADR-065,
+ADR-068, ADR-074, and ADR-078.
+
+Issue #652 is design-only. Names in the contract sketches are conceptual unless
+ADR-084 says otherwise; follow-on issues publish the actual models and schemas.
+The semantic boundaries, identities, phase order, and failure behavior are
+binding and are not left for each implementation issue to rediscover.
+
+## Scope And Claims
+
+The design covers:
+
+- deterministic composition of an authored scenario family;
+- named, bounded scalar and structural variation points;
+- experiment-owned selection, allocation, sampling, and stochastic controls;
+- schedule-independent compilation and admission of a trial set;
+- explicit SDL instantiation and derivation provenance;
+- typed late-bound runtime facts;
+- backend realization within a selected envelope;
+- scheduling as an external consumer; and
+- linkage to the existing experiment run, study, apparatus, evidence, and
+  lineage records.
+
+It does not implement a generator, sampler, compiler, scheduler, runtime fact
+service, schema, persistence service, API, scenario pack, or adaptive policy.
+It does not guarantee identical backend behavior, artifact availability,
+reconstruction of hidden state, or exact replay from a seed alone.
+
+## Terminology
+
+**Scenario family**
+: A composed, semantically admitted SDL authoring artifact with zero or more
+  named variation points. Zero points denotes a singleton family.
+
+**Variation point**
+: A stable SDL symbol that declares one bounded location at which a concrete
+  scenario may differ. The point declares the valid domain and target kind; it
+  does not choose a value.
+
+**Selection policy**
+: Experiment-owned intent that enumerates or samples values from one or more
+  scenario-family domains and binds them to logical trial coordinates.
+
+**Logical trial coordinate**
+: A stable, experiment-meaningful address such as condition, replicate, and
+  attempt coordinate. It exists before scheduling and is not a worker or queue
+  index.
+
+**Admitted trial plan**
+: A closed immutable execution-intent artifact containing only fully selected,
+  valid, apparatus-realizable trial entries. It is neither a scheduler queue
+  nor an archival run.
+
+**Trial realization**
+: The processor-owned operation that applies one admitted entry's structural
+  selections and scalar bindings through the public SDL instantiation path.
+
+**Runtime fact**
+: An authorized observation or secret reference that fills a compiled
+  late-bound sink after admission. It cannot change scenario or experiment
+  meaning.
+
+**Run**
+: The existing `experiment-run-v1` archival record for one execution. “Trial”
+  is experiment terminology; it does not introduce a second archival root.
+
+### Composition and the campaign boundary
+
+SCE-002's “atomic scenarios into larger campaigns” uses the existing ADR-053
+composition model. A reusable SDL module may be authored and validated as a
+bounded unit, and a root SDL document may import the typed exports of many such
+units. Composition resolves trust, parameters, namespaces, references, and
+collisions and then produces one expanded canonical `Scenario`. The processor
+and runtime never execute a nested tree of atomic scenario lifecycles.
+
+“Campaign” is therefore an author-facing view, not a new portable root:
+
+- one executable composed campaign is one canonical scenario assembled from
+  reusable SDL modules and fragments; and
+- a campaign spanning multiple executions is an experiment design and its
+  admitted trial plan, archived through the existing run/study contracts.
+
+The second form does not compose scenario snapshots by concatenating runtime
+state. It selects already composed families through experiment policies. This
+preserves ADR-055's scenario/task/run/study separation and prevents a campaign
+object, scheduler job, or study record from becoming a second SDL lifecycle.
+
+## The One-Way Pipeline
+
+```text
+authored root SDL + trusted module sources
+  |
+  v
+normalized authored scenario family
+  |  resolve imports, trust, locks, namespaces, digests
+  v
+semantically admitted expanded scenario family
+  |  bind experiment task/spec, factors, allocation, selection/RNG profiles
+  v
+closed experiment design
+  |  compile logical coordinates and selections; check family + apparatus
+  v
+admitted trial plan
+  |  apply one recorded selection through public SDL instantiation
+  v
+admitted instantiated scenario + canonical snapshot
+  |  compile and plan using existing processor/planner boundaries
+  v
+typed provisioning/orchestration/evaluation plans
+  |  fill only declared late-bound sinks; realize through selected backend
+  v
+operation receipts, status, runtime snapshots, evidence
+  |  seal one archival run per started trial; aggregate in study/allocation
+  v
+experiment run/study provenance
+```
+
+Every arrow is a partial function. A failed transition emits bounded diagnostics
+and no artifact for the next phase. There is no path from runtime observations,
+scheduler state, or backend refusal back into experiment selection.
+
+## Authority And Phase Matrix
+
+| Plane | Named authority | Input artifact | Immutable output artifact | Admission and identity rule | Provenance carried forward |
+| --- | --- | --- | --- | --- | --- |
+| 1. Module composition | `aces_sdl.composition` and `module_registry` | Normalized root SDL, locked imports, trust policy, verified module bytes | Expanded scenario family | Resolve the complete declaration graph before selection; preserve qualified canonical symbols; selected values never influence module or declaration identity | Import preorder, namespace, requested and resolved source identities, versions, content/manifest/export digests, signer attribution, bindings |
+| 2. Scenario-family declaration | SDL models and `SemanticValidator` | Normalized/composed family with a keyed map of variation points | Semantically admitted expanded scenario family | Every point has a stable qualified id, a closed kind, a bounded domain, a typed target, and locally valid alternatives; the family is not experiment allocation | Family semantic digest, point/domain/profile versions, source locations, expansion evidence |
+| 3. Experiment design | `experiment-authoring-input-v1` and experiment-core validators | Task/family refs, factors, allocation, selection policies, stochastic controls, apparatus intent | Closed experiment specification | Policies target existing point ids; factors and conditions remain experiment concepts; refs/digests pin the family and task; descriptive legacy randomization fields cannot execute by convention | Spec identity/digest, task/family refs, factor and condition ids, policy/control ids and versions, randomness namespace, requested apparatus and capture refs |
+| 4. Trial-set compilation and admission | `aces_processor` using neutral DTOs from `aces_contracts` | Admitted experiment spec, exact family/task bytes, apparatus manifests/accepted envelopes, compiler/identity/RNG profiles | One canonical admitted trial plan | Pure deterministic function of admitted inputs; preallocate one archival `run_id` per logical coordinate; emit no plan if any selected entry is invalid, impossible, duplicate, or unrealizable | All input refs/digests, profiles, coordinates, run ids, selections, factor assignments, stochastic controls and stream addresses, apparatus bindings, bounded admission evidence |
+| 5. SDL instantiation | Public `aces_sdl` selection/instantiation/admission APIs, orchestrated by `aces_processor` | One plan entry and the exact expanded family it pins | Admitted `InstantiatedScenario` and canonical snapshot | Apply only recorded selections/bindings; no new draw, import, query, fallback, or private binder; rerun whole-scenario semantic validation | Existing expansion/instantiation evidence plus point selections and trial-plan/run linkage |
+| 6. Runtime fact binding | `aces_runtime` over compiled slots and neutral fact DTOs | Admitted compiled plans, authorized observations and secret references | Run-local bound operation/action input and binding event evidence | Fill only a declared sink with matching type/source/scope/freshness/sensitivity; never mutate the plan, snapshot, factors, topology, choices, run id, or streams | Slot id, safe fact/source ref, scope, freshness, sensitivity, authorization/evidence refs, binding outcome; no raw secret |
+| 7. Backend realization | Existing planner, manifest, realization-envelope, and backend protocols | Admitted plans plus selected apparatus/envelope/manifests | Existing backend plans, operation receipts/status, runtime snapshots, and realized-form disclosures | Realize only within the selected envelope and capabilities; backend refusal is failure/deviation, never permission to resample | Manifest/envelope/configuration refs/digests, realized forms, transformations, omissions, operation ids, receipts |
+| 8. Orchestration and scheduling | External scheduler, including APTL for SCE-006 | Admitted plan entries and execution/isolation policy | Queue/placement state and dispatch decisions, outside scenario identity | May order, delay, pause, retry transport, and use bounded parallelism after isolation proof; cannot select, instantiate, randomize, compare, or score | Dispatch order, instance/lock/storage allocation, timeouts, clean-state/cleanup evidence, retry reason |
+| 9. Archival provenance | `ExperimentRunModel`, `ExperimentStudyModel`, evidence and cross-artifact validators | Sealed execution/evidence plus plan/snapshot refs | One run per started trial and study/allocation records | The preallocated plan-entry `run_id` becomes the archival `run_id`; a genuine re-execution receives a new admitted id; live state is not the run record | Actual parameters/stochastic/apparatus facts, scenario snapshot, realized forms, evidence, deviations, lineage to plan/spec/task and source run where applicable |
+
+### Why the admitted plan is a separate artifact
+
+The experiment specification states intended design. The admitted plan states
+that a concrete finite set of trial entries has been selected, validated, and
+shown realizable against pinned apparatus claims. A scheduler queue states
+where and when work may run. A run states what happened. Combining any two of
+those would make a mutable operational concern authoritative for scientific
+intent or archival truth.
+
+The plan is therefore immutable and content-addressed. Operational state refers
+to it; operational state never edits it.
+
+## Scenario-Family Variation Model
+
+### Placement and identity
+
+The SDL authoring model gains one optional, keyed `variation_points` registry.
+The registry participates in module composition and namespace rewriting under
+ADR-053. Each key is the point's local id and agrees with any repeated id field,
+following the existing keyed-object convention. Imported points receive the
+module namespace exactly as other declarations do.
+
+A point id identifies the semantic location of variation. It does not include:
+
+- a selected value or alternative;
+- a source filename or line number;
+- a module cache path;
+- a trial, worker, process, or backend id; or
+- a hash of any selected value.
+
+Changing the declared point, domain, alternatives, or constraints changes the
+scenario-family semantic digest. Selecting a member does not rename the point
+or any declaration.
+
+### Closed point kinds
+
+The first version admits the following semantic kinds:
+
+| Kind | Meaning | Required bound | Selection result |
+| --- | --- | --- | --- |
+| Parameter | Select a JSON scalar for an existing typed SDL variable | Exact, finite enum, boolean, or bounded numeric domain compatible with the variable | Existing root or module-local parameter binding |
+| Governed reference | Select one declared reference under a named authority and revision/digest | Finite allowed reference set | Typed reference binding; referent is resolved through the owning registry |
+| Alternative | Select exactly one labeled typed fragment for one model-declared structural slot | Non-empty finite keyed alternatives | Selected alternative id and its typed content |
+| Subset | Select a set of labeled typed members for one model-declared collection slot | Finite members plus minimum/maximum cardinality; optional typed requires/excludes | Canonically keyed selected member set; semantic list order is separate |
+| Order | Choose a total order of declared semantic item ids | Finite item set plus a precedence DAG and optional fixed positions | Ordered tuple of item ids satisfying every edge |
+| Logical timing | Select a logical duration, offset, cadence, window, or declared timing profile | Exact/enum/bounded numeric or governed timing profile; explicit unit/time domain | Concrete logical timing value/profile, never host wall time |
+
+The SCE-002 examples map to these semantics without special cases: attack-order
+variation is an `order` point, target selection is a bounded `subset` or
+`governed-reference` point according to target ownership, and timing variation
+is a `logical-timing` point. The experiment chooses among these authored
+possibilities; the SDL declaration, runtime, backend, and scheduler do not draw
+independently.
+
+These kinds form a closed discriminated union. A future kind requires a versioned
+contract extension, semantic validator, provenance form, and property tests. An
+unknown kind fails closed.
+
+### Typed targets, not document patches
+
+Every point names a target descriptor owned by an SDL model. A target descriptor
+states the target kind, owning declaration, slot, and expected value/fragment
+type. It is not an RFC 6901 pointer, JSONPath expression, YAML path, template,
+callback, or arbitrary field name.
+
+The owning model decides which slots are variable. A structural alternative is
+a typed child accepted by that slot's ordinary validator; a subset member is a
+typed keyed child; an order point addresses the stable ids of an explicitly
+order-sensitive collection. This keeps target authorization in the model that
+owns the semantics.
+
+When exact/enum/boolean/bounded-number/governed-reference/acyclic-record value
+semantics fit, implementations reuse or extract the `DomainDescriptor`
+primitives introduced with ADR-070. They do not reuse
+`RealizationEnvelopeModel`, `EnvelopeBinding`, `WitnessPolicy`, backend posture,
+or witness generation as experiment selection. ADR-070 is accepted and owns
+only the realizability relation; its witness seed is not experiment randomness.
+
+### Structural validity and combination constraints
+
+Authoring validation checks every alternative/member in its typed local
+context, all target and reference ids, cardinality bounds, timing units, and
+precedence edges. Cross-point restrictions use only closed relations:
+
+- selection A requires one of a finite set of selections at point B;
+- selection A excludes a finite set of selections at point B;
+- subset cardinality constraints; and
+- order precedence/fixed-position constraints.
+
+There is no general Boolean expression language, arithmetic predicate, external
+query, or executable callback. Cycles or contradictions that make a declared
+domain empty are authoring errors. Local validity does not prove every
+cross-product combination valid; the trial compiler validates each selected
+whole scenario. If any requested coordinate selects an invalid combination, the
+entire requested admitted plan fails.
+
+### Order and time are semantic only when declared
+
+An `order` or `logical-timing` point changes scenario meaning only at its typed
+target. Worker launch order, queue latency, backend provisioning duration, retry
+backoff, batch placement, and host time are apparatus/scheduler facts. They
+cannot satisfy or alter an SDL variation point.
+
+## Experiment Selection And Allocation
+
+SDL declares what values and structures are valid. The experiment specification
+declares which valid points form the study.
+
+Every executable selection policy has:
+
+- a stable policy id and versioned kind;
+- one or more qualified variation-point targets;
+- a finite output count or an independently enforced compilation budget;
+- explicit semantics such as enumerate, explicit values, zip, Cartesian
+  product, sample-without-replacement, stratified sample, block, or declared
+  t-way coverage;
+- factor/condition mappings where selections are experimental treatments;
+- a logical-coordinate profile; and
+- a stochastic profile reference when the policy makes random choices.
+
+Scenario validity domains and experiment selection policies never collapse into
+one object. A domain can be reused by many experiments. Two experiments can
+select different subsets without changing the scenario-family digest.
+
+Selections that are secret, hidden answers, benchmark-only truth, or raw
+credentials cannot be factor levels or condition assignments. A scenario may
+declare a secret late-binding slot or governed secret-reference policy, but the
+experiment plan carries no secret value and no secret-derived identity.
+
+Address-like inputs such as IP addresses and typed path inputs continue through
+existing SDL `Variable` binding with their declared allowed-value constraints.
+Credential-shaped inputs are parameterized only as governed secret references
+or declared late-bound secret-reference sinks, never as public credential
+values. Thus IP, credential, and path variation share the same selection spine
+without weakening the secret boundary.
+
+Exercise variety comes from admitting multiple explicit selections over the
+same stable family. “Prevents rote memorization” is not inferred from the mere
+presence of randomness: a study must state the intended coverage or sampling
+claim and preserve the selected conditions and outcomes needed to evaluate it.
+
+## Random-Stream And Reproducibility Contract
+
+### Profile contents
+
+A random seed is data, not a complete algorithm. Every executable stochastic
+policy references an accepted random-stream profile that fixes:
+
+1. generator algorithm and version;
+2. seed type, size, and canonical byte encoding;
+3. canonical semantic-address encoding;
+4. key/stream derivation function and domain-separation labels;
+5. raw-bit interpretation;
+6. bounded-integer, real, weighted-choice, permutation, subset, and distribution
+   transformation versions used by the policy;
+7. rejection, tie, precision, and exhaustion behavior; and
+8. the compatibility promise for the complete profile.
+
+Changing any element creates a new profile id. An existing profile's output is
+immutable. A library default, package version range, `random.seed()` call, or
+free-text algorithm name is not a profile.
+
+The experiment's stochastic control combines that profile with a canonical
+root seed and an explicit stable randomness namespace. The namespace is not
+derived from the experiment-spec id, revision, or content digest. Keeping the
+same namespace and seed across a controlled revision requests common random
+numbers at unchanged semantic addresses; an independent randomization mints a
+new namespace or changes the seed. Copying an experiment mints a new namespace
+by default, and deliberate reuse is recorded as provenance.
+
+### Semantic addresses
+
+For each draw purpose, the compiler derives a stream address from immutable
+semantic coordinates:
+
+```text
+StreamAddress = (
+  randomness_namespace,
+  logical_trial_coordinate,
+  selection_policy_id,
+  variation_point_id,
+  draw_purpose,
+  local_draw_coordinate
+)
+```
+
+`local_draw_coordinate` is a stable semantic member id or explicit draw index,
+not “the next call.” Canonical maps are traversed by canonical identifier.
+Lists whose order is part of SDL meaning retain their declared or selected
+order.
+
+The following are forbidden inputs: worker/process/thread/host id, wall time,
+queue position, batch number, completion order, map/hash iteration order,
+retry count, backend availability, and aggregate experiment-spec identity or
+digest. The compiler may evaluate addresses in any order or in parallel. The
+plan still pins the exact experiment id/digest as provenance.
+
+### Non-interference and permutation operations
+
+Each concern receives its own derived stream. Adding a draw to policy A cannot
+change policy B or another point. Adding a trial coordinate under the same
+namespace cannot change draw outcomes or selection bindings at existing
+coordinates. The plan digest and preallocated run ids may still change when the
+run-identity profile commits to a revised experiment specification.
+
+Random order and subset operations are defined from stable member-addressed
+priorities (with canonical-id tie breaking), or another profile-defined
+schedule-independent transform. They are not a shared in-place shuffle whose
+result depends on prior draws or collection iteration order.
+
+### Required reproducibility witnesses
+
+An implementation cannot claim conformance until identical admitted inputs
+produce byte-identical plans under:
+
+- one worker and many workers;
+- forward and reversed worker assignment;
+- different batch partitions and completion orders;
+- retries before plan sealing;
+- different process hash seeds;
+- serialization/deserialization between phases; and
+- repeated execution in separate processes on supported platforms.
+
+It must also prove stream non-interference by adding an unrelated point/draw
+or changing unrelated experiment metadata while retaining the namespace, then
+observing unchanged draws and selections at every unaffected address.
+
+These properties establish deterministic plan construction. They do not prove
+identical runtime behavior or exact replay of hidden backend state.
+
+## Trial Identity And Admitted Plan Semantics
+
+### Stable coordinates and run ids
+
+Allocation first creates a set of unique logical coordinates. A coordinate is a
+closed tuple whose dimensions are named by the allocation profile, for example
+condition id, block id, replicate index, and explicit execution ordinal. The
+tuple is canonicalized by profile; it is not a list position.
+
+The run-identity profile deterministically derives a `run_id` from:
+
+- the admitted experiment-spec identity;
+- the pinned task and scenario-family identities;
+- the logical coordinate;
+- the trial-compiler and identity-profile ids; and
+- any plan-wide input whose change makes this a different execution intent.
+
+Recompiling the same admitted inputs yields the same run ids. An idempotent
+transport retry before execution reuses them. A genuine re-execution after a
+trial starts is new scientific intent: it uses a new explicit execution
+ordinal or replicate coordinate, is admitted again, and receives a new run id.
+It may cite the source run through existing lineage.
+
+### Plan admission is atomic
+
+Let `F` be the admitted expanded family, `E` the admitted experiment spec,
+`A` the pinned apparatus claims, and `P` the compiler/identity/random profiles.
+Conceptually:
+
+```text
+compile_and_admit(F, E, A, P) -> AdmittedTrialPlan | DiagnosticSet
+```
+
+For the same canonical inputs, the function returns identical bytes or
+identical ordered diagnostics. It stages entries internally, validates every
+entry, checks plan-wide uniqueness and budgets, and seals one plan only after
+all entries pass. It never emits a “valid subset” after dropping failed
+coordinates.
+
+The plan has its own content identity. That identity is not a run id. It groups
+the immutable intended executions, while each entry's preallocated run id is
+the archival identity if that entry starts.
+
+### Minimum plan contents
+
+The admitted plan records:
+
+- plan schema/profile and canonical digest;
+- compiler, coordinate, run-identity, canonicalization, and random-stream
+  profile ids;
+- exact refs and digests for experiment spec, task, expanded scenario family,
+  capture specs, and required associated artifacts;
+- selected apparatus intent plus pinned manifest, capability, realization
+  envelope, and material-configuration refs/digests;
+- explicit cardinality and compilation-budget facts;
+- a canonically ordered/keyed collection of entries;
+- each entry's logical coordinate and preallocated run id;
+- factor, condition, block, cohort, and replicate assignments;
+- every structural selection and non-secret scalar/reference binding;
+- stochastic control, namespace, root-seed, profile, policy, semantic-address,
+  and selected-outcome provenance;
+- selection-to-instantiation provenance expectations;
+- safe admission decisions and diagnostic counts; and
+- any disclosed limitation on reproducibility, comparability, or realized-form
+  freedom.
+
+It does not contain queue state, worker assignment, mutable status, live
+snapshots, backend-private objects, raw evidence, secret values, environment
+dumps, or result summaries.
+
+### Failure taxonomy
+
+At minimum, implementations distinguish:
+
+- family/point/target invalid;
+- policy target or factor unbound;
+- domain empty or constraint unsatisfiable;
+- allocation cardinality/budget exceeded;
+- unsupported or malformed compiler/RNG/identity profile;
+- duplicate logical coordinate or derived run id;
+- selected whole scenario semantically invalid;
+- selected point outside its family domain;
+- selected apparatus or envelope unavailable/incompatible;
+- selection not a member of the selected backend envelope;
+- required artifact/digest/trust evidence missing; and
+- canonicalization or sealing failure.
+
+Diagnostics identify the safe stage, code, canonical ids/paths, profile, and
+counts. They do not render selected/supplied values, allowed domains, secret or
+fact refs, raw documents, backend objects, or tracebacks.
+
+## Explicit SDL Instantiation
+
+Trial realization is processor orchestration over public SDL APIs. For one plan
+entry it:
+
+1. verifies that the family digest and plan/entry identities match;
+2. applies the recorded structural selection to model-declared targets;
+3. supplies the recorded scalar bindings to the existing variable mechanism;
+4. constructs no authoring identity from a selected value;
+5. performs no random draw, import resolution, external query, secret read, or
+   backend callback;
+6. creates the closed instantiated representation;
+7. admits it with the ordinary whole-scenario semantic validator; and
+8. emits the existing canonical instantiated snapshot.
+
+Selection may use a private transient selected-expanded value internally, but
+that value is not an exchange contract, compiler input, or bypass around
+`instantiate_scenario()` / `admit_instantiated_scenario()`.
+
+`InstantiationProvenance` is extended by its owning implementation issue to
+carry the plan id, run id, and canonical selection records in addition to the
+existing authored digest, bindings, imports, capability constraints,
+explicitness, and realization designations. The instantiated snapshot digest
+therefore commits to the selected scenario and its derivation evidence.
+
+## Runtime Fact Binding
+
+Runtime fact binding is deliberately narrower than pre-run parameterization.
+A compiled late-bound slot declares:
+
+- stable slot id and compiled owning address;
+- accepted scalar/reference type;
+- allowed fact source kinds and scopes;
+- required sensitivity class and disclosure behavior;
+- freshness/expiry rule;
+- whether absence blocks, fails, or leaves an operation inapplicable; and
+- the exact run-local operation/action field that may receive the value.
+
+A fact or secret-reference carrier declares source, type, scope, observation
+time/freshness, sensitivity, authorization context, and optional evidence
+references. Binding succeeds only when all slot constraints hold.
+
+Facts may specialize a run-local operation input such as a discovered host,
+session, credential handle, or tool result. They cannot:
+
+- add/remove/rename topology or declarations;
+- choose an SDL alternative, subset, order, or timing point;
+- alter factors, condition assignment, logical coordinate, run id, plan id, or
+  snapshot identity;
+- advance or replace a random stream;
+- select another backend or apparatus; or
+- retroactively rewrite an experiment or archival record.
+
+Raw credentials and secret values are resolved only at the authorized sink.
+The portable plan and binding evidence record slot/source identities and
+redaction/loss disclosures, not secret material. Missing, stale, wrong-scope,
+wrong-type, or unauthorized facts produce an explicit runtime disposition; no
+fallback value or scenario resampling is permitted.
+
+## Backend Realization And Scheduling
+
+### Realization is proof against a selected envelope
+
+The processor first establishes membership in the scenario-family domain, then
+checks the selected instance/requested family against the selected backend
+realization envelope and manifest capabilities. Those are different proofs.
+
+Open or constrained realization choices remain governed by accepted ADR-070
+envelope semantics and existing manifest/realized-form disclosures. Where an
+experiment requires cross-run comparability, the experiment may tighten
+apparatus intent or make the realized form a recorded factor. A backend default
+is never an experiment selection.
+
+If a pinned backend/envelope becomes unavailable or refuses a previously
+admitted point, execution records failure/deviation. It does not silently
+substitute a backend, clamp a value, omit a member, or ask the randomizer for
+another trial.
+
+### Scheduler authority is intentionally small
+
+A scheduler consumes sealed entries and may:
+
+- choose dispatch order without changing logical order;
+- delay, pause, resume, or cancel under policy;
+- apply a transport retry with the same idempotency key before execution;
+- allocate an isolated range instance, ports, storage, and control-plane locks;
+- enforce bounded timeouts and cleanup; and
+- select bounded parallelism only when SCE-006 isolation proof permits it.
+
+It may not compose SDL, resolve imports, select variation points, call the
+randomizer, instantiate a different scenario, create run ids, decide factors,
+evaluate scientific results, or implement a private comparison/scoring engine.
+APTL and any other scheduler use this same handoff.
+
+## Conceptual Contract Sketches
+
+The following shapes are review aids, not published schemas. They bind ownership
+and relationships while leaving exact field spelling and version numbers to the
+contract implementation issues.
+
+### SDL variation point
+
+```yaml
+variation_point:
+  variation_point_id: stable-local-symbol
+  kind: parameter | governed-reference | alternative | subset | order | logical-timing
+  target: <closed descriptor owned by the target SDL model>
+  domain: <named bounded value domain, where applicable>
+  alternatives_or_members: <keyed typed children, where applicable>
+  cardinality_or_precedence: <closed kind-specific constraints>
+  requires: <finite typed selection relations>
+  excludes: <finite typed selection relations>
+```
+
+### Experiment selection policy
+
+```yaml
+selection_policy:
+  policy_id: stable-symbol
+  policy_profile: versioned closed kind
+  point_refs: [qualified-variation-point-id]
+  expansion: explicit | enumerate | zip | product | sample | stratify | coverage
+  output_bound: finite-positive-integer
+  factor_bindings: <existing experiment factor/condition ids>
+  stochastic_control_ref: <required only for stochastic policies>
+  logical_coordinate_profile: versioned-profile
+```
+
+### Experiment stochastic control
+
+```yaml
+stochastic_control:
+  control_id: stable-symbol
+  randomness_namespace: stable-experiment-owned-id
+  root_seed: canonical-non-secret-value
+  random_stream_profile_ref: immutable-versioned-id
+  namespace_reuse: explicit-provenance
+```
+
+The namespace and seed are experiment data. The referenced profile defines how
+their bytes are encoded and transformed; neither field is inferred from a
+document digest, process environment, or library default.
+
+### Random-stream profile
+
+```yaml
+random_stream_profile:
+  profile_id: immutable-versioned-id
+  generator: {algorithm: governed-id, version: exact-version}
+  seed_encoding: exact-profile
+  address_encoding: exact-profile
+  stream_derivation: exact-profile
+  transformations:
+    bounded_integer: exact-version
+    weighted_choice: exact-version
+    permutation: exact-version
+    subset: exact-version
+  failure_semantics: exact-version
+```
+
+### Admitted plan and entry
+
+```yaml
+admitted_trial_plan:
+  plan_identity: <profile + canonical digest>
+  input_refs_and_digests: <experiment, task, family, artifacts>
+  compiler_and_identity_profiles: <exact versions>
+  stochastic_controls: <namespace + seed + exact random-stream profile>
+  apparatus_bindings: <intent + pinned manifests/envelopes/configuration>
+  entries:
+    <logical-coordinate-key>:
+      run_id: <preallocated archival run identity>
+      allocation_assignments: <condition/factor/block/replicate>
+      structural_selections: <point id -> selected member ids>
+      parameter_bindings: <non-secret point id -> typed value/ref>
+      stochastic_provenance: <policy, address, selected outcome>
+      expected_instantiation_provenance: <plan/run/family linkage>
+  admission: <bounded success facts and limitations>
+```
+
+### Runtime fact binding
+
+```yaml
+fact_binding_event:
+  run_id: <existing run identity>
+  slot_id: <compiled late-bound slot>
+  fact_source_ref: <safe reference or redacted handle>
+  type_scope_freshness_sensitivity: <validated metadata>
+  authorization_and_evidence_refs: <safe refs>
+  disposition: bound | absent | stale | unauthorized | invalid
+  value: <present only on the protected run-local carrier; never duplicated>
+```
+
+## Compatibility And Migration
+
+### SDL documents
+
+- A current static SDL document has no variation points and denotes a singleton
+  family. Its composition, instantiation, compiled meaning, and identifiers do
+  not change.
+- A current variable-only SDL document keeps the same `Variable`,
+  substitution-token syntax, binding, default, and `InstantiationProvenance`
+  semantics. A future parameter variation point targets that existing variable
+  rather than adding a second substitution language.
+- Existing module documents retain ADR-053 resolution and namespace behavior.
+  Composition completes before points are selected.
+- Structural variation is opt-in and versioned. Consumers that do not implement
+  its published schema/profile reject it cleanly; they do not ignore points.
+
+### Experiment documents
+
+- Existing `experiment-authoring-input-v1` documents remain valid authoring
+  artifacts.
+- Current free-text `allocation_method`, `randomization_unit`,
+  `replication_policy`, stopping rules, red-variant selections, seeds, and
+  stochastic-control descriptions remain declarations/provenance. They do not
+  become executable selection semantics by convention.
+- To compile trials, an experiment migrates to typed selection policies,
+  coordinate/identity profiles, and accepted random-stream profiles. A
+  compatibility adapter may translate a narrowly recognized legacy form only
+  under a named migration profile and must emit the typed result for review.
+- Existing task, capture-spec, factor, allocation, apparatus-intent, run, study,
+  evidence, and measure concepts are extended at their owning boundaries rather
+  than copied into a new trial family.
+
+### Runs and studies
+
+- `experiment-run-v1` remains the only archival record for one execution.
+- `experiment-study-v1` remains the authority for factors, compared
+  conditions, allocation, replication, stopping, and analysis.
+- Existing run/study records need no migration merely because a future producer
+  uses an admitted plan. New records may add plan/selection lineage through
+  version-governed optional or new-version fields under ADR-061.
+- Live operation state, runtime snapshots, scheduler jobs, and plan entries
+  never masquerade as archival runs.
+
+### ADR-070 and domain reuse
+
+ADR-070 is accepted by this change after its closed value-domain primitives,
+membership/subsumption relation, contract carriage, posture semantics, and
+honesty conformance landed. Those neutral `aces_contracts`/SDL primitives may
+be reused, but `WitnessPolicy.seed` is not randomness and backend posture is
+never scenario or experiment selection.
+
+## Consumer Boundaries
+
+| Consumer | What it may contribute | Required handoff | What it may not own |
+| --- | --- | --- | --- |
+| SCE-001 ATT&CK coverage | Revision-pinned technique inventory, coverage targets, scenario-pack evidence | Valid authored families and/or experiment selection objectives | SDL semantics, hidden candidate execution, or a coverage claim based only on generated count |
+| SCE-003 adaptive difficulty | Policy, observations, trigger, intervention, and validity disclosure | Run event/intervention provenance; a new admitted coordinate for a derived follow-up trial | Retroactive factor/topology/identity/stream mutation |
+| SCE-004 goal/tool flexibility | Goal, success criteria, tool/affordance set, decision-surface policy, typed fact sinks | Ordinary SDL/participant semantics and runtime fact bindings | Hidden scenario selection through tool choice or observations |
+| SCE-005 ATT&CK/CTI generation | Revision-pinned inputs, mappings, candidate rationale, confidence and gaps | Candidate SDL that passes ordinary trust, validation, and admission | Direct execution of CTI, bypass of semantic validation, or backend-directed repair |
+| SCE-006/APTL scheduling | Isolation/capacity policy, placement, bounded parallelism, timeouts, cleanup | Sealed admitted entries over the existing single-scenario execution path | A second lifecycle, randomizer, run-id allocator, comparison, or scoring engine |
+
+## Requirement And Follow-On Trace Map
+
+### SCE requirements
+
+| Requirement | Relationship to this spine | Owning implementation issue(s) |
+| --- | --- | --- |
+| SCE-001 | Consumes revision-pinned coverage sets and admitted scenario candidates; coverage remains separate from trial validity | #783; generation support also depends on #786 and #654 |
+| SCE-002 | Owns the full family/selection/plan/instantiation semantics defined here | #656, #274, #786, #787, #788, #789, #790, #791 |
+| SCE-003 | Consumes baseline plan/run identity and records adaptation as intervention or a newly admitted follow-up | #784 after #790 |
+| SCE-004 | Uses goal/decision semantics and typed late-bound facts without becoming a selector | #657, #791, #653 |
+| SCE-005 | Produces candidate SDL from ATT&CK/CTI, then uses normal validation/admission | #660, #786, #654 |
+| SCE-006 | Consumes admitted plans and proves clean-state isolation; owns no SDL/randomization semantics | #658, #788, #789, #790, #785 |
+
+### Existing DSL, EXP, and RUN requirements
+
+| Requirements | Preserved or extended boundary |
+| --- | --- |
+| DSL-101, DSL-102 | Selected values never change stable declaration ids; imported point/target refs remain qualified and unambiguous |
+| DSL-103 | Module composition, namespace isolation, integrity, and locks complete before selection |
+| DSL-104, DSL-115 | Scenario meaning stays backend-neutral; specificity/domain declarations remain distinct from backend realization |
+| DSL-105 | One typed SDL parse/normalization path; no second template or evaluation language |
+| EXP-701, EXP-702 | Tasks reference scenario families; experiment procedure remains separate from scenario meaning |
+| EXP-703, EXP-720 | One started trial becomes one canonical archival run with the preallocated run id |
+| EXP-704, EXP-721, EXP-722 | Apparatus intent, compatibility, selected envelopes/manifests, and realized forms stay explicit and distinct |
+| EXP-705, EXP-706, EXP-719 | Factors, conditions, allocation, repetition, and controlled variation remain study/experiment semantics |
+| EXP-710, EXP-712 | Plan, snapshot, run, evidence, and result lineage support bounded reproducibility/replay claims |
+| EXP-718 | Owns accepted RNG/stream profiles, controlled randomness, and seed preservation |
+| EXP-736 | The authoring input is the pre-run design consumed by trial compilation, not the admitted plan or run |
+| RUN-300, RUN-301 | The existing lifecycle and explicit pre-compilation instantiation remain authoritative |
+| RUN-302, RUN-303 | Typed compilation and planning consume only admitted instantiated scenarios and preserve dependency/order meaning |
+| RUN-304 | Live execution state remains separate from plans and archival runs |
+| RUN-309 | Reproducible participant context/history may cite the plan and streams but cannot redefine them |
+
+### Native issue dependency sequence
+
+The milestone uses GitHub's native blocked-by graph rather than an umbrella
+issue. The design issue gates the existing/follow-on chain:
+
+```text
+#652
+  -> #656 -> #786 -> #787 -> #788 -> #789 -> #790 -> #785
+          |       |                                -> #784
+          |       -> #654
+          |
+  -> #274 --------+
+  -> #658 ---------------------> #788
+  -> #657 -> #791 -> #653
+  -> #660
+  -> #783
+```
+
+The chain is intentionally contract-first: family declarations, executable
+selection/RNG policy, plan contract, compiler/admission, and realization/run
+integration land before batch scheduling or adaptation.
+
+## Security, Reliability, And Scale
+
+### Security gates
+
+1. SDL input uses the existing bounded YAML/profile, duplicate-key,
+   canonical-key, closed-model, semantic, composition, lock, digest, signature,
+   cycle, collision, and path-confinement gates.
+2. Experiment and plan inputs use closed `ContractModel` shapes, published
+   schemas, bounded parsing, and owning cross-artifact validators. Later remote
+   ingress must not expose raw Pydantic/YAML errors.
+3. Any API reuses strict control-plane authentication, verified identity,
+   role/target authorization, request-size bounds, idempotency fingerprints,
+   and append-only audit events.
+4. Secret material is neither a factor nor identity input and never appears in
+   plan bytes, snapshots, diagnostics, fixtures, argv, logs, or telemetry.
+5. Ambient environment variables, process-global RNG state, mutable parameter
+   stores, and backend defaults cannot influence selection.
+6. Selection/binding remains in-process over typed DTOs or bounded files/stdin;
+   no raw plan, parameter/fact map, secret ref, or credential is placed in
+   process argv, shell interpolation, or `shell=True`.
+7. Manifest capability, compatibility, target conformance, and accepted
+   realization-envelope membership remain mandatory backend admission gates.
+8. Errors and logs expose only safe ids, digests, profiles, stages, counts, and
+   durations. Raw documents, selected values, domains, facts, evidence bodies,
+   backend objects, environment dumps, and tracebacks stay off secondary
+   surfaces.
+9. Immutable plans are artifact-service candidates, not
+   `RuntimeSnapshot.metadata`, operation-detail blobs, tags, audit blobs, or a
+   mutable per-target parameter database.
+10. Artifact dereference, secret resolution, fact reads, plan reads, and
+    execution are separately authorized operations.
+
+### Reliability and determinism
+
+- All transforms are pure with respect to admitted inputs and explicit
+  profiles.
+- Plan sealing is atomic; retries are idempotent.
+- Duplicate coordinates/ids, missing refs, profile drift, and artifact digest
+  mismatch fail before dispatch.
+- Backend or scheduler failure never advances selection streams.
+- Actual realized forms, deviations, cleanup, and evidence loss are disclosed
+  rather than rewritten as intended state.
+
+### Resource bounds and scalability
+
+Every implementation enforces declared budgets for source bytes, imports,
+variation points, alternatives/members, constraint edges, numeric/sample
+cardinality, trial count, per-entry bindings, plan bytes, diagnostics, and
+artifact dereferences.
+
+The compiler must not materialize an unbounded or accidental Cartesian product.
+It may evaluate independent logical coordinates in parallel and cache pure
+subresults by input/profile digest. Internal partitioning is invisible in the
+canonical output. Large plans may be constructed through bounded staging or
+content-addressed chunks, but the portable admitted plan remains one sealed
+logical artifact with deterministic entry ordering and all-or-nothing
+admission.
+
+## Verification Contract For Follow-On Work
+
+The implementation issues inherit these minimum evidence obligations:
+
+- positive and negative contract fixtures for every closed union/profile;
+- whole-scenario semantic tests for every point/target kind;
+- selection membership and contradiction/exhaustion tests;
+- plan atomicity, uniqueness, budget, and diagnostic-redaction tests;
+- serial/parallel/reordered/batched/retried/cross-process byte-equivalence
+  tests;
+- stream non-interference and map/hash-order differential tests;
+- apparatus envelope membership/subsumption and refusal-without-resampling
+  properties;
+- public SDL instantiation/admission equivalence after serialization;
+- secret/fact authorization, type/scope/freshness, and non-retroactivity tests;
+- run/study/plan/snapshot lineage cross-artifact validation; and
+- scheduler conformance proving that dispatch order and bounded parallelism do
+  not change plan entries or selection provenance.
+
+Until those artifacts land, this document and the formal invariant list are
+design coverage only. SCE-002 remains DRAFT.

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ explain/reference/assessment-semantics
 explain/reference/objective-semantics
 explain/reference/explicitness-realization-semantics
 explain/reference/realization-envelopes
+explain/reference/scenario-variation-and-trial-realization
 ```
 
 ```{toctree}
@@ -141,6 +142,7 @@ lessons/README
 migration/README
 research/experiment-core/index
 research/realization-envelope/index
+research/scenario-variation-trial-realization/index
 research/scoring-scope/index
 research/validation-admission-profiles/index
 research/primary/index

--- a/docs/research/scenario-variation-trial-realization/index.md
+++ b/docs/research/scenario-variation-trial-realization/index.md
@@ -1,0 +1,19 @@
+# Scenario Variation And Trial Realization Research
+
+These notes support issue #652 and SCE-002. They compare primary standards,
+language specifications, simulation literature, random-stream designs, and
+cyber-exercise systems in order to derive design criteria for ACES. They are
+research evidence, not contract authority.
+
+The binding decision is
+[ADR-084](../../decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md).
+The complete architecture is
+[Scenario Variation And Trial Realization](../../explain/reference/scenario-variation-and-trial-realization.md),
+and the normative invariant set is
+{download}`the formal specification <../../../specs/formal/scenario-variation-trial-realization/README.md>`.
+
+```{toctree}
+:maxdepth: 1
+
+prior-art-and-design-criteria
+```

--- a/docs/research/scenario-variation-trial-realization/prior-art-and-design-criteria.md
+++ b/docs/research/scenario-variation-trial-realization/prior-art-and-design-criteria.md
@@ -1,0 +1,492 @@
+# Prior Art And Design Criteria For Scenario Variation And Trial Realization
+
+Date: 2026-07-15
+
+Issue: #652
+
+Requirement: SCE-002
+
+## Research Question And Method
+
+The question is not merely how to substitute values in YAML. It is how ACES
+can describe a bounded family of valid cyber-range scenarios, select trials as
+part of an experiment, realize every selected trial deterministically, and
+preserve enough provenance to make scientific claims without allowing a
+scheduler, backend, or mutable runtime state to become a second source of
+scenario meaning.
+
+The review prioritizes normative specifications, official project
+documentation, and original papers. Secondary surveys were used only to locate
+primary work. The transfer question for every source is explicit: which
+property is useful to ACES, and which authority boundary must not be imported
+with it?
+
+## Typed Configuration And Module Languages
+
+### CUE: constraints as values
+
+The [CUE language specification](https://cuelang.org/docs/reference/spec/)
+models values in a lattice and defines unification as commutative,
+associative, and idempotent. That makes evaluation order irrelevant for the
+core constraint operation. Disjunction supplies a typed alternative surface,
+while closed structures and concrete-value checks distinguish a constraint
+from a completed configuration.
+
+Useful transfer:
+
+- a declared domain and a selected concrete value should be different phases;
+- intersection of constraints should be deterministic and fail with no value
+  when the intersection is empty; and
+- alternatives should be members of a closed union rather than callbacks or
+  arbitrary document patches.
+
+Limit: ACES does not adopt CUE evaluation, comprehensions, interpolation, or a
+general constraint language. SDL remains the normative language, and the
+selected scenario must pass its ordinary semantic validator.
+
+### Dhall: total configuration and import integrity
+
+The [Dhall Language Tour](https://docs.dhall-lang.org/tutorials/Language-Tour.html)
+describes a total, strongly typed configuration language with typed records,
+unions, functions, imports, semantic hashes, and normalization. Dhall's import
+hashes demonstrate that reproducible composition requires the imported
+content and resolution semantics to be identified, not just an author-provided
+path.
+
+Useful transfer: preserve trusted, digest-pinned module resolution before
+selection, and make normalized artifacts independent of checkout location.
+Limit: functions and arbitrary normalization are deliberately outside the SDL
+variation surface. ADR-053 and ADR-078 already own the narrower ACES import and
+phase model.
+
+### Jsonnet: programmable generation is powerful but changes the trust model
+
+The [Jsonnet specification](https://jsonnet.org/ref/spec.html) defines a lazy,
+pure functional configuration language with objects, inheritance, local
+bindings, comprehensions, and functions. It shows why a configuration program
+can generate families compactly, but also why adopting one would move
+authorship, termination, diagnostics, and review into another evaluator.
+
+Useful transfer: distinguish reusable declarations from their manifested JSON
+result. Limit: ACES rejects an embedded configuration program; scenario
+variation must remain finite or otherwise explicitly bounded, typed, and
+reviewable without executing author code.
+
+### Terraform: stable instance keys matter
+
+Terraform separates
+[declared input variables](https://developer.hashicorp.com/terraform/language/values/variables)
+from resource instances, and its
+[`for_each` meta-argument](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each)
+uses map keys or set members to identify instances. This is a useful warning:
+positional expansion or value-derived names make identity churn when an
+unrelated item is inserted or a parameter changes.
+
+Useful transfer: variation-point ids, logical trial coordinates, and selected
+declaration ids must be stable symbols. Limit: ACES does not inherit
+Terraform's resource state, provider lifecycle, or plan/apply semantics.
+
+### Common Workflow Language: explicit scatter products
+
+The [CWL Workflow specification](https://www.commonwl.org/v1.2/Workflow.html)
+makes scatter expansion explicit and distinguishes dot-product,
+flat-cross-product, and nested-cross-product methods. This prevents a list of
+factors from silently implying a product shape.
+
+Useful transfer: an experiment selection policy must state whether it
+enumerates, zips, samples, blocks, or crosses domains, and it must assign
+stable logical coordinates before execution. Limit: ACES trial compilation is
+not a dataflow workflow engine, and scheduler concurrency cannot influence the
+expansion result.
+
+### Language-design conclusion
+
+The strongest shared lesson is phase separation:
+
+```text
+declaration + bounded domain -> validated family -> concrete selection
+```
+
+Generic template or evaluation languages offer expressiveness by allowing
+authors to compute structure. ACES instead needs inspectability, boundedness,
+portable diagnostics, and stable identity. The appropriate seam is therefore
+a closed variation-point union and a separate experiment selection policy,
+not a second language runtime.
+
+## Simulation Experiment And Model Separation
+
+### MIASE and SED-ML
+
+The original
+[MIASE paper](https://doi.org/10.1371/journal.pcbi.1001122) distinguishes the
+models used by a simulation from the simulation procedures, their order,
+intermediate processing, and outputs. It also distinguishes reproducibility
+of an experiment from identical numerical results. The
+[SED-ML specifications](https://sed-ml.org/specifications.html) operationalize
+the same separation with model references, simulation descriptions, tasks,
+repeated tasks, data generators, and outputs.
+
+Useful transfer:
+
+- the SDL scenario family is not the experiment design;
+- parameter scans, allocation, repetition, and stochastic policy belong to an
+  experiment artifact that references the model/family;
+- the selected procedure and transformations must be preserved alongside the
+  selected values; and
+- replay support is a claim bounded by preserved inputs, algorithms,
+  apparatus, and unavailable external state.
+
+Limit: ACES is not claiming SED-ML or MIASE conformance, numerical equivalence
+across backends, or a particular simulation algorithm.
+
+### SSP and FMI
+
+The Modelica Association's
+[System Structure and Parameterization specification](https://ssp-standard.org/docs/main/)
+separates system structure, component references, connections, and parameter
+bindings. The
+[Functional Mock-up Interface 3.0.2 specification](https://fmi-standard.org/docs/3.0.2/)
+defines a portable execution interface with variables, causality, variability,
+clocks, state, and co-simulation/model-exchange roles.
+
+Useful transfer: parameter binding should target declared typed locations,
+and a backend execution interface should consume an already-defined model
+rather than reinterpret its experimental design. Limit: FMI variables and SSP
+parameter sets do not define ACES scenario identity, experiment allocation, or
+cyber-range backend feasibility.
+
+### Experimental frames
+
+Zeigler's work on
+[modular separation between models and experimental frames](https://doi.org/10.1080/03081078408934871)
+treats the conditions under which a model is observed or exercised as a
+separate concern. This supports ACES's existing scenario/task/apparatus split:
+the scenario states possible world meaning, while task, experiment, and
+apparatus artifacts state how that meaning is exercised and observed.
+
+Limit: ACES does not adopt DEVS as its execution semantics. The transfer is the
+separation principle, not the formalism.
+
+## Reproducible Random Streams And Parallel Execution
+
+### A seed does not identify an algorithm
+
+The [NumPy random design](https://numpy.org/doc/stable/reference/random/)
+separates a bit generator from distribution transforms and documents multiple
+parallel-generation patterns. Its
+[compatibility policy](https://numpy.org/doc/stable/reference/random/compatibility.html)
+and [NEP 19](https://numpy.org/neps/nep-0019-rng-policy.html) are especially
+important: a reproducibility promise must say which layer is stable. A seed
+alone omits the generator, seed-to-state mixing, bit interpretation,
+distribution transformation, and library/version behavior.
+
+Therefore an ACES random-stream profile must identify:
+
+1. generator family and version;
+2. seed value and canonical seed encoding;
+3. canonical semantic-address encoding and derivation function;
+4. integer/real conversion and distribution/sampling transformation versions;
+5. rejection/exhaustion semantics; and
+6. the compatibility promise for that complete profile.
+
+### Streams must follow semantic coordinates
+
+L'Ecuyer and colleagues' original
+[streams and substreams work](https://doi.org/10.1287/opre.50.6.1073.358)
+shows how independently addressable streams support simulation organization.
+NumPy's
+[`SeedSequence`](https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html)
+mixes entropy reproducibly and derives child streams through a spawn key.
+These are useful mechanisms, but a spawn sequence tied to worker creation order
+would still be wrong for ACES.
+
+An ACES stream address must instead be a canonical tuple of immutable semantic
+coordinates, for example:
+
+```text
+(explicit randomness namespace,
+ logical trial coordinate,
+ policy or variation-point id,
+ draw purpose,
+ local draw coordinate)
+```
+
+Worker id, process id, thread id, host, queue position, wall time, completion
+order, retry number, and map iteration order are forbidden address inputs.
+The aggregate experiment-spec identity/digest is also forbidden: an unrelated
+metadata edit would otherwise re-key every stream. The experiment instead owns
+a stable randomness namespace and root seed. Retaining them requests common
+random numbers at unchanged addresses; an independent randomization explicitly
+rotates the namespace or seed. Adding a draw for one variation point must not
+perturb another point.
+
+### Counter-based generation is the reference design shape
+
+The original
+[Random123 paper](https://www.thesalmons.org/john/random123/papers/random123sc11.pdf)
+and [project](https://random123.com/) describe counter-based generators where
+a random block is a stateless function of a counter and key. This shape makes
+random access and parallel evaluation natural: scheduling does not advance a
+shared mutable state.
+
+ACES need not select Random123 in this design issue. It should, however, require
+the same externally visible property: a draw is determined from its governed
+profile and semantic address, never from how many draws happened to occur on a
+worker. A future implementation may use a counter-based generator or a
+carefully specified derivation of independent stateful streams, provided it
+passes the schedule-permutation and non-interference properties.
+
+## Experimental Coverage And Sampling
+
+NIST's
+[combinatorial coverage measurement](https://www.nist.gov/publications/combinatorial-coverage-measurement)
+measures which t-way combinations of parameter values a test set covers. It
+supports a useful distinction between a scenario-family domain and a policy
+that chooses a subset of that domain. Pairwise or t-way coverage is a selection
+objective, not part of scenario validity and not proof of behavioral coverage.
+
+A selection policy may therefore enumerate, sample, block, stratify, or target
+combinatorial coverage. It must record the domain version, policy version,
+logical coordinates, exclusions, and achieved/target coverage disclosure. A
+backend may reject an unrealizable point, but may not replace it with a nearby
+point and claim the original coverage.
+
+## Cyber Playbooks, CTI, And Range Generation
+
+### CACAO, ATT&CK, STIX, and Attack Flow
+
+[CACAO Security Playbooks 2.0](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/security-playbooks-v2.0.pdf)
+defines a portable playbook vocabulary with workflow steps, commands,
+variables, targets, and control flow. It is useful alignment material for
+declared attack/defense procedures, but a CACAO playbook is neither an ACES
+topology nor an experiment allocation.
+
+[STIX 2.1](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)
+is a CTI object and relationship language. MITRE states that the
+[ATT&CK STIX dataset](https://attack.mitre.org/resources/attack-data-and-tools/)
+is its most granular machine-readable representation. The
+[ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator) annotates
+and visualizes matrices and coverage, while
+[Attack Flow](https://github.com/center-for-threat-informed-defense/attack-flow)
+represents how ATT&CK techniques are composed into attacks.
+
+Useful transfer:
+
+- retain external object ids, revisions, mappings, and source digests;
+- represent logical technique/action order explicitly when it has scenario
+  meaning;
+- measure ATT&CK coverage against revision-pinned technique sets; and
+- treat CTI/layers/flows as evidence-bearing candidate inputs, not as trusted
+  executable SDL or runtime selectors.
+
+Limit: ATT&CK membership does not supply preconditions, effects, infrastructure,
+credentials, concrete commands, success criteria, evidence requirements, or
+backend feasibility. An automated mapping must emit candidates that pass the
+ordinary authoring, trust, semantic-validation, and trial-admission gates.
+
+### CALDERA and Atomic Red Team
+
+MITRE CALDERA distinguishes abilities, adversary profiles, operations, agents,
+facts, and objectives in its
+[terminology](https://caldera.readthedocs.io/en/2.7/Learning-the-terminology.html)
+and [objective model](https://caldera.readthedocs.io/en/latest/Objectives.html).
+Facts can feed ability variables during an operation. This demonstrates useful
+late binding, but it also demonstrates the authority risk: discovered runtime
+facts must not silently become pre-run factor selection or scenario topology.
+
+[Atomic Red Team](https://github.com/redcanaryco/atomic-red-team) publishes
+small ATT&CK-mapped tests with explicit input arguments, dependencies, execute
+commands, and cleanup commands. It demonstrates the value of bounded,
+inspectable inputs and reusable atomic actions. It does not supply a scientific
+trial compiler or an ACES campaign composition model.
+
+### Planning and cyber-range generation
+
+The [PDDL reference](https://ipc06.icaps-conference.org/deterministic/pddl.html)
+separates a planning domain from a problem instance and makes action
+preconditions/effects explicit. Cyber-range work including
+[VSDL](https://arxiv.org/abs/2001.06681) and
+[CRACK](https://doi.org/10.1016/j.cose.2020.101837) uses DSLs, model
+verification, generation, and automated testing to reduce scenario-authoring
+cost.
+
+Useful transfer: generation should produce a reviewable candidate with a
+declared constraint/model basis, followed by independent validation and
+admission. Limit: a planner, LLM, CTI mapper, or generator is not SDL semantic
+authority. It cannot mint imports, bypass trust, invent unbounded values, or
+turn a failed candidate into a different admitted trial through hidden search.
+
+## Adaptive Difficulty And Benchmark Validity
+
+Hunicke and Chapman's
+[Hamlet](https://www.cs.northwestern.edu/~hunicke/pubs/Hamlet.pdf) models
+dynamic difficulty adjustment as a control problem driven by predicted player
+performance. The lesson is not a particular controller; it is that adaptation
+has a policy, observations, trigger, intervention, and outcome that must be
+separable and inspectable.
+
+For training, an adaptive intervention may be desirable. For benchmarking, it
+changes the treatment received and can destroy comparability if hidden. ACES
+must therefore preserve the admitted baseline trial and record any adaptive
+intervention as a later run event with policy identity, observation basis,
+trigger, action, timing, and effect disclosure. A derived follow-up trial needs
+a new admitted run identity linked to the source run. Runtime performance may
+never retroactively rewrite baseline factors, snapshot identity, or random
+streams.
+
+## Rejected Architecture Families
+
+### Arbitrary templates, expressions, callbacks, or patches
+
+Rejected because they can compute unbounded structure, target unstable document
+paths, hide dependencies, weaken static review, and require another evaluator
+and security model. JSON Patch also lets selected values mutate identity-bearing
+fields unless a second semantic access-control language is invented.
+
+### Ambient or worker-local randomness
+
+Rejected because OS entropy, process-global RNG state, worker allocation, retry
+count, and traversal order make the trial set depend on scheduling. Recording a
+seed after the fact does not repair an unspecified generator/draw contract.
+
+### One shared mutable parameter or fact store
+
+Rejected because reads become time-dependent, authorization and redaction
+boundaries blur, retries can observe different values, and runtime discoveries
+can retroactively change experiment meaning. Pre-run selections belong in a
+sealed admitted plan; runtime observations may fill only typed late-bound sinks.
+
+### Backend-directed selection or resampling
+
+Rejected because feasibility and selection are different authorities. A
+backend envelope can prove or refute realizability of a selected point; it may
+not choose the scientific treatment. Failure must remain visible.
+
+### Trial as a second archival root
+
+Rejected because ADR-068 and ADR-065 already make one execution one
+`experiment-run-v1` record. The plan entry preallocates that run identity; it
+does not create a parallel trial provenance graph.
+
+## Derived Design Criteria
+
+The research yields the following criteria for the binding design:
+
+1. **One phase, one authority.** Composition, family validity, experiment
+   selection, trial admission, instantiation, runtime fact binding, backend
+   realization, scheduling, and archival provenance have named owners.
+2. **Composition closes first.** All imports are trusted, resolved, namespace
+   qualified, and digested before any trial selection.
+3. **Stable symbols.** Declaration, variation-point, policy, and logical-trial
+   ids do not depend on selected values, source paths, or worker order.
+4. **Closed bounded variation.** Scalar/reference domains, alternatives,
+   subsets, constrained order, and logical timing are closed discriminated
+   kinds with explicit bounds.
+5. **Independent validity.** Every structural alternative must be semantically
+   valid when selected; a family declaration is not permission to emit an
+   invalid intermediate scenario.
+6. **Selection is experiment design.** Enumeration, crossing, sampling,
+   allocation, blocking, and coverage belong to experiment policies, not SDL
+   composition or backend behavior.
+7. **Scenario and backend domains differ.** Scenario membership is checked
+   before realization-envelope membership/subsumption.
+8. **Profile the full RNG stack.** Generator, seed encoding, address
+   derivation, canonical input, transformations, and exhaustion are versioned.
+9. **Semantic stream addressing.** Streams derive from an explicit stable
+   randomness namespace plus trial/policy/purpose coordinates, never the
+   aggregate experiment digest.
+10. **Stream non-interference.** A draw added to one concern cannot perturb
+    another concern's selected value.
+11. **Schedule independence.** Serial, parallel, batched, reordered, retried,
+    and cross-process compilation produces byte-identical admitted plans.
+12. **Fail closed.** Empty domains, exhausted constraints, invalid choices,
+    duplicate coordinates, and apparatus mismatch produce no plan.
+13. **One planned/executed identity.** A plan entry's preallocated run id
+    becomes the archival run id when execution starts.
+14. **Immutable intent.** The admitted plan seals refs/digests, coordinates,
+    selections, factors, profiles, apparatus intent, and admission evidence.
+15. **Ordinary instantiation.** Realization calls the public SDL phase APIs and
+    reuses their validation and provenance; no private binder mints results.
+16. **Typed late binding only.** Runtime facts fill declared sinks with source,
+    type, scope, freshness, sensitivity, and evidence metadata.
+17. **Secrets remain references.** Secret values never enter factors, stream
+    addresses, identities, digests, plan summaries, diagnostics, or logs.
+18. **Scheduler is a consumer.** It may place, delay, pause, retry transport,
+    and enforce isolation; it cannot select, instantiate, score, or resample.
+19. **Adaptation is an intervention.** It never rewrites the admitted baseline
+    and is disclosed for validity/comparability review.
+20. **Generation is candidate production.** CTI, ATT&CK layers, playbooks,
+    planners, and AI systems enter through normal trust, validation, and
+    admission gates.
+21. **Compatibility is monotone.** Existing static SDL is a singleton family;
+    current variable-only SDL retains its meaning; existing run/study records
+    remain archival authority.
+22. **Claims remain bounded.** A deterministic plan is not proof of backend
+    equivalence, artifact availability, hidden-state recreation, or exact
+    replay from a seed alone.
+
+These criteria are adopted by ADR-084 and restated as formal invariants in
+`specs/formal/scenario-variation-trial-realization/README.md`.
+
+## References
+
+Language and workflow specifications:
+
+- CUE, [The CUE Language Specification](https://cuelang.org/docs/reference/spec/).
+- Dhall, [Language Tour](https://docs.dhall-lang.org/tutorials/Language-Tour.html).
+- Jsonnet, [Language Specification](https://jsonnet.org/ref/spec.html).
+- HashiCorp, [Input Variables](https://developer.hashicorp.com/terraform/language/values/variables)
+  and [`for_each`](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each).
+- Common Workflow Language,
+  [Workflow Description v1.2.1](https://www.commonwl.org/v1.2/Workflow.html).
+
+Simulation, experiment, and random-stream sources:
+
+- Waltemath et al.,
+  [Minimum Information About a Simulation Experiment](https://doi.org/10.1371/journal.pcbi.1001122),
+  *PLoS Computational Biology* 7(4), 2011.
+- COMBINE, [SED-ML specifications](https://sed-ml.org/specifications.html).
+- Modelica Association,
+  [System Structure and Parameterization](https://ssp-standard.org/docs/main/)
+  and [FMI 3.0.2](https://fmi-standard.org/docs/3.0.2/).
+- Zeigler,
+  [Theory of Discrete Event Specified Models](https://doi.org/10.1080/03081078408934871),
+  *International Journal of General Systems* 10(1), 1984.
+- NumPy, [Random sampling](https://numpy.org/doc/stable/reference/random/),
+  [compatibility policy](https://numpy.org/doc/stable/reference/random/compatibility.html),
+  [NEP 19](https://numpy.org/neps/nep-0019-rng-policy.html), and
+  [`SeedSequence`](https://numpy.org/doc/stable/reference/random/bit_generators/generated/numpy.random.SeedSequence.html).
+- L'Ecuyer et al.,
+  [An Object-Oriented Random-Number Package with Many Long Streams and Substreams](https://doi.org/10.1287/opre.50.6.1073.358),
+  *Operations Research* 50(6), 2002.
+- Salmon et al.,
+  [Parallel Random Numbers: As Easy as 1, 2, 3](https://www.thesalmons.org/john/random123/papers/random123sc11.pdf),
+  SC11, 2011.
+- NIST,
+  [Combinatorial Coverage Measurement](https://www.nist.gov/publications/combinatorial-coverage-measurement).
+
+Cyber and adaptive-system sources:
+
+- OASIS,
+  [CACAO Security Playbooks 2.0](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/security-playbooks-v2.0.pdf)
+  and [STIX 2.1](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html).
+- MITRE ATT&CK,
+  [Data and Tools](https://attack.mitre.org/resources/attack-data-and-tools/)
+  and [ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator).
+- Center for Threat-Informed Defense,
+  [Attack Flow](https://github.com/center-for-threat-informed-defense/attack-flow).
+- MITRE CALDERA,
+  [Terminology](https://caldera.readthedocs.io/en/2.7/Learning-the-terminology.html)
+  and [Objectives](https://caldera.readthedocs.io/en/latest/Objectives.html).
+- Red Canary, [Atomic Red Team](https://github.com/redcanaryco/atomic-red-team).
+- International Planning Competition,
+  [PDDL reference](https://ipc06.icaps-conference.org/deterministic/pddl.html).
+- Costa, Russo, and Armando,
+  [Automating the Generation of Cyber Range Virtual Scenarios with VSDL](https://arxiv.org/abs/2001.06681),
+  2020.
+- Russo, Costa, and Armando,
+  [Building Next Generation Cyber Ranges with CRACK](https://doi.org/10.1016/j.cose.2020.101837),
+  *Computers & Security* 95, 2020.
+- Hunicke and Chapman,
+  [AI for Dynamic Difficulty Adjustment in Games](https://www.cs.northwestern.edu/~hunicke/pubs/Hamlet.pdf),
+  AAAI workshop, 2004.

--- a/docs/specs/formal.md
+++ b/docs/specs/formal.md
@@ -24,6 +24,10 @@ formal artifacts are warranted.
   apparatus-context, study/collection, capture specification, raw evidence,
   derived measure, backend observation capability, and archival provenance
   contracts
+- **Scenario Variation And Trial Realization**
+  (`specs/formal/scenario-variation-trial-realization/`) -- Scenario-family
+  identity, bounded selection, schedule-independent random streams, admitted
+  plans, explicit instantiation, late binding, and archival linkage
 - **Realization** (`specs/formal/realization/`) -- Exact/constrained/open
   realization boundaries, backend realization support, and proposed
   realization-envelope membership, subsumption, witness, and negative

--- a/specs/formal/README.md
+++ b/specs/formal/README.md
@@ -14,6 +14,7 @@ Examples:
 - `specs/formal/participant-behavior-model/`
 - `specs/formal/participant-runtime/`
 - `specs/formal/experiment-core/`
+- `specs/formal/scenario-variation-trial-realization/`
 - `specs/formal/validation-admission-profiles/`
 - `specs/formal/sdl-phases/`
 

--- a/specs/formal/assurance-fulfillment.yaml
+++ b/specs/formal/assurance-fulfillment.yaml
@@ -28,6 +28,7 @@ adr_refs:
   - ADR-018
   - ADR-078
   - ADR-081
+  - ADR-084
 
 # Registry of classified formal-spec subsystems. Every immediate subdirectory of
 # specs/formal/ carrying a README.md must appear here (the checker fails on any
@@ -47,6 +48,9 @@ subsystems:
     fm_level: FM2
   - id: experiment-core
     path: specs/formal/experiment-core
+    fm_level: FM2
+  - id: scenario-variation-trial-realization
+    path: specs/formal/scenario-variation-trial-realization
     fm_level: FM2
   - id: runtime-contracts
     path: specs/formal/runtime-contracts
@@ -150,6 +154,50 @@ entries:
           Contract validation in test_runtime_contracts.py is example-based; no
           property-based or differential coverage of the EXP-701-705 contracts
           yet; tracked for delivery.
+
+  - subsystem: scenario-variation-trial-realization
+    # Design coverage only (SCE-002): issue #652 fixes the semantic boundary.
+    # Contract, compiler, runtime, and schedule-permutation evidence belongs to
+    # the native dependency chain rather than this design-only issue.
+    delivered_artifacts:
+      - kind: invariant_list
+        path: specs/formal/scenario-variation-trial-realization/README.md
+    waived_artifacts:
+      - kind: unit_tests
+        date: 2026-07-15
+        tracking:
+          - "#786"
+          - "#787"
+          - "#789"
+          - "#790"
+          - "#791"
+        rationale: >-
+          Issue #652 publishes design coverage only. Family validation,
+          selection, compilation/admission, instantiation/provenance, and fact
+          binding unit tests are owned by the sequenced implementation issues.
+      - kind: typed_ir_or_contract_coverage
+        date: 2026-07-15
+        tracking:
+          - "#274"
+          - "#786"
+          - "#787"
+          - "#788"
+          - "#791"
+        rationale: >-
+          No contract or typed carrier is published by issue #652. Random
+          stream profiles, variation points, selection policies, admitted
+          plans, and fact DTOs are owned by their contract-first follow-ons.
+      - kind: property_based_or_differential_tests
+        date: 2026-07-15
+        tracking:
+          - "#274"
+          - "#789"
+          - "#790"
+          - "#791"
+        rationale: >-
+          Schedule-permutation, stream non-interference, serialized
+          instantiation-equivalence, backend refusal, and fact
+          non-retroactivity properties require the follow-on implementations.
 
   - subsystem: runtime-contracts
     delivered_artifacts:

--- a/specs/formal/scenario-variation-trial-realization/README.md
+++ b/specs/formal/scenario-variation-trial-realization/README.md
@@ -1,0 +1,430 @@
+# Scenario Variation And Trial Realization Invariants
+
+Status: normative design invariant set
+
+Classification: FM2 (semantic graph / constraint)
+
+Requirements: SCE-002, DSL-101, DSL-103, EXP-706, EXP-718, EXP-719,
+EXP-720, EXP-736, RUN-300, RUN-301
+
+Decisions: ADR-084 and accepted ADR-070
+
+## Scope
+
+This specification constrains the path from a composed SDL scenario family to
+an admitted trial plan, an instantiated scenario, and existing archival
+experiment provenance. It fixes identity, phase ordering, selection,
+random-stream, secrecy, admission, backend, scheduling, and late-binding
+properties for follow-on implementations.
+
+It is not an executable model and defines no published schema. The executable
+contracts, compiler, properties, and differential witnesses are tracked by
+#274 and #786 through #791.
+
+## Model
+
+Let:
+
+- `A` be a normalized authored scenario family;
+- `C(A) = F` be trusted deterministic composition yielding an admitted expanded
+  family `F`;
+- `V(F)` be the finite map of stable variation-point identities to bounded
+  domains and typed targets;
+- `E` be an admitted experiment specification that references `F`;
+- `Q(E)` be the finite set of unique logical trial coordinates required by its
+  allocation/selection policies;
+- `N(E)` be the explicit stable randomness namespace carried by the experiment's
+  stochastic control, independent of the aggregate identity/digest of `E`;
+- `M(q, v)` mean selection `v` is a member of all family domains and closed
+  cross-point constraints for coordinate `q`;
+- `B` be the selected apparatus manifests, capability declarations, and
+  accepted realization-envelope evidence;
+- `R_B(F, v)` mean the selected scenario is realizable under `B`;
+- `G` be the exact compiler, identity, canonicalization, and random-stream
+  profiles;
+- `T(F, E, B, G) = P` be trial compilation and admission;
+- `P[q]` be the immutable plan entry at logical coordinate `q`;
+- `I(F, P[q]) = S_q` be public SDL selection/instantiation/admission yielding
+  instantiated scenario `S_q`;
+- `H` be authorized runtime facts and secret references;
+- `L(S_q, H)` be late binding into explicitly compiled run-local sinks; and
+- `Run(P[q])` be the archival experiment run produced if execution of entry
+  `q` starts.
+
+Every named transform is partial. Undefined means failure with bounded
+diagnostics and no output artifact at the next boundary.
+
+## Phase And Authority Invariants
+
+### SVR-001 — Composition precedes selection
+
+For every admitted plan:
+
+```text
+T(F, E, B, G) is defined => exists A such that C(A) = F
+```
+
+No policy, random draw, backend, scheduler, or runtime fact participates in
+`C`. All imports, namespaces, locks, trust checks, and digests are resolved
+before any variation point is selected.
+
+### SVR-002 — Canonical symbols are selection-independent
+
+For every declaration or variation point `x` and valid selections `v1` and
+`v2`:
+
+```text
+canonical_id(x, v1) = canonical_id(x, v2) = canonical_id(x)
+```
+
+The id contains no selected value, source/cache path, run id, worker id,
+backend id, or schedule position.
+
+### SVR-003 — One authority per plane
+
+SDL owns family domains and typed targets; experiment contracts own selection,
+factors, allocation, and stochastic intent; the processor owns trial
+compilation/admission and realization orchestration; runtime owns typed
+late-bound facts; backends own realization within admitted envelopes;
+schedulers own placement/isolation; experiment run/study contracts own archival
+provenance. No artifact from one plane may be interpreted as authority for
+another.
+
+### SVR-004 — Closed phase progression
+
+The only supported progression is:
+
+```text
+A -> F -> E-bound design -> P -> S_q -> compiled/planned forms
+  -> run-local bindings/operations -> Run(P[q])
+```
+
+An operational artifact cannot move backward and edit an earlier artifact.
+Every exchange artifact is closed for its phase.
+
+## Family And Selection Invariants
+
+### SVR-005 — Closed, bounded variation kinds
+
+Every point belongs to the versioned closed set:
+
+```text
+{parameter, governed-reference, alternative, subset, order, logical-timing}
+```
+
+Every point has a finite member set or explicit bounded numeric interval plus a
+selection/output budget. Unknown kinds, unbounded evaluation, external queries,
+callbacks, templates, and arbitrary document patches are invalid.
+
+### SVR-006 — Typed target ownership
+
+Every point target is a closed descriptor admitted by the SDL model that owns
+the target slot. No generic path language may authorize mutation. Selected
+content must pass the owning value/fragment validator.
+
+### SVR-007 — Independent branch validity
+
+Each declared alternative/member is well-typed and semantically valid in its
+declared local context. Requires/excludes/cardinality/precedence constraints
+are closed finite relations. A contradictory or empty declared domain makes
+the family invalid.
+
+### SVR-008 — Selection membership
+
+For every plan entry:
+
+```text
+q in Q(E) and P[q].selection = v => M(q, v)
+```
+
+The compiler cannot clamp, coerce, substitute, silently omit, or select an
+undeclared value.
+
+### SVR-009 — Whole-scenario admission
+
+Local point validity is insufficient:
+
+```text
+P[q] exists => semantic_valid(I(F, P[q]))
+```
+
+Every selected combination is admitted as a whole concrete scenario. One
+invalid combination prevents the requested plan from being emitted.
+
+### SVR-010 — Experiment selection is separate from family validity
+
+Changing an enumeration/sampling/allocation policy without changing `F` does
+not change the family identity. Reusing a family in multiple experiments does
+not copy its declarations into those experiment documents.
+
+### SVR-011 — Scenario and backend membership are ordered
+
+For every entry:
+
+```text
+P[q] exists => M(q, P[q].selection)
+               and R_B(F, P[q].selection)
+```
+
+Backend realizability is checked after family membership. Backend feasibility
+cannot widen, narrow, or choose the experiment selection.
+
+## Random-Stream Invariants
+
+### SVR-012 — Complete stochastic profile
+
+Every stochastic selection names exact versions for generator, seed encoding,
+semantic-address encoding, stream derivation, raw-bit interpretation,
+distribution/sampling transformations, and failure behavior. A seed or library
+default alone is not executable stochastic control. The experiment also carries
+a canonical root seed and explicit randomness namespace; both are admitted
+inputs rather than values inferred from the experiment document digest.
+
+### SVR-013 — Semantic stream address
+
+Every draw address is a pure canonical function of:
+
+```text
+(randomness namespace N(E),
+ logical trial coordinate,
+ policy id,
+ variation-point id,
+ draw purpose,
+ stable local draw coordinate)
+```
+
+It contains no aggregate experiment id/digest, worker, process, thread, host,
+wall-time, queue, batch, completion-order, retry, hash-order, or
+backend-availability input. The exact experiment id/digest remains plan and run
+provenance. Independent randomization requires an explicit namespace or seed
+change.
+
+### SVR-014 — Schedule independence
+
+For any two execution schedules `s1` and `s2` over identical admitted inputs:
+
+```text
+bytes(T_s1(F, E, B, G)) = bytes(T_s2(F, E, B, G))
+```
+
+This includes serial/parallel, worker permutation, batch partition, completion
+order, pre-seal retry, and supported cross-process/hash-seed variation.
+
+### SVR-015 — Stream non-interference
+
+If input `E'` retains `N(E)` and the root seed while adding or changing a draw
+or unrelated metadata outside concern `c`, then every draw and selection at
+addresses in unaffected concern `c` is unchanged. No mutable global stream is
+shared across points, policies, or coordinates. This does not require plan
+digests or run ids to survive an experiment-spec revision.
+
+### SVR-016 — Canonical traversal preserves semantic order
+
+Maps are traversed by canonical id. A semantically ordered SDL collection keeps
+its declared or selected order. Serialization cannot sort away meaningful
+order, and runtime scheduling cannot stand in for logical order.
+
+### SVR-017 — Failure does not consume or replace randomness
+
+Constraint exhaustion, invalid selection, apparatus rejection, worker failure,
+timeout, retry, or cancellation does not advance a shared stream or trigger
+resampling. The same address always denotes the same draw under the same
+profile.
+
+## Plan And Identity Invariants
+
+### SVR-018 — Atomic plan admission
+
+`T` returns exactly one fully admitted plan or one deterministic diagnostic set:
+
+```text
+T(F, E, B, G) = P
+  iff for every q in Q(E), P[q] is valid and realizable
+```
+
+There is no partially admitted subset formed by dropping failed coordinates.
+
+### SVR-019 — Unique stable logical coordinates
+
+`Q(E)` contains no duplicate canonical coordinate. Coordinate identity is
+experiment meaning, never list position or scheduler order.
+
+### SVR-020 — Preallocated archival run identity
+
+For each `q`, `P[q].run_id` is a deterministic function of admitted execution
+intent and `q`. It is unique within `P`. If execution starts:
+
+```text
+Run(P[q]).run_id = P[q].run_id
+```
+
+No `experiment-trial-v1` or second archival trial identity is introduced.
+
+### SVR-021 — Retry and re-execution differ
+
+An idempotent pre-execution transport retry reuses `P[q].run_id`. A genuine
+re-execution uses a new explicit replicate/execution ordinal, is admitted
+again, receives a distinct run id, and may cite the source run by lineage.
+
+### SVR-022 — Plan identity is not run identity
+
+The plan is immutable grouped execution intent and has its own canonical
+content identity. Scheduler jobs, operation ids, runtime snapshots, and plan
+ids cannot be used as archival run ids.
+
+### SVR-023 — Complete plan provenance
+
+The plan commits to exact task/family/spec/artifact refs and digests, all
+compiler/identity/RNG/canonicalization profiles, logical coordinates,
+selections, factor assignments, non-secret bindings, selected apparatus
+claims, and bounded admission evidence.
+
+## Instantiation, Fact, And Secret Invariants
+
+### SVR-024 — Public SDL instantiation only
+
+`I(F, P[q])` applies only plan-recorded selections/bindings, performs no new
+draw/import/query/secret read/backend callback, uses the public SDL
+instantiation and admission path, and reruns whole-scenario semantic validation.
+A private binder cannot mint an admitted `S_q`.
+
+### SVR-025 — Selection provenance is snapshot identity
+
+`S_q` carries family, plan, run, point-selection, binding, and existing
+composition/instantiation provenance. Canonical snapshot identity includes that
+provenance; serialization cannot discard it.
+
+### SVR-026 — Late binding is monotone
+
+`L(S_q, H)` may fill only a compiled declared sink after validating source,
+type, scope, freshness, sensitivity, authorization, and evidence metadata. It
+does not mutate `F`, `E`, `P`, `S_q`, or their identities.
+
+### SVR-027 — Runtime facts are not selectors
+
+No fact or observation may choose an alternative/subset/order/timing point,
+change a scalar factor, alter topology, change a logical coordinate/run id,
+select apparatus, or advance a random stream. Missing/invalid facts cause an
+explicit runtime disposition, not fallback selection.
+
+### SVR-028 — Secret non-disclosure and non-identity
+
+Raw credentials and secret values are not factors, condition assignments,
+random seeds, stream-address inputs, canonical ids/digests, portable plan
+bindings, diagnostics, fixtures, argv, logs, or telemetry. Secret references
+are resolved only at authorized run-local sinks, and secondary provenance is
+redacted.
+
+## Backend, Scheduler, And Archive Invariants
+
+### SVR-029 — Envelope-governed realization
+
+Every plan entry pins selected apparatus claims and passes manifest capability
+and accepted ADR-070 realization-envelope membership/subsumption checks. A
+backend may choose only a realized form permitted by that envelope and must
+disclose the choice.
+
+### SVR-030 — Backend refusal is observable failure
+
+Availability change or refusal after admission yields failure/deviation
+provenance. It cannot authorize another value, backend, omitted member, clamped
+configuration, or resampled trial.
+
+### SVR-031 — Scheduler opacity
+
+Any two valid scheduler placements/orders for the same `P` observe identical
+plan entries, run ids, selections, factors, snapshots, and streams. A scheduler
+may control placement, isolation, bounded parallelism, timeouts, cancellation,
+and cleanup only.
+
+### SVR-032 — Archival separation
+
+The admitted plan is not stored as mutable runtime state, and live operation
+records are not archival runs. `ExperimentRunModel` and `ExperimentStudyModel`
+remain the authorities for actual execution context, evidence, factors,
+allocation, deviations, and analysis lineage.
+
+### SVR-033 — Adaptation is an intervention
+
+Adaptive difficulty cannot rewrite the admitted baseline. An intervention is a
+run event with policy/observation/trigger/action provenance. A derived follow-up
+trial has a new admitted coordinate and run id linked to its source.
+
+### SVR-034 — Generated content re-enters normal admission
+
+ATT&CK layers, STIX, playbooks, PDDL/planners, CTI reports, and AI generators
+may produce candidates only. Candidates pass ordinary authoring, trust,
+composition, semantic validation, experiment binding, and trial admission.
+
+## Compatibility Invariants
+
+### SVR-035 — Static SDL is a singleton family
+
+An existing SDL document with no variation points retains its identifiers and
+meaning and denotes exactly one family member.
+
+### SVR-036 — Existing variable binding remains authoritative
+
+Existing `Variable` declarations and substitution semantics are reused for
+scalar parameterization. Structural variation does not create a second string
+template or binder. IP/address and typed path inputs use those variables under
+their declared constraints. Credential-shaped inputs use governed secret
+references or declared late-bound secret-reference sinks; raw credentials are
+never portable selection values.
+
+### SVR-037 — Existing experiment and archive artifacts remain distinct
+
+Existing experiment authoring documents remain valid but descriptive
+randomization text cannot execute without typed profiles. Existing task, run,
+study, apparatus, evidence, and measure contracts retain their authority.
+
+### SVR-038 — Campaign composition preserves canonical roots
+
+An executable campaign composed from reusable SDL units is exactly one expanded
+canonical `Scenario` produced by `C`; it is not a tree of independently running
+scenario lifecycles. A campaign across multiple executions is represented by
+an experiment design and admitted plan and is archived through the existing
+run/study contracts. Neither form creates a `Campaign` runtime root or derives
+meaning by concatenating mutable runtime state.
+
+## Deterministic Failure Properties
+
+For identical invalid inputs, diagnostic records are byte-equivalent after
+canonical serialization. Diagnostics are ordered by stage, safe canonical
+address/id, and code. They are bounded by explicit count/size budgets and never
+render supplied values, complete domains, secret/fact refs, raw artifacts,
+backend-private objects, environment data, or tracebacks.
+
+At minimum, `T` is undefined for:
+
+- invalid/untrusted composition or digest mismatch;
+- unknown point/target/policy/profile;
+- empty or contradictory domain;
+- selection outside a domain or closed constraint;
+- unbounded/exceeded product, trial, plan, or diagnostic budget;
+- duplicate coordinate or derived run id;
+- invalid selected whole scenario;
+- unavailable/incompatible apparatus evidence;
+- realization-envelope non-membership; and
+- canonicalization or sealing failure.
+
+## Claim Boundary
+
+These invariants support claims of deterministic scenario-family selection,
+schedule-independent admitted-plan construction, explicit instantiation
+provenance, and bounded archival lineage. They do not establish behavioral
+equivalence between backends, validity of an adaptive benchmark, continuing
+artifact availability, truth of provenance claims, recreation of hidden
+backend state, cryptographic unpredictability, or exact replay from a seed.
+
+## Assurance Fulfillment
+
+The invariant list is delivered by this file. Because issue #652 is design-only:
+
+- unit-test evidence is waived to #786, #787, #789, #790, and #791;
+- typed IR/contract evidence is waived to #274, #786, #787, #788, and #791; and
+- property/differential evidence is waived to #274, #789, #790, and #791.
+
+The dated waivers and paths are registered in
+`specs/formal/assurance-fulfillment.yaml`. No SCE-002 implementation claim is
+made until those follow-on artifacts land.


### PR DESCRIPTION
## Summary

Defines one cohesive, literature-backed SDL path from deterministic scenario-family composition through experiment-owned selection, admitted trial plans, explicit instantiation, backend realization, and archival provenance, while keeping SCE-002 in DRAFT until the ordered implementation work lands.

## Requirement UIDs

- `SCE-002`

## Related Issues

Closes #652

## ADR Impact

- ADR-084
- ADR-068 (amended)
- ADR-070 (accepted and amended)
- ADR-074 (amended)

## Changes

- Add the prior-art synthesis and design criteria across configuration languages, simulation experiment design, reproducible random streams, cyber playbooks, and range generation.
- Add the end-to-end reference architecture, authority matrix, immutable boundary artifacts, contract sketches, migration rules, and SCE-001 through SCE-006 consumer map.
- Add ADR-084 and the formal SCE-002 obligations for variation domains, stable randomness namespaces, schedule-independent trial compilation, admission, secrecy, and provenance.
- Amend ADR-068 and ADR-074, and accept/amend ADR-070 now that its envelope contract and conformance implementation exist.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

The canonical `nox -s verify` graph passed policy, lint, contracts, unit tests, integration tests, coverage, and docs. The two integration skips require real libvirt; the unit skip and existing Starlette deprecation warning are unchanged.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SCE-002 ← docs/decisions/adrs/adr-084-scenario-variation-and-deterministic-trial-realization.md, SCE-002 ← docs/explain/reference/scenario-variation-and-trial-realization.md, SCE-002 ← specs/formal/scenario-variation-trial-realization/README.md
- TESTS: SCE-002 ← canonical nox verify: 3822 passed, 1 skipped; integration: 34 passed, 2 environment skips; 92% coverage, SCE-002 ← all-files pre-commit gate and warning-free Sphinx documentation build

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.