### PR TITLE
feat: add researcher accessibility evidence protocol

### DIFF
--- a/docs/decisions/issue-178-researcher-accessibility-protocol-preflight.md
+++ b/docs/decisions/issue-178-researcher-accessibility-protocol-preflight.md
@@ -1,0 +1,311 @@
+# Issue 178 Researcher Accessibility Protocol Preflight
+
+Date: 2026-07-17
+
+Issue: #178. Requirement: none.
+
+Issue #178 is a falsification/evidence gate for a bounded accessibility claim,
+not an SDL feature, authoring-tool redesign, or backend design. The issue body
+is the authoritative contract.
+
+No new ADR is needed. ADR-021 already governs claim evidence, ADR-009 and
+ADR-019 govern artifact authority, and the issue-346 DSL language-evaluation
+preflight already establishes the applicable protocol/snapshot/analysis,
+privacy, semantic-stage, and research-integrity boundaries. This note fixes the
+#178-specific guardrails without running the study, preparing its task corpus,
+collecting evidence, or correcting gaps that the study may expose.
+
+## Decision Boundary
+
+Keep three independently revisioned concerns:
+
+1. **Preregistered protocol:** the four issue personas, their qualification and
+   infrastructure-experience bands, bounded positive and negative tasks,
+   allowed public surfaces, assistance conditions, intended semantics,
+   measures, denominators, pass/fail thresholds, stopping and missing-data
+   rules, privacy constraints, and validity threats.
+2. **Execution snapshot:** the exact ACES revision and public docs, examples,
+   guidance, adapters, modes, and parameters supplied to each subject; sanitized
+   attempts and submitted artifacts; exact public diagnostics; wrong turns,
+   assistance, review judgments, deviations, withdrawals, and missing or
+   abandoned attempts.
+3. **Claim-scoped analysis:** recomputed results for the #178 accessibility
+   claim, its objective pass/fail disposition, limitations, and ADR-021 evidence
+   status. A versioned manifest binding fixes the stable claim id's exact
+   persona, task, condition, stage, dimension, and measure scope. The analysis
+   must repeat that scope exactly and persist independently recomputed results
+   for each preregistered gating and comparison stratum.
+
+Reuse the structure and integrity machinery under
+`docs/research/dsl-language-evaluation/` and
+`tools/check_dsl_language_evaluation.py`. The #346 language-adequacy claim and
+the #178 researcher-accessibility claim remain separate analyses even when they
+reuse a protocol, task, attempt, or observation. A result for one claim must not
+silently promote or refute the other. Preserve existing frozen artifacts; a
+changed construct, task meaning, rubric, threshold, or exclusion rule creates a
+new protocol revision, while a tool/doc refresh or new execution creates a new
+snapshot.
+
+Do not introduce a second research schema, a second parser/validator hierarchy,
+or a parallel persistence and reporting workflow. If the current research
+bundle cannot express more than one scoped claim, the only justified seam is a
+claim analysis that selects stable protocol ids; it is not a generic research
+platform or a new normative contract family.
+
+The following concepts remain distinct:
+
+| Concept | Boundary |
+| --- | --- |
+| Accessibility | Correct completion by the stated persona using only the pinned public condition, not feature count, parser success, or maintainer familiarity. |
+| Expressibility | Whether the intended benchmark meaning is representable or explicitly dispositioned, not whether a YAML document can be constructed. |
+| Validity | Structural and semantic acceptance by the production SDL boundary, not deployability, benchmark adequacy, or accessibility. |
+| Unsupported request | A validly recognized boundary that public guidance or diagnostics teaches clearly; it is not interchangeable with invalid YAML, underspecification, profile dependence, or a missing implementation. |
+| Diagnostic usefulness | Whether the exact public response locates and explains the defect and supports a correct repair, not whether an internal exception contains enough information. |
+| Infrastructure independence | No task success depends on cloud, Terraform, OpenStack, Docker, deployment manifests, backend source, or undocumented backend conventions. It does not claim that installing Python tooling has zero prerequisites. |
+| Study subject | A researcher or reviewer in the evidence protocol, never an SDL `participant`, participant implementation, agent, or runtime principal. |
+| Evidence status | ADR-021 `untested`/`partial`/`demonstrated`/`refuted`, separate from task outcome, validation result, review status, requirement status, and ADR status. |
+
+## Persona, Task, And Evidence Guardrails
+
+- Use stable persona ids for `security-researcher`, `benchmark-designer`,
+  `backend-implementer`, and `evaluator-reviewer`. Reuse the existing latter
+  three ids and meanings. Do not relabel a scenario author as a security
+  researcher without the issue's qualification boundary. Record relevant SDL,
+  cyber-range, cloud/container, programming, and benchmark experience as
+  bounded bands rather than names, employers, or free-form biographies.
+- Treat the backend implementer as a comparison and boundary-testing persona,
+  not as evidence that a non-infrastructure expert succeeded. Report each
+  persona, experience band, and tooling condition before any pooled result.
+  Preregister which strata gate promotion. A pooled result or comparison
+  population cannot mask a target-stratum failure or promote the claim.
+- Separate `public-docs-only`, MCP, CLI, and direct documented-library
+  conditions. Pin the exact artifact or tool name, adapter, mode, ACES commit or
+  release, source/migration profile, parameters, and assistance policy. Do not
+  aggregate `sdl_validate` prose, `sdl_diagnostics` structured records,
+  parse-only inspection, and stub-backend planning as one equivalent “public
+  tools” condition.
+- Derive non-trivial tasks from the current scenario corpus, example library,
+  participant/information-boundary semantics, and benchmark-relevant tasks
+  already preregistered by the DSL language evaluation. Preserve source ids and
+  a derivation rationale. A minimal tutorial scenario alone cannot satisfy the
+  issue's benchmark-relevance criterion.
+- Preregister at least positive authoring/review tasks and focused invalid,
+  unsupported, underspecified, and profile-dependent cases. Give each negative
+  case one intended defect or boundary. Do not rewrite one outcome class as
+  another after observing the response.
+- Seal intended semantics and scoring rubrics before execution. Correct task
+  completion requires semantic agreement with that record at the owning
+  artifact stage; a file that parses, validates, or produces a plan is not
+  automatically correct. Independent reviewers fix their judgments before the
+  sealed intent is revealed, and disagreement remains observable after
+  adjudication.
+- Measure completion, critical semantic errors, ambiguity/wrong-turn classes,
+  prohibited assistance or source-inspection requests, repair cycles,
+  diagnostic localization and repair, and public-surface gaps. Predeclare
+  denominators, timing treatment, task order, repetitions, exclusions,
+  missing-data handling, and stopping rules. Missing, abandoned, tool-failed,
+  and withdrawn attempts remain explicit according to those rules.
+- Record a missing doc, example, glossary entry, guidance rule, diagnostic
+  field, or unsupported-boundary explanation as evidence. Do not edit the live
+  surface mid-run or replace the failed snapshot. A later product correction is
+  a separate issue and can be evaluated in a new snapshot.
+- Human recruitment and raw-data collection require the applicable ethics,
+  consent, privacy, and data-protection review. Simulated personas, maintainers,
+  or agent walkthroughs are exploratory evidence only and cannot demonstrate a
+  generalized researcher-accessibility claim.
+- Keep the claim `untested` until qualifying observations exist. `Demonstrated`
+  applies only to the exact preregistered population, tasks, conditions,
+  versions, and thresholds; it is not a universal ease-of-use or backend-
+  independence claim.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and boundary |
+| --- | --- |
+| Authority and claim discipline | ADR-009/019, `specs/authority/authority-boundary.yaml`, ADR-021, and the documentation style guide. Research under `docs/` is non-normative and cannot redefine SDL meaning. |
+| Research bundle and integrity | `docs/research/dsl-language-evaluation/`, its issue-346 preflight, `tools/check_dsl_language_evaluation.py`, `tools.policy.common.load_bounded_json_object`, `safe_repo_path`, and `PolicyFailure`. Reuse the closed protocol/snapshot/analysis graph and recomputation rules; do not copy them into an accessibility-only framework. |
+| Public authoring guidance | `docs/explain/getting-started.md`, `docs/explain/sdl/`, `docs/explain/reference/glossary.md`, `specs/sdl/`, `specs/agent-guidance/agent-guidance.yaml`, `aces_agent_guidance`, and `aces_intended_use_profiles`. The repository's materialized canonical guidance profile is AUT-811; do not create an AUT-807-labeled duplicate solely to mirror the issue context. |
+| Examples and templates | `examples/scenarios/`, `examples/library/catalog.yaml`, `examples/library/templates/`, `examples/library/patterns/`, and `tools/check_example_library.py`. Positive examples stay non-normative and parser-validated; invalid research stimuli do not belong in the positive library. |
+| Source syntax and shape | `sdl-yaml/v1`, `SDLParserLimits`, `_SDLSafeLoader`, mapping-key analysis, `parse_sdl()`/`parse_sdl_file()`, closed `SDLModel` descendants, and the published SDL schemas and source-profile fixtures. The normalized JSON Schema is not a raw-YAML validator. |
+| Static semantics | `SemanticValidator`, `specs/sdl/references.md`, `specs/sdl/diagnostics.md`, and the shared declaration/reference indexes. The study observes production acceptance and never adds study-local reference resolution or validation exceptions. |
+| Language-service and MCP surfaces | `aces_sdl.language_service`; `aces_mcp.tools.reference`, `authoring`, `language_service`, `inspection`, and `operations`; and `implementations/python/tests/test_language_service.py` / `test_mcp_server.py`. Record the exact entrypoint and mode because these adapters intentionally expose different envelopes and validation strength. |
+| Later artifact stages | `instantiate_scenario()`, instantiated-SDL admission and canonicalization, `compile_runtime_model()`, processor `Diagnostic`/`Severity`, the reference processor, and `plan()`. Stub planning is a bounded capability check, not deployment or runtime evidence. |
+| Error and reporting patterns | `SDLParseDiagnostic`, `SDLParseError`, `SDLValidationError`, `SDLInstantiationError`, processor `Diagnostic`/`Severity`, `PolicyFailure`, and nox `SessionReporter`. Do not add an accessibility exception hierarchy, logger, or telemetry channel. |
+| Persistence and workflow | Git-tracked sanitized research artifacts, `.ground-control.yaml`, `.gc/plan-rules.md`, `.pre-commit-config.yaml`, ADR-014, `noxfile.py`, private-key detection, gitleaks, Sphinx, and `.github/workflows/ci.yml`. Add at most one call in the existing nox graph; never create a parallel workflow. |
+
+There is no controller, HTTP DTO, service, runtime repository, control-plane
+store, or mutable database in the intended design. `RuntimeControlPlane`,
+`ControlPlaneStore`, runtime snapshots, backend audit events, experiment-run
+records, and participant history are not stores for author/reviewer study data.
+
+## Cross-Cutting Security, Validation, And Operational Layers
+
+1. **Research-file shape gate:** research artifacts are inert, local, bounded
+   JSON. Reuse duplicate-key rejection, exact-field checks, bounded ids/counts,
+   referential integrity, recomputed results, and `safe_repo_path`. Reject
+   absolute/traversing/symlink-escaping paths, unpinned surfaces, unsafe URI
+   userinfo/query data, stale aggregates, and incomplete persona/task/condition
+   coverage.
+2. **SDL source gate:** every submitted SDL artifact enters through production
+   UTF-8 handling, the YAML 1.2 Core resolver, `_SDLSafeLoader`, tag/directive
+   rejection, duplicate and normalized-key collision checks, string-keyed JSON
+   domain enforcement, and `SDLParserLimits` for input, scalar, depth, node,
+   alias, import, composition, and expansion work. MCP/language-service tools
+   retain their 64 KiB adapter bound; the direct parser's larger bound is not a
+   reason to bypass an adapter condition.
+3. **Model/schema and config-shape gate:** construct the existing closed
+   `SDLModel`/`Scenario` shapes (`extra="forbid"`) and use a published schema only
+   for the matching normalized phase. Representative runtime configuration
+   still passes its owning validators. In particular,
+   `RuntimeEnvironmentVariable` and `enforce_observed_value_redaction`,
+   `RuntimeInitProcess.argv_redacted`, SSH/sudo command-redaction rules, and
+   `RuntimeAppAuthorizationPrincipal`'s no-raw-credential shape remain active
+   when a task touches those surfaces. Do not create a study SDL DTO or weaken
+   a model to make a task pass.
+4. **Semantic and composition gate:** run `SemanticValidator` with its existing
+   collect-all, ambiguity, uniqueness, graph, profile, and redaction rules.
+   Imported material retains base-directory confinement, registry allowlists,
+   lock/version/digest/signature/export checks, namespace and cycle rules, and
+   composition budgets. An offline study must not fetch an OCI/import source or
+   inspect a backend to repair meaning.
+5. **Instantiation/processor gate:** when a task claims more than authored SDL
+   validity, use existing instantiation/admission, canonicalization, compiler,
+   reference-processor, and planner entrypoints. Preserve unsupported,
+   degraded, and diagnostic outcomes. Never infer success from a filename, raw
+   mapping, backend label, or hand-built summary.
+6. **Tool-adapter and environment gate:** source profile, migration policy,
+   semantic-validation mode, intended-use profile, adapter, assistance, and
+   task condition are explicit protocol data, not environment-selected
+   semantics. Add no issue-specific environment variable, daemon, listener,
+   backend profile, or auth bypass. Installation/setup friction is observable
+   separately from task correctness.
+7. **Authentication and authorization gate:** the current MCP study surface is
+   local stdio and the evidence checker is offline, so #178 traverses no HTTP
+   authentication or control-plane authorization layer. Do not add one. A
+   future hosted surface requires a separate decision and must reuse
+   `ControlPlaneSecurityConfig.strict_defaults()`, verified identity,
+   target-bound roles, request-size/idempotency/fingerprint guards, audit
+   events, and redacted internal errors.
+8. **Secret and privacy gate:** tasks use synthetic facts or governed public
+   examples. Published artifacts, diagnostics, study metadata, and logs contain
+   no real credentials, tokens, private keys, environment dumps, live
+   infrastructure identifiers, private prompts, hidden answers, raw backend
+   objects, unrestricted subject text, or pseudonym linkage keys. Existing
+   `redacted`/`operator_secret` omission rules remain authoritative; a digest is
+   not redaction and pseudonymized data is not anonymous data.
+9. **OS, network, and supply-chain gate:** pass SDL through files or MCP message
+   bodies, not secret-bearing process arguments. The study checker performs no
+   network access, shell evaluation, backend deployment, container/cloud
+   invocation, privileged host operation, or compared-project code execution.
+   Existing pinned nox/CI bootstrap is the only default tool-install path; live
+   range execution is outside this issue and must not become a CI prerequisite.
+10. **Error-envelope and observability gate:** capture what the selected public
+    entrypoint actually emits. Preserve parser code, stage, severity, bounded
+    message, path/range, authored-key and related-location data when present;
+    preserve processor code/domain/address/severity/message when present.
+    `sdl_validate` prose, language-service JSON, inspection's parse-only prose,
+    and operation-stage JSON are not interchangeable. Missing location, code,
+    or repair direction is evidence, not permission to read source, synthesize
+    fields, emit a traceback, or dump Pydantic input/environment state. Use
+    content-based entrypoints or a declared sanitized projection so absolute
+    host paths never enter the public bundle.
+11. **Persistence and integrity gate:** the durable public record is the
+    Git-tracked protocol, sanitized immutable snapshot, claim-scoped analysis,
+    source/public-surface inventory, and checksums. Raw human-subject material,
+    if approved for collection, stays in the approved controlled store and
+    retention regime. Add no database, mutable cache, object store, runtime
+    metadata field, audit blob, or result registry.
+
+## Whole-Repository Scope
+
+The evidence design must account for all of these surfaces without editing them
+merely to improve the result:
+
+- normative SDL prose, diagnostics, references, scientific-completeness and
+  authority material under `specs/` and `contracts/`;
+- explanatory authoring docs, glossary, limitations, language-service guide,
+  non-trivial scenarios, templates, and patterns;
+- SDL source profiles, parser/model/semantic/composition/instantiation layers,
+  canonical artifacts, compiler/planner contracts, and their negative tests;
+- the machine-readable agent guidance, intended-use profiles, CLI, MCP
+  reference/authoring/language/inspection/assessment surfaces, and adapter
+  tests;
+- redaction, environment/config, command/argv, import trust, information-
+  boundary, observability, and diagnostic contracts touched by selected tasks;
+- the existing language-evaluation research bundle and checker; and
+- the canonical Ground Control, policy, contracts, tests, docs, secret scan,
+  hooks, nox, and CI graph.
+
+Every ambiguity, backend-private assumption, divergent public explanation,
+unhelpful diagnostic, unsupported request, missing example, tool-setup failure,
+reviewer disagreement, or prohibited source-inspection request is an evidence
+result. It is not authorization to modify the owning surface during the study.
+
+## Extensibility Seam
+
+The stable observation join is:
+
+```text
+(protocol_revision, snapshot_id, claim_id, persona_id, subject_id,
+ condition_id, task_id, variant_id, attempt_id, artifact_stage_id, measure_id)
+```
+
+`subject_id` is study-local and pseudonymous and appears publicly only when the
+applicable review permits that minimized projection. Personas, task classes,
+public surfaces, adapter/mode conditions, stages, measures, and claim scopes are
+versioned protocol data with stable ids, not Python enums or hard-coded issue
+branches. The next public adapter, researcher experience band, scenario family,
+or independent replication adds catalog records and a new snapshot. A new
+claim adds a separately scoped analysis over eligible frozen observations. None
+requires editing SDL models, contracts, controllers, repositories, or prior
+evidence.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- claiming accessibility from schema completeness, parser success, accepted
+  ADRs, example count, one maintainer, an agent simulation, or the existing
+  not-started #346 snapshot;
+- pooling backend implementers with non-infrastructure experts or treating
+  prior cloud/container knowledge as an unrecorded subject characteristic;
+- treating docs-only, MCP, CLI, direct-library, parse-only, semantic, migration,
+  and stub-planning conditions as equivalent;
+- counting a syntactically valid but semantically wrong scenario as completed,
+  or treating `structural_only`/parse-only success as full validation;
+- collapsing invalid, unsupported, underspecified, profile-dependent,
+  unavailable, missing, abandoned, withdrawn, and not-applicable outcomes;
+- scoring diagnostics by message substring alone or enriching a weak public
+  response from implementation exceptions, models, tests, or backend source;
+- changing docs, examples, guidance, diagnostics, or product behavior during
+  execution and overwriting the falsifying observation;
+- putting invalid study cases in `examples/scenarios/`, turning research cases
+  into normative fixtures, or using the research bundle as the only regression
+  for a discovered defect;
+- adding an accessibility schema under `contracts/`, a second guidance profile,
+  duplicate SDL DTO/model/validation/exception/logging stacks, or a separate CI
+  workflow;
+- storing study data in experiment-run, runtime, control-plane, participant,
+  evidence, or backend repositories merely because those records already
+  persist other kinds of observations; and
+- committing raw chats/prompts, recordings, biographies, host paths, secrets,
+  hidden answers, source dumps, or a pseudonym linkage key.
+
+## Non-Goals And Implementation Boundaries
+
+- Do not change SDL syntax, schemas, models, parser or semantic behavior,
+  diagnostics, examples, guidance, compiler/planner behavior, backends,
+  completeness profiles, or migration behavior merely to improve #178's
+  outcome.
+- Do not implement gaps found by the protocol. Record them and route each later
+  correction to its owning docs, glossary, example, guidance, validator, tool,
+  or backend issue while preserving the original observation.
+- Do not deploy a range, execute participant cyber actions, evaluate model
+  quality, prove backend portability, or require cloud, Terraform, OpenStack,
+  Docker, or backend-private source for the study.
+- Do not create a universal usability/research-evidence schema, hosted study
+  service, API, controller, UI, database, analytics pipeline, participant
+  telemetry system, or recruitment workflow.
+- Do not claim general usability, scientific adequacy, productivity,
+  deployability, runtime success, or infrastructure independence beyond the
+  exact preregistered population, tasks, conditions, versions, and evidence.

--- a/docs/research/dsl-language-evaluation/analysis-accessibility-v1.json
+++ b/docs/research/dsl-language-evaluation/analysis-accessibility-v1.json
@@ -1,0 +1,351 @@
+{
+  "analysis_id": "aces-researcher-accessibility-analysis-v1",
+  "protocol_revision": "2.0.0",
+  "snapshot_id": "aces-researcher-accessibility-not-started-v1",
+  "generated_at": "2026-07-17",
+  "execution_status": "not_started",
+  "measure_results": [
+    {
+      "measure_id": "semantic-elements-correct",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "task-completion",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "critical-semantic-errors",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "semantic-rework-cycles",
+      "status": "not_evaluated",
+      "statistic": "median",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "relation-classification-accuracy",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "diagnostic-localization",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "diagnostic-repair",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "critical-review-items",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "critical-silent-omissions",
+      "status": "not_evaluated",
+      "statistic": "count",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "majority-missed-critical-items",
+      "status": "not_evaluated",
+      "statistic": "count",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "untraced-critical-changes",
+      "status": "not_evaluated",
+      "statistic": "count",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "prohibited-infrastructure-assistance",
+      "status": "not_evaluated",
+      "statistic": "count",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    },
+    {
+      "measure_id": "nontrivial-example-support",
+      "status": "not_evaluated",
+      "statistic": "proportion",
+      "numerator": null,
+      "denominator": 0,
+      "opportunity_count": 0,
+      "observed_count": 0,
+      "missing_count": 0,
+      "abandoned_count": 0,
+      "tool_failed_count": 0,
+      "withdrawn_count": 0,
+      "value": null,
+      "supporting_observation_ids": []
+    }
+  ],
+  "dimension_results": [
+    {
+      "dimension_id": "expressiveness",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    },
+    {
+      "dimension_id": "usability-comprehension",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    },
+    {
+      "dimension_id": "effectiveness-productivity",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    },
+    {
+      "dimension_id": "diagnostic-quality",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    },
+    {
+      "dimension_id": "reviewability",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    },
+    {
+      "dimension_id": "semantic-traceability",
+      "status": "not_evaluated",
+      "threshold_result": "not_evaluated",
+      "condition_results": [],
+      "supporting_observation_ids": []
+    }
+  ],
+  "stratum_results": [],
+  "evidence_status": "untested",
+  "claim": {
+    "claim_id": "aces-researcher-accessibility",
+    "statement": "Target security researchers and benchmark designers can author and validate representative ACES benchmark scenarios, and evaluator-reviewers can review them, through pinned public documentation and tools without cloud, Terraform, OpenStack, Docker, backend implementation source, or undocumented backend conventions; backend implementers are reported only as a comparison persona.",
+    "threats_to_validity": [
+      "No qualifying human-subject or independent-review observations have been collected.",
+      "The preregistered sample, experience bands, tasks, and adapters support only bounded conclusions.",
+      "Backend-implementer results cannot substitute for non-infrastructure-expert researcher results.",
+      "Results apply only to the pinned ACES revision, public surfaces, modes, parameters, and assistance policies."
+    ],
+    "falsification_protocol": "docs/research/dsl-language-evaluation/protocol-v2.json",
+    "objective_pass_criteria": "Every dimension in every manifest-bound target infrastructure-novice persona and tooling-condition stratum passes: representative non-trivial scenarios are authored and validated without prohibited infrastructure/source assistance; diagnostics localize defects and support correction; examples/templates support the sealed benchmark meaning; unsupported or profile-dependent requests are classified and explained at the owning public boundary; and independent reviewers recover critical meaning before intent reveal. Pooled or comparison-stratum success cannot substitute for a target-stratum pass.",
+    "objective_fail_criteria": "Any manifest-bound gating stratum falls below its completion or semantic-fidelity threshold, any critical meaning is silently lost, public examples support only a trivial substitute, diagnostics or unsupported-boundary explanations require source/backend inspection, prohibited infrastructure expertise is used, or reviewers cannot recover critical meaning from the assigned public condition.",
+    "allowed_evidence": [
+      "sanitized consented attempt observations",
+      "exact production public-tool outputs",
+      "blinded reviewer judgments",
+      "pinned public documentation and examples",
+      "preregistered setup-friction and assistance records",
+      "independently recomputed manifest-bound stratum measures"
+    ],
+    "disallowed_evidence": [
+      "schema or parser success alone",
+      "maintainer confidence or walkthroughs",
+      "agent or simulated-persona results as generalized human evidence",
+      "backend-private interpretation",
+      "implementation-source inspection",
+      "cloud or container deployment success",
+      "private prompts",
+      "post-hoc thresholds, exclusions, or diagnostic enrichment"
+    ],
+    "scope": {
+      "persona_ids": [
+        "security-researcher",
+        "benchmark-designer",
+        "backend-implementer",
+        "evaluator-reviewer"
+      ],
+      "task_ids": [
+        "accessibility-author-benchmark-scenario",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "mcp-tools",
+        "cli-tools",
+        "direct-library"
+      ],
+      "variant_ids": [
+        "accessibility-nontrivial-benchmark",
+        "accessibility-single-dangling-reference",
+        "accessibility-unsupported-live-realization",
+        "accessibility-hidden-boundary-error"
+      ],
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "instantiated",
+        "compiled",
+        "planned",
+        "review-judgment"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "usability-comprehension",
+        "effectiveness-productivity",
+        "diagnostic-quality",
+        "reviewability",
+        "semantic-traceability"
+      ],
+      "measure_ids": [
+        "semantic-elements-correct",
+        "task-completion",
+        "critical-semantic-errors",
+        "semantic-rework-cycles",
+        "relation-classification-accuracy",
+        "diagnostic-localization",
+        "diagnostic-repair",
+        "critical-review-items",
+        "critical-silent-omissions",
+        "majority-missed-critical-items",
+        "untraced-critical-changes",
+        "prohibited-infrastructure-assistance",
+        "nontrivial-example-support"
+      ]
+    },
+    "evidence_artifacts": [
+      "docs/research/dsl-language-evaluation/protocol-v2.json",
+      "docs/research/dsl-language-evaluation/execution-snapshot-accessibility-v1.json",
+      "docs/research/dsl-language-evaluation/analysis-accessibility-v1.json"
+    ]
+  },
+  "plain_language_outcome": "The accessibility study is preregistered and pinned, but it has not started. ACES researcher accessibility therefore remains untested; the protocol and structural gate are evidence infrastructure, not positive accessibility evidence.",
+  "limitations": [
+    "This record validates the falsification protocol and claim boundary, not researcher accessibility.",
+    "The snapshot intentionally contains no subjects, attempts, observations, reviews, deviations, withdrawals, or disagreements.",
+    "Human recruitment and raw-data collection require the applicable ethics, consent, privacy, and data-protection review.",
+    "Maintainer, agent, or simulated-persona walkthroughs remain exploratory and cannot promote the generalized human claim.",
+    "A later product correction must preserve this frozen snapshot and be evaluated in a new snapshot rather than rewriting failed evidence."
+  ]
+}

--- a/docs/research/dsl-language-evaluation/analysis-v1.json
+++ b/docs/research/dsl-language-evaluation/analysis-v1.json
@@ -29,6 +29,7 @@
     {"dimension_id": "reviewability", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []},
     {"dimension_id": "semantic-traceability", "status": "not_evaluated", "threshold_result": "not_evaluated", "condition_results": [], "supporting_observation_ids": []}
   ],
+  "stratum_results": [],
   "evidence_status": "untested",
   "claim": {
     "claim_id": "aces-dsl-language-adequacy",
@@ -43,6 +44,15 @@
     "objective_fail_criteria": "Any dimension meets its preregistered failure threshold, a critical semantic ambiguity or silent loss is observed, or reviewers/tools cannot recover meaning without backend-private interpretation.",
     "allowed_evidence": ["sanitized attempt observations", "production tool outputs", "blinded reviewer judgments", "pinned public documentation", "recomputed aggregate measures"],
     "disallowed_evidence": ["schema or parser success alone", "formal prose alone", "maintainer confidence", "backend-private interpretation", "private prompts", "post-hoc thresholds or exclusions", "fabricated or simulated human evidence"],
+    "scope": {
+      "persona_ids": ["benchmark-designer", "scenario-author", "participant-model-author", "backend-implementer", "evaluator-reviewer", "assurance-auditor"],
+      "task_ids": ["author-multihost-experiment", "author-information-boundary", "reject-dangling-reference", "classify-underspecified-realization", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "maintain-versioned-import", "independent-review-change"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["multihost-reference", "visibility-boundary-change", "dangling-reference-single-defect", "profile-dependent-realization", "normalized-key-collision", "format-only-equivalent", "field-order-equivalent", "hidden-asset-non-equivalent", "compatible-import-update", "lossy-import-update", "review-hidden-assumption-change"],
+      "artifact_stage_ids": ["authored", "validated", "canonical-authored", "instantiated", "compiled", "planned", "review-judgment"],
+      "dimension_ids": ["expressiveness", "usability-comprehension", "effectiveness-productivity", "maintainability-evolution", "ambiguity", "diagnostic-quality", "reviewability", "semantic-traceability"],
+      "measure_ids": ["semantic-elements-correct", "task-completion", "critical-semantic-errors", "semantic-rework-cycles", "relation-classification-accuracy", "diagnostic-localization", "diagnostic-repair", "critical-review-items", "critical-silent-omissions", "silent-lossy-migrations", "critical-silent-ambiguities", "majority-missed-critical-items", "untraced-critical-changes"]
+    },
     "evidence_artifacts": [
       "docs/research/dsl-language-evaluation/protocol-v1.json",
       "docs/research/dsl-language-evaluation/execution-snapshot-v1.json",

--- a/docs/research/dsl-language-evaluation/bundle-manifest.json
+++ b/docs/research/dsl-language-evaluation/bundle-manifest.json
@@ -1,7 +1,84 @@
 {
   "bundle_id": "aces-dsl-language-evaluation",
-  "revision": "1.0.0",
+  "revision": "2.0.0",
   "protocol_path": "docs/research/dsl-language-evaluation/protocol-v1.json",
   "snapshot_path": "docs/research/dsl-language-evaluation/execution-snapshot-v1.json",
-  "analysis_path": "docs/research/dsl-language-evaluation/analysis-v1.json"
+  "analysis_path": "docs/research/dsl-language-evaluation/analysis-v1.json",
+  "claim_binding": {
+    "claim_id": "aces-dsl-language-adequacy",
+    "scope": {
+      "persona_ids": ["benchmark-designer", "scenario-author", "participant-model-author", "backend-implementer", "evaluator-reviewer", "assurance-auditor"],
+      "task_ids": ["author-multihost-experiment", "author-information-boundary", "reject-dangling-reference", "classify-underspecified-realization", "reject-normalized-key-ambiguity", "round-trip-format-equivalence", "distinguish-hidden-asset-mutation", "maintain-versioned-import", "independent-review-change"],
+      "tooling_condition_ids": ["public-docs-only", "public-tools"],
+      "variant_ids": ["multihost-reference", "visibility-boundary-change", "dangling-reference-single-defect", "profile-dependent-realization", "normalized-key-collision", "format-only-equivalent", "field-order-equivalent", "hidden-asset-non-equivalent", "compatible-import-update", "lossy-import-update", "review-hidden-assumption-change"],
+      "artifact_stage_ids": ["authored", "validated", "canonical-authored", "instantiated", "compiled", "planned", "review-judgment"],
+      "dimension_ids": ["expressiveness", "usability-comprehension", "effectiveness-productivity", "maintainability-evolution", "ambiguity", "diagnostic-quality", "reviewability", "semantic-traceability"],
+      "measure_ids": ["semantic-elements-correct", "task-completion", "critical-semantic-errors", "semantic-rework-cycles", "relation-classification-accuracy", "diagnostic-localization", "diagnostic-repair", "critical-review-items", "critical-silent-omissions", "silent-lossy-migrations", "critical-silent-ambiguities", "majority-missed-critical-items", "untraced-critical-changes"]
+    },
+    "strata": [
+      {
+        "group_id": "language-adequacy-population",
+        "role": "gating",
+        "partition_by": [],
+        "persona_ids": ["benchmark-designer", "scenario-author", "participant-model-author", "backend-implementer", "evaluator-reviewer", "assurance-auditor"],
+        "experience_band_ids": ["qualified-novice-to-aces", "prior-aces-user"],
+        "tooling_condition_ids": ["public-docs-only", "public-tools"]
+      }
+    ]
+  },
+  "supplemental_bundles": [
+    {
+      "bundle_id": "aces-researcher-accessibility-evaluation",
+      "revision": "1.0.0",
+      "protocol_path": "docs/research/dsl-language-evaluation/protocol-v2.json",
+      "snapshot_path": "docs/research/dsl-language-evaluation/execution-snapshot-accessibility-v1.json",
+      "analysis_path": "docs/research/dsl-language-evaluation/analysis-accessibility-v1.json",
+      "claim_binding": {
+        "claim_id": "aces-researcher-accessibility",
+        "scope": {
+          "persona_ids": ["security-researcher", "benchmark-designer", "backend-implementer", "evaluator-reviewer"],
+          "task_ids": ["accessibility-author-benchmark-scenario", "accessibility-repair-invalid-scenario", "accessibility-classify-unsupported-request", "accessibility-review-nontrivial-scenario"],
+          "tooling_condition_ids": ["public-docs-only", "mcp-tools", "cli-tools", "direct-library"],
+          "variant_ids": ["accessibility-nontrivial-benchmark", "accessibility-single-dangling-reference", "accessibility-unsupported-live-realization", "accessibility-hidden-boundary-error"],
+          "artifact_stage_ids": ["authored", "validated", "instantiated", "compiled", "planned", "review-judgment"],
+          "dimension_ids": ["expressiveness", "usability-comprehension", "effectiveness-productivity", "diagnostic-quality", "reviewability", "semantic-traceability"],
+          "measure_ids": ["semantic-elements-correct", "task-completion", "critical-semantic-errors", "semantic-rework-cycles", "relation-classification-accuracy", "diagnostic-localization", "diagnostic-repair", "critical-review-items", "critical-silent-omissions", "majority-missed-critical-items", "untraced-critical-changes", "prohibited-infrastructure-assistance", "nontrivial-example-support"]
+        },
+        "strata": [
+          {
+            "group_id": "target-infrastructure-novice",
+            "role": "gating",
+            "partition_by": ["persona_id", "tooling_condition_id"],
+            "persona_ids": ["security-researcher", "benchmark-designer", "evaluator-reviewer"],
+            "experience_band_ids": ["research-qualified-infrastructure-novice"],
+            "tooling_condition_ids": ["public-docs-only", "mcp-tools", "cli-tools", "direct-library"]
+          },
+          {
+            "group_id": "target-infrastructure-familiar",
+            "role": "comparison",
+            "partition_by": ["persona_id", "tooling_condition_id"],
+            "persona_ids": ["security-researcher", "benchmark-designer", "evaluator-reviewer"],
+            "experience_band_ids": ["research-qualified-infrastructure-familiar"],
+            "tooling_condition_ids": ["public-docs-only", "mcp-tools", "cli-tools", "direct-library"]
+          },
+          {
+            "group_id": "target-prior-aces-user",
+            "role": "comparison",
+            "partition_by": ["persona_id", "tooling_condition_id"],
+            "persona_ids": ["security-researcher", "benchmark-designer", "evaluator-reviewer"],
+            "experience_band_ids": ["prior-aces-user"],
+            "tooling_condition_ids": ["public-docs-only", "mcp-tools", "cli-tools", "direct-library"]
+          },
+          {
+            "group_id": "backend-implementer-comparison",
+            "role": "comparison",
+            "partition_by": ["experience_band", "tooling_condition_id"],
+            "persona_ids": ["backend-implementer"],
+            "experience_band_ids": ["research-qualified-infrastructure-novice", "research-qualified-infrastructure-familiar", "prior-aces-user"],
+            "tooling_condition_ids": ["public-docs-only", "mcp-tools", "cli-tools", "direct-library"]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/docs/research/dsl-language-evaluation/execution-snapshot-accessibility-v1.json
+++ b/docs/research/dsl-language-evaluation/execution-snapshot-accessibility-v1.json
@@ -1,0 +1,127 @@
+{
+  "snapshot_id": "aces-researcher-accessibility-not-started-v1",
+  "protocol_revision": "2.0.0",
+  "captured_at": "2026-07-17",
+  "execution_status": "not_started",
+  "aces_revision": "c3ce41a5dbfd519582de7c7f6b77764525f31932",
+  "public_surface": [
+    {
+      "surface_id": "getting-started",
+      "kind": "documentation",
+      "artifact": "docs/explain/getting-started.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "public onboarding path; no implementation source"
+    },
+    {
+      "surface_id": "sdl-explanation",
+      "kind": "documentation",
+      "artifact": "docs/explain/sdl",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "public SDL authoring, parser, diagnostics, limitation, and language-service explanations"
+    },
+    {
+      "surface_id": "public-glossary",
+      "kind": "documentation",
+      "artifact": "docs/explain/reference/glossary.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "public domain terminology"
+    },
+    {
+      "surface_id": "agent-guidance-aut-811",
+      "kind": "guidance",
+      "artifact": "specs/agent-guidance/agent-guidance.yaml",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "materialized canonical guidance profile AUT-811; no issue-local duplicate"
+    },
+    {
+      "surface_id": "intended-use-profiles",
+      "kind": "tool",
+      "artifact": "implementations/python/packages/aces_mcp/tools/completeness.py",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "aces_intended_use_profiles with a task-declared profile only"
+    },
+    {
+      "surface_id": "example-scenarios",
+      "kind": "examples",
+      "artifact": "examples/scenarios",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "positive parser-validated scenario corpus"
+    },
+    {
+      "surface_id": "example-library",
+      "kind": "examples",
+      "artifact": "examples/library",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "cataloged templates and patterns; invalid stimuli remain outside this library"
+    },
+    {
+      "surface_id": "sdl-source-profile",
+      "kind": "documentation",
+      "artifact": "docs/explain/sdl/parser.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "sdl-yaml/v1; explicit strict or migration mode per task"
+    },
+    {
+      "surface_id": "sdl-references",
+      "kind": "documentation",
+      "artifact": "specs/sdl/references.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "fail-closed resolution and ambiguity rules"
+    },
+    {
+      "surface_id": "sdl-diagnostics",
+      "kind": "documentation",
+      "artifact": "specs/sdl/diagnostics.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "public diagnostic codes, stages, severities, and locations"
+    },
+    {
+      "surface_id": "participant-semantics",
+      "kind": "documentation",
+      "artifact": "specs/formal/participant-semantics/README.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "participant information-boundary and outcome obligations"
+    },
+    {
+      "surface_id": "mcp-authoring-tools",
+      "kind": "tool",
+      "artifact": "implementations/python/packages/aces_mcp/tools",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "named local-stdio reference, authoring, language-service, inspection, or operation tool; exact mode and profile recorded per attempt; 64 KiB adapter bound"
+    },
+    {
+      "surface_id": "human-cli",
+      "kind": "tool",
+      "artifact": "implementations/python/packages/aces_cli",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "named command, source profile, migration policy, semantic-validation mode, and arguments recorded per attempt"
+    },
+    {
+      "surface_id": "documented-library",
+      "kind": "library",
+      "artifact": "implementations/python/packages/aces_sdl",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "documented content-based parse, semantic validation, canonicalization, instantiation, compiler, reference-processor, and stub-planner entrypoints only"
+    },
+    {
+      "surface_id": "language-service",
+      "kind": "library",
+      "artifact": "implementations/python/packages/aces_sdl/language_service.py",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "parameters": "structured public diagnostics kept distinct from CLI prose and MCP operation envelopes"
+    }
+  ],
+  "ethics_review": {
+    "status": "pending",
+    "protocol_identifier": null,
+    "approved_population": null,
+    "approved_data_boundary": null
+  },
+  "subjects": [],
+  "attempts": [],
+  "observations": [],
+  "reviews": [],
+  "deviations": [],
+  "withdrawals": [],
+  "disagreements": []
+}

--- a/docs/research/dsl-language-evaluation/index.md
+++ b/docs/research/dsl-language-evaluation/index.md
@@ -1,10 +1,11 @@
 # ACES SDL Language Evaluation
 
-This directory is the evidence gate for issue #346 and requirement ASR-530.
-It does **not** claim that ACES is already an experimentally adequate language.
-It preregisters how that claim can be tested and pins a sanitized, not-started
-execution snapshot so architecture, parsing, or schema completeness cannot be
-mistaken for study evidence.
+This directory is the shared evidence gate for issues #346 and #178 under
+requirement ASR-530. It does **not** claim that ACES is already an
+experimentally adequate language or accessible to non-infrastructure-expert
+researchers. It preregisters how those distinct claims can be tested and pins
+sanitized, not-started execution snapshots so architecture, parsing, schema
+completeness, or the protocol itself cannot be mistaken for study evidence.
 
 The protocol follows the concern raised by Gabriel, Goulão, and Amaral that a
 domain-specific language is not validated merely by using domain concepts:
@@ -17,8 +18,12 @@ protocol.
 
 ## Bundle
 
-- [`bundle-manifest.json`](bundle-manifest.json) selects the exact active
-  artifacts without making a mutable branch name part of evidence identity.
+- [`bundle-manifest.json`](bundle-manifest.json) selects the exact primary and
+  supplemental claim bundles without making a mutable branch name part of
+  evidence identity. It also binds each stable claim id to its exact required
+  scope and preregistered gating/comparison strata. Every selected bundle is
+  checked; adding a claim cannot stop the frozen issue-346 record from being
+  validated.
 - [`protocol-v1.json`](protocol-v1.json) freezes constructs, personas, tasks,
   variants, artifact stages, tooling conditions, measures, thresholds,
   sampling, missing-data rules, stopping rules, privacy boundaries, and
@@ -30,12 +35,61 @@ protocol.
 - [`analysis-v1.json`](analysis-v1.json) names the ADR-021 claim, allowed and
   disallowed evidence, objective pass/fail criteria, and recomputable measure
   slots. Its evidence status is `untested`.
+- [`protocol-v2.json`](protocol-v2.json) adds the issue-178
+  `security-researcher` persona, adapter-specific docs/MCP/CLI/direct-library
+  conditions, representative authoring/review tasks, and focused invalid and
+  unsupported-boundary tasks without editing the frozen revision-1 protocol.
+- [`execution-snapshot-accessibility-v1.json`](execution-snapshot-accessibility-v1.json)
+  pins the public authoring docs, AUT-811 guidance, intended-use discovery,
+  examples, CLI, MCP, language-service, and documented library surfaces. It is
+  `not_started` and contains no study records.
+- [`analysis-accessibility-v1.json`](analysis-accessibility-v1.json) selects
+  only the issue-178 personas, tasks, conditions, variants, stages, dimensions,
+  and measures. Its evidence status is `untested`.
 
 Protocol, snapshot, and analysis are independently revisioned. An executed
 study creates a new immutable snapshot and analysis. It does not edit the
 not-started record or silently change protocol thresholds. A changed construct,
 rubric, threshold, sampling rule, task meaning, or exclusion rule creates a new
 protocol revision and amendment entry.
+
+Each analysis repeats a closed scope of stable protocol identifiers, but it
+cannot choose or narrow that scope: the checker requires an exact match with
+the versioned manifest binding for the claim id. Frozen observations outside a
+bound scope remain valid inputs for another claim but are excluded from its
+recomputation, completion decision, and ADR-021 evidence status. A legitimately
+narrower scope requires a distinct claim identity and statement. This prevents
+accessibility results from silently promoting or refuting language adequacy,
+and prevents a publisher from discarding unfavorable dimensions or populations.
+
+## Researcher accessibility claim
+
+Issue #178 separates four personas: `security-researcher`,
+`benchmark-designer`, `backend-implementer`, and `evaluator-reviewer`. Backend
+implementers are a comparison and boundary-testing population; their results
+cannot substitute for non-infrastructure-expert researcher results. Relevant
+SDL, benchmark, cloud/container, and programming experience is recorded only as
+bounded bands. The manifest partitions target infrastructure novices by persona
+and tooling condition as claim-gating strata. Infrastructure-familiar and prior
+ACES users, plus backend implementers partitioned by experience and condition,
+are persisted as comparison strata and cannot promote or refute the claim.
+
+The protocol keeps `public-docs-only`, MCP, CLI, and documented-library
+conditions separate. Every attempt pins the exact adapter, mode, source or
+migration profile, intended-use profile, parameters, assistance policy, and
+ACES revision. Positive tasks require a non-trivial benchmark scenario and
+independent review. Negative tasks distinguish invalid, unsupported, and
+profile-dependent outcomes and preserve the exact public diagnostic rather
+than enriching it from source.
+
+Success requires representative authoring and validation without cloud,
+Terraform, OpenStack, Docker, backend source, or undocumented backend
+conventions; diagnostics that locate defects and support correction; public
+examples/templates that support the sealed non-trivial meaning; clear teaching
+of unsupported boundaries; and blinded review that recovers critical meaning.
+Requests for prohibited assistance, setup failures, wrong turns, missing public
+guidance, weak diagnostics, abandoned attempts, and failed tasks remain
+evidence. Product corrections belong to separate issues and later snapshots.
 
 ## What is evaluated
 
@@ -100,23 +154,26 @@ Run the focused integrity gate with:
 implementations/python/.venv/bin/python tools/check_dsl_language_evaluation.py
 ```
 
-The checker validates bounded duplicate-safe JSON, closed shapes, stable IDs,
-catalog and cross-artifact joins, source pins, repository path containment,
-secret-safe locators, the closed subject-attempt-observation-review graph,
-per-subject workload assignment, the protocol-derived task-variant-stage
-opportunity matrix, recomputed measure results with outcome counts, complete
-execution coverage, preserved disagreements, and ADR-021 evidence-status
-promotion. It performs no network access, backend deployment, shell evaluation,
-or private-data lookup. The same check runs once in the canonical nox contracts
-graph.
+The checker validates every manifest-selected bundle: bounded duplicate-safe
+JSON, closed shapes, stable IDs, claim-scope joins, source pins, repository path
+containment, secret-safe locators, the closed
+subject-attempt-observation-review graph, scoped workload assignment, the
+protocol-derived task-variant-stage opportunity matrix, exact manifest claim
+bindings, independently persisted persona/experience/condition stratum
+recomputation, complete execution coverage, preserved disagreements, and
+gating-stratum-only ADR-021 evidence-status promotion. It performs no network
+access, backend deployment, shell evaluation, or private-data lookup. The same
+check runs once in the canonical nox contracts graph.
 
 ## Interpretation boundary
 
-`demonstrated` is permitted only for the exact preregistered population, tasks,
-conditions, ACES revision, and public surfaces after every dimension passes and
-coverage is complete. `partial` preserves incomplete but relevant evidence.
-Any objective fail criterion yields `refuted`; absent execution remains
-`untested`.
+`demonstrated` is permitted only for the manifest-bound population, tasks,
+conditions, variants, stages, measures, ACES revision, and public surfaces
+after every dimension in every preregistered gating stratum passes and coverage
+is complete. Pooled success and comparison-population success cannot mask a
+target persona, experience band, or condition failure. `partial` preserves
+incomplete but relevant evidence. Any gating-stratum objective fail criterion
+yields `refuted`; absent execution remains `untested`.
 
 Failed observations are evidence. Product fixes belong to separately scoped
 issues and owning SDL/specification/test surfaces. A later correction may be

--- a/docs/research/dsl-language-evaluation/protocol-v2.json
+++ b/docs/research/dsl-language-evaluation/protocol-v2.json
@@ -1,0 +1,2304 @@
+{
+  "protocol_id": "aces-researcher-accessibility-evaluation",
+  "revision": "2.0.0",
+  "registered_at": "2026-07-17",
+  "title": "ACES SDL researcher-accessibility evaluation protocol",
+  "claim": "Target security researchers, benchmark designers, backend implementers, and evaluator-reviewers can author, validate, and review representative ACES scenarios through pinned public surfaces without infrastructure expertise or backend-private interpretation.",
+  "research_question": "Can each issue-178 persona complete benchmark-relevant positive and negative authoring or review tasks through the declared public ACES condition with useful diagnostics and without cloud, Terraform, OpenStack, Docker, or implementation-source inspection?",
+  "evidence_status_values": [
+    "untested",
+    "partial",
+    "demonstrated",
+    "refuted"
+  ],
+  "dimensions": [
+    {
+      "dimension_id": "expressiveness",
+      "label": "Expressiveness",
+      "construct": "Whether every experimental concern in a task brief has a native representation or an explicit unsupported, underspecified, or profile-dependent disposition.",
+      "pass_rule": "At least 90 percent of required semantic elements are represented or explicitly dispositioned, with no silent loss of a critical element.",
+      "fail_rule": "A critical element is silently omitted or represented only by backend-private convention, or aggregate coverage is below 90 percent."
+    },
+    {
+      "dimension_id": "usability-comprehension",
+      "label": "Usability and comprehension",
+      "construct": "Whether qualified subjects complete assigned authoring or review tasks using only the declared public surface and assistance condition.",
+      "pass_rule": "At least 80 percent of scored attempts complete without prohibited assistance and the critical semantic-error rate is at most 10 percent.",
+      "fail_rule": "Completion is below 80 percent, critical semantic errors exceed 10 percent, or success depends on backend/source inspection."
+    },
+    {
+      "dimension_id": "effectiveness-productivity",
+      "label": "Effectiveness and productivity",
+      "construct": "Task correctness, bounded effort, diagnostic repair, and rework under a fixed task and assistance condition rather than elapsed time or self-report alone.",
+      "pass_rule": "At least 80 percent of attempts meet the task outcome and median rework is no more than two semantic repair cycles; timing is reported descriptively by persona and task.",
+      "fail_rule": "Outcome success is below 80 percent or median semantic rework exceeds two cycles; no universal speed claim is permitted."
+    },
+    {
+      "dimension_id": "maintainability-evolution",
+      "label": "Maintainability and evolution",
+      "construct": "Whether controlled edits and migrations preserve, change, invalidate, or replace declared meaning with visible status.",
+      "pass_rule": "At least 90 percent of maintenance attempts produce the preregistered semantic relation and every lossy or invalid migration is surfaced.",
+      "fail_rule": "A meaning-changing edit is reported as preserving meaning, a lossy migration is silent, or relation accuracy is below 90 percent."
+    },
+    {
+      "dimension_id": "ambiguity",
+      "label": "Ambiguity",
+      "construct": "Whether one artifact admits multiple materially defensible meanings or intended-equivalent authorings diverge without an explicit disposition.",
+      "pass_rule": "No critical ambiguity is accepted silently and at least 90 percent of preregistered ambiguous or relation-bearing variants receive the expected disposition.",
+      "fail_rule": "Any critical ambiguity is silently accepted or expected relation classification falls below 90 percent."
+    },
+    {
+      "dimension_id": "diagnostic-quality",
+      "label": "Diagnostic quality",
+      "construct": "Whether the selected public entrypoint reports a bounded code, stage, severity, location, explanation, and repair direction sufficient for a valid correction.",
+      "pass_rule": "At least 80 percent of negative attempts locate the injected defect and at least 75 percent are repaired without prohibited assistance.",
+      "fail_rule": "Defect localization is below 80 percent, repair success is below 75 percent, or resolution requires implementation-source inspection."
+    },
+    {
+      "dimension_id": "reviewability",
+      "label": "Reviewability",
+      "construct": "Whether an independent reviewer identifies intended meaning, material changes, hidden assumptions, and information boundaries before intent is revealed.",
+      "pass_rule": "At least 80 percent of critical rubric items are identified and no critical hidden-assumption or information-boundary change is missed by a majority of reviewers.",
+      "fail_rule": "Critical-item recall is below 80 percent or a majority miss a critical assumption or boundary change."
+    },
+    {
+      "dimension_id": "semantic-traceability",
+      "label": "Semantic traceability",
+      "construct": "Whether intent can be followed across authored, expanded, instantiated, compiled, and planned artifacts through canonical public identities.",
+      "pass_rule": "At least 90 percent of required intent-to-artifact links resolve at the owning stage and no critical change disappears from all machine artifacts.",
+      "fail_rule": "A critical intent element cannot be traced, a meaning change collapses at every observed stage, or link coverage is below 90 percent."
+    }
+  ],
+  "personas": [
+    {
+      "persona_id": "benchmark-designer",
+      "label": "Benchmark designer",
+      "qualification": "Has designed or evaluated at least one cyber, agent, or security benchmark and can state tasks, measures, and validity limits.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "scenario-author",
+      "label": "Scenario author",
+      "qualification": "Has authored cyber-range, infrastructure, exercise, or security-scenario material but need not know ACES internals.",
+      "minimum_completed_subjects": 0
+    },
+    {
+      "persona_id": "participant-model-author",
+      "label": "Participant-model author",
+      "qualification": "Has modeled agent or human actions, observations, information boundaries, episodes, or outcomes.",
+      "minimum_completed_subjects": 0
+    },
+    {
+      "persona_id": "backend-implementer",
+      "label": "Backend implementer",
+      "qualification": "Has implemented or integrated a cyber range, simulator, orchestration backend, or execution adapter.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "evaluator-reviewer",
+      "label": "Evaluator or reviewer",
+      "qualification": "Has independently reviewed experimental protocols, scenario specifications, or agent-evaluation artifacts.",
+      "minimum_completed_subjects": 5
+    },
+    {
+      "persona_id": "assurance-auditor",
+      "label": "Assurance auditor",
+      "qualification": "Has assessed traceability, evidence, security controls, reproducibility, or compliance claims.",
+      "minimum_completed_subjects": 0
+    },
+    {
+      "persona_id": "security-researcher",
+      "label": "Security researcher",
+      "qualification": "Has designed, run, or evaluated security experiments or cyber-agent studies, but is not required to know cloud, container, infrastructure-as-code, cyber-range backend, or ACES implementation internals.",
+      "minimum_completed_subjects": 5
+    }
+  ],
+  "tooling_conditions": [
+    {
+      "condition_id": "public-docs-only",
+      "label": "Public documentation only",
+      "allowed_surface": "Pinned public documentation and task materials; no source, backend internals, or private prompts.",
+      "assistance": "Search within the pinned documentation is allowed; maintainers and generative assistants are not."
+    },
+    {
+      "condition_id": "public-tools",
+      "label": "Public documentation and production tools",
+      "allowed_surface": "Pinned public documentation plus the selected production parser, validator, canonicalizer, compiler, planner, CLI, or MCP adapter named by the task.",
+      "assistance": "Tool diagnostics may be used; implementation-source inspection, backend-private interpretation, and manual artifact repair after scoring are prohibited."
+    },
+    {
+      "condition_id": "mcp-tools",
+      "label": "Public documentation and MCP authoring tools",
+      "allowed_surface": "Pinned public documentation plus the named local-stdio MCP tool, mode, intended-use profile, and parameters; no other adapter or implementation source.",
+      "assistance": "Exact MCP diagnostics may be used; maintainers, generative assistants, backend internals, and source-derived enrichment are prohibited."
+    },
+    {
+      "condition_id": "cli-tools",
+      "label": "Public documentation and CLI",
+      "allowed_surface": "Pinned public documentation plus the named human CLI command, source profile, migration policy, semantic-validation mode, and parameters; no other adapter or implementation source.",
+      "assistance": "Exact CLI output may be used; maintainers, generative assistants, backend internals, and source-derived enrichment are prohibited."
+    },
+    {
+      "condition_id": "direct-library",
+      "label": "Public documentation and documented Python library",
+      "allowed_surface": "Pinned public documentation plus the named documented content-based Python entrypoints and explicit validation mode; no private helper or backend source.",
+      "assistance": "Public exceptions and diagnostics may be used; undocumented imports, maintainers, generative assistants, and backend-private interpretation are prohibited."
+    }
+  ],
+  "artifact_stages": [
+    {
+      "stage_id": "authored",
+      "label": "Authored SDL",
+      "canonical_entrypoint": "parse_sdl() or parse_sdl_file() using sdl-yaml/v1 and the task's explicit source/migration profile"
+    },
+    {
+      "stage_id": "validated",
+      "label": "Semantically validated SDL",
+      "canonical_entrypoint": "SemanticValidator in collect-all fail-closed mode"
+    },
+    {
+      "stage_id": "canonical-authored",
+      "label": "Canonical authored SDL",
+      "canonical_entrypoint": "canonical_sdl_bytes() and canonical_sdl_digest() after expansion and semantic validation"
+    },
+    {
+      "stage_id": "instantiated",
+      "label": "Admitted instantiated SDL",
+      "canonical_entrypoint": "instantiate_scenario(), admit_instantiated_scenario(), and canonical_instantiated_sdl_digest()"
+    },
+    {
+      "stage_id": "compiled",
+      "label": "Compiled runtime model",
+      "canonical_entrypoint": "compile_runtime_model() with canonical SDL addresses"
+    },
+    {
+      "stage_id": "planned",
+      "label": "Processor plan",
+      "canonical_entrypoint": "the reference processor and plan(); stub planning must be labeled as such"
+    },
+    {
+      "stage_id": "review-judgment",
+      "label": "Independent review judgment",
+      "canonical_entrypoint": "a blinded rubric response fixed before intended semantics are revealed"
+    }
+  ],
+  "sources": [
+    {
+      "source_id": "gabriel-language-evaluation",
+      "kind": "publication",
+      "title": "Do Software Languages Engineers Evaluate their Languages?",
+      "authors": "Pedro Gabriel; Miguel Goulao; Vasco Amaral",
+      "year": 2011,
+      "locator": "https://arxiv.org/abs/1109.6794v1",
+      "version": "arXiv:1109.6794v1",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "mernik-dsl-method",
+      "kind": "publication",
+      "title": "When and How to Develop Domain-Specific Languages",
+      "authors": "Marjan Mernik; Jan Heering; Anthony M. Sloane",
+      "year": 2005,
+      "locator": "https://doi.org/10.1145/1118890.1118892",
+      "version": "ACM Computing Surveys 37(4)",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "kosar-dsl-mapping",
+      "kind": "publication",
+      "title": "Domain-Specific Languages: A Systematic Mapping Study",
+      "authors": "Tomaž Kosar; Sudev Bohra; Marjan Mernik",
+      "year": 2016,
+      "locator": "https://doi.org/10.1016/j.infsof.2015.11.001",
+      "version": "Information and Software Technology 71",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "vsdl",
+      "kind": "publication",
+      "title": "Automating the Generation of Cyber Range Virtual Scenarios with VSDL",
+      "authors": "Gabriele Costa; Enrico Russo; Alessandro Armando",
+      "year": 2023,
+      "locator": "https://arxiv.org/abs/2001.06681v2",
+      "version": "arXiv:2001.06681v2",
+      "revision": null,
+      "artifact_path": null,
+      "primary": true
+    },
+    {
+      "source_id": "aces-participant-semantics",
+      "kind": "repository-internal",
+      "title": "ACES participant behavior and interaction semantics",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/38ba081714b12a4dcc7a5c527e2f1250d80a4d1b/specs/formal/participant-semantics/README.md",
+      "version": "ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "revision": "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "artifact_path": "specs/formal/participant-semantics/README.md",
+      "primary": true
+    },
+    {
+      "source_id": "aces-related-work-protocol",
+      "kind": "repository-internal",
+      "title": "ACES reproducible related-work comparison protocol",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/38ba081714b12a4dcc7a5c527e2f1250d80a4d1b/docs/research/related-work-comparison/protocol-v1.json",
+      "version": "protocol 1.0.0 at ACES revision 38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "revision": "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b",
+      "artifact_path": "docs/research/related-work-comparison/protocol-v1.json",
+      "primary": true
+    },
+    {
+      "source_id": "aces-public-authoring-guidance",
+      "kind": "repository-internal",
+      "title": "ACES public getting-started, SDL, glossary, and intended-use guidance",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/c3ce41a5dbfd519582de7c7f6b77764525f31932/docs/explain/getting-started.md",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "revision": "c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "artifact_path": "docs/explain/getting-started.md",
+      "primary": true
+    },
+    {
+      "source_id": "aces-example-library",
+      "kind": "repository-internal",
+      "title": "ACES scenario example, template, and pattern catalog",
+      "authors": "ACES project",
+      "year": 2026,
+      "locator": "https://github.com/Brad-Edwards/aces/blob/c3ce41a5dbfd519582de7c7f6b77764525f31932/examples/library/catalog.yaml",
+      "version": "ACES revision c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "revision": "c3ce41a5dbfd519582de7c7f6b77764525f31932",
+      "artifact_path": "examples/library/catalog.yaml",
+      "primary": true
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "author-multihost-experiment",
+      "title": "Author a multi-host participant experiment",
+      "kind": "positive",
+      "persona_ids": [
+        "benchmark-designer",
+        "scenario-author",
+        "participant-model-author"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "usability-comprehension",
+        "effectiveness-productivity",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "aces-related-work-protocol",
+        "aces-participant-semantics",
+        "vsdl"
+      ],
+      "intended_semantics_ref": "sealed-intent/author-multihost-experiment-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "instantiated",
+        "compiled",
+        "planned"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "public-tools"
+      ],
+      "variant_ids": [
+        "multihost-reference"
+      ],
+      "success_rule": "The artifact expresses topology, participant views/actions, an objective, evidence, and declared external obligations without implementation-specific credentials or private conventions.",
+      "failure_rule": "A critical concern is omitted, silently externalized, or only recoverable from backend or implementation source."
+    },
+    {
+      "task_id": "author-information-boundary",
+      "title": "Author participant visibility and outcome boundaries",
+      "kind": "positive",
+      "persona_ids": [
+        "participant-model-author",
+        "assurance-auditor"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "reviewability",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "aces-participant-semantics"
+      ],
+      "intended_semantics_ref": "sealed-intent/author-information-boundary-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "compiled",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "public-tools"
+      ],
+      "variant_ids": [
+        "visibility-boundary-change"
+      ],
+      "success_rule": "World truth, participant-visible projection, action applicability, observation, and outcome meaning remain distinguishable to tools and reviewers.",
+      "failure_rule": "A reviewer cannot determine what the participant can observe or a machine artifact collapses hidden truth into the visible projection."
+    },
+    {
+      "task_id": "reject-dangling-reference",
+      "title": "Reject one dangling authored reference",
+      "kind": "negative",
+      "persona_ids": [
+        "scenario-author",
+        "backend-implementer"
+      ],
+      "dimension_ids": [
+        "diagnostic-quality",
+        "usability-comprehension",
+        "effectiveness-productivity"
+      ],
+      "source_refs": [
+        "aces-related-work-protocol"
+      ],
+      "intended_semantics_ref": "sealed-intent/reject-dangling-reference-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated"
+      ],
+      "tooling_condition_ids": [
+        "public-tools"
+      ],
+      "variant_ids": [
+        "dangling-reference-single-defect"
+      ],
+      "success_rule": "The production semantic boundary rejects the single defect with a bounded, located diagnostic and the subject repairs it without source inspection.",
+      "failure_rule": "The defect is accepted, mislocated, only reported by a private path, or cannot be repaired from the declared public output."
+    },
+    {
+      "task_id": "classify-underspecified-realization",
+      "title": "Classify underspecified or profile-dependent realization",
+      "kind": "underspecified",
+      "persona_ids": [
+        "scenario-author",
+        "backend-implementer",
+        "evaluator-reviewer"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "ambiguity",
+        "reviewability"
+      ],
+      "source_refs": [
+        "aces-participant-semantics",
+        "vsdl"
+      ],
+      "intended_semantics_ref": "sealed-intent/classify-underspecified-realization-v1",
+      "artifact_stage_ids": [
+        "validated",
+        "compiled",
+        "planned",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "public-tools"
+      ],
+      "variant_ids": [
+        "profile-dependent-realization"
+      ],
+      "success_rule": "The artifact and reviewer classify the concern as underspecified or profile-dependent at the owning stage rather than inventing backend meaning.",
+      "failure_rule": "The concern is reported as fully specified, silently defaulted, or resolved only through private backend assumptions."
+    },
+    {
+      "task_id": "reject-normalized-key-ambiguity",
+      "title": "Reject a deliberately ambiguous mapping key",
+      "kind": "ambiguous",
+      "persona_ids": [
+        "scenario-author",
+        "backend-implementer"
+      ],
+      "dimension_ids": [
+        "ambiguity",
+        "diagnostic-quality",
+        "effectiveness-productivity"
+      ],
+      "source_refs": [
+        "gabriel-language-evaluation",
+        "aces-related-work-protocol"
+      ],
+      "intended_semantics_ref": "sealed-intent/reject-normalized-key-ambiguity-v1",
+      "artifact_stage_ids": [
+        "authored"
+      ],
+      "tooling_condition_ids": [
+        "public-tools"
+      ],
+      "variant_ids": [
+        "normalized-key-collision"
+      ],
+      "success_rule": "The production parser fails closed before construction, identifies the collision, and supports a valid repair.",
+      "failure_rule": "One key silently wins, the ambiguity reaches later stages, or the diagnostic cannot support repair."
+    },
+    {
+      "task_id": "round-trip-format-equivalence",
+      "title": "Preserve meaning across source-format variation",
+      "kind": "round-trip",
+      "persona_ids": [
+        "scenario-author",
+        "evaluator-reviewer"
+      ],
+      "dimension_ids": [
+        "ambiguity",
+        "maintainability-evolution",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "mernik-dsl-method",
+        "kosar-dsl-mapping"
+      ],
+      "intended_semantics_ref": "sealed-intent/round-trip-format-equivalence-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "canonical-authored",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-tools"
+      ],
+      "variant_ids": [
+        "format-only-equivalent",
+        "field-order-equivalent"
+      ],
+      "success_rule": "Strict reparse and canonical authored identity converge for both variants while reviewers classify the change as non-material.",
+      "failure_rule": "Equivalent source variants diverge semantically, a tool reports false material change, or a reviewer must rely on hidden conventions."
+    },
+    {
+      "task_id": "distinguish-hidden-asset-mutation",
+      "title": "Distinguish a non-equivalent hidden-asset mutation",
+      "kind": "mutation",
+      "persona_ids": [
+        "participant-model-author",
+        "evaluator-reviewer",
+        "assurance-auditor"
+      ],
+      "dimension_ids": [
+        "ambiguity",
+        "reviewability",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "aces-participant-semantics"
+      ],
+      "intended_semantics_ref": "sealed-intent/distinguish-hidden-asset-mutation-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "instantiated",
+        "compiled",
+        "planned",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-tools"
+      ],
+      "variant_ids": [
+        "hidden-asset-non-equivalent"
+      ],
+      "success_rule": "At least one owning machine artifact and the independent review distinguish the declared information-boundary change.",
+      "failure_rule": "All observed machine stages collapse the change or reviewers classify it as equivalent because the boundary is not public."
+    },
+    {
+      "task_id": "maintain-versioned-import",
+      "title": "Maintain a versioned imported scenario",
+      "kind": "maintenance",
+      "persona_ids": [
+        "scenario-author",
+        "backend-implementer",
+        "assurance-auditor"
+      ],
+      "dimension_ids": [
+        "maintainability-evolution",
+        "diagnostic-quality",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "mernik-dsl-method",
+        "aces-related-work-protocol"
+      ],
+      "intended_semantics_ref": "sealed-intent/maintain-versioned-import-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "canonical-authored",
+        "instantiated"
+      ],
+      "tooling_condition_ids": [
+        "public-tools"
+      ],
+      "variant_ids": [
+        "compatible-import-update",
+        "lossy-import-update"
+      ],
+      "success_rule": "The compatible update preserves the declared relation and the lossy update reports invalidation, migration, or replacement status.",
+      "failure_rule": "A lossy update is accepted as meaning-preserving, identity silently drifts, or repair requires private registry/source knowledge."
+    },
+    {
+      "task_id": "independent-review-change",
+      "title": "Review a blinded semantic change",
+      "kind": "independent-review",
+      "persona_ids": [
+        "benchmark-designer",
+        "evaluator-reviewer",
+        "assurance-auditor"
+      ],
+      "dimension_ids": [
+        "reviewability",
+        "ambiguity",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "gabriel-language-evaluation",
+        "kosar-dsl-mapping"
+      ],
+      "intended_semantics_ref": "sealed-intent/independent-review-change-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "compiled",
+        "planned",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "public-tools"
+      ],
+      "variant_ids": [
+        "review-hidden-assumption-change"
+      ],
+      "success_rule": "The blinded reviewer identifies the material change, hidden assumption, affected artifact stage, and information boundary before intent is revealed.",
+      "failure_rule": "The critical change or assumption is missed by a majority or can be explained only after backend-private intent is disclosed."
+    },
+    {
+      "task_id": "accessibility-author-benchmark-scenario",
+      "title": "Author and validate a non-trivial benchmark scenario",
+      "kind": "positive",
+      "persona_ids": [
+        "security-researcher",
+        "benchmark-designer"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "usability-comprehension",
+        "effectiveness-productivity",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "aces-public-authoring-guidance",
+        "aces-example-library",
+        "aces-participant-semantics"
+      ],
+      "intended_semantics_ref": "sealed-intent/accessibility-author-benchmark-scenario-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "instantiated",
+        "compiled",
+        "planned"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "mcp-tools",
+        "cli-tools",
+        "direct-library"
+      ],
+      "variant_ids": [
+        "accessibility-nontrivial-benchmark"
+      ],
+      "success_rule": "The subject expresses and validates the sealed topology, participant information boundary, actions, objective, evidence, and declared external obligations without infrastructure setup, backend source, or undocumented convention.",
+      "failure_rule": "A critical benchmark element is missing or wrong, only a trivial toy scenario is produced, validation is mistaken for semantic correctness, or completion requires infrastructure/backend expertise."
+    },
+    {
+      "task_id": "accessibility-repair-invalid-scenario",
+      "title": "Repair one invalid benchmark scenario from public diagnostics",
+      "kind": "negative",
+      "persona_ids": [
+        "security-researcher",
+        "benchmark-designer",
+        "backend-implementer"
+      ],
+      "dimension_ids": [
+        "usability-comprehension",
+        "effectiveness-productivity",
+        "diagnostic-quality"
+      ],
+      "source_refs": [
+        "aces-public-authoring-guidance",
+        "aces-example-library"
+      ],
+      "intended_semantics_ref": "sealed-intent/accessibility-repair-invalid-scenario-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated"
+      ],
+      "tooling_condition_ids": [
+        "mcp-tools",
+        "cli-tools",
+        "direct-library"
+      ],
+      "variant_ids": [
+        "accessibility-single-dangling-reference"
+      ],
+      "success_rule": "The assigned production entrypoint rejects the single dangling reference, localizes and explains it, and the subject produces a semantically valid repair within the preregistered cycle limit without source inspection.",
+      "failure_rule": "The defect is accepted, mislocated, explained only by source/private output, or cannot be repaired from the exact public diagnostic."
+    },
+    {
+      "task_id": "accessibility-classify-unsupported-request",
+      "title": "Classify an unsupported or profile-dependent request",
+      "kind": "underspecified",
+      "persona_ids": [
+        "security-researcher",
+        "benchmark-designer",
+        "backend-implementer",
+        "evaluator-reviewer"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "usability-comprehension",
+        "effectiveness-productivity",
+        "diagnostic-quality",
+        "reviewability"
+      ],
+      "source_refs": [
+        "aces-public-authoring-guidance",
+        "aces-participant-semantics"
+      ],
+      "intended_semantics_ref": "sealed-intent/accessibility-classify-unsupported-request-v1",
+      "artifact_stage_ids": [
+        "validated",
+        "planned",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "mcp-tools",
+        "cli-tools",
+        "direct-library"
+      ],
+      "variant_ids": [
+        "accessibility-unsupported-live-realization"
+      ],
+      "success_rule": "The subject identifies the sealed request as unsupported or profile-dependent at the owning stage, explains the public boundary, and does not invent deployment semantics.",
+      "failure_rule": "The request is mislabeled as invalid or fully supported, silently defaulted, or resolved through cloud, container, backend, or implementation-source assumptions."
+    },
+    {
+      "task_id": "accessibility-review-nontrivial-scenario",
+      "title": "Independently review a non-trivial scenario and public-tool result",
+      "kind": "independent-review",
+      "persona_ids": [
+        "benchmark-designer",
+        "evaluator-reviewer"
+      ],
+      "dimension_ids": [
+        "usability-comprehension",
+        "reviewability",
+        "semantic-traceability"
+      ],
+      "source_refs": [
+        "aces-public-authoring-guidance",
+        "aces-example-library",
+        "aces-participant-semantics"
+      ],
+      "intended_semantics_ref": "sealed-intent/accessibility-review-nontrivial-scenario-v1",
+      "artifact_stage_ids": [
+        "authored",
+        "validated",
+        "compiled",
+        "planned",
+        "review-judgment"
+      ],
+      "tooling_condition_ids": [
+        "public-docs-only",
+        "mcp-tools",
+        "cli-tools",
+        "direct-library"
+      ],
+      "variant_ids": [
+        "accessibility-hidden-boundary-error"
+      ],
+      "success_rule": "Before intent reveal, the reviewer identifies the critical information-boundary error, the affected artifact stages, the public diagnostic or guidance gap, and whether the scenario is benchmark-relevant.",
+      "failure_rule": "A majority miss the critical error, accept a toy scenario as representative, or need backend-private meaning to explain the result."
+    }
+  ],
+  "variants": [
+    {
+      "variant_id": "multihost-reference",
+      "task_id": "author-multihost-experiment",
+      "kind": "reference",
+      "expected_relation": "reference",
+      "description": "The sealed reference meaning for the positive task."
+    },
+    {
+      "variant_id": "visibility-boundary-change",
+      "task_id": "author-information-boundary",
+      "kind": "non-equivalent",
+      "expected_relation": "non-equivalent",
+      "description": "Changes one participant-visible fact while retaining topology."
+    },
+    {
+      "variant_id": "dangling-reference-single-defect",
+      "task_id": "reject-dangling-reference",
+      "kind": "invalid",
+      "expected_relation": "invalid",
+      "description": "Introduces exactly one undeclared reference."
+    },
+    {
+      "variant_id": "profile-dependent-realization",
+      "task_id": "classify-underspecified-realization",
+      "kind": "profile-dependent",
+      "expected_relation": "profile-dependent",
+      "description": "Leaves one realization choice outside portable SDL meaning."
+    },
+    {
+      "variant_id": "normalized-key-collision",
+      "task_id": "reject-normalized-key-ambiguity",
+      "kind": "ambiguous",
+      "expected_relation": "invalid",
+      "description": "Introduces two mapping keys that collide under the source profile."
+    },
+    {
+      "variant_id": "format-only-equivalent",
+      "task_id": "round-trip-format-equivalence",
+      "kind": "equivalent",
+      "expected_relation": "equivalent",
+      "description": "Changes comments and formatting only."
+    },
+    {
+      "variant_id": "field-order-equivalent",
+      "task_id": "round-trip-format-equivalence",
+      "kind": "equivalent",
+      "expected_relation": "equivalent",
+      "description": "Reorders mapping fields without changing values."
+    },
+    {
+      "variant_id": "hidden-asset-non-equivalent",
+      "task_id": "distinguish-hidden-asset-mutation",
+      "kind": "non-equivalent",
+      "expected_relation": "non-equivalent",
+      "description": "Changes whether one asset is visible to one participant."
+    },
+    {
+      "variant_id": "compatible-import-update",
+      "task_id": "maintain-versioned-import",
+      "kind": "equivalent",
+      "expected_relation": "equivalent",
+      "description": "Updates a versioned imported unit without changing declared semantics."
+    },
+    {
+      "variant_id": "lossy-import-update",
+      "task_id": "maintain-versioned-import",
+      "kind": "migration",
+      "expected_relation": "lossy",
+      "description": "Removes a referenced semantic element and requires explicit invalidation or migration status."
+    },
+    {
+      "variant_id": "review-hidden-assumption-change",
+      "task_id": "independent-review-change",
+      "kind": "non-equivalent",
+      "expected_relation": "non-equivalent",
+      "description": "Changes one hidden assumption without changing the high-level topology summary."
+    },
+    {
+      "variant_id": "accessibility-nontrivial-benchmark",
+      "task_id": "accessibility-author-benchmark-scenario",
+      "kind": "reference",
+      "expected_relation": "reference",
+      "description": "A sealed representative multi-host benchmark task with participant information boundaries, actions, objective, evidence, and external obligations."
+    },
+    {
+      "variant_id": "accessibility-single-dangling-reference",
+      "task_id": "accessibility-repair-invalid-scenario",
+      "kind": "invalid",
+      "expected_relation": "invalid",
+      "description": "Introduces exactly one dangling authored reference into a representative scenario."
+    },
+    {
+      "variant_id": "accessibility-unsupported-live-realization",
+      "task_id": "accessibility-classify-unsupported-request",
+      "kind": "profile-dependent",
+      "expected_relation": "profile-dependent",
+      "description": "Requests a live realization detail outside portable SDL and the declared stub-planning condition."
+    },
+    {
+      "variant_id": "accessibility-hidden-boundary-error",
+      "task_id": "accessibility-review-nontrivial-scenario",
+      "kind": "non-equivalent",
+      "expected_relation": "non-equivalent",
+      "description": "Introduces one critical participant information-boundary error into a non-trivial benchmark scenario."
+    }
+  ],
+  "measures": [
+    {
+      "measure_id": "semantic-elements-correct",
+      "task_ids": [
+        "author-multihost-experiment",
+        "author-information-boundary",
+        "classify-underspecified-realization",
+        "round-trip-format-equivalence",
+        "distinguish-hidden-asset-mutation",
+        "maintain-versioned-import",
+        "independent-review-change",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "semantic-traceability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "author-information-boundary",
+          "variant_ids": [
+            "visibility-boundary-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "compiled",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "validated",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "canonical-authored",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "instantiated",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "canonical-authored",
+            "instantiated"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "validated",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Score every declared task-variant-stage opportunity against the sealed intent after the attempt is fixed; a missing stage score leaves the aggregate incomplete."
+    },
+    {
+      "measure_id": "task-completion",
+      "task_ids": [
+        "author-multihost-experiment",
+        "reject-dangling-reference",
+        "reject-normalized-key-ambiguity",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "usability-comprehension",
+        "effectiveness-productivity"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        },
+        {
+          "task_id": "reject-dangling-reference",
+          "variant_ids": [
+            "dangling-reference-single-defect"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Count every assigned non-withdrawn attempt at its declared terminal decision stage; tool failures, missing records, and abandoned attempts are explicit zeroes unless the preregistered withdrawal rule applies."
+    },
+    {
+      "measure_id": "critical-semantic-errors",
+      "task_ids": [
+        "author-multihost-experiment",
+        "reject-dangling-reference",
+        "classify-underspecified-realization",
+        "reject-normalized-key-ambiguity",
+        "round-trip-format-equivalence",
+        "distinguish-hidden-asset-mutation",
+        "independent-review-change",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "usability-comprehension",
+        "ambiguity"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        },
+        {
+          "task_id": "reject-dangling-reference",
+          "variant_ids": [
+            "dangling-reference-single-defect"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "lower-is-better",
+      "capture_rule": "Count attempts containing at least one preregistered critical meaning error at the declared decision stage; missing scores leave the aggregate incomplete."
+    },
+    {
+      "measure_id": "semantic-rework-cycles",
+      "task_ids": [
+        "author-multihost-experiment",
+        "reject-dangling-reference",
+        "reject-normalized-key-ambiguity",
+        "round-trip-format-equivalence",
+        "maintain-versioned-import",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-repair-invalid-scenario"
+      ],
+      "dimension_ids": [
+        "effectiveness-productivity",
+        "maintainability-evolution"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "reject-dangling-reference",
+          "variant_ids": [
+            "dangling-reference-single-defect"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "median",
+      "direction": "lower-is-better",
+      "capture_rule": "Count submitted semantic repair cycles at each task's declared authored-stage opportunity; formatting-only edits do not count and missing scores leave the aggregate incomplete."
+    },
+    {
+      "measure_id": "relation-classification-accuracy",
+      "task_ids": [
+        "classify-underspecified-realization",
+        "reject-normalized-key-ambiguity",
+        "round-trip-format-equivalence",
+        "distinguish-hidden-asset-mutation",
+        "maintain-versioned-import",
+        "independent-review-change",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "ambiguity",
+        "maintainability-evolution",
+        "diagnostic-quality",
+        "reviewability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "canonical-authored",
+            "instantiated"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Compare each declared stage's fixed machine or reviewer relation judgment with the variant's preregistered expected relation; missing judgments leave the aggregate incomplete."
+    },
+    {
+      "measure_id": "diagnostic-localization",
+      "task_ids": [
+        "reject-dangling-reference",
+        "reject-normalized-key-ambiguity",
+        "maintain-versioned-import",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request"
+      ],
+      "dimension_ids": [
+        "diagnostic-quality"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "reject-dangling-reference",
+          "variant_ids": [
+            "dangling-reference-single-defect"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Count every declared diagnostic stage opportunity where the public diagnostic identifies the defect's owning stage and location; missing output leaves the aggregate incomplete."
+    },
+    {
+      "measure_id": "diagnostic-repair",
+      "task_ids": [
+        "reject-dangling-reference",
+        "reject-normalized-key-ambiguity",
+        "maintain-versioned-import",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request"
+      ],
+      "dimension_ids": [
+        "diagnostic-quality",
+        "effectiveness-productivity"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "reject-dangling-reference",
+          "variant_ids": [
+            "dangling-reference-single-defect"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Count every declared repair stage opportunity achieved using only the assigned public surface before the stopping limit; missing output leaves the aggregate incomplete."
+    },
+    {
+      "measure_id": "critical-review-items",
+      "task_ids": [
+        "author-information-boundary",
+        "classify-underspecified-realization",
+        "distinguish-hidden-asset-mutation",
+        "independent-review-change",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "reviewability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-information-boundary",
+          "variant_ids": [
+            "visibility-boundary-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Score every blinded fixed review-judgment-stage rubric before intent reveal; missing judgments leave the aggregate incomplete and adjudication never overwrites the original judgment."
+    },
+    {
+      "measure_id": "critical-silent-omissions",
+      "task_ids": [
+        "author-multihost-experiment",
+        "author-information-boundary",
+        "classify-underspecified-realization",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-classify-unsupported-request"
+      ],
+      "dimension_ids": [
+        "expressiveness"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "author-information-boundary",
+          "variant_ids": [
+            "visibility-boundary-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "compiled"
+          ]
+        },
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "validated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "validated",
+            "planned"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count critical intended semantic elements silently omitted or recoverable only through backend-private convention at each declared machine stage."
+    },
+    {
+      "measure_id": "silent-lossy-migrations",
+      "task_ids": [
+        "round-trip-format-equivalence",
+        "maintain-versioned-import"
+      ],
+      "dimension_ids": [
+        "maintainability-evolution"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "canonical-authored"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "canonical-authored",
+            "instantiated"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count lossy or invalid migrations accepted without visible invalidation, migration, or replacement status at each declared canonical or instantiated stage."
+    },
+    {
+      "measure_id": "critical-silent-ambiguities",
+      "task_ids": [
+        "classify-underspecified-realization",
+        "reject-normalized-key-ambiguity",
+        "round-trip-format-equivalence",
+        "distinguish-hidden-asset-mutation",
+        "independent-review-change"
+      ],
+      "dimension_ids": [
+        "ambiguity"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "validated",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "reject-normalized-key-ambiguity",
+          "variant_ids": [
+            "normalized-key-collision"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "canonical-authored",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "instantiated",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "compiled",
+            "planned",
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count critical ambiguities accepted without rejection or explicit underspecified/profile-dependent disposition at each declared stage."
+    },
+    {
+      "measure_id": "majority-missed-critical-items",
+      "task_ids": [
+        "author-information-boundary",
+        "classify-underspecified-realization",
+        "distinguish-hidden-asset-mutation",
+        "independent-review-change",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "reviewability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-information-boundary",
+          "variant_ids": [
+            "visibility-boundary-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "classify-underspecified-realization",
+          "variant_ids": [
+            "profile-dependent-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count critical hidden assumptions or information-boundary changes missed by a majority of assigned reviewers at each declared review-judgment stage."
+    },
+    {
+      "measure_id": "untraced-critical-changes",
+      "task_ids": [
+        "author-multihost-experiment",
+        "author-information-boundary",
+        "round-trip-format-equivalence",
+        "distinguish-hidden-asset-mutation",
+        "maintain-versioned-import",
+        "independent-review-change",
+        "accessibility-author-benchmark-scenario",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "semantic-traceability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "author-multihost-experiment",
+          "variant_ids": [
+            "multihost-reference"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "author-information-boundary",
+          "variant_ids": [
+            "visibility-boundary-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "compiled"
+          ]
+        },
+        {
+          "task_id": "round-trip-format-equivalence",
+          "variant_ids": [
+            "format-only-equivalent",
+            "field-order-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "canonical-authored"
+          ]
+        },
+        {
+          "task_id": "distinguish-hidden-asset-mutation",
+          "variant_ids": [
+            "hidden-asset-non-equivalent"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "maintain-versioned-import",
+          "variant_ids": [
+            "compatible-import-update",
+            "lossy-import-update"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "canonical-authored",
+            "instantiated"
+          ]
+        },
+        {
+          "task_id": "independent-review-change",
+          "variant_ids": [
+            "review-hidden-assumption-change"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "instantiated",
+            "compiled",
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "authored",
+            "validated",
+            "compiled",
+            "planned"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count critical intended changes absent from each required owning machine artifact stage; every declared task-variant-stage opportunity is preserved before aggregation."
+    },
+    {
+      "measure_id": "prohibited-infrastructure-assistance",
+      "task_ids": [
+        "accessibility-author-benchmark-scenario",
+        "accessibility-repair-invalid-scenario",
+        "accessibility-classify-unsupported-request",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "usability-comprehension",
+        "effectiveness-productivity"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "planned"
+          ]
+        },
+        {
+          "task_id": "accessibility-repair-invalid-scenario",
+          "variant_ids": [
+            "accessibility-single-dangling-reference"
+          ],
+          "artifact_stage_ids": [
+            "validated"
+          ]
+        },
+        {
+          "task_id": "accessibility-classify-unsupported-request",
+          "variant_ids": [
+            "accessibility-unsupported-live-realization"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "count",
+      "aggregation": "count",
+      "direction": "lower-is-better",
+      "capture_rule": "Count attempts that request or use cloud, Terraform, OpenStack, Docker, backend implementation source, undocumented conventions, maintainer interpretation, or another prohibited assistance channel."
+    },
+    {
+      "measure_id": "nontrivial-example-support",
+      "task_ids": [
+        "accessibility-author-benchmark-scenario",
+        "accessibility-review-nontrivial-scenario"
+      ],
+      "dimension_ids": [
+        "expressiveness",
+        "reviewability"
+      ],
+      "stage_applicability": [
+        {
+          "task_id": "accessibility-author-benchmark-scenario",
+          "variant_ids": [
+            "accessibility-nontrivial-benchmark"
+          ],
+          "artifact_stage_ids": [
+            "authored"
+          ]
+        },
+        {
+          "task_id": "accessibility-review-nontrivial-scenario",
+          "variant_ids": [
+            "accessibility-hidden-boundary-error"
+          ],
+          "artifact_stage_ids": [
+            "review-judgment"
+          ]
+        }
+      ],
+      "unit": "proportion",
+      "aggregation": "proportion",
+      "direction": "higher-is-better",
+      "capture_rule": "Score whether the pinned public example, template, and pattern catalog supports the sealed non-trivial benchmark meaning without a toy-only substitution or backend-private convention."
+    }
+  ],
+  "sampling_plan": {
+    "target_total": 20,
+    "minimum_per_persona": 5,
+    "experience_bands": [
+      "research-qualified-infrastructure-novice",
+      "research-qualified-infrastructure-familiar",
+      "prior-aces-user"
+    ],
+    "inclusion_rule": "Each subject satisfies one issue-178 persona qualification, records bounded SDL, benchmark, cloud/container, and programming experience bands, completes consent where applicable, and has not seen sealed intent or adjudication material.",
+    "exclusion_rule": "Exclude only preregistered ineligibility, consent withdrawal, corrupted capture before task exposure, duplicate enrollment, or prior access to sealed intent; preserve all other failures, setup friction, missing records, and prohibited-assistance requests in the declared denominator."
+  },
+  "execution_plan": {
+    "unit_of_analysis": "One subject-task-tooling-condition-attempt and its variant-stage observations.",
+    "attempts_per_subject": "Each subject completes at least one positive or underspecified accessibility task and at least one negative or independent-review accessibility task appropriate to the assigned persona.",
+    "subject_task_requirements": [
+      {
+        "requirement_id": "accessibility-constructive-or-boundary",
+        "minimum_assigned_attempts": 1,
+        "task_kinds": [
+          "positive",
+          "underspecified"
+        ]
+      },
+      {
+        "requirement_id": "accessibility-challenge-or-review",
+        "minimum_assigned_attempts": 1,
+        "task_kinds": [
+          "negative",
+          "ambiguous",
+          "round-trip",
+          "mutation",
+          "maintenance",
+          "independent-review"
+        ]
+      }
+    ],
+    "task_order": "Use a preregistered balanced order within persona, infrastructure-experience band, and public-surface condition; record installation/setup friction and learning exposure separately from task correctness.",
+    "blinding": "Seal intended semantics and expected relations from independent reviewers until their judgments are fixed.",
+    "stopping_rule": "Stop at 20 completed subjects with at least five per issue-178 persona, or at the approved recruitment deadline; do not extend or stop based on observed outcomes.",
+    "missing_data_rule": "Report denominator, missing, abandoned, tool-failed, and withdrawn counts separately for every measure; do not impute success.",
+    "withdrawal_rule": "Honor consent withdrawal and retain only the minimum aggregate count permitted by the approved protocol; never relabel withdrawal as task failure."
+  },
+  "thresholds": [
+    {
+      "dimension_id": "expressiveness",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "semantic-elements-correct",
+          "operator": ">=",
+          "target": 0.9
+        },
+        {
+          "measure_id": "critical-silent-omissions",
+          "operator": "==",
+          "target": 0
+        },
+        {
+          "measure_id": "nontrivial-example-support",
+          "operator": ">=",
+          "target": 0.8
+        }
+      ]
+    },
+    {
+      "dimension_id": "usability-comprehension",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "task-completion",
+          "operator": ">=",
+          "target": 0.8
+        },
+        {
+          "measure_id": "critical-semantic-errors",
+          "operator": "<=",
+          "target": 0.1
+        },
+        {
+          "measure_id": "prohibited-infrastructure-assistance",
+          "operator": "==",
+          "target": 0
+        }
+      ]
+    },
+    {
+      "dimension_id": "effectiveness-productivity",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "task-completion",
+          "operator": ">=",
+          "target": 0.8
+        },
+        {
+          "measure_id": "semantic-rework-cycles",
+          "operator": "<=",
+          "target": 2
+        },
+        {
+          "measure_id": "prohibited-infrastructure-assistance",
+          "operator": "==",
+          "target": 0
+        }
+      ]
+    },
+    {
+      "dimension_id": "maintainability-evolution",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "relation-classification-accuracy",
+          "operator": ">=",
+          "target": 0.9
+        },
+        {
+          "measure_id": "silent-lossy-migrations",
+          "operator": "==",
+          "target": 0
+        }
+      ]
+    },
+    {
+      "dimension_id": "ambiguity",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "relation-classification-accuracy",
+          "operator": ">=",
+          "target": 0.9
+        },
+        {
+          "measure_id": "critical-silent-ambiguities",
+          "operator": "==",
+          "target": 0
+        }
+      ]
+    },
+    {
+      "dimension_id": "diagnostic-quality",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "diagnostic-localization",
+          "operator": ">=",
+          "target": 0.8
+        },
+        {
+          "measure_id": "diagnostic-repair",
+          "operator": ">=",
+          "target": 0.75
+        },
+        {
+          "measure_id": "relation-classification-accuracy",
+          "operator": ">=",
+          "target": 0.9
+        }
+      ]
+    },
+    {
+      "dimension_id": "reviewability",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "critical-review-items",
+          "operator": ">=",
+          "target": 0.8
+        },
+        {
+          "measure_id": "majority-missed-critical-items",
+          "operator": "==",
+          "target": 0
+        },
+        {
+          "measure_id": "nontrivial-example-support",
+          "operator": ">=",
+          "target": 0.8
+        }
+      ]
+    },
+    {
+      "dimension_id": "semantic-traceability",
+      "logic": "all",
+      "conditions": [
+        {
+          "measure_id": "semantic-elements-correct",
+          "operator": ">=",
+          "target": 0.9
+        },
+        {
+          "measure_id": "untraced-critical-changes",
+          "operator": "==",
+          "target": 0
+        }
+      ]
+    }
+  ],
+  "ethics_and_privacy": {
+    "review_status_required": "Obtain applicable institutional ethics, privacy, and data-protection review before recruiting or collecting from human subjects.",
+    "consent_required": true,
+    "committed_data_rule": "Commit only consented, minimized, pseudonymous observations or aggregates; keep the pseudonym linkage key outside the repository in an approved controlled store.",
+    "prohibited_data": [
+      "names",
+      "email addresses",
+      "recordings",
+      "raw chats or prompts",
+      "keystroke streams",
+      "free-form biographies",
+      "pseudonym linkage keys",
+      "credentials",
+      "private backend output"
+    ]
+  },
+  "disagreement_policy": "Preserve every original reviewer judgment, confidence, rationale code, and disagreement. Adjudication adds a separate record after intent reveal and never replaces or edits the independent result.",
+  "validity_threats": [
+    "Construct validity: task completion, diagnostics, and infrastructure independence are distinct constructs and do not prove universal usability or language adequacy.",
+    "Population validity: five subjects per issue-178 persona is exploratory and supports only the recruited qualification and infrastructure-experience bands.",
+    "Task validity: the selected representative and negative tasks cannot cover every cyber-agent benchmark scenario.",
+    "Condition validity: docs-only, MCP, CLI, and direct-library results apply only to the pinned adapter, mode, parameters, and assistance policy and are never pooled as equivalent surfaces.",
+    "Learning and order effects: repeated ACES exposure may improve later attempts despite balanced ordering.",
+    "Reviewer reliability: agreement measures scoring consistency, not semantic correctness.",
+    "Implementation-version validity: later ACES changes require a new immutable snapshot and cannot rewrite a failed observation.",
+    "External validity: simulated personas, maintainers, or agents are exploratory only and cannot demonstrate generalized researcher accessibility."
+  ],
+  "analysis_plan": "Compute only the measures and dimensions in the stable claim id's exact versioned manifest binding from frozen attempt and review records; reject an analysis that narrows its own scope; persist independently recomputed numerators, denominators, and dimension results for the preregistered persona, infrastructure-experience, and tooling-condition strata; keep backend implementers, infrastructure-familiar researchers, and prior ACES users as comparison strata that cannot promote or refute the claim; apply thresholds without post-hoc exclusions; and set the issue-178 ADR-021 status to demonstrated only when every dimension in every target infrastructure-novice gating stratum passes with complete coverage, no prohibited infrastructure/source assistance, no unresolved critical disagreement, and no invalidating deviation. Any gating-stratum objective failure sets refuted; incomplete qualifying evidence remains untested or partial.",
+  "amendment_log": [
+    {
+      "revision": "2.0.0",
+      "date": "2026-07-17",
+      "summary": "Added issue-178 personas, adapter-specific conditions, benchmark-relevant positive and negative tasks, accessibility measures and thresholds, and claim-scoped analysis support without altering the frozen revision-1 protocol."
+    }
+  ]
+}

--- a/implementations/python/tests/test_dsl_language_evaluation.py
+++ b/implementations/python/tests/test_dsl_language_evaluation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from pathlib import Path
 
+import tools.check_dsl_language_evaluation as evaluation_gate
 from tools.check_dsl_language_evaluation import (
     REQUIRED_DIMENSION_IDS,
     REQUIRED_PERSONA_IDS,
@@ -33,13 +34,28 @@ def _bundle() -> tuple[dict, dict, dict, dict]:
     )
 
 
+def _full_claim_scope(protocol: dict) -> dict[str, list[str]]:
+    return {
+        "persona_ids": [item["persona_id"] for item in protocol["personas"]],
+        "task_ids": [item["task_id"] for item in protocol["tasks"]],
+        "tooling_condition_ids": [item["condition_id"] for item in protocol["tooling_conditions"]],
+        "variant_ids": [item["variant_id"] for item in protocol["variants"]],
+        "artifact_stage_ids": [item["stage_id"] for item in protocol["artifact_stages"]],
+        "dimension_ids": [item["dimension_id"] for item in protocol["dimensions"]],
+        "measure_ids": [item["measure_id"] for item in protocol["measures"]],
+    }
+
+
 def _refresh_analysis(
     protocol: dict,
     snapshot: dict,
     analysis: dict,
     evidence_status: str,
+    *,
+    claim_binding: dict | None = None,
 ) -> None:
-    measure_results = recompute_measure_results(protocol, snapshot)
+    scope = analysis["claim"]["scope"]
+    measure_results = recompute_measure_results(protocol, snapshot, scope=scope)
     analysis["measure_results"] = [
         {
             "measure_id": measure_id,
@@ -56,8 +72,25 @@ def _refresh_analysis(
     ]
     analysis["dimension_results"] = [
         {"dimension_id": dimension_id, **result}
-        for dimension_id, result in recompute_dimension_results(protocol, measure_results).items()
+        for dimension_id, result in recompute_dimension_results(
+            protocol,
+            measure_results,
+            dimension_ids=scope["dimension_ids"],
+        ).items()
     ]
+    claim_id = analysis["claim"]["claim_id"]
+    if claim_binding is None:
+        claim_binding = next(
+            entry[0]["claim_binding"]
+            for entry in evaluation_gate.load_bundles(REPO_ROOT)
+            if entry[0]["claim_binding"]["claim_id"] == claim_id
+        )
+    strata = evaluation_gate.resolve_claim_strata(protocol, analysis, claim_binding)
+    analysis["stratum_results"] = (
+        []
+        if snapshot["execution_status"] == "not_started"
+        else evaluation_gate.recompute_stratum_results(protocol, snapshot, strata)
+    )
     analysis["execution_status"] = snapshot["execution_status"]
     analysis["evidence_status"] = evidence_status
 
@@ -79,7 +112,7 @@ def _executed_bundle(*, failing: bool = False) -> tuple[dict, dict, dict]:
             subject = {
                 "subject_id": f"subject-{persona_id}-{index}",
                 "persona_id": persona_id,
-                "experience_band": "qualified",
+                "experience_band": protocol["sampling_plan"]["experience_bands"][0],
                 "consent_status": "consented",
             }
             subjects_by_persona[persona_id].append(subject)
@@ -235,6 +268,359 @@ def test_current_bundle_passes_with_required_catalogs_and_an_honest_status() -> 
     assert snapshot["execution_status"] == "not_started"
     assert snapshot["aces_revision"] == "38ba081714b12a4dcc7a5c527e2f1250d80a4d1b"
     assert analysis["evidence_status"] == "untested"
+
+
+def test_manifest_loads_primary_and_accessibility_bundles() -> None:
+    bundles = evaluation_gate.load_bundles(REPO_ROOT)
+
+    assert [entry[0]["bundle_id"] for entry in bundles] == [
+        "aces-dsl-language-evaluation",
+        "aces-researcher-accessibility-evaluation",
+    ]
+    assert all(validate_bundle(REPO_ROOT, *entry[1:]) == [] for entry in bundles)
+    _, accessibility_protocol, accessibility_snapshot, accessibility_analysis = bundles[1]
+    assert accessibility_protocol["revision"] == "2.0.0"
+    assert accessibility_snapshot["execution_status"] == "not_started"
+    assert accessibility_analysis["evidence_status"] == "untested"
+    assert accessibility_analysis["claim"]["scope"]["persona_ids"] == [
+        "security-researcher",
+        "benchmark-designer",
+        "backend-implementer",
+        "evaluator-reviewer",
+    ]
+
+
+def test_manifest_rejects_malformed_supplemental_bundle_entries(tmp_path: Path) -> None:
+    manifest_path = tmp_path / evaluation_gate.MANIFEST_PATH
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        """{
+          "bundle_id": "primary-bundle",
+          "revision": "1.0.0",
+              "protocol_path": "protocol.json",
+              "snapshot_path": "snapshot.json",
+              "analysis_path": "analysis.json",
+              "claim_binding": {},
+              "supplemental_bundles": ["not-an-object"]
+        }\n""",
+        encoding="utf-8",
+    )
+
+    try:
+        evaluation_gate.load_bundles(tmp_path)
+    except ValueError as exc:
+        assert "supplemental_bundles[0] must be an object" in str(exc)
+    else:
+        raise AssertionError("malformed supplemental bundle entries must fail closed")
+
+
+def test_claim_scope_rejects_unknown_catalog_ids() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    analysis["claim"]["scope"] = _full_claim_scope(protocol)
+    analysis["claim"]["scope"]["task_ids"].append("missing-task")
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-claim-scope" in _rule_ids(failures)
+
+
+def test_bundle_validation_reports_the_selected_analysis_path() -> None:
+    _, protocol, snapshot, analysis = _bundle()
+    analysis["claim"]["scope"]["task_ids"].append("missing-task")
+
+    failures = validate_bundle(
+        REPO_ROOT,
+        protocol,
+        snapshot,
+        analysis,
+        artifact_paths={"analysis_path": "docs/research/dsl-language-evaluation/custom-analysis.json"},
+    )
+
+    scope_failure = next(failure for failure in failures if failure.rule_id == "dsl-evaluation-claim-scope")
+    assert scope_failure.path == "docs/research/dsl-language-evaluation/custom-analysis.json"
+
+
+def test_claim_scope_ignores_frozen_records_from_another_persona() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    scope = _full_claim_scope(protocol)
+    scope["persona_ids"].remove("assurance-auditor")
+    next(item for item in protocol["personas"] if item["persona_id"] == "assurance-auditor")[
+        "minimum_completed_subjects"
+    ] = 0
+    protocol["sampling_plan"]["target_total"] = 25
+    analysis["claim"]["claim_id"] = "aces-language-adequacy-without-assurance-auditor"
+    analysis["claim"]["scope"] = scope
+    measure_results = recompute_measure_results(protocol, snapshot, scope=scope)
+    analysis["measure_results"] = [
+        {
+            "measure_id": measure_id,
+            "status": "evaluated",
+            **result,
+        }
+        for measure_id, result in measure_results.items()
+    ]
+    analysis["dimension_results"] = [
+        {"dimension_id": dimension_id, **result}
+        for dimension_id, result in recompute_dimension_results(protocol, measure_results).items()
+        if dimension_id in scope["dimension_ids"]
+    ]
+    claim_binding = deepcopy(load_bundle(REPO_ROOT)[0]["claim_binding"])
+    claim_binding["claim_id"] = analysis["claim"]["claim_id"]
+    claim_binding["scope"] = deepcopy(scope)
+    claim_binding["strata"][0]["persona_ids"].remove("assurance-auditor")
+    strata = evaluation_gate.resolve_claim_strata(protocol, analysis, claim_binding)
+    analysis["stratum_results"] = evaluation_gate.recompute_stratum_results(protocol, snapshot, strata)
+
+    assert (
+        validate_bundle(
+            REPO_ROOT,
+            protocol,
+            snapshot,
+            analysis,
+            artifact_paths={"claim_binding": claim_binding},
+        )
+        == []
+    )
+
+
+def test_analysis_cannot_narrow_the_manifest_bound_claim_scope() -> None:
+    protocol, snapshot, analysis = _executed_bundle(failing=True)
+    scope = _full_claim_scope(protocol)
+    scope["persona_ids"] = ["evaluator-reviewer"]
+    scope["task_ids"] = [
+        "classify-underspecified-realization",
+        "round-trip-format-equivalence",
+    ]
+    scope["variant_ids"] = [
+        "profile-dependent-realization",
+        "format-only-equivalent",
+    ]
+    public_tools_attempt = next(
+        attempt
+        for attempt in snapshot["attempts"]
+        if attempt["task_id"] == "classify-underspecified-realization"
+        and attempt["tooling_condition_id"] == "public-tools"
+    )
+    evaluator = next(subject for subject in snapshot["subjects"] if subject["persona_id"] == "evaluator-reviewer")
+    public_tools_attempt["persona_id"] = "evaluator-reviewer"
+    public_tools_attempt["subject_id"] = evaluator["subject_id"]
+    for observation in snapshot["observations"]:
+        if observation["attempt_id"] == public_tools_attempt["attempt_id"]:
+            observation["persona_id"] = "evaluator-reviewer"
+            observation["subject_id"] = evaluator["subject_id"]
+    scope["dimension_ids"] = ["ambiguity"]
+    scope["measure_ids"] = ["relation-classification-accuracy", "critical-silent-ambiguities"]
+    for persona in protocol["personas"]:
+        persona["minimum_completed_subjects"] = 5 if persona["persona_id"] == "evaluator-reviewer" else 0
+    protocol["sampling_plan"]["target_total"] = 5
+    analysis["claim"]["scope"] = scope
+    measure_results = recompute_measure_results(protocol, snapshot, scope=scope)
+    analysis["measure_results"] = [
+        {"measure_id": measure_id, "status": "evaluated", **result} for measure_id, result in measure_results.items()
+    ]
+    analysis["dimension_results"] = [
+        {"dimension_id": dimension_id, **result}
+        for dimension_id, result in recompute_dimension_results(
+            protocol,
+            measure_results,
+            dimension_ids=scope["dimension_ids"],
+        ).items()
+    ]
+    analysis["evidence_status"] = "demonstrated"
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-claim-binding" in _rule_ids(failures)
+
+
+def test_gating_persona_failure_cannot_be_masked_by_pooled_success() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    subject_ids = {
+        item["subject_id"]
+        for item in snapshot["subjects"]
+        if item["persona_id"] == "benchmark-designer"
+        and (item["subject_id"].endswith("-1") or item["subject_id"].endswith("-2"))
+    }
+    failed_attempt_ids = {
+        observation["attempt_id"]
+        for observation in snapshot["observations"]
+        if observation["subject_id"] in subject_ids and observation["measure_id"] == "task-completion"
+    }
+    for attempt in snapshot["attempts"]:
+        if attempt["attempt_id"] in failed_attempt_ids:
+            attempt["outcome"] = "failed"
+    for observation in snapshot["observations"]:
+        if observation["attempt_id"] in failed_attempt_ids:
+            observation["outcome"] = "failed"
+            if observation["measure_id"] == "task-completion":
+                observation["value"] = 0
+
+    claim_binding = deepcopy(load_bundle(REPO_ROOT)[0]["claim_binding"])
+    analysis["claim"]["claim_id"] = "aces-language-adequacy-persona-gated"
+    claim_binding["claim_id"] = analysis["claim"]["claim_id"]
+    claim_binding["strata"][0]["group_id"] = "persona-gates"
+    claim_binding["strata"][0]["partition_by"] = ["persona_id"]
+    _refresh_analysis(
+        protocol,
+        snapshot,
+        analysis,
+        "demonstrated",
+        claim_binding=claim_binding,
+    )
+
+    assert all(result["threshold_result"] == "pass" for result in analysis["dimension_results"])
+    benchmark_result = next(
+        item for item in analysis["stratum_results"] if item["stratum_id"].endswith("benchmark-designer")
+    )
+    assert any(result["threshold_result"] == "fail" for result in benchmark_result["dimension_results"])
+
+    failures = validate_bundle(
+        REPO_ROOT,
+        protocol,
+        snapshot,
+        analysis,
+        artifact_paths={"claim_binding": claim_binding},
+    )
+
+    assert "dsl-evaluation-evidence-status" in _rule_ids(failures)
+
+
+def test_comparison_persona_is_persisted_but_cannot_decide_promotion() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    failed_attempt_ids = {
+        observation["attempt_id"]
+        for observation in snapshot["observations"]
+        if observation["persona_id"] == "backend-implementer" and observation["measure_id"] == "task-completion"
+    }
+    for attempt in snapshot["attempts"]:
+        if attempt["attempt_id"] in failed_attempt_ids:
+            attempt["outcome"] = "failed"
+    for observation in snapshot["observations"]:
+        if observation["attempt_id"] in failed_attempt_ids:
+            observation["outcome"] = "failed"
+            if observation["measure_id"] == "task-completion":
+                observation["value"] = 0
+
+    claim_binding = deepcopy(load_bundle(REPO_ROOT)[0]["claim_binding"])
+    analysis["claim"]["claim_id"] = "aces-language-adequacy-with-backend-comparison"
+    claim_binding["claim_id"] = analysis["claim"]["claim_id"]
+    base_group = claim_binding["strata"][0]
+    claim_binding["strata"] = [
+        {
+            **deepcopy(base_group),
+            "group_id": "target-population",
+            "persona_ids": [
+                persona_id for persona_id in base_group["persona_ids"] if persona_id != "backend-implementer"
+            ],
+        },
+        {
+            **deepcopy(base_group),
+            "group_id": "backend-comparison",
+            "role": "comparison",
+            "persona_ids": ["backend-implementer"],
+        },
+    ]
+    _refresh_analysis(
+        protocol,
+        snapshot,
+        analysis,
+        "demonstrated",
+        claim_binding=claim_binding,
+    )
+
+    comparison = next(item for item in analysis["stratum_results"] if item["role"] == "comparison")
+    assert any(result["threshold_result"] == "fail" for result in comparison["dimension_results"])
+    assert (
+        validate_bundle(
+            REPO_ROOT,
+            protocol,
+            snapshot,
+            analysis,
+            artifact_paths={"claim_binding": claim_binding},
+        )
+        == []
+    )
+
+
+def test_claim_binding_rejects_an_invalid_stratum_role() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    claim_binding = deepcopy(load_bundle(REPO_ROOT)[0]["claim_binding"])
+    claim_binding["strata"][0]["role"] = "observer"
+
+    failures = validate_bundle(
+        REPO_ROOT,
+        protocol,
+        snapshot,
+        analysis,
+        artifact_paths={"claim_binding": claim_binding},
+    )
+
+    assert "dsl-evaluation-claim-strata" in _rule_ids(failures)
+
+
+def test_gate_rejects_stale_stratum_results() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    analysis["stratum_results"][0]["measure_results"][0]["denominator"] += 1
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-stratum-drift" in _rule_ids(failures)
+
+
+def test_gate_rejects_missing_stratum_results() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    analysis["stratum_results"].clear()
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-stratum-coverage" in _rule_ids(failures)
+
+
+def test_scope_completion_requires_each_subjects_in_scope_condition() -> None:
+    protocol, snapshot, analysis = _executed_bundle()
+    scope = _full_claim_scope(protocol)
+    scope["persona_ids"] = ["benchmark-designer"]
+    scope["task_ids"] = ["author-multihost-experiment", "independent-review-change"]
+    scope["tooling_condition_ids"] = ["public-docs-only"]
+    scope["variant_ids"] = ["multihost-reference", "review-hidden-assumption-change"]
+    scope["dimension_ids"] = ["usability-comprehension", "reviewability"]
+    scope["measure_ids"] = [
+        "task-completion",
+        "critical-semantic-errors",
+        "critical-review-items",
+        "majority-missed-critical-items",
+    ]
+    benchmark_subjects = [subject for subject in snapshot["subjects"] if subject["persona_id"] == "benchmark-designer"]
+    for persona in protocol["personas"]:
+        persona["minimum_completed_subjects"] = 5 if persona["persona_id"] == "benchmark-designer" else 0
+    protocol["sampling_plan"]["target_total"] = 5
+    for attempt in snapshot["attempts"]:
+        if (
+            attempt["subject_id"] in {subject["subject_id"] for subject in benchmark_subjects[1:]}
+            and attempt["task_id"] == "author-multihost-experiment"
+            and attempt["tooling_condition_id"] == "public-docs-only"
+        ):
+            attempt["tooling_condition_id"] = "public-tools"
+            for observation in snapshot["observations"]:
+                if observation["attempt_id"] == attempt["attempt_id"]:
+                    observation["tooling_condition_id"] = "public-tools"
+    analysis["claim"]["scope"] = scope
+    measure_results = recompute_measure_results(protocol, snapshot, scope=scope)
+    analysis["measure_results"] = [
+        {"measure_id": measure_id, "status": "evaluated", **result} for measure_id, result in measure_results.items()
+    ]
+    analysis["dimension_results"] = [
+        {"dimension_id": dimension_id, **result}
+        for dimension_id, result in recompute_dimension_results(
+            protocol,
+            measure_results,
+            dimension_ids=scope["dimension_ids"],
+        ).items()
+    ]
+
+    failures = validate_bundle(REPO_ROOT, protocol, snapshot, analysis)
+
+    assert "dsl-evaluation-subject-workload" in _rule_ids(failures)
 
 
 def test_not_started_bundle_cannot_claim_observations_or_demonstration() -> None:

--- a/tools/check_dsl_language_evaluation.py
+++ b/tools/check_dsl_language_evaluation.py
@@ -9,6 +9,7 @@ import re
 import sys
 from collections import Counter
 from collections.abc import Mapping, Sequence
+from itertools import product
 from pathlib import Path
 from statistics import median
 from urllib.parse import parse_qsl, urlsplit
@@ -66,7 +67,21 @@ _MANIFEST_KEYS = {
     "protocol_path",
     "snapshot_path",
     "analysis_path",
+    "claim_binding",
+    "supplemental_bundles",
 }
+_BUNDLE_ENTRY_KEYS = _MANIFEST_KEYS - {"supplemental_bundles"}
+_CLAIM_BINDING_KEYS = {"claim_id", "scope", "strata"}
+_STRATUM_GROUP_KEYS = {
+    "group_id",
+    "role",
+    "partition_by",
+    "persona_ids",
+    "experience_band_ids",
+    "tooling_condition_ids",
+}
+_STRATUM_PARTITION_AXES = {"persona_id", "experience_band", "tooling_condition_id"}
+_STRATUM_ROLES = {"gating", "comparison"}
 _PROTOCOL_KEYS = {
     "protocol_id",
     "revision",
@@ -248,10 +263,17 @@ _ANALYSIS_KEYS = {
     "execution_status",
     "measure_results",
     "dimension_results",
+    "stratum_results",
     "evidence_status",
     "claim",
     "plain_language_outcome",
     "limitations",
+}
+_STRATUM_RESULT_KEYS = {
+    "stratum_id",
+    "role",
+    "measure_results",
+    "dimension_results",
 }
 _DIMENSION_RESULT_KEYS = {
     "dimension_id",
@@ -285,6 +307,16 @@ _CLAIM_KEYS = {
     "allowed_evidence",
     "disallowed_evidence",
     "evidence_artifacts",
+    "scope",
+}
+_CLAIM_SCOPE_KEYS = {
+    "persona_ids",
+    "task_ids",
+    "tooling_condition_ids",
+    "variant_ids",
+    "artifact_stage_ids",
+    "dimension_ids",
+    "measure_ids",
 }
 
 _ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -439,6 +471,415 @@ def _protocol_records_by_id(
     }
 
 
+def _full_claim_scope(catalogs: Mapping[str, set[str]]) -> dict[str, set[str]]:
+    return {
+        "persona_ids": set(catalogs.get("persona_ids", set())),
+        "task_ids": set(catalogs.get("task_ids", set())),
+        "tooling_condition_ids": set(catalogs.get("condition_ids", set())),
+        "variant_ids": set(catalogs.get("variant_ids", set())),
+        "artifact_stage_ids": set(catalogs.get("stage_ids", set())),
+        "dimension_ids": set(catalogs.get("dimension_ids", set())),
+        "measure_ids": set(catalogs.get("measure_ids", set())),
+    }
+
+
+def _attempt_matches_scope(
+    attempt: Mapping[str, object],
+    scope: Mapping[str, set[str]],
+) -> bool:
+    return (
+        attempt.get("task_id") in scope.get("task_ids", set())
+        and attempt.get("persona_id") in scope.get("persona_ids", set())
+        and attempt.get("tooling_condition_id") in scope.get("tooling_condition_ids", set())
+        and attempt.get("variant_id") in scope.get("variant_ids", set())
+    )
+
+
+def _validate_claim_scope(
+    protocol: Mapping[str, object],
+    analysis: Mapping[str, object],
+    catalogs: Mapping[str, set[str]],
+    failures: list[PolicyFailure],
+    *,
+    path: str = "docs/research/dsl-language-evaluation/analysis-v1.json",
+) -> dict[str, set[str]]:
+    """Validate and resolve the exact catalog slice owned by one claim."""
+
+    fallback = _full_claim_scope(catalogs)
+    claim = analysis.get("claim")
+    scope = claim.get("scope") if isinstance(claim, Mapping) else None
+    if not _exact_keys(
+        scope,
+        _CLAIM_SCOPE_KEYS,
+        failures,
+        rule_id="dsl-evaluation-claim-scope",
+        label="claim scope",
+        path=path,
+    ):
+        return fallback
+
+    catalog_fields = {
+        "persona_ids": "persona_ids",
+        "task_ids": "task_ids",
+        "tooling_condition_ids": "condition_ids",
+        "variant_ids": "variant_ids",
+        "artifact_stage_ids": "stage_ids",
+        "dimension_ids": "dimension_ids",
+        "measure_ids": "measure_ids",
+    }
+    resolved: dict[str, set[str]] = {}
+    for field, catalog_field in catalog_fields.items():
+        values = _string_list(scope[field], non_empty=True)
+        known = catalogs.get(catalog_field, set())
+        if values is None or len(values) != len(set(values)) or not set(values).issubset(known):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-scope",
+                    f"claim scope {field} must be a non-empty unique subset of the protocol catalog",
+                    path,
+                )
+            )
+            resolved[field] = set(values or []) & known
+        else:
+            resolved[field] = set(values)
+
+    tasks = _protocol_records_by_id(protocol, "tasks", "task_id")
+    measures = _protocol_records_by_id(protocol, "measures", "measure_id")
+    for task_id in resolved["task_ids"]:
+        task = tasks.get(task_id, {})
+        joins = (
+            ("persona_ids", "persona_ids"),
+            ("tooling_condition_ids", "tooling_condition_ids"),
+            ("variant_ids", "variant_ids"),
+            ("artifact_stage_ids", "artifact_stage_ids"),
+        )
+        if any(
+            not (set(_string_list(task.get(task_field), non_empty=True) or []) & resolved[scope_field])
+            for task_field, scope_field in joins
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-scope",
+                    f"{task_id}: claim scope must retain an eligible persona, condition, variant, and stage",
+                    path,
+                )
+            )
+        if not any(
+            task_id in (_string_list(measures[measure_id].get("task_ids"), non_empty=True) or [])
+            for measure_id in resolved["measure_ids"]
+            if measure_id in measures
+        ):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-scope",
+                    f"{task_id}: claim scope has no applicable measure",
+                    path,
+                )
+            )
+
+    thresholds = {
+        threshold.get("dimension_id"): threshold
+        for threshold in protocol.get("thresholds", [])
+        if isinstance(threshold, Mapping) and isinstance(threshold.get("dimension_id"), str)
+    }
+    for dimension_id in resolved["dimension_ids"]:
+        threshold = thresholds.get(dimension_id)
+        conditions = threshold.get("conditions", []) if isinstance(threshold, Mapping) else []
+        required_measures = {
+            condition.get("measure_id")
+            for condition in conditions
+            if isinstance(condition, Mapping) and isinstance(condition.get("measure_id"), str)
+        }
+        if not required_measures or not required_measures.issubset(resolved["measure_ids"]):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-scope",
+                    f"{dimension_id}: claim scope must include every threshold measure",
+                    path,
+                )
+            )
+    return resolved
+
+
+def _validate_claim_binding(
+    protocol: Mapping[str, object],
+    analysis: Mapping[str, object],
+    claim_binding: object,
+    catalogs: Mapping[str, set[str]],
+    scope: Mapping[str, set[str]],
+    failures: list[PolicyFailure],
+    *,
+    path: str,
+) -> list[dict[str, object]]:
+    """Bind one stable claim to its immutable scope and reporting strata."""
+
+    if not _exact_keys(
+        claim_binding,
+        _CLAIM_BINDING_KEYS,
+        failures,
+        rule_id="dsl-evaluation-claim-binding",
+        label="claim binding",
+        path=path,
+    ):
+        return []
+    assert isinstance(claim_binding, dict)
+    claim = analysis.get("claim")
+    claim_id = claim.get("claim_id") if isinstance(claim, Mapping) else None
+    if not _valid_id(claim_binding["claim_id"]) or claim_binding["claim_id"] != claim_id:
+        failures.append(
+            _failure(
+                "dsl-evaluation-claim-binding",
+                "manifest claim binding must name the analysis claim_id exactly",
+                path,
+            )
+        )
+
+    bound_scope = claim_binding["scope"]
+    if _exact_keys(
+        bound_scope,
+        _CLAIM_SCOPE_KEYS,
+        failures,
+        rule_id="dsl-evaluation-claim-binding",
+        label="claim binding scope",
+        path=path,
+    ):
+        assert isinstance(bound_scope, dict)
+        for field in _CLAIM_SCOPE_KEYS:
+            values = _string_list(bound_scope[field], non_empty=True)
+            if values is None or len(values) != len(set(values)) or set(values) != scope.get(field, set()):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-claim-binding",
+                        f"analysis claim scope {field} must exactly match its manifest binding",
+                        path,
+                    )
+                )
+
+    groups = _bounded_list(
+        claim_binding["strata"],
+        16,
+        failures,
+        rule_id="dsl-evaluation-claim-strata",
+        label="claim binding strata",
+        path=path,
+    )
+    group_ids = _record_ids(
+        groups,
+        "group_id",
+        failures,
+        rule_id="dsl-evaluation-claim-strata",
+        label="claim stratum group",
+        path=path,
+    )
+    experience_bands = set()
+    sampling_plan = protocol.get("sampling_plan")
+    if isinstance(sampling_plan, Mapping):
+        experience_bands = set(_string_list(sampling_plan.get("experience_bands"), non_empty=True) or [])
+
+    expanded: list[dict[str, object]] = []
+    for index, group in enumerate(groups):
+        if not _exact_keys(
+            group,
+            _STRATUM_GROUP_KEYS,
+            failures,
+            rule_id="dsl-evaluation-claim-strata",
+            label=f"claim binding strata[{index}]",
+            path=path,
+        ):
+            continue
+        assert isinstance(group, dict)
+        group_id = group["group_id"]
+        role = group["role"]
+        partition_by = _string_list(group["partition_by"])
+        persona_ids = _string_list(group["persona_ids"], non_empty=True)
+        band_ids = _string_list(group["experience_band_ids"], non_empty=True)
+        condition_ids = _string_list(group["tooling_condition_ids"], non_empty=True)
+        valid = (
+            _valid_id(group_id)
+            and role in _STRATUM_ROLES
+            and partition_by is not None
+            and len(partition_by) == len(set(partition_by))
+            and set(partition_by).issubset(_STRATUM_PARTITION_AXES)
+            and persona_ids is not None
+            and len(persona_ids) == len(set(persona_ids))
+            and set(persona_ids).issubset(scope.get("persona_ids", set()))
+            and band_ids is not None
+            and len(band_ids) == len(set(band_ids))
+            and set(band_ids).issubset(experience_bands)
+            and condition_ids is not None
+            and len(condition_ids) == len(set(condition_ids))
+            and set(condition_ids).issubset(scope.get("tooling_condition_ids", set()))
+        )
+        if not valid:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-claim-strata",
+                    f"claim stratum group {group_id!r} has invalid role, partition axes, or catalog filters",
+                    path,
+                )
+            )
+            continue
+
+        assert isinstance(group_id, str)
+        assert isinstance(role, str)
+        assert partition_by is not None
+        assert persona_ids is not None
+        assert band_ids is not None
+        assert condition_ids is not None
+        axis_values = {
+            "persona_id": persona_ids,
+            "experience_band": band_ids,
+            "tooling_condition_id": condition_ids,
+        }
+        split_axes = [
+            axis for axis in ("persona_id", "experience_band", "tooling_condition_id") if axis in partition_by
+        ]
+        combinations = product(*(axis_values[axis] for axis in split_axes)) if split_axes else [()]
+        for combination in combinations:
+            selected = dict(zip(split_axes, combination, strict=True))
+            stratum_id = "-".join([group_id, *(str(selected[axis]) for axis in split_axes)])
+            stratum_personas = {str(selected["persona_id"])} if "persona_id" in selected else set(persona_ids)
+            stratum_bands = {str(selected["experience_band"])} if "experience_band" in selected else set(band_ids)
+            stratum_conditions = (
+                {str(selected["tooling_condition_id"])} if "tooling_condition_id" in selected else set(condition_ids)
+            )
+            stratum_scope = _derive_stratum_scope(
+                protocol,
+                scope,
+                persona_ids=stratum_personas,
+                experience_band_ids=stratum_bands,
+                tooling_condition_ids=stratum_conditions,
+            )
+            if (
+                not _valid_id(stratum_id)
+                or not stratum_scope["task_ids"]
+                or not stratum_scope["measure_ids"]
+                or not stratum_scope["dimension_ids"]
+            ):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-claim-strata",
+                        f"claim stratum {stratum_id!r} has no complete task/measure/dimension slice",
+                        path,
+                    )
+                )
+                continue
+            expanded.append({"stratum_id": stratum_id, "role": role, "scope": stratum_scope})
+
+    expanded_ids = [str(item["stratum_id"]) for item in expanded]
+    if len(group_ids) != len(groups) or len(expanded_ids) != len(set(expanded_ids)) or not expanded:
+        failures.append(
+            _failure(
+                "dsl-evaluation-claim-strata",
+                "claim binding requires unique groups and expanded stratum ids",
+                path,
+            )
+        )
+    if not any(item["role"] == "gating" for item in expanded):
+        failures.append(_failure("dsl-evaluation-claim-strata", "claim binding requires a gating stratum", path))
+    if len(expanded) > _MAX_CATALOG_ITEMS:
+        failures.append(
+            _failure(
+                "dsl-evaluation-claim-strata",
+                f"claim binding expands beyond {_MAX_CATALOG_ITEMS} strata",
+                path,
+            )
+        )
+        return expanded[:_MAX_CATALOG_ITEMS]
+    return expanded
+
+
+def _derive_stratum_scope(
+    protocol: Mapping[str, object],
+    claim_scope: Mapping[str, set[str]],
+    *,
+    persona_ids: set[str],
+    experience_band_ids: set[str],
+    tooling_condition_ids: set[str],
+) -> dict[str, set[str]]:
+    """Derive the protocol-applicable claim slice for one preregistered stratum."""
+
+    tasks = _protocol_records_by_id(protocol, "tasks", "task_id")
+    selected_tasks = {
+        task_id
+        for task_id, task in tasks.items()
+        if task_id in claim_scope.get("task_ids", set())
+        and set(_string_list(task.get("persona_ids"), non_empty=True) or []) & persona_ids
+        and set(_string_list(task.get("tooling_condition_ids"), non_empty=True) or []) & tooling_condition_ids
+    }
+    variants = _protocol_records_by_id(protocol, "variants", "variant_id")
+    selected_variants = {
+        variant_id
+        for variant_id, variant in variants.items()
+        if variant_id in claim_scope.get("variant_ids", set()) and variant.get("task_id") in selected_tasks
+    }
+    measures = _protocol_records_by_id(protocol, "measures", "measure_id")
+    selected_measures = {
+        measure_id
+        for measure_id, measure in measures.items()
+        if measure_id in claim_scope.get("measure_ids", set())
+        and set(_string_list(measure.get("task_ids"), non_empty=True) or []) & selected_tasks
+    }
+    thresholds = {
+        threshold.get("dimension_id"): threshold
+        for threshold in protocol.get("thresholds", [])
+        if isinstance(threshold, Mapping) and isinstance(threshold.get("dimension_id"), str)
+    }
+    selected_dimensions = set()
+    for dimension_id in claim_scope.get("dimension_ids", set()):
+        threshold = thresholds.get(dimension_id)
+        conditions = threshold.get("conditions", []) if isinstance(threshold, Mapping) else []
+        required_measures = {
+            condition.get("measure_id")
+            for condition in conditions
+            if isinstance(condition, Mapping) and isinstance(condition.get("measure_id"), str)
+        }
+        if required_measures and required_measures.issubset(selected_measures):
+            selected_dimensions.add(dimension_id)
+    return {
+        "persona_ids": set(persona_ids),
+        "experience_band_ids": set(experience_band_ids),
+        "task_ids": selected_tasks,
+        "tooling_condition_ids": set(tooling_condition_ids),
+        "variant_ids": selected_variants,
+        "artifact_stage_ids": set(claim_scope.get("artifact_stage_ids", set())),
+        "dimension_ids": selected_dimensions,
+        "measure_ids": selected_measures,
+    }
+
+
+def resolve_claim_strata(
+    protocol: Mapping[str, object],
+    analysis: Mapping[str, object],
+    claim_binding: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Resolve a validated manifest binding for recomputation and fixtures."""
+
+    catalogs = {
+        "persona_ids": set(_protocol_records_by_id(protocol, "personas", "persona_id")),
+        "task_ids": set(_protocol_records_by_id(protocol, "tasks", "task_id")),
+        "condition_ids": set(_protocol_records_by_id(protocol, "tooling_conditions", "condition_id")),
+        "variant_ids": set(_protocol_records_by_id(protocol, "variants", "variant_id")),
+        "stage_ids": set(_protocol_records_by_id(protocol, "artifact_stages", "stage_id")),
+        "dimension_ids": set(_protocol_records_by_id(protocol, "dimensions", "dimension_id")),
+        "measure_ids": set(_protocol_records_by_id(protocol, "measures", "measure_id")),
+    }
+    failures: list[PolicyFailure] = []
+    scope = _validate_claim_scope(protocol, analysis, catalogs, failures, path=MANIFEST_PATH)
+    strata = _validate_claim_binding(
+        protocol,
+        analysis,
+        claim_binding,
+        catalogs,
+        scope,
+        failures,
+        path=MANIFEST_PATH,
+    )
+    if failures:
+        raise ValueError("; ".join(f"{failure.rule_id}: {failure.message}" for failure in failures))
+    return strata
+
+
 def _measure_stage_ids(
     measure: Mapping[str, object],
     task_id: str,
@@ -465,6 +906,7 @@ def _measure_stage_ids(
 def _measure_opportunities(
     protocol: Mapping[str, object],
     snapshot: Mapping[str, object],
+    scope: Mapping[str, Sequence[str] | set[str]] | None = None,
 ) -> tuple[
     dict[str, Mapping[str, object]],
     list[tuple[Mapping[str, object], Mapping[str, object], str, bool]],
@@ -474,9 +916,22 @@ def _measure_opportunities(
 
     tasks = _protocol_records_by_id(protocol, "tasks", "task_id")
     measures = _protocol_records_by_id(protocol, "measures", "measure_id")
+    scope_sets = {field: set(values) for field, values in scope.items()} if scope is not None else None
+    if scope_sets is not None:
+        measures = {
+            measure_id: measure
+            for measure_id, measure in measures.items()
+            if measure_id in scope_sets.get("measure_ids", set())
+        }
     attempts = snapshot.get("attempts", [])
     observations = snapshot.get("observations", [])
     withdrawals = snapshot.get("withdrawals", [])
+    subjects = snapshot.get("subjects", [])
+    subjects_by_id = {
+        subject.get("subject_id"): subject
+        for subject in subjects
+        if isinstance(subject, Mapping) and isinstance(subject.get("subject_id"), str)
+    }
     if not isinstance(attempts, list) or not isinstance(observations, list) or not isinstance(withdrawals, list):
         raise ValueError("snapshot execution records must be lists")
 
@@ -501,6 +956,7 @@ def _measure_opportunities(
 
     opportunities: list[tuple[Mapping[str, object], Mapping[str, object], str, bool]] = []
     expected_keys: set[tuple[str, str, str]] = set()
+    selected_attempt_ids: set[str] = set()
     for attempt in attempts:
         if not isinstance(attempt, Mapping):
             continue
@@ -513,6 +969,16 @@ def _measure_opportunities(
         task = tasks.get(task_id)
         if task is None:
             continue
+        if scope_sets is not None and not _attempt_matches_scope(attempt, scope_sets):
+            continue
+        if scope_sets is not None and "experience_band_ids" in scope_sets:
+            subject = subjects_by_id.get(subject_id)
+            if (
+                not isinstance(subject, Mapping)
+                or subject.get("experience_band") not in scope_sets["experience_band_ids"]
+            ):
+                continue
+        selected_attempt_ids.add(attempt_id)
         withdrawn = (isinstance(subject_id, str) and subject_id in withdrawn_subjects) or attempt.get(
             "outcome"
         ) == "withdrawn"
@@ -524,10 +990,21 @@ def _measure_opportunities(
             if not isinstance(measure_id, str):
                 continue
             for artifact_stage in _measure_stage_ids(measure, task_id, variant_id):
+                if scope_sets is not None and artifact_stage not in scope_sets.get("artifact_stage_ids", set()):
+                    continue
                 opportunities.append((attempt, measure, artifact_stage, withdrawn))
                 expected_keys.add((attempt_id, measure_id, artifact_stage))
 
-    extras = sorted(set(observation_by_opportunity) - expected_keys)
+    observed_keys = set(observation_by_opportunity)
+    if scope_sets is not None:
+        observed_keys = {
+            key
+            for key in observed_keys
+            if key[0] in selected_attempt_ids
+            and key[1] in scope_sets.get("measure_ids", set())
+            and key[2] in scope_sets.get("artifact_stage_ids", set())
+        }
+    extras = sorted(observed_keys - expected_keys)
     if extras:
         raise ValueError(f"observations without protocol-declared opportunities: {extras[:5]}")
     return measures, opportunities, observation_by_opportunity
@@ -536,10 +1013,12 @@ def _measure_opportunities(
 def recompute_measure_results(
     protocol: Mapping[str, object],
     snapshot: Mapping[str, object],
+    *,
+    scope: Mapping[str, Sequence[str] | set[str]] | None = None,
 ) -> dict[str, dict[str, object]]:
     """Recompute measures from the complete protocol-derived opportunity matrix."""
 
-    measures, opportunities, observation_by_opportunity = _measure_opportunities(protocol, snapshot)
+    measures, opportunities, observation_by_opportunity = _measure_opportunities(protocol, snapshot, scope)
     results: dict[str, dict[str, object]] = {}
     for measure_id, measure in measures.items():
         aggregation = measure.get("aggregation")
@@ -617,6 +1096,8 @@ def recompute_measure_results(
 def recompute_dimension_results(
     protocol: Mapping[str, object],
     measure_results: Mapping[str, Mapping[str, object]],
+    *,
+    dimension_ids: Sequence[str] | set[str] | None = None,
 ) -> dict[str, dict[str, object]]:
     """Apply protocol-declared threshold conditions to recomputed measures."""
 
@@ -626,6 +1107,7 @@ def recompute_dimension_results(
         "==": lambda actual, target: actual == target,
     }
     results: dict[str, dict[str, object]] = {}
+    selected_dimensions = set(dimension_ids) if dimension_ids is not None else None
     for threshold in protocol.get("thresholds", []):
         if not isinstance(threshold, Mapping):
             continue
@@ -638,6 +1120,8 @@ def recompute_dimension_results(
             or not conditions
         ):
             raise ValueError(f"invalid threshold for {dimension_id!r}")
+        if selected_dimensions is not None and dimension_id not in selected_dimensions:
+            continue
         resolved: list[tuple[Mapping[str, object], Mapping[str, object]]] = []
         for condition in conditions:
             if not isinstance(condition, Mapping):
@@ -692,12 +1176,59 @@ def recompute_dimension_results(
     return results
 
 
+def recompute_stratum_results(
+    protocol: Mapping[str, object],
+    snapshot: Mapping[str, object],
+    strata: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Recompute independently persisted results for every bound claim stratum."""
+
+    results: list[dict[str, object]] = []
+    for stratum in strata:
+        stratum_id = stratum.get("stratum_id")
+        role = stratum.get("role")
+        scope = stratum.get("scope")
+        if not isinstance(stratum_id, str) or role not in _STRATUM_ROLES or not isinstance(scope, Mapping):
+            raise ValueError("invalid resolved claim stratum")
+        measures = recompute_measure_results(protocol, snapshot, scope=scope)
+        measure_results = [
+            {
+                "measure_id": measure_id,
+                "status": (
+                    "not_evaluated"
+                    if result["denominator"] == 0
+                    else "incomplete"
+                    if result["observed_count"] != result["denominator"]
+                    else "evaluated"
+                ),
+                **result,
+            }
+            for measure_id, result in measures.items()
+        ]
+        dimensions = recompute_dimension_results(
+            protocol,
+            measures,
+            dimension_ids=scope.get("dimension_ids", set()),
+        )
+        dimension_results = [{"dimension_id": dimension_id, **result} for dimension_id, result in dimensions.items()]
+        results.append(
+            {
+                "stratum_id": stratum_id,
+                "role": role,
+                "measure_results": measure_results,
+                "dimension_results": dimension_results,
+            }
+        )
+    return results
+
+
 def _validate_protocol(
     repo_root: Path,
     protocol: dict[str, object],
     failures: list[PolicyFailure],
+    *,
+    path: str = "docs/research/dsl-language-evaluation/protocol-v1.json",
 ) -> dict[str, set[str]]:
-    path = "docs/research/dsl-language-evaluation/protocol-v1.json"
     if not _exact_keys(
         protocol,
         _PROTOCOL_KEYS,
@@ -895,11 +1426,15 @@ def _validate_protocol(
             path=path,
         ):
             continue
-        if not isinstance(record["minimum_completed_subjects"], int) or record["minimum_completed_subjects"] < 1:
+        if (
+            not isinstance(record["minimum_completed_subjects"], int)
+            or isinstance(record["minimum_completed_subjects"], bool)
+            or record["minimum_completed_subjects"] < 0
+        ):
             failures.append(
                 _failure(
                     "dsl-evaluation-sampling-plan",
-                    f"{record['persona_id']}: minimum_completed_subjects must be positive",
+                    f"{record['persona_id']}: minimum_completed_subjects must be non-negative",
                     path,
                 )
             )
@@ -1265,7 +1800,11 @@ def _validate_protocol(
         target = sampling["target_total"]
         if not isinstance(minimum, int) or minimum < 1 or not isinstance(target, int):
             failures.append(_failure("dsl-evaluation-sampling-plan", "invalid sample sizes", path))
-        elif target < minimum * len(REQUIRED_PERSONA_IDS):
+        elif target < sum(
+            item.get("minimum_completed_subjects", 0)
+            for item in personas
+            if isinstance(item, Mapping) and isinstance(item.get("minimum_completed_subjects"), int)
+        ):
             failures.append(
                 _failure(
                     "dsl-evaluation-sampling-plan",
@@ -1385,9 +1924,11 @@ def _validate_snapshot(
     protocol: Mapping[str, object],
     snapshot: dict[str, object],
     catalogs: Mapping[str, set[str]],
+    scope: Mapping[str, set[str]],
     failures: list[PolicyFailure],
+    *,
+    path: str = "docs/research/dsl-language-evaluation/execution-snapshot-v1.json",
 ) -> set[str]:
-    path = "docs/research/dsl-language-evaluation/execution-snapshot-v1.json"
     if not _exact_keys(
         snapshot,
         _SNAPSHOT_KEYS,
@@ -1562,12 +2103,19 @@ def _validate_snapshot(
         for subject in subjects
         if isinstance(subject, Mapping) and set(subject) == _SUBJECT_KEYS and isinstance(subject.get("subject_id"), str)
     }
+    sampling_plan = protocol.get("sampling_plan")
+    experience_bands = set()
+    if isinstance(sampling_plan, Mapping):
+        experience_bands = set(_string_list(sampling_plan.get("experience_bands"), non_empty=True) or [])
     for subject_id, subject in subjects_by_id.items():
         if subject.get("persona_id") not in catalogs.get("persona_ids", set()):
             failures.append(_failure("dsl-evaluation-subject-join", f"{subject_id}: unknown persona", path))
         if subject.get("consent_status") not in {"consented", "withdrawn"}:
             failures.append(_failure("dsl-evaluation-consent-status", f"{subject_id}: invalid consent status", path))
-        if not _bounded_text(subject.get("experience_band"), maximum=200):
+        if (
+            not _bounded_text(subject.get("experience_band"), maximum=200)
+            or subject.get("experience_band") not in experience_bands
+        ):
             failures.append(_failure("dsl-evaluation-subject-shape", f"{subject_id}: invalid experience band", path))
     declared_withdrawn_subjects = {
         subject_id for subject_id, subject in subjects_by_id.items() if subject.get("consent_status") == "withdrawn"
@@ -1674,6 +2222,7 @@ def _validate_snapshot(
             )
             continue
         opportunity = (attempt_id, measure_id, artifact_stage)
+        observation_dimensions = _string_list(observation.get("dimension_ids"), non_empty=True)
         if opportunity in observations_by_opportunity:
             failures.append(
                 _failure(
@@ -1720,7 +2269,6 @@ def _validate_snapshot(
         task_dimensions = set(_string_list(task.get("dimension_ids"), non_empty=True) or [])
         measure_dimensions = set(_string_list(measure.get("dimension_ids"), non_empty=True) or [])
         expected_dimensions = task_dimensions & measure_dimensions
-        observation_dimensions = _string_list(observation.get("dimension_ids"), non_empty=True)
         parent_task_id = attempt.get("task_id")
         parent_variant_id = attempt.get("variant_id")
         try:
@@ -1892,13 +2440,18 @@ def _validate_snapshot(
 
     if snapshot["execution_status"] == "complete":
         nonwithdrawn_subject_ids = {
-            subject_id for subject_id, subject in subjects_by_id.items() if subject.get("consent_status") == "consented"
+            subject_id
+            for subject_id, subject in subjects_by_id.items()
+            if subject.get("consent_status") == "consented"
+            and subject.get("persona_id") in scope.get("persona_ids", set())
         }
         active_subject_ids = {
             subject_id
             for subject_id in nonwithdrawn_subject_ids
             if any(
-                attempt.get("subject_id") == subject_id and attempt.get("outcome") != "withdrawn"
+                attempt.get("subject_id") == subject_id
+                and attempt.get("outcome") != "withdrawn"
+                and _attempt_matches_scope(attempt, scope)
                 for attempt in attempts_by_id.values()
             )
         }
@@ -1908,6 +2461,7 @@ def _validate_snapshot(
             if isinstance(item, Mapping)
             and isinstance(item.get("persona_id"), str)
             and isinstance(item.get("minimum_completed_subjects"), int)
+            and item["persona_id"] in scope.get("persona_ids", set())
         }
         persona_counts = Counter(subjects_by_id[subject_id]["persona_id"] for subject_id in active_subject_ids)
         missing_personas = sorted(
@@ -1916,17 +2470,21 @@ def _validate_snapshot(
         expected_task_shapes = {
             (task["task_id"], condition_id, variant_id)
             for task in tasks.values()
+            if task["task_id"] in scope.get("task_ids", set())
             for condition_id in (_string_list(task.get("tooling_condition_ids"), non_empty=True) or [])
+            if condition_id in scope.get("tooling_condition_ids", set())
             for variant_id in (_string_list(task.get("variant_ids"), non_empty=True) or [])
+            if variant_id in scope.get("variant_ids", set())
         }
         actual_task_shapes = {
             (attempt.get("task_id"), attempt.get("tooling_condition_id"), attempt.get("variant_id"))
             for attempt in attempts_by_id.values()
-            if attempt.get("outcome") != "withdrawn"
+            if attempt.get("outcome") != "withdrawn" and _attempt_matches_scope(attempt, scope)
         }
         review_required_attempts = {
             attempt_id
             for attempt_id, attempt in attempts_by_id.items()
+            if _attempt_matches_scope(attempt, scope)
             if "review-judgment"
             in (_string_list(tasks.get(attempt.get("task_id"), {}).get("artifact_stage_ids"), non_empty=True) or [])
             and attempt.get("outcome") != "withdrawn"
@@ -1945,7 +2503,9 @@ def _validate_snapshot(
                 subject_attempts = [
                     attempt
                     for attempt in attempts_by_id.values()
-                    if attempt.get("subject_id") == subject_id and attempt.get("outcome") != "withdrawn"
+                    if attempt.get("subject_id") == subject_id
+                    and attempt.get("outcome") != "withdrawn"
+                    and _attempt_matches_scope(attempt, scope)
                 ]
                 for requirement in subject_task_requirements:
                     if not isinstance(requirement, Mapping):
@@ -1999,10 +2559,13 @@ def _validate_analysis(
     snapshot: Mapping[str, object],
     analysis: dict[str, object],
     catalogs: Mapping[str, set[str]],
+    scope: Mapping[str, set[str]],
+    strata: Sequence[Mapping[str, object]],
     observation_ids: set[str],
     failures: list[PolicyFailure],
+    *,
+    path: str = "docs/research/dsl-language-evaluation/analysis-v1.json",
 ) -> None:
-    path = "docs/research/dsl-language-evaluation/analysis-v1.json"
     if not _exact_keys(
         analysis,
         _ANALYSIS_KEYS,
@@ -2037,16 +2600,16 @@ def _validate_analysis(
         label="measure result",
         path=path,
     )
-    if measure_result_ids != catalogs.get("measure_ids", set()):
+    if measure_result_ids != scope.get("measure_ids", set()):
         failures.append(
             _failure(
                 "dsl-evaluation-analysis-measure-coverage",
-                "analysis must contain one result for every protocol measure",
+                "analysis must contain one result for every claim-scoped measure",
                 path,
             )
         )
     try:
-        recomputed_measures = recompute_measure_results(protocol, snapshot)
+        recomputed_measures = recompute_measure_results(protocol, snapshot, scope=scope)
     except ValueError as exc:
         failures.append(_failure("dsl-evaluation-observation-value", str(exc), path))
         recomputed_measures = {}
@@ -2081,7 +2644,11 @@ def _validate_analysis(
             )
 
     try:
-        recomputed_dimensions = recompute_dimension_results(protocol, recomputed_measures)
+        recomputed_dimensions = recompute_dimension_results(
+            protocol,
+            recomputed_measures,
+            dimension_ids=scope.get("dimension_ids", set()),
+        )
     except ValueError as exc:
         failures.append(_failure("dsl-evaluation-threshold-evaluation", str(exc), path))
         recomputed_dimensions = {}
@@ -2102,11 +2669,11 @@ def _validate_analysis(
         label="dimension result",
         path=path,
     )
-    if result_ids != catalogs.get("dimension_ids", set()):
+    if result_ids != scope.get("dimension_ids", set()):
         failures.append(
             _failure(
                 "dsl-evaluation-analysis-dimension-coverage",
-                "analysis must contain one result for every protocol dimension",
+                "analysis must contain one result for every claim-scoped dimension",
                 path,
             )
         )
@@ -2142,6 +2709,65 @@ def _validate_analysis(
                 )
             )
 
+    stored_strata = _bounded_list(
+        analysis["stratum_results"],
+        _MAX_CATALOG_ITEMS,
+        failures,
+        rule_id="dsl-evaluation-analysis-shape",
+        label="stratum_results",
+        path=path,
+    )
+    expected_strata: list[dict[str, object]] = []
+    if snapshot.get("execution_status") == "not_started":
+        if stored_strata:
+            failures.append(
+                _failure(
+                    "dsl-evaluation-stratum-drift",
+                    "not-started analysis cannot persist derived stratum results",
+                    path,
+                )
+            )
+    else:
+        try:
+            expected_strata = recompute_stratum_results(protocol, snapshot, strata)
+        except ValueError as exc:
+            failures.append(_failure("dsl-evaluation-stratum-drift", str(exc), path))
+        expected_by_id = {item["stratum_id"]: item for item in expected_strata}
+        stored_ids = _record_ids(
+            stored_strata,
+            "stratum_id",
+            failures,
+            rule_id="dsl-evaluation-analysis-id",
+            label="stratum result",
+            path=path,
+        )
+        if stored_ids != set(expected_by_id):
+            failures.append(
+                _failure(
+                    "dsl-evaluation-stratum-coverage",
+                    "analysis must persist one independently recomputed result for every bound stratum",
+                    path,
+                )
+            )
+        for index, result in enumerate(stored_strata):
+            if not _exact_keys(
+                result,
+                _STRATUM_RESULT_KEYS,
+                failures,
+                rule_id="dsl-evaluation-analysis-shape",
+                label=f"stratum_results[{index}]",
+                path=path,
+            ):
+                continue
+            assert isinstance(result, dict)
+            if result != expected_by_id.get(result["stratum_id"]):
+                failures.append(
+                    _failure(
+                        "dsl-evaluation-stratum-drift",
+                        f"{result['stratum_id']}: stored stratum result does not match frozen observations",
+                        path,
+                    )
+                )
     claim = analysis["claim"]
     if _exact_keys(
         claim,
@@ -2198,12 +2824,28 @@ def _validate_analysis(
                         path,
                     )
                 )
-    dimension_values = list(recomputed_dimensions.values())
-    all_pass = set(recomputed_dimensions) == catalogs.get("dimension_ids", set()) and all(
-        result.get("status") == "evaluated" and result.get("threshold_result") == "pass" for result in dimension_values
+    gating_strata = [item for item in expected_strata if item.get("role") == "gating"]
+    gating_dimensions = [
+        item.get("dimension_results", []) for item in gating_strata if isinstance(item.get("dimension_results"), list)
+    ]
+    all_pass = (
+        bool(gating_strata)
+        and len(gating_dimensions) == len(gating_strata)
+        and all(
+            dimension_results
+            and all(
+                isinstance(result, Mapping)
+                and result.get("status") == "evaluated"
+                and result.get("threshold_result") == "pass"
+                for result in dimension_results
+            )
+            for dimension_results in gating_dimensions
+        )
     )
     any_fail = any(
-        result.get("status") == "evaluated" and result.get("threshold_result") == "fail" for result in dimension_values
+        isinstance(result, Mapping) and result.get("status") == "evaluated" and result.get("threshold_result") == "fail"
+        for dimension_results in gating_dimensions
+        for result in dimension_results
     )
     unresolved = any(
         isinstance(item, Mapping) and item.get("status") == "unresolved" for item in snapshot.get("disagreements", [])
@@ -2222,7 +2864,7 @@ def _validate_analysis(
         failures.append(
             _failure(
                 "dsl-evaluation-evidence-status",
-                "demonstrated requires complete all-pass results without unresolved critical disagreement or invalidating deviation",
+                "demonstrated requires every bound gating stratum to pass without unresolved critical disagreement or invalidating deviation",
                 path,
             )
         )
@@ -2230,7 +2872,7 @@ def _validate_analysis(
         failures.append(
             _failure(
                 "dsl-evaluation-evidence-status",
-                "refuted requires a complete execution with at least one recomputed dimension failure",
+                "refuted requires a complete execution with at least one gating-stratum dimension failure",
                 path,
             )
         )
@@ -2262,42 +2904,147 @@ def validate_bundle(
     protocol: dict[str, object],
     snapshot: dict[str, object],
     analysis: dict[str, object],
+    *,
+    artifact_paths: Mapping[str, object] | None = None,
 ) -> list[PolicyFailure]:
     """Validate closed shapes, preregistration, joins, and evidence-status honesty."""
 
     failures: list[PolicyFailure] = []
-    catalogs = _validate_protocol(repo_root, protocol, failures)
-    observation_ids = _validate_snapshot(repo_root, protocol, snapshot, catalogs, failures)
-    _validate_analysis(repo_root, protocol, snapshot, analysis, catalogs, observation_ids, failures)
+    paths = artifact_paths or {}
+    protocol_path = paths.get("protocol_path")
+    snapshot_path = paths.get("snapshot_path")
+    analysis_path = paths.get("analysis_path")
+    claim_binding = paths.get("claim_binding")
+    if claim_binding is None:
+        claim = analysis.get("claim")
+        claim_id = claim.get("claim_id") if isinstance(claim, Mapping) else None
+        try:
+            claim_binding = next(
+                entry[0]["claim_binding"]
+                for entry in load_bundles(repo_root)
+                if isinstance(entry[0].get("claim_binding"), Mapping)
+                and entry[0]["claim_binding"].get("claim_id") == claim_id
+            )
+        except (OSError, ValueError, json.JSONDecodeError, StopIteration):
+            claim_binding = None
+    catalogs = _validate_protocol(
+        repo_root,
+        protocol,
+        failures,
+        path=protocol_path
+        if isinstance(protocol_path, str)
+        else "docs/research/dsl-language-evaluation/protocol-v1.json",
+    )
+    scope = _validate_claim_scope(
+        protocol,
+        analysis,
+        catalogs,
+        failures,
+        path=analysis_path
+        if isinstance(analysis_path, str)
+        else "docs/research/dsl-language-evaluation/analysis-v1.json",
+    )
+    strata = _validate_claim_binding(
+        protocol,
+        analysis,
+        claim_binding,
+        catalogs,
+        scope,
+        failures,
+        path=analysis_path
+        if isinstance(analysis_path, str)
+        else "docs/research/dsl-language-evaluation/analysis-v1.json",
+    )
+    observation_ids = _validate_snapshot(
+        repo_root,
+        protocol,
+        snapshot,
+        catalogs,
+        scope,
+        failures,
+        path=(
+            snapshot_path
+            if isinstance(snapshot_path, str)
+            else "docs/research/dsl-language-evaluation/execution-snapshot-v1.json"
+        ),
+    )
+    _validate_analysis(
+        repo_root,
+        protocol,
+        snapshot,
+        analysis,
+        catalogs,
+        scope,
+        strata,
+        observation_ids,
+        failures,
+        path=analysis_path
+        if isinstance(analysis_path, str)
+        else "docs/research/dsl-language-evaluation/analysis-v1.json",
+    )
     return failures
 
 
 def load_bundle(
     repo_root: Path = REPO_ROOT,
 ) -> tuple[dict[str, object], dict[str, object], dict[str, object], dict[str, object]]:
+    """Load the primary compatibility bundle selected by the manifest."""
+
+    return load_bundles(repo_root)[0]
+
+
+def _load_bundle_entry(
+    repo_root: Path,
+    entry: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object], dict[str, object], dict[str, object]]:
+    if set(entry) != _BUNDLE_ENTRY_KEYS:
+        raise ValueError(f"bundle entry fields must exactly match {sorted(_BUNDLE_ENTRY_KEYS)}; got {sorted(entry)}")
+    paths: list[str] = []
+    for field in ("protocol_path", "snapshot_path", "analysis_path"):
+        value = entry[field]
+        if not isinstance(value, str) or safe_repo_path(repo_root, value) is None:
+            raise ValueError(f"bundle entry contains unsafe {field}")
+        paths.append(value)
+    protocol, snapshot, analysis = (
+        load_bounded_json_object(repo_root, path, max_bytes=_MAX_FILE_BYTES) for path in paths
+    )
+    return entry, protocol, snapshot, analysis
+
+
+def load_bundles(
+    repo_root: Path = REPO_ROOT,
+) -> list[tuple[dict[str, object], dict[str, object], dict[str, object], dict[str, object]]]:
+    """Load every independently revisioned claim bundle named by the manifest."""
+
     manifest = load_bounded_json_object(repo_root, MANIFEST_PATH, max_bytes=_MAX_FILE_BYTES)
     if set(manifest) != _MANIFEST_KEYS:
         raise ValueError(
             f"{MANIFEST_PATH!r} fields must exactly match {sorted(_MANIFEST_KEYS)}; got {sorted(manifest)}"
         )
-    paths: list[str] = []
-    for field in ("protocol_path", "snapshot_path", "analysis_path"):
-        value = manifest[field]
-        if not isinstance(value, str) or safe_repo_path(repo_root, value) is None:
-            raise ValueError(f"{MANIFEST_PATH!r} contains unsafe {field}")
-        paths.append(value)
-    protocol, snapshot, analysis = (
-        load_bounded_json_object(repo_root, path, max_bytes=_MAX_FILE_BYTES) for path in paths
-    )
-    return manifest, protocol, snapshot, analysis
+    supplemental = manifest["supplemental_bundles"]
+    if not isinstance(supplemental, list) or len(supplemental) > 32:
+        raise ValueError(f"{MANIFEST_PATH!r} supplemental_bundles must be a list with at most 32 entries")
+    primary = {field: manifest[field] for field in _BUNDLE_ENTRY_KEYS}
+    entries = [primary]
+    for index, entry in enumerate(supplemental):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{MANIFEST_PATH!r} supplemental_bundles[{index}] must be an object")
+        entries.append(entry)
+    bundle_ids = [entry.get("bundle_id") for entry in entries]
+    if any(not _valid_id(bundle_id) for bundle_id in bundle_ids) or len(bundle_ids) != len(set(bundle_ids)):
+        raise ValueError(f"{MANIFEST_PATH!r} bundle ids must be unique stable ids")
+    return [_load_bundle_entry(repo_root, entry) for entry in entries]
 
 
 def evaluate(repo_root: Path = REPO_ROOT) -> list[PolicyFailure]:
     try:
-        _, protocol, snapshot, analysis = load_bundle(repo_root)
+        bundles = load_bundles(repo_root)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         return [_failure("dsl-evaluation-bundle-invalid", str(exc), MANIFEST_PATH)]
-    return validate_bundle(repo_root, protocol, snapshot, analysis)
+    failures: list[PolicyFailure] = []
+    for entry, protocol, snapshot, analysis in bundles:
+        failures.extend(validate_bundle(repo_root, protocol, snapshot, analysis, artifact_paths=entry))
+    return failures
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Preregister the issue-178 researcher-accessibility study as a distinct, falsifiable evidence bundle and harden the shared integrity gate so claim scope and subgroup results cannot be narrowed or pooled into a misleading ADR-021 evidence status.

## Requirement UIDs

- `ASR-530`

## Related Issues

Closes #178

## ADR Impact

- ADR-021
- ADR-009
- ADR-019

## Changes

- Add the version-2 accessibility protocol, not-started execution snapshot, untested analysis, and architecture preflight for the four issue personas and docs/MCP/CLI/library conditions.
- Extend the manifest and checker to validate multiple bundles, bind stable claims to exact scopes, persist persona/experience/condition strata, and promote evidence only when every target gating stratum passes.
- Document the claim boundary and add focused positive and anti-fabrication tests for bundle loading, scope binding, subgroup masking, comparison populations, malformed strata, result drift, and missing coverage.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused integrity suite: 40 passed. Canonical verification: 3,894 passed, 1 skipped, 46 deselected; 34 integration tests passed, 2 skipped; 92% coverage; Sphinx and pre-commit passed. Requirement governance exited successfully through the repository's documented offline fallback after the Ground Control service timed out.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-530 ← docs/research/dsl-language-evaluation/protocol-v2.json, ASR-530 ← tools/check_dsl_language_evaluation.py
- TESTS: ASR-530 ← implementations/python/tests/test_dsl_language_evaluation.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.