### PR TITLE
feat: add processor plan CLI to serialize execution plans to JSON

### DIFF
--- a/docs/decisions/issue-609-plan-inspection-cli-preflight.md
+++ b/docs/decisions/issue-609-plan-inspection-cli-preflight.md
@@ -1,0 +1,218 @@
+# Issue 609 Plan Inspection CLI Preflight
+
+Date: 2026-07-17
+
+Issue: #609.
+
+Requirement: none. The issue title, body, and acceptance criteria are the
+contract.
+
+This note records architecture guardrails for exposing compiled plans as JSON.
+It does not implement the command, add a serializer, change a published
+contract, or define an implementation plan.
+
+## Binding Boundaries
+
+- ADR-008 keeps compile and plan in the semantics-bearing processor; inspection
+  stops before runtime apply.
+- ADR-009 and ADR-061 make `contracts/schemas/plans/` and
+  `contracts/fixtures/plans/` the published authority. Python models prove
+  compatibility with those artifacts; they do not replace them.
+- ADR-036 assigns CLI wiring to `aces_cli`, processing to `aces_processor`,
+  neutral plan DTOs to `aces_contracts`, backend declarations to
+  `aces_backend_protocols`, and live apply/security/persistence to
+  `aces_runtime`.
+- `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`, and
+  `tools/policy/adr_policy.yaml` are the workflow and import-policy gates.
+
+## Architecture Decisions
+
+- The command is a read-only adapter over the existing reference processor
+  path. Reuse `ReferenceProcessor.realize()` / `run_reference_processor()` so
+  parsing, import expansion, instantiation, compilation, planning, and
+  diagnostics cannot drift from library behavior. Do not reproduce the MCP
+  `compile_pipeline()` or call private compiler/planner helpers from the CLI.
+- The published JSON units are the three domain plans:
+  `ProvisioningPlanModel`, `OrchestrationPlanModel`, and
+  `EvaluationPlanModel`, each containing `PlanOperationModel` values. The
+  internal `ExecutionPlan` is a composite orchestration object; there is no
+  published `ExecutionPlanModel` or execution-plan schema.
+- A single JSON stdout document may therefore contain `provisioning`,
+  `orchestration`, and `evaluation` members whose values independently validate
+  against the three published schemas, plus the aggregate execution-plan
+  diagnostics needed to explain a non-zero result. That top-level object is
+  only a CLI presentation envelope, not a fourth plan contract. If acceptance
+  is read to require the whole stdout document to validate as one published
+  contract, stop for an explicit contract decision rather than inventing an
+  `ExecutionPlanModel` in implementation code.
+- Add one owning-package projection from internal plan dataclasses to the
+  existing Pydantic contract models and reuse it from the CLI. The projection
+  must explicitly include operations, startup order, diagnostics, and the
+  optional realization-envelope identity; convert enum values and tuples to
+  JSON values; omit absent optional fields; and validate before
+  `model_dump(mode="json")`. It must exclude the internal `resources` map,
+  compiled `RuntimeModel`, backend manifest object, base snapshot, target
+  binding, and other `ExecutionPlan` implementation state. Raw `asdict(plan)`
+  is not contract serialization: it includes the forbidden `resources` field.
+- Keep serializer ownership with the neutral plan-contract boundary, following
+  the existing `backend_manifest_v2_model()` / `backend_manifest_payload()`
+  renderer pattern. The CLI selects format and writes stdout; it does not own
+  field mapping or contract validation.
+- Treat `--manifest` as a UTF-8 JSON `backend-manifest-v2` file unless the issue
+  owner specifies a backend-name selector. Validate it first with
+  `BackendManifestV2Model`, then convert it through one backend-protocol-owned
+  adapter to the internal `BackendManifest` used by the planner. Do not pass a
+  Pydantic model or an unvalidated dictionary into planner logic, and do not
+  duplicate capability, controlled-vocabulary, compatibility, or realization
+  validation in `aces_cli`.
+- The absent-manifest behavior must be the same clearly labelled reference
+  dry-run manifest used by the incumbent MCP `sdl_plan` surface. It is a
+  convenience planning target, not evidence that a backend ran or that a
+  production target supports the scenario. Avoid importing
+  `aces_backend_stubs.stubs` into the CLI if that also pulls live-runtime
+  implementation modules into the authoring process; expose or reuse a pure
+  manifest declaration seam instead.
+- JSON stdout must be deterministic and automation-safe: one document, stable
+  member ordering, stable operation order inherited from the planner, UTF-8,
+  and a trailing newline. Human/progress text belongs on stderr. Planning
+  diagnostics remain data in the emitted plan surface; admission/parse failures
+  produce no partial JSON document and exit non-zero.
+- Use `execution_plan.diagnostics` for the aggregate CLI diagnostics and
+  `execution_plan.is_valid` for status. Do not serialize
+  `ReferenceProcessorResult.diagnostics` blindly: the current reference facade
+  prepends `model.diagnostics` to an execution-plan diagnostic list that already
+  includes the model diagnostics, so doing so can duplicate entries.
+
+## Required Incumbents
+
+- CLI: `aces_cli.main`, `aces_cli.processor`, Typer `Path` arguments,
+  `typer.BadParameter`, `typer.Exit`, and the JSON-output/exit convention in
+  `aces_cli.conformance.backend()`.
+- Processing: `aces_processor.reference.ReferenceProcessor`,
+  `run_reference_processor`, `compile_scenario_runtime_model()`, and
+  `aces_processor.planner.plan()` through the public reference facade.
+- SDL admission: `parse_sdl_file()`, the YAML safe loader and source limits,
+  module composition lock/trust handling, closed SDL Pydantic models,
+  `SemanticValidator`, and `instantiate_scenario()` as reached by the reference
+  processor.
+- Plan authority: `aces_contracts.planning` dataclasses,
+  `PlanOperationModel`, the three `*PlanModel` classes,
+  `ContractModel(extra="forbid")`, `require_plan_operation_identity()`,
+  `schema_bundle()`, and `contracts/fixtures/plans/*`.
+- Manifest authority: `BackendManifestV2Model`, the dataclasses and validators
+  in `aces_backend_protocols`, `manifest_authority`, controlled-vocabulary and
+  concept-binding validation, and the existing backend manifest renderer as
+  the reverse-direction pattern.
+- Diagnostics and secret posture: `SDLParseError`, `SDLValidationError`,
+  `SDLInstantiationError`, Pydantic `ValidationError`,
+  `aces_contracts.diagnostics.Diagnostic`, and the explicit-redaction rules in
+  `specs/sdl/diagnostics.md` and `aces_sdl.runtime_values`.
+- Verification: plan valid/invalid fixtures, `test_runtime_contracts.py`,
+  `test_runtime_planner.py`, `test_reference_processor.py`, CLI tests using
+  `typer.testing.CliRunner`, the generated-schema parity gate, repo policy, and
+  the canonical nox `verify` graph.
+
+## Cross-Cutting Layers
+
+- **SDL source gate:** use file-backed `parse_sdl_file()` so UTF-8 handling,
+  the 8 MiB input bound, scalar/depth/node/alias/composition limits, forbidden
+  tags/directives, duplicate/colliding-key checks, JSON-domain checks, import
+  trust/lock resolution, structural closure, semantic validation, and
+  instantiation all remain active. Never use `yaml.load`,
+  `skip_semantic_validation`, or direct `Scenario.model_validate()` here.
+- **Manifest gate:** bound the local file read before decoding; require UTF-8
+  JSON mapping input; validate the closed published model; then construct the
+  internal typed manifest so its capability, contract-id, compatibility,
+  realization-support, concept-binding, and controlled-vocabulary validators
+  run too. A local path is not permission to accept unknown fields or coerce a
+  malformed declaration.
+- **Realization-envelope gate:** a `backend-manifest-v2` payload carries only
+  the realization-envelope identity, while planner envelope membership needs
+  the full configured envelope expression. Resolve an identity only through a
+  canonical, digest-checked envelope declaration. If no such declaration is
+  available, reject that manifest as insufficient for planning; never drop the
+  envelope, strip `realization-envelope-v1` support, or silently weaken the
+  planner gate.
+- **Plan contract gate:** build the published Pydantic model, which enforces
+  closed fields, canonical compiled addresses, domain/resource identity,
+  unique operation addresses, and valid startup-order references. Serialize
+  the validated model, not internal dataclasses or `__dict__` output.
+- **Secret/output gate:** explicit `redacted` and `operator_secret` SDL fields
+  must already omit raw values before compile. Do not echo parameter maps,
+  source documents, manifest bodies, environment variables, tracebacks, or
+  exception input representations on errors. Deliberate `secret_fixture`
+  scenario values may enter a plan payload, so stdout is an explicit
+  user-requested disclosure surface and must never be copied to logs or a
+  second diagnostic channel.
+- **OS/process gate:** accept SDL and manifest paths, not inline manifest JSON,
+  parameter maps, tokens, private keys, or credentials in argv. This command
+  needs no subprocess, shell, environment binding, network service, temporary
+  file, or permission change. Existing SDL imports may use their established
+  trust-controlled resolver; the CLI must not add another fetch path.
+- **Error envelope:** catch the established SDL, manifest/Pydantic, and bounded
+  conversion errors at the CLI boundary and render concise stderr messages
+  without raw framework payloads. Do not add a CLI exception hierarchy. When a
+  plan is produced with error diagnostics, emit the complete JSON plan and use
+  a non-zero exit status, matching the conformance CLI's machine-readable
+  failure convention.
+- **Observability and persistence:** stdout JSON, stderr diagnostics, and the
+  process exit code are sufficient. Do not add telemetry, audit storage, a
+  `ControlPlaneStore`, snapshot persistence, cache files, or runtime operation
+  records for inspection.
+- **Import/workflow policy:** `aces_cli` currently allows only
+  `aces_processor.manifest` and `aces_processor.models` as public processor
+  prefixes and forbids runtime imports. Any use of `aces_processor.reference`
+  or a backend-manifest adapter must be reflected narrowly and deliberately in
+  `tools/policy/adr_policy.yaml`; do not evade the gate through compatibility
+  imports under `implementations/python/src/aces/` or local dynamic imports.
+
+## Extension Boundary
+
+The durable seam is the typed plan projector: it accepts an internal domain
+plan (or the three domain plans from an `ExecutionPlan`) and returns the
+corresponding existing contract model. The CLI's `--format` dispatch consumes
+those models. A future YAML renderer, single-domain selection, or file-output
+option should reuse that projector and change only presentation.
+
+Keep backend selection as a separate input seam: default reference dry-run
+manifest versus an explicitly supplied, fully resolved manifest. A future
+named backend selector or base-snapshot input should change selection/planning
+inputs, not serialization or published plan shapes.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- serializing `ExecutionPlan`, `RuntimeModel`, or plan dataclasses with
+  `asdict()`, `default=str`, `__dict__`, or a generic JSON encoder;
+- emitting the internal `resources` map or inventing a duplicate
+  `ExecutionPlanModel`, schema, diagnostic envelope, or action enum;
+- hand-mapping plan fields separately in CLI, MCP, runtime API, and tests;
+- copying `ReferenceProcessorResult.diagnostics` into output without accounting
+  for its current aggregate duplication;
+- treating the three domain plans as one published contract or claiming the
+  CLI wrapper round-trips against a schema that does not exist;
+- accepting manifest capabilities without both published-model and internal
+  dataclass validation, or ignoring an unresolved realization envelope;
+- recompiling through a second CLI pipeline, bypassing scenario instantiation,
+  or changing planner ordering for prettier JSON;
+- importing live runtime/control-plane APIs for a read-only inspection command;
+- writing plans, snapshots, caches, or lockfiles as a side effect;
+- printing banners, warnings, progress, tracebacks, or error prose on stdout;
+- leaking source/parameter/manifest values through exceptions or logs;
+- editing published schemas merely to make Python serialization convenient;
+- placing implementation logic in the legacy `aces.*` compatibility tree.
+
+## Non-Goals
+
+- Applying, provisioning, reconciling, or otherwise executing the plan.
+- Adding authentication, authorization, control-plane APIs, persistence,
+  telemetry, or backend discovery.
+- Adding a published composite execution-plan contract, changing the three
+  published plan schemas, or changing planner semantics/diagnostic ownership.
+- Adding snapshot input, parameter/profile CLI syntax, YAML output, output-file
+  writes, or backend runtime configuration beyond the issue's stated surface.
+- Treating inspection output as run provenance, backend-conformance evidence,
+  or proof that a live target can realize the plan.
+- Implementing any command, serializer, manifest loader, policy change, or test
+  in this preflight.

--- a/docs/explain/getting-started.md
+++ b/docs/explain/getting-started.md
@@ -97,6 +97,19 @@ uv run aces sdl resolve ../../examples/scenarios/hospital-ransomware-surgery-day
 uv run aces sdl verify-imports ../../examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml
 ```
 
+Inspect a compiled execution plan as JSON:
+
+```shell
+cd implementations/python
+uv run aces processor plan ../../examples/scenarios/techvault-defensive-min.sdl.yaml --format json
+```
+
+This is a read-only dry run: it parses, compiles, and plans the scenario against
+the reference backend manifest and prints the resulting provisioning,
+orchestration, and evaluation plans as published-contract JSON. It does not
+apply or start anything. Pass `--manifest <backend-manifest-v2.json>` to plan
+against an explicitly supplied backend manifest.
+
 Expose the agent-facing MCP tools:
 
 ```shell

--- a/docs/research/specification-coverage/analysis-v1.json
+++ b/docs/research/specification-coverage/analysis-v1.json
@@ -2,7 +2,7 @@
   "analysis_id": "aces-standardized-specification-coverage-analysis-v1",
   "protocol_revision": "1.0.0",
   "snapshot_id": "aces-standardized-specification-coverage-8bf12ee-v1",
-  "snapshot_sha256": "f8ff56958cb47ca927f8acbf8a23fc3e6eddd1ba78e66a42870602e885b2766e",
+  "snapshot_sha256": "d933b6427c1032bee7a511fa291fd1b4f4c1de60529ea990360b7c8964a3498e",
   "generated_at": "2026-07-17",
   "execution_status": "complete",
   "classification_counts": {

--- a/docs/research/specification-coverage/bundle-manifest.json
+++ b/docs/research/specification-coverage/bundle-manifest.json
@@ -4,7 +4,7 @@
   "protocol_path": "docs/research/specification-coverage/protocol-v1.json",
   "protocol_sha256": "e97a19e643e94c9e589dca823a63c6ce49d3329fe2a3cb888ab630838ed93125",
   "snapshot_path": "docs/research/specification-coverage/execution-snapshot-v1.json",
-  "snapshot_sha256": "e11af164a2f140e0722188b6cfd6a000a3ad677e9d37542eaee3d6d1e944637a",
+  "snapshot_sha256": "7f6ddcd783feddaa63d3f66004344c7142de71933baa96dab949d63ed7cf4b01",
   "analysis_path": "docs/research/specification-coverage/analysis-v1.json",
-  "analysis_sha256": "736a651fa7236b747653e5217009f96bfbcbc0ef80ecee245310abc33d126831"
+  "analysis_sha256": "939f1f9b75ffe3f017602927ed8c7c44b825c7ebd358f37b4344da56da7c639f"
 }

--- a/docs/research/specification-coverage/execution-snapshot-v1.json
+++ b/docs/research/specification-coverage/execution-snapshot-v1.json
@@ -9,7 +9,7 @@
     {
       "surface_id": "contract-models",
       "path": "implementations/python/packages/aces_contracts",
-      "content_sha256": "39cce7d49ddc862b0ab2ec4154dcd295b0446627ef50c1fc86fc1aa80f8a98ca"
+      "content_sha256": "00d0e745c69f6a1add1867750d851a4445705eeea995d2e0cd9b748163a2ab9e"
     },
     {
       "surface_id": "processor-pipeline",

--- a/implementations/python/packages/aces_backend_protocols/manifest.py
+++ b/implementations/python/packages/aces_backend_protocols/manifest.py
@@ -4,18 +4,45 @@ from __future__ import annotations
 
 from typing import Any
 
+from aces_contracts.apparatus import ApparatusIdentity, ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.contracts import (
     ApparatusIdentityModel,
+    BackendCapabilitiesV2Model,
     BackendCompatibilityModel,
     BackendManifestV2Model,
     ConceptBindingEntryModel,
+    EvaluatorCapabilitiesModel,
     ObservationCapabilitiesModel,
+    OrchestratorCapabilitiesModel,
     ParticipantFeatureSupportModel,
+    ParticipantRuntimeCapabilitiesModel,
+    ProvisionerCapabilitiesModel,
     RealizationSupportDeclarationModel,
 )
 from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
 
-from .capabilities import BackendManifest
+from .capabilities import (
+    BackendCapabilitySet,
+    BackendCompatibility,
+    BackendManifest,
+    EvaluatorCapabilities,
+    ObservationCapabilities,
+    OrchestratorCapabilities,
+    ParticipantFeatureSupport,
+    ParticipantRuntimeCapabilities,
+    ProvisionerCapabilities,
+)
+
+
+class BackendManifestEnvelopeUnsupportedError(ValueError):
+    """A backend-manifest-v2 payload declares a realization envelope that cannot be resolved.
+
+    A ``backend-manifest-v2`` payload carries only the realization-envelope
+    *identity*, not the full digest-checked declaration the planner needs for
+    envelope-membership checks. :func:`backend_manifest_from_v2_model` raises this
+    (a ``ValueError`` subclass, so existing ``except ValueError`` handlers still
+    catch it) so callers can render a stable, input-free message for this case.
+    """
 
 
 def _evaluator_capability_payload(manifest: BackendManifest) -> dict[str, Any] | None:
@@ -161,3 +188,153 @@ def backend_manifest_payload(manifest: BackendManifest) -> dict[str, Any]:
     if payload.get("realization_envelope") is None:
         payload.pop("realization_envelope", None)
     return payload
+
+
+def _realization_support_from_model(model: RealizationSupportDeclarationModel) -> RealizationSupportDeclaration:
+    return RealizationSupportDeclaration(
+        domain=model.domain,
+        support_mode=model.support_mode,
+        supported_constraint_kinds=frozenset(model.supported_constraint_kinds),
+        supported_exact_requirement_kinds=frozenset(model.supported_exact_requirement_kinds),
+        disclosure_kinds=frozenset(model.disclosure_kinds),
+        constraints=dict(model.constraints),
+    )
+
+
+def _provisioner_from_model(model: ProvisionerCapabilitiesModel) -> ProvisionerCapabilities:
+    return ProvisionerCapabilities(
+        name=model.name,
+        supported_node_types=frozenset(model.supported_node_types),
+        supported_os_families=frozenset(model.supported_os_families),
+        supported_content_types=frozenset(model.supported_content_types),
+        supported_account_features=frozenset(model.supported_account_features),
+        supported_domain_profiles=frozenset(model.supported_domain_profiles),
+        max_total_nodes=model.max_total_nodes,
+        supports_acls=model.supports_acls,
+        supports_accounts=model.supports_accounts,
+        supports_generated_artifacts=model.supports_generated_artifacts,
+        supports_persistent_volumes=model.supports_persistent_volumes,
+        constraints=dict(model.constraints),
+    )
+
+
+def _orchestrator_from_model(model: OrchestratorCapabilitiesModel | None) -> OrchestratorCapabilities | None:
+    if model is None:
+        return None
+    return OrchestratorCapabilities(
+        name=model.name,
+        supported_sections=frozenset(model.supported_sections),
+        supports_workflows=model.supports_workflows,
+        supports_assertion_refs=model.supports_assertion_refs,
+        supports_inject_bindings=model.supports_inject_bindings,
+        supported_workflow_features=frozenset(model.supported_workflow_features),
+        supported_workflow_state_predicates=frozenset(model.supported_workflow_state_predicates),
+        constraints=dict(model.constraints),
+    )
+
+
+def _evaluator_from_model(model: EvaluatorCapabilitiesModel | None) -> EvaluatorCapabilities | None:
+    if model is None:
+        return None
+    return EvaluatorCapabilities(
+        name=model.name,
+        supported_sections=frozenset(model.supported_sections),
+        supports_scoring=model.supports_scoring,
+        supports_objectives=model.supports_objectives,
+        supported_predicate_families=frozenset(model.supported_predicate_families),
+        supported_quantifiers=frozenset(model.supported_quantifiers),
+        supported_truth_outcomes=frozenset(model.supported_truth_outcomes),
+        supported_evidence_channels=frozenset(model.supported_evidence_channels),
+        supported_time_domains=frozenset(model.supported_time_domains),
+        preserves_binding_provenance=model.preserves_binding_provenance,
+        constraints=dict(model.constraints),
+    )
+
+
+def _participant_feature_support_from_model(model: ParticipantFeatureSupportModel) -> ParticipantFeatureSupport:
+    return ParticipantFeatureSupport(
+        feature=model.feature,
+        support_level=model.support_level,
+        constraint_refs=tuple(model.constraint_refs),
+        disclosure_refs=tuple(model.disclosure_refs),
+    )
+
+
+def _participant_runtime_from_model(
+    model: ParticipantRuntimeCapabilitiesModel | None,
+) -> ParticipantRuntimeCapabilities | None:
+    if model is None:
+        return None
+    return ParticipantRuntimeCapabilities(
+        name=model.name,
+        supported_participant_roles=frozenset(model.supported_participant_roles),
+        supported_behavior_features=frozenset(model.supported_behavior_features),
+        supported_interaction_features=frozenset(model.supported_interaction_features),
+        feature_support=tuple(_participant_feature_support_from_model(entry) for entry in model.feature_support),
+        constraints=dict(model.constraints),
+    )
+
+
+def _observation_from_model(model: ObservationCapabilitiesModel | None) -> ObservationCapabilities | None:
+    if model is None:
+        return None
+    return ObservationCapabilities(
+        name=model.name,
+        supported_capture_kinds=frozenset(model.supported_capture_kinds),
+        supported_channel_kinds=frozenset(model.supported_channel_kinds),
+        supported_evidence_contracts=frozenset(model.supported_evidence_contracts),
+        supported_media_types=frozenset(model.supported_media_types),
+        supported_sealing_modes=frozenset(model.supported_sealing_modes),
+        supports_redaction=model.supports_redaction,
+        supports_loss_disclosure=model.supports_loss_disclosure,
+        supports_chain_of_custody=model.supports_chain_of_custody,
+        constraints=dict(model.constraints),
+    )
+
+
+def _capability_set_from_model(model: BackendCapabilitiesV2Model) -> BackendCapabilitySet:
+    return BackendCapabilitySet(
+        provisioner=_provisioner_from_model(model.provisioner),
+        orchestrator=_orchestrator_from_model(model.orchestrator),
+        evaluator=_evaluator_from_model(model.evaluator),
+        participant_runtime=_participant_runtime_from_model(model.participant_runtime),
+        observation=_observation_from_model(model.observation),
+    )
+
+
+def backend_manifest_from_v2_model(model: BackendManifestV2Model) -> BackendManifest:
+    """Reconstruct the internal typed ``BackendManifest`` from its v2 contract model.
+
+    Inverse of :func:`backend_manifest_v2_model`. Constructing ``BackendManifest``
+    re-runs the internal capability, controlled-vocabulary, compatibility, and
+    contract-authority validators, so a payload that merely passed
+    ``BackendManifestV2Model`` schema validation still cannot smuggle in an
+    inconsistent internal manifest.
+
+    Fails closed on realization-envelope-bearing manifests: a
+    ``backend-manifest-v2`` payload carries only the realization-envelope
+    *identity*, not the full digest-checked declaration the planner needs for
+    envelope-membership checks. Such a manifest is insufficient for planning, so
+    the caller must supply an envelope-free manifest (or use the default).
+    """
+
+    if model.realization_envelope is not None or "realization-envelope-v1" in model.supported_contract_versions:
+        raise BackendManifestEnvelopeUnsupportedError(
+            "backend manifest declares a realization envelope, but a backend-manifest-v2 payload "
+            "carries only the envelope identity, not the full digest-checked declaration the planner "
+            "requires. Supply an envelope-free manifest or omit it to use the default reference "
+            "dry-run manifest."
+        )
+    return BackendManifest(
+        identity=ApparatusIdentity(name=model.identity.name, version=model.identity.version),
+        supported_contract_versions=frozenset(model.supported_contract_versions),
+        compatibility=BackendCompatibility(processors=frozenset(model.compatibility.processors)),
+        realization_support=tuple(
+            _realization_support_from_model(declaration) for declaration in model.realization_support
+        ),
+        concept_bindings=tuple(
+            ConceptBinding(scope=binding.scope, family=binding.family) for binding in model.concept_bindings
+        ),
+        constraints=dict(model.constraints),
+        capabilities=_capability_set_from_model(model.capabilities),
+    )

--- a/implementations/python/packages/aces_backend_stubs/manifest.py
+++ b/implementations/python/packages/aces_backend_stubs/manifest.py
@@ -1,0 +1,255 @@
+"""Pure stub backend manifest declaration (issue #609).
+
+This module holds the stub backend's :class:`BackendManifest` factory and its
+supporting constants, separated from ``stubs.py`` so callers that only need the
+capability *declaration* -- authoring/inspection surfaces such as the
+``aces processor plan`` CLI and the MCP dry-run planning tools -- can import the
+manifest without dragging the live stub runtime components (and their
+``aces_runtime`` dependency) into the process. It imports only the
+capability/contract declaration layers; nothing here touches ``aces_runtime``.
+
+``stubs.py`` re-exports :func:`create_stub_manifest` and the ``REFERENCE_*``
+constants so its historical public surface is unchanged.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+
+from aces_backend_protocols.capabilities import (
+    PARTICIPANT_RUNTIME_BEHAVIOR_FEATURE_SCOPE,
+    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS,
+    PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE,
+    PARTICIPANT_RUNTIME_ROLE_SCOPE,
+    BackendCapabilitySet,
+    BackendManifest,
+    EvaluatorCapabilities,
+    ObservationCapabilities,
+    OrchestratorCapabilities,
+    ParticipantRuntimeCapabilities,
+    ProvisionerCapabilities,
+    WorkflowFeature,
+    WorkflowStatePredicateFeature,
+)
+from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
+from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
+from aces_contracts.vocabulary import RealizationSupportMode
+
+REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS = frozenset(BACKEND_SUPPORTED_CONTRACT_IDS) - {"realization-envelope-v1"}
+REFERENCE_PARTICIPANT_ROLES = frozenset(
+    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_ROLE_SCOPE]
+)
+REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES = frozenset(
+    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_BEHAVIOR_FEATURE_SCOPE]
+)
+REFERENCE_PARTICIPANT_INTERACTION_FEATURES = frozenset(
+    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE]
+)
+
+
+def _current_backend_version() -> str:
+    try:
+        return distribution_version("aces-sdl")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+def create_stub_manifest(
+    *,
+    with_participant_runtime: bool = True,
+    with_observation: bool = True,
+    **config,
+) -> BackendManifest:
+    """Return the fully capable stub manifest.
+
+    ``with_participant_runtime=False`` omits the participant runtime
+    capability block so legacy tests that construct targets with only
+    provisioner/orchestrator/evaluator components still satisfy
+    ``registry.target-shape-mismatch`` validation. Production callers
+    should leave this at its default.
+    """
+
+    del config
+    supported_contract_versions = set(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS)
+    if not with_participant_runtime:
+        supported_contract_versions.discard("participant-episode-state-envelope-v1")
+        supported_contract_versions.discard("participant-episode-history-event-stream-v1")
+        supported_contract_versions.discard("participant-behavior-history-event-stream-v1")
+        supported_contract_versions.discard("participant-lifecycle-event-v1")
+        supported_contract_versions.discard("participant-observation-envelope-v1")
+        supported_contract_versions.discard("participant-shared-state-record-v1")
+        supported_contract_versions.discard("participant-joint-action-record-v1")
+        supported_contract_versions.discard("participant-time-management-context-v1")
+        supported_contract_versions.discard("participant-outcome-report-v1")
+    if not with_observation:
+        supported_contract_versions.discard("experiment-capture-spec-v1")
+        supported_contract_versions.discard("experiment-evidence-record-v1")
+        supported_contract_versions.discard("experiment-derived-measure-v1")
+        supported_contract_versions.discard("experiment-run-v1")
+    concept_bindings = (
+        ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
+        ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
+        ConceptBinding(scope="capabilities.provisioner.supported_content_types", family="tools-and-artifacts"),
+        ConceptBinding(scope="capabilities.provisioner.supported_account_features", family="identities"),
+        ConceptBinding(scope="capabilities.provisioner.supported_domain_profiles", family="identities"),
+        ConceptBinding(scope="capabilities.orchestrator.supported_sections", family="actions-and-events"),
+        ConceptBinding(scope="capabilities.evaluator.supported_sections", family="observables"),
+    )
+    if with_participant_runtime:
+        concept_bindings += (
+            ConceptBinding(
+                scope="capabilities.participant_runtime.supported_participant_roles",
+                family="identities",
+            ),
+            ConceptBinding(
+                scope="capabilities.participant_runtime.supported_behavior_features",
+                family="actions-and-events",
+            ),
+            ConceptBinding(
+                scope="capabilities.participant_runtime.supported_interaction_features",
+                family="relationships",
+            ),
+        )
+    if with_observation:
+        concept_bindings += (
+            ConceptBinding(
+                scope="capabilities.observation.supported_capture_kinds",
+                family="provenance-and-evidence",
+            ),
+            ConceptBinding(
+                scope="capabilities.observation.supported_channel_kinds",
+                family="apparatus-declarations",
+            ),
+            ConceptBinding(
+                scope="capabilities.observation.supported_sealing_modes",
+                family="provenance-and-evidence",
+            ),
+        )
+    return BackendManifest(
+        name="stub",
+        version=_current_backend_version(),
+        supported_contract_versions=frozenset(supported_contract_versions),
+        compatible_processors=frozenset({"aces-reference-processor"}),
+        concept_bindings=concept_bindings,
+        realization_support=(
+            RealizationSupportDeclaration(
+                domain="runtime-realization",
+                support_mode=RealizationSupportMode.CONSTRAINED,
+                supported_constraint_kinds=frozenset(
+                    {
+                        "node-type",
+                        "os-family",
+                        "content-type",
+                        "account-feature",
+                        "workflow-feature",
+                        "workflow-state-predicate",
+                    }
+                ),
+                supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
+                disclosure_kinds=frozenset(
+                    {
+                        "backend-manifest-v2",
+                        "runtime-snapshot-v1",
+                        "operation-status-v1",
+                    }
+                ),
+            ),
+        ),
+        capabilities=BackendCapabilitySet(
+            provisioner=ProvisionerCapabilities(
+                name="stub-provisioner",
+                supported_node_types=frozenset({"vm", "switch"}),
+                supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
+                supported_content_types=frozenset({"file", "dataset", "directory"}),
+                supported_account_features=frozenset(
+                    {"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}
+                ),
+                supported_domain_profiles=frozenset({"active_directory"}),
+                max_total_nodes=None,
+                supports_acls=True,
+                supports_accounts=True,
+                supports_generated_artifacts=True,
+                supports_persistent_volumes=True,
+            ),
+            orchestrator=OrchestratorCapabilities(
+                name="stub-orchestrator",
+                supported_sections=frozenset({"injects", "events", "scripts", "stories", "workflows"}),
+                supports_workflows=True,
+                supports_assertion_refs=True,
+                supports_inject_bindings=True,
+                supported_workflow_features=frozenset(
+                    {
+                        WorkflowFeature.DECISION,
+                        WorkflowFeature.SWITCH,
+                        WorkflowFeature.CALL,
+                        WorkflowFeature.PARALLEL_BARRIER,
+                        WorkflowFeature.RETRY,
+                        WorkflowFeature.FAILURE_TRANSITIONS,
+                        WorkflowFeature.CANCELLATION,
+                        WorkflowFeature.TIMEOUTS,
+                        WorkflowFeature.COMPENSATION,
+                    }
+                ),
+                supported_workflow_state_predicates=frozenset(
+                    {
+                        WorkflowStatePredicateFeature.OUTCOME_MATCHING,
+                        WorkflowStatePredicateFeature.ATTEMPT_COUNTS,
+                    }
+                ),
+            ),
+            evaluator=EvaluatorCapabilities(
+                name="stub-evaluator",
+                supported_sections=frozenset({"conditions", "propositions", "assertions", "objectives"}),
+                supports_scoring=True,
+                supports_objectives=True,
+                supported_predicate_families=frozenset({"presence", "boolean", "string", "number"}),
+                supported_quantifiers=frozenset({"all", "any", "at_least"}),
+                supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
+                supported_evidence_channels=frozenset({"log", "api_response", "file_artifact"}),
+                supported_time_domains=frozenset({"scenario_time"}),
+                preserves_binding_provenance=True,
+            ),
+            participant_runtime=(
+                ParticipantRuntimeCapabilities(
+                    name="stub-participant-runtime",
+                    supported_participant_roles=REFERENCE_PARTICIPANT_ROLES,
+                    supported_behavior_features=REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES,
+                    supported_interaction_features=REFERENCE_PARTICIPANT_INTERACTION_FEATURES,
+                )
+                if with_participant_runtime
+                else None
+            ),
+            observation=(
+                ObservationCapabilities(
+                    name="stub-observation",
+                    supported_capture_kinds=frozenset({"artifact", "log", "observation", "telemetry", "trace"}),
+                    supported_channel_kinds=frozenset(
+                        {
+                            "backend-log",
+                            "evaluation-history",
+                            "file-artifact",
+                            "participant-observation",
+                            "runtime-snapshot",
+                            "workflow-history",
+                        }
+                    ),
+                    supported_evidence_contracts=frozenset(
+                        {
+                            "experiment-capture-spec-v1",
+                            "experiment-evidence-record-v1",
+                            "experiment-derived-measure-v1",
+                            "experiment-run-v1",
+                        }
+                    ),
+                    supported_media_types=frozenset({"application/json", "text/plain"}),
+                    supported_sealing_modes=frozenset({"digest", "immutable-store"}),
+                    supports_redaction=True,
+                    supports_loss_disclosure=True,
+                    supports_chain_of_custody=False,
+                )
+                if with_observation
+                else None
+            ),
+        ),
+    )

--- a/implementations/python/packages/aces_backend_stubs/manifest.py
+++ b/implementations/python/packages/aces_backend_stubs/manifest.py
@@ -47,12 +47,195 @@ REFERENCE_PARTICIPANT_INTERACTION_FEATURES = frozenset(
     PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE]
 )
 
+_PARTICIPANT_CONTRACT_VERSIONS = frozenset(
+    {
+        "participant-episode-state-envelope-v1",
+        "participant-episode-history-event-stream-v1",
+        "participant-behavior-history-event-stream-v1",
+        "participant-lifecycle-event-v1",
+        "participant-observation-envelope-v1",
+        "participant-shared-state-record-v1",
+        "participant-joint-action-record-v1",
+        "participant-time-management-context-v1",
+        "participant-outcome-report-v1",
+    }
+)
+_OBSERVATION_CONTRACT_VERSIONS = frozenset(
+    {
+        "experiment-capture-spec-v1",
+        "experiment-evidence-record-v1",
+        "experiment-derived-measure-v1",
+        "experiment-run-v1",
+    }
+)
+
 
 def _current_backend_version() -> str:
     try:
         return distribution_version("aces-sdl")
     except PackageNotFoundError:
         return "0.0.0+unknown"
+
+
+def _stub_supported_contract_versions(*, with_participant_runtime: bool, with_observation: bool) -> frozenset[str]:
+    versions = set(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS)
+    if not with_participant_runtime:
+        versions -= _PARTICIPANT_CONTRACT_VERSIONS
+    if not with_observation:
+        versions -= _OBSERVATION_CONTRACT_VERSIONS
+    return frozenset(versions)
+
+
+def _stub_concept_bindings(*, with_participant_runtime: bool, with_observation: bool) -> tuple[ConceptBinding, ...]:
+    bindings = (
+        ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
+        ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
+        ConceptBinding(scope="capabilities.provisioner.supported_content_types", family="tools-and-artifacts"),
+        ConceptBinding(scope="capabilities.provisioner.supported_account_features", family="identities"),
+        ConceptBinding(scope="capabilities.provisioner.supported_domain_profiles", family="identities"),
+        ConceptBinding(scope="capabilities.orchestrator.supported_sections", family="actions-and-events"),
+        ConceptBinding(scope="capabilities.evaluator.supported_sections", family="observables"),
+    )
+    if with_participant_runtime:
+        bindings += (
+            ConceptBinding(scope="capabilities.participant_runtime.supported_participant_roles", family="identities"),
+            ConceptBinding(
+                scope="capabilities.participant_runtime.supported_behavior_features", family="actions-and-events"
+            ),
+            ConceptBinding(
+                scope="capabilities.participant_runtime.supported_interaction_features", family="relationships"
+            ),
+        )
+    if with_observation:
+        bindings += (
+            ConceptBinding(scope="capabilities.observation.supported_capture_kinds", family="provenance-and-evidence"),
+            ConceptBinding(scope="capabilities.observation.supported_channel_kinds", family="apparatus-declarations"),
+            ConceptBinding(scope="capabilities.observation.supported_sealing_modes", family="provenance-and-evidence"),
+        )
+    return bindings
+
+
+def _stub_realization_support() -> tuple[RealizationSupportDeclaration, ...]:
+    return (
+        RealizationSupportDeclaration(
+            domain="runtime-realization",
+            support_mode=RealizationSupportMode.CONSTRAINED,
+            supported_constraint_kinds=frozenset(
+                {
+                    "node-type",
+                    "os-family",
+                    "content-type",
+                    "account-feature",
+                    "workflow-feature",
+                    "workflow-state-predicate",
+                }
+            ),
+            supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
+            disclosure_kinds=frozenset({"backend-manifest-v2", "runtime-snapshot-v1", "operation-status-v1"}),
+        ),
+    )
+
+
+def _stub_provisioner() -> ProvisionerCapabilities:
+    return ProvisionerCapabilities(
+        name="stub-provisioner",
+        supported_node_types=frozenset({"vm", "switch"}),
+        supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
+        supported_content_types=frozenset({"file", "dataset", "directory"}),
+        supported_account_features=frozenset({"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}),
+        supported_domain_profiles=frozenset({"active_directory"}),
+        max_total_nodes=None,
+        supports_acls=True,
+        supports_accounts=True,
+        supports_generated_artifacts=True,
+        supports_persistent_volumes=True,
+    )
+
+
+def _stub_orchestrator() -> OrchestratorCapabilities:
+    return OrchestratorCapabilities(
+        name="stub-orchestrator",
+        supported_sections=frozenset({"injects", "events", "scripts", "stories", "workflows"}),
+        supports_workflows=True,
+        supports_assertion_refs=True,
+        supports_inject_bindings=True,
+        supported_workflow_features=frozenset(
+            {
+                WorkflowFeature.DECISION,
+                WorkflowFeature.SWITCH,
+                WorkflowFeature.CALL,
+                WorkflowFeature.PARALLEL_BARRIER,
+                WorkflowFeature.RETRY,
+                WorkflowFeature.FAILURE_TRANSITIONS,
+                WorkflowFeature.CANCELLATION,
+                WorkflowFeature.TIMEOUTS,
+                WorkflowFeature.COMPENSATION,
+            }
+        ),
+        supported_workflow_state_predicates=frozenset(
+            {
+                WorkflowStatePredicateFeature.OUTCOME_MATCHING,
+                WorkflowStatePredicateFeature.ATTEMPT_COUNTS,
+            }
+        ),
+    )
+
+
+def _stub_evaluator() -> EvaluatorCapabilities:
+    return EvaluatorCapabilities(
+        name="stub-evaluator",
+        supported_sections=frozenset({"conditions", "propositions", "assertions", "objectives"}),
+        supports_scoring=True,
+        supports_objectives=True,
+        supported_predicate_families=frozenset({"presence", "boolean", "string", "number"}),
+        supported_quantifiers=frozenset({"all", "any", "at_least"}),
+        supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
+        supported_evidence_channels=frozenset({"log", "api_response", "file_artifact"}),
+        supported_time_domains=frozenset({"scenario_time"}),
+        preserves_binding_provenance=True,
+    )
+
+
+def _stub_participant_runtime() -> ParticipantRuntimeCapabilities:
+    return ParticipantRuntimeCapabilities(
+        name="stub-participant-runtime",
+        supported_participant_roles=REFERENCE_PARTICIPANT_ROLES,
+        supported_behavior_features=REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES,
+        supported_interaction_features=REFERENCE_PARTICIPANT_INTERACTION_FEATURES,
+    )
+
+
+def _stub_observation() -> ObservationCapabilities:
+    return ObservationCapabilities(
+        name="stub-observation",
+        supported_capture_kinds=frozenset({"artifact", "log", "observation", "telemetry", "trace"}),
+        supported_channel_kinds=frozenset(
+            {
+                "backend-log",
+                "evaluation-history",
+                "file-artifact",
+                "participant-observation",
+                "runtime-snapshot",
+                "workflow-history",
+            }
+        ),
+        supported_evidence_contracts=frozenset(_OBSERVATION_CONTRACT_VERSIONS),
+        supported_media_types=frozenset({"application/json", "text/plain"}),
+        supported_sealing_modes=frozenset({"digest", "immutable-store"}),
+        supports_redaction=True,
+        supports_loss_disclosure=True,
+        supports_chain_of_custody=False,
+    )
+
+
+def _stub_capabilities(*, with_participant_runtime: bool, with_observation: bool) -> BackendCapabilitySet:
+    return BackendCapabilitySet(
+        provisioner=_stub_provisioner(),
+        orchestrator=_stub_orchestrator(),
+        evaluator=_stub_evaluator(),
+        participant_runtime=_stub_participant_runtime() if with_participant_runtime else None,
+        observation=_stub_observation() if with_observation else None,
+    )
 
 
 def create_stub_manifest(
@@ -71,185 +254,21 @@ def create_stub_manifest(
     """
 
     del config
-    supported_contract_versions = set(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS)
-    if not with_participant_runtime:
-        supported_contract_versions.discard("participant-episode-state-envelope-v1")
-        supported_contract_versions.discard("participant-episode-history-event-stream-v1")
-        supported_contract_versions.discard("participant-behavior-history-event-stream-v1")
-        supported_contract_versions.discard("participant-lifecycle-event-v1")
-        supported_contract_versions.discard("participant-observation-envelope-v1")
-        supported_contract_versions.discard("participant-shared-state-record-v1")
-        supported_contract_versions.discard("participant-joint-action-record-v1")
-        supported_contract_versions.discard("participant-time-management-context-v1")
-        supported_contract_versions.discard("participant-outcome-report-v1")
-    if not with_observation:
-        supported_contract_versions.discard("experiment-capture-spec-v1")
-        supported_contract_versions.discard("experiment-evidence-record-v1")
-        supported_contract_versions.discard("experiment-derived-measure-v1")
-        supported_contract_versions.discard("experiment-run-v1")
-    concept_bindings = (
-        ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
-        ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
-        ConceptBinding(scope="capabilities.provisioner.supported_content_types", family="tools-and-artifacts"),
-        ConceptBinding(scope="capabilities.provisioner.supported_account_features", family="identities"),
-        ConceptBinding(scope="capabilities.provisioner.supported_domain_profiles", family="identities"),
-        ConceptBinding(scope="capabilities.orchestrator.supported_sections", family="actions-and-events"),
-        ConceptBinding(scope="capabilities.evaluator.supported_sections", family="observables"),
-    )
-    if with_participant_runtime:
-        concept_bindings += (
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_participant_roles",
-                family="identities",
-            ),
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_behavior_features",
-                family="actions-and-events",
-            ),
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_interaction_features",
-                family="relationships",
-            ),
-        )
-    if with_observation:
-        concept_bindings += (
-            ConceptBinding(
-                scope="capabilities.observation.supported_capture_kinds",
-                family="provenance-and-evidence",
-            ),
-            ConceptBinding(
-                scope="capabilities.observation.supported_channel_kinds",
-                family="apparatus-declarations",
-            ),
-            ConceptBinding(
-                scope="capabilities.observation.supported_sealing_modes",
-                family="provenance-and-evidence",
-            ),
-        )
     return BackendManifest(
         name="stub",
         version=_current_backend_version(),
-        supported_contract_versions=frozenset(supported_contract_versions),
-        compatible_processors=frozenset({"aces-reference-processor"}),
-        concept_bindings=concept_bindings,
-        realization_support=(
-            RealizationSupportDeclaration(
-                domain="runtime-realization",
-                support_mode=RealizationSupportMode.CONSTRAINED,
-                supported_constraint_kinds=frozenset(
-                    {
-                        "node-type",
-                        "os-family",
-                        "content-type",
-                        "account-feature",
-                        "workflow-feature",
-                        "workflow-state-predicate",
-                    }
-                ),
-                supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
-                disclosure_kinds=frozenset(
-                    {
-                        "backend-manifest-v2",
-                        "runtime-snapshot-v1",
-                        "operation-status-v1",
-                    }
-                ),
-            ),
+        supported_contract_versions=_stub_supported_contract_versions(
+            with_participant_runtime=with_participant_runtime,
+            with_observation=with_observation,
         ),
-        capabilities=BackendCapabilitySet(
-            provisioner=ProvisionerCapabilities(
-                name="stub-provisioner",
-                supported_node_types=frozenset({"vm", "switch"}),
-                supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
-                supported_content_types=frozenset({"file", "dataset", "directory"}),
-                supported_account_features=frozenset(
-                    {"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}
-                ),
-                supported_domain_profiles=frozenset({"active_directory"}),
-                max_total_nodes=None,
-                supports_acls=True,
-                supports_accounts=True,
-                supports_generated_artifacts=True,
-                supports_persistent_volumes=True,
-            ),
-            orchestrator=OrchestratorCapabilities(
-                name="stub-orchestrator",
-                supported_sections=frozenset({"injects", "events", "scripts", "stories", "workflows"}),
-                supports_workflows=True,
-                supports_assertion_refs=True,
-                supports_inject_bindings=True,
-                supported_workflow_features=frozenset(
-                    {
-                        WorkflowFeature.DECISION,
-                        WorkflowFeature.SWITCH,
-                        WorkflowFeature.CALL,
-                        WorkflowFeature.PARALLEL_BARRIER,
-                        WorkflowFeature.RETRY,
-                        WorkflowFeature.FAILURE_TRANSITIONS,
-                        WorkflowFeature.CANCELLATION,
-                        WorkflowFeature.TIMEOUTS,
-                        WorkflowFeature.COMPENSATION,
-                    }
-                ),
-                supported_workflow_state_predicates=frozenset(
-                    {
-                        WorkflowStatePredicateFeature.OUTCOME_MATCHING,
-                        WorkflowStatePredicateFeature.ATTEMPT_COUNTS,
-                    }
-                ),
-            ),
-            evaluator=EvaluatorCapabilities(
-                name="stub-evaluator",
-                supported_sections=frozenset({"conditions", "propositions", "assertions", "objectives"}),
-                supports_scoring=True,
-                supports_objectives=True,
-                supported_predicate_families=frozenset({"presence", "boolean", "string", "number"}),
-                supported_quantifiers=frozenset({"all", "any", "at_least"}),
-                supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
-                supported_evidence_channels=frozenset({"log", "api_response", "file_artifact"}),
-                supported_time_domains=frozenset({"scenario_time"}),
-                preserves_binding_provenance=True,
-            ),
-            participant_runtime=(
-                ParticipantRuntimeCapabilities(
-                    name="stub-participant-runtime",
-                    supported_participant_roles=REFERENCE_PARTICIPANT_ROLES,
-                    supported_behavior_features=REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES,
-                    supported_interaction_features=REFERENCE_PARTICIPANT_INTERACTION_FEATURES,
-                )
-                if with_participant_runtime
-                else None
-            ),
-            observation=(
-                ObservationCapabilities(
-                    name="stub-observation",
-                    supported_capture_kinds=frozenset({"artifact", "log", "observation", "telemetry", "trace"}),
-                    supported_channel_kinds=frozenset(
-                        {
-                            "backend-log",
-                            "evaluation-history",
-                            "file-artifact",
-                            "participant-observation",
-                            "runtime-snapshot",
-                            "workflow-history",
-                        }
-                    ),
-                    supported_evidence_contracts=frozenset(
-                        {
-                            "experiment-capture-spec-v1",
-                            "experiment-evidence-record-v1",
-                            "experiment-derived-measure-v1",
-                            "experiment-run-v1",
-                        }
-                    ),
-                    supported_media_types=frozenset({"application/json", "text/plain"}),
-                    supported_sealing_modes=frozenset({"digest", "immutable-store"}),
-                    supports_redaction=True,
-                    supports_loss_disclosure=True,
-                    supports_chain_of_custody=False,
-                )
-                if with_observation
-                else None
-            ),
+        compatible_processors=frozenset({"aces-reference-processor"}),
+        concept_bindings=_stub_concept_bindings(
+            with_participant_runtime=with_participant_runtime,
+            with_observation=with_observation,
+        ),
+        realization_support=_stub_realization_support(),
+        capabilities=_stub_capabilities(
+            with_participant_runtime=with_participant_runtime,
+            with_observation=with_observation,
         ),
     )

--- a/implementations/python/packages/aces_backend_stubs/stubs.py
+++ b/implementations/python/packages/aces_backend_stubs/stubs.py
@@ -1,252 +1,36 @@
 """Stub runtime backends for compiler/planner testing."""
 
 from datetime import UTC, datetime
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as distribution_version
 
-from aces_backend_protocols.capabilities import (
-    PARTICIPANT_RUNTIME_BEHAVIOR_FEATURE_SCOPE,
-    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS,
-    PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE,
-    PARTICIPANT_RUNTIME_ROLE_SCOPE,
-    BackendCapabilitySet,
-    BackendManifest,
-    EvaluatorCapabilities,
-    ObservationCapabilities,
-    OrchestratorCapabilities,
-    ParticipantRuntimeCapabilities,
-    ProvisionerCapabilities,
-    WorkflowFeature,
-    WorkflowStatePredicateFeature,
-)
+from aces_backend_protocols.capabilities import BackendManifest
 from aces_backend_protocols.participant_runtime_base import BaseParticipantRuntime
-from aces_contracts.apparatus import ConceptBinding, RealizationSupportDeclaration
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.manifest_authority import BACKEND_SUPPORTED_CONTRACT_IDS
 from aces_contracts.planning import ChangeAction, EvaluationPlan, OrchestrationPlan, ProvisioningPlan, RuntimeDomain
 from aces_contracts.runtime_state import ApplyResult, RuntimeSnapshot, SnapshotEntry
-from aces_contracts.vocabulary import RealizationSupportMode
 from aces_runtime.registry import RuntimeTarget, RuntimeTargetComponents
 
 from .evaluation_support import apply_evaluation_operation
-
-REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS = frozenset(BACKEND_SUPPORTED_CONTRACT_IDS) - {"realization-envelope-v1"}
-REFERENCE_PARTICIPANT_ROLES = frozenset(
-    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_ROLE_SCOPE]
-)
-REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES = frozenset(
-    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_BEHAVIOR_FEATURE_SCOPE]
-)
-REFERENCE_PARTICIPANT_INTERACTION_FEATURES = frozenset(
-    PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS[PARTICIPANT_RUNTIME_INTERACTION_FEATURE_SCOPE]
+from .manifest import (
+    REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS,
+    REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES,
+    REFERENCE_PARTICIPANT_INTERACTION_FEATURES,
+    REFERENCE_PARTICIPANT_ROLES,
+    create_stub_manifest,
 )
 
-
-def _current_backend_version() -> str:
-    try:
-        return distribution_version("aces-sdl")
-    except PackageNotFoundError:
-        return "0.0.0+unknown"
-
-
-def create_stub_manifest(
-    *,
-    with_participant_runtime: bool = True,
-    with_observation: bool = True,
-    **config,
-) -> BackendManifest:
-    """Return the fully capable stub manifest.
-
-    ``with_participant_runtime=False`` omits the participant runtime
-    capability block so legacy tests that construct targets with only
-    provisioner/orchestrator/evaluator components still satisfy
-    ``registry.target-shape-mismatch`` validation. Production callers
-    should leave this at its default.
-    """
-
-    del config
-    supported_contract_versions = set(REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS)
-    if not with_participant_runtime:
-        supported_contract_versions.discard("participant-episode-state-envelope-v1")
-        supported_contract_versions.discard("participant-episode-history-event-stream-v1")
-        supported_contract_versions.discard("participant-behavior-history-event-stream-v1")
-        supported_contract_versions.discard("participant-lifecycle-event-v1")
-        supported_contract_versions.discard("participant-observation-envelope-v1")
-        supported_contract_versions.discard("participant-shared-state-record-v1")
-        supported_contract_versions.discard("participant-joint-action-record-v1")
-        supported_contract_versions.discard("participant-time-management-context-v1")
-        supported_contract_versions.discard("participant-outcome-report-v1")
-    if not with_observation:
-        supported_contract_versions.discard("experiment-capture-spec-v1")
-        supported_contract_versions.discard("experiment-evidence-record-v1")
-        supported_contract_versions.discard("experiment-derived-measure-v1")
-        supported_contract_versions.discard("experiment-run-v1")
-    concept_bindings = (
-        ConceptBinding(scope="capabilities.provisioner.supported_node_types", family="assets"),
-        ConceptBinding(scope="capabilities.provisioner.supported_os_families", family="assets"),
-        ConceptBinding(scope="capabilities.provisioner.supported_content_types", family="tools-and-artifacts"),
-        ConceptBinding(scope="capabilities.provisioner.supported_account_features", family="identities"),
-        ConceptBinding(scope="capabilities.provisioner.supported_domain_profiles", family="identities"),
-        ConceptBinding(scope="capabilities.orchestrator.supported_sections", family="actions-and-events"),
-        ConceptBinding(scope="capabilities.evaluator.supported_sections", family="observables"),
-    )
-    if with_participant_runtime:
-        concept_bindings += (
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_participant_roles",
-                family="identities",
-            ),
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_behavior_features",
-                family="actions-and-events",
-            ),
-            ConceptBinding(
-                scope="capabilities.participant_runtime.supported_interaction_features",
-                family="relationships",
-            ),
-        )
-    if with_observation:
-        concept_bindings += (
-            ConceptBinding(
-                scope="capabilities.observation.supported_capture_kinds",
-                family="provenance-and-evidence",
-            ),
-            ConceptBinding(
-                scope="capabilities.observation.supported_channel_kinds",
-                family="apparatus-declarations",
-            ),
-            ConceptBinding(
-                scope="capabilities.observation.supported_sealing_modes",
-                family="provenance-and-evidence",
-            ),
-        )
-    return BackendManifest(
-        name="stub",
-        version=_current_backend_version(),
-        supported_contract_versions=frozenset(supported_contract_versions),
-        compatible_processors=frozenset({"aces-reference-processor"}),
-        concept_bindings=concept_bindings,
-        realization_support=(
-            RealizationSupportDeclaration(
-                domain="runtime-realization",
-                support_mode=RealizationSupportMode.CONSTRAINED,
-                supported_constraint_kinds=frozenset(
-                    {
-                        "node-type",
-                        "os-family",
-                        "content-type",
-                        "account-feature",
-                        "workflow-feature",
-                        "workflow-state-predicate",
-                    }
-                ),
-                supported_exact_requirement_kinds=frozenset({"declared-capability-match"}),
-                disclosure_kinds=frozenset(
-                    {
-                        "backend-manifest-v2",
-                        "runtime-snapshot-v1",
-                        "operation-status-v1",
-                    }
-                ),
-            ),
-        ),
-        capabilities=BackendCapabilitySet(
-            provisioner=ProvisionerCapabilities(
-                name="stub-provisioner",
-                supported_node_types=frozenset({"vm", "switch"}),
-                supported_os_families=frozenset({"linux", "windows", "macos", "freebsd", "other"}),
-                supported_content_types=frozenset({"file", "dataset", "directory"}),
-                supported_account_features=frozenset(
-                    {"groups", "mail", "spn", "shell", "home", "disabled", "auth_method"}
-                ),
-                supported_domain_profiles=frozenset({"active_directory"}),
-                max_total_nodes=None,
-                supports_acls=True,
-                supports_accounts=True,
-                supports_generated_artifacts=True,
-                supports_persistent_volumes=True,
-            ),
-            orchestrator=OrchestratorCapabilities(
-                name="stub-orchestrator",
-                supported_sections=frozenset({"injects", "events", "scripts", "stories", "workflows"}),
-                supports_workflows=True,
-                supports_assertion_refs=True,
-                supports_inject_bindings=True,
-                supported_workflow_features=frozenset(
-                    {
-                        WorkflowFeature.DECISION,
-                        WorkflowFeature.SWITCH,
-                        WorkflowFeature.CALL,
-                        WorkflowFeature.PARALLEL_BARRIER,
-                        WorkflowFeature.RETRY,
-                        WorkflowFeature.FAILURE_TRANSITIONS,
-                        WorkflowFeature.CANCELLATION,
-                        WorkflowFeature.TIMEOUTS,
-                        WorkflowFeature.COMPENSATION,
-                    }
-                ),
-                supported_workflow_state_predicates=frozenset(
-                    {
-                        WorkflowStatePredicateFeature.OUTCOME_MATCHING,
-                        WorkflowStatePredicateFeature.ATTEMPT_COUNTS,
-                    }
-                ),
-            ),
-            evaluator=EvaluatorCapabilities(
-                name="stub-evaluator",
-                supported_sections=frozenset({"conditions", "propositions", "assertions", "objectives"}),
-                supports_scoring=True,
-                supports_objectives=True,
-                supported_predicate_families=frozenset({"presence", "boolean", "string", "number"}),
-                supported_quantifiers=frozenset({"all", "any", "at_least"}),
-                supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
-                supported_evidence_channels=frozenset({"log", "api_response", "file_artifact"}),
-                supported_time_domains=frozenset({"scenario_time"}),
-                preserves_binding_provenance=True,
-            ),
-            participant_runtime=(
-                ParticipantRuntimeCapabilities(
-                    name="stub-participant-runtime",
-                    supported_participant_roles=REFERENCE_PARTICIPANT_ROLES,
-                    supported_behavior_features=REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES,
-                    supported_interaction_features=REFERENCE_PARTICIPANT_INTERACTION_FEATURES,
-                )
-                if with_participant_runtime
-                else None
-            ),
-            observation=(
-                ObservationCapabilities(
-                    name="stub-observation",
-                    supported_capture_kinds=frozenset({"artifact", "log", "observation", "telemetry", "trace"}),
-                    supported_channel_kinds=frozenset(
-                        {
-                            "backend-log",
-                            "evaluation-history",
-                            "file-artifact",
-                            "participant-observation",
-                            "runtime-snapshot",
-                            "workflow-history",
-                        }
-                    ),
-                    supported_evidence_contracts=frozenset(
-                        {
-                            "experiment-capture-spec-v1",
-                            "experiment-evidence-record-v1",
-                            "experiment-derived-measure-v1",
-                            "experiment-run-v1",
-                        }
-                    ),
-                    supported_media_types=frozenset({"application/json", "text/plain"}),
-                    supported_sealing_modes=frozenset({"digest", "immutable-store"}),
-                    supports_redaction=True,
-                    supports_loss_disclosure=True,
-                    supports_chain_of_custody=False,
-                )
-                if with_observation
-                else None
-            ),
-        ),
-    )
+__all__ = [
+    "REFERENCE_BACKEND_SUPPORTED_CONTRACT_VERSIONS",
+    "REFERENCE_PARTICIPANT_BEHAVIOR_FEATURES",
+    "REFERENCE_PARTICIPANT_INTERACTION_FEATURES",
+    "REFERENCE_PARTICIPANT_ROLES",
+    "StubEvaluator",
+    "StubOrchestrator",
+    "StubParticipantRuntime",
+    "StubProvisioner",
+    "create_stub_components",
+    "create_stub_manifest",
+    "create_stub_target",
+]
 
 
 class StubProvisioner:

--- a/implementations/python/packages/aces_cli/processor.py
+++ b/implementations/python/packages/aces_cli/processor.py
@@ -1,13 +1,42 @@
-"""Processor declaration commands."""
+"""Processor declaration and plan-inspection commands."""
 
 from __future__ import annotations
 
 import json
+from enum import Enum
+from pathlib import Path
+from typing import Any
 
 import typer
+from aces_backend_protocols.manifest import (
+    BackendManifest,
+    BackendManifestEnvelopeUnsupportedError,
+    backend_manifest_from_v2_model,
+)
+from aces_backend_stubs.manifest import create_stub_manifest
+from aces_contracts.contracts import BackendManifestV2Model
+from aces_contracts.diagnostics import diagnostic_payload
+from aces_contracts.plan_projection import (
+    evaluation_plan_model,
+    orchestration_plan_model,
+    provisioning_plan_model,
+)
 from aces_processor.manifest import reference_processor_manifest_payload
+from aces_processor.models import ExecutionPlan
+from aces_processor.reference import run_reference_processor
+from aces_sdl import SDLError, SDLInstantiationError, SDLParseError, SDLValidationError
+from pydantic import ValidationError
 
 app = typer.Typer(help="Processor declarations and compatibility surfaces.")
+
+# Backend-manifest JSON is small; bound the read before decoding untrusted input.
+_MANIFEST_MAX_BYTES = 1 * 1024 * 1024
+
+
+class PlanOutputFormat(str, Enum):
+    """Serialization format for the compiled plan."""
+
+    JSON = "json"
 
 
 @app.command("manifest")
@@ -15,3 +44,129 @@ def manifest() -> None:
     """Print the reference processor manifest."""
 
     typer.echo(json.dumps(reference_processor_manifest_payload(), indent=2, sort_keys=True))
+
+
+def _manifest_validation_summary(error: ValidationError) -> str:
+    # Report field paths and error kinds only -- never the offending input values.
+    locations = "; ".join(
+        f"{'.'.join(str(part) for part in item['loc']) or '<root>'}: {item['type']}" for item in error.errors()[:5]
+    )
+    return f"manifest is not a valid backend-manifest-v2: {locations}"
+
+
+def _sdl_error_summary(source: Path, exc: SDLError) -> str:
+    """Render a stable, sanitized SDL compilation-failure line for stderr.
+
+    Emits only the failure kind plus safe metadata -- diagnostic codes and
+    1-based line:column positions for parse failures, error counts otherwise --
+    never the exception's message text, source snippets, or rejected authored
+    values, which can carry untrusted SDL content or terminal control sequences.
+    """
+
+    prefix = f"error: could not compile {source}:"
+    if isinstance(exc, SDLParseError) and exc.diagnostics:
+        markers = ", ".join(
+            f"{diagnostic.code}@{diagnostic.primary_range.start.line}:{diagnostic.primary_range.start.column}"
+            for diagnostic in exc.diagnostics[:10]
+        )
+        return f"{prefix} SDL parse failed [{markers}]"
+    if isinstance(exc, SDLValidationError):
+        count = len(exc.errors)
+        return f"{prefix} {count} SDL validation error{'s' if count != 1 else ''}"
+    if isinstance(exc, SDLInstantiationError):
+        count = len(exc.errors)
+        return f"{prefix} {count} SDL instantiation error{'s' if count != 1 else ''}"
+    return f"{prefix} SDL compilation failed ({type(exc).__name__})"
+
+
+def _load_backend_manifest(manifest_path: Path | None) -> BackendManifest:
+    """Resolve the backend manifest the plan targets.
+
+    Defaults to the reference stub dry-run manifest -- the same target the MCP
+    ``sdl_plan`` surface uses, a convenience planning target rather than evidence
+    a backend ran. A supplied ``--manifest`` is size-bounded, read as UTF-8 JSON,
+    validated against the published ``backend-manifest-v2`` model, then adapted to
+    the internal manifest (which re-runs the capability validators). It fails
+    closed on realization-envelope-bearing manifests, which a v2 payload cannot
+    fully carry.
+    """
+
+    if manifest_path is None:
+        return create_stub_manifest()
+    if manifest_path.stat().st_size > _MANIFEST_MAX_BYTES:
+        raise typer.BadParameter(f"manifest exceeds the {_MANIFEST_MAX_BYTES}-byte limit")
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise typer.BadParameter("manifest must be UTF-8 encoded JSON") from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"manifest is not valid JSON: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise typer.BadParameter("manifest must be a JSON object")
+    try:
+        model = BackendManifestV2Model.model_validate(payload)
+    except ValidationError as exc:
+        raise typer.BadParameter(_manifest_validation_summary(exc)) from exc
+    try:
+        return backend_manifest_from_v2_model(model)
+    except BackendManifestEnvelopeUnsupportedError as exc:
+        raise typer.BadParameter(
+            "manifest declares a realization envelope the plan CLI cannot resolve; "
+            "supply an envelope-free manifest or omit --manifest"
+        ) from exc
+    except ValueError as exc:
+        # Deeper backend-capability validators can interpolate rejected manifest
+        # values into their messages; render a stable, input-free message.
+        raise typer.BadParameter("manifest was rejected by backend capability validation") from exc
+
+
+def _execution_plan_payload(execution_plan: ExecutionPlan) -> dict[str, Any]:
+    return {
+        "scenario_name": execution_plan.scenario_name,
+        "provisioning": provisioning_plan_model(execution_plan.provisioning).model_dump(mode="json"),
+        "orchestration": orchestration_plan_model(execution_plan.orchestration).model_dump(mode="json"),
+        "evaluation": evaluation_plan_model(execution_plan.evaluation).model_dump(mode="json"),
+        "diagnostics": [diagnostic_payload(diagnostic) for diagnostic in execution_plan.diagnostics],
+    }
+
+
+@app.command("plan")
+def plan(
+    sdl: Path = typer.Argument(..., exists=True, readable=True, help="SDL scenario file to compile and plan."),
+    manifest_path: Path | None = typer.Option(
+        None,
+        "--manifest",
+        exists=True,
+        readable=True,
+        help="Backend-manifest-v2 JSON to plan against (defaults to the reference dry-run manifest).",
+    ),
+    output_format: PlanOutputFormat = typer.Option(
+        ...,
+        "--format",
+        help="Output format for the compiled plan.",
+    ),
+) -> None:
+    """Compile an SDL scenario and emit its execution plan as published-contract JSON.
+
+    Plans against the reference dry-run manifest by default; ``--manifest`` targets
+    an explicitly supplied backend-manifest-v2. stdout is a single JSON envelope
+    whose ``provisioning`` / ``orchestration`` / ``evaluation`` members each
+    validate against the published plan contracts. A plan produced with error
+    diagnostics is still emitted in full, with a non-zero exit status. This is a
+    read-only dry run: it does not apply, provision, or start anything.
+    """
+
+    del output_format  # only JSON is supported today; the enum reserves the seam.
+    backend_manifest = _load_backend_manifest(manifest_path)
+    try:
+        result = run_reference_processor(sdl, backend_manifest)
+    except SDLError as exc:
+        typer.echo(_sdl_error_summary(sdl, exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    payload = _execution_plan_payload(result.execution_plan)
+    typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if not result.execution_plan.is_valid:
+        raise typer.Exit(code=1)

--- a/implementations/python/packages/aces_cli/processor.py
+++ b/implementations/python/packages/aces_cli/processor.py
@@ -63,20 +63,21 @@ def _sdl_error_summary(source: Path, exc: SDLError) -> str:
     values, which can carry untrusted SDL content or terminal control sequences.
     """
 
-    prefix = f"error: could not compile {source}:"
     if isinstance(exc, SDLParseError) and exc.diagnostics:
         markers = ", ".join(
             f"{diagnostic.code}@{diagnostic.primary_range.start.line}:{diagnostic.primary_range.start.column}"
             for diagnostic in exc.diagnostics[:10]
         )
-        return f"{prefix} SDL parse failed [{markers}]"
-    if isinstance(exc, SDLValidationError):
+        detail = f"SDL parse failed [{markers}]"
+    elif isinstance(exc, SDLValidationError):
         count = len(exc.errors)
-        return f"{prefix} {count} SDL validation error{'s' if count != 1 else ''}"
-    if isinstance(exc, SDLInstantiationError):
+        detail = f"{count} SDL validation error{'s' if count != 1 else ''}"
+    elif isinstance(exc, SDLInstantiationError):
         count = len(exc.errors)
-        return f"{prefix} {count} SDL instantiation error{'s' if count != 1 else ''}"
-    return f"{prefix} SDL compilation failed ({type(exc).__name__})"
+        detail = f"{count} SDL instantiation error{'s' if count != 1 else ''}"
+    else:
+        detail = f"SDL compilation failed ({type(exc).__name__})"
+    return f"error: could not compile {source}: {detail}"
 
 
 def _load_backend_manifest(manifest_path: Path | None) -> BackendManifest:
@@ -158,7 +159,8 @@ def plan(
     read-only dry run: it does not apply, provision, or start anything.
     """
 
-    del output_format  # only JSON is supported today; the enum reserves the seam.
+    # Only JSON is supported today; the enum reserves the seam for future formats.
+    del output_format
     backend_manifest = _load_backend_manifest(manifest_path)
     try:
         result = run_reference_processor(sdl, backend_manifest)

--- a/implementations/python/packages/aces_contracts/diagnostics.py
+++ b/implementations/python/packages/aces_contracts/diagnostics.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class Severity(str, Enum):
@@ -27,4 +28,16 @@ class Diagnostic:
         return self.severity == Severity.ERROR
 
 
-__all__ = ("Diagnostic", "Severity")
+def diagnostic_payload(diagnostic: Diagnostic) -> dict[str, Any]:
+    """Render a diagnostic as a JSON-ready mapping (severity as its string value)."""
+
+    return {
+        "code": diagnostic.code,
+        "domain": diagnostic.domain,
+        "address": diagnostic.address,
+        "message": diagnostic.message,
+        "severity": diagnostic.severity.value,
+    }
+
+
+__all__ = ("Diagnostic", "Severity", "diagnostic_payload")

--- a/implementations/python/packages/aces_contracts/plan_projection.py
+++ b/implementations/python/packages/aces_contracts/plan_projection.py
@@ -1,0 +1,81 @@
+"""Project internal plan dataclasses into published plan contract models (issue #609).
+
+Forward counterpart of the reverse converters in
+``aces_runtime.control_plane_api_models``: maps the in-memory
+``aces_contracts.planning`` plan dataclasses the planner produces into the
+published ``ProvisioningPlanModel`` / ``OrchestrationPlanModel`` /
+``EvaluationPlanModel`` contract models. Constructing each model runs its
+closed-world (``extra="forbid"``) validators -- unique operation addresses,
+domain/resource identity, startup-order references -- so a projected plan is a
+valid published-contract instance before serialization.
+
+Only the published plan surface is projected: operations, startup order,
+diagnostics, and (for provisioning) the realization-envelope identity. The
+internal ``resources`` map and the compiled model / manifest / snapshot / target
+binding carried by the composite ``ExecutionPlan`` are deliberately excluded;
+they are not part of any published plan contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import (
+    EvaluationPlanModel,
+    OrchestrationPlanModel,
+    PlanOperationModel,
+    ProvisioningPlanModel,
+)
+from .diagnostics import Diagnostic, diagnostic_payload
+from .planning import EvaluationPlan, OrchestrationPlan, PlanOperation, ProvisioningPlan
+
+__all__ = [
+    "evaluation_plan_model",
+    "orchestration_plan_model",
+    "provisioning_plan_model",
+]
+
+
+def _plan_operation_model(operation: PlanOperation) -> PlanOperationModel:
+    return PlanOperationModel(
+        action=operation.action.value,
+        address=operation.address,
+        resource_type=operation.resource_type,
+        payload=dict(operation.payload),
+        ordering_dependencies=list(operation.ordering_dependencies),
+        refresh_dependencies=list(operation.refresh_dependencies),
+    )
+
+
+def _diagnostic_payloads(diagnostics: list[Diagnostic]) -> list[dict[str, Any]]:
+    return [diagnostic_payload(diagnostic) for diagnostic in diagnostics]
+
+
+def provisioning_plan_model(plan: ProvisioningPlan) -> ProvisioningPlanModel:
+    """Project a provisioning plan into its published contract model."""
+
+    return ProvisioningPlanModel(
+        operations=[_plan_operation_model(operation) for operation in plan.operations],
+        diagnostics=_diagnostic_payloads(plan.diagnostics),
+        realization_envelope=plan.realization_envelope,
+    )
+
+
+def orchestration_plan_model(plan: OrchestrationPlan) -> OrchestrationPlanModel:
+    """Project an orchestration plan into its published contract model."""
+
+    return OrchestrationPlanModel(
+        operations=[_plan_operation_model(operation) for operation in plan.operations],
+        startup_order=list(plan.startup_order),
+        diagnostics=_diagnostic_payloads(plan.diagnostics),
+    )
+
+
+def evaluation_plan_model(plan: EvaluationPlan) -> EvaluationPlanModel:
+    """Project an evaluation plan into its published contract model."""
+
+    return EvaluationPlanModel(
+        operations=[_plan_operation_model(operation) for operation in plan.operations],
+        startup_order=list(plan.startup_order),
+        diagnostics=_diagnostic_payloads(plan.diagnostics),
+    )

--- a/implementations/python/tests/test_backend_manifest_v2_adapter.py
+++ b/implementations/python/tests/test_backend_manifest_v2_adapter.py
@@ -1,0 +1,73 @@
+"""Tests for the backend-manifest-v2 -> BackendManifest reverse adapter (issue #609).
+
+The adapter is the inverse of ``backend_manifest_v2_model``: it reconstructs the
+internal typed :class:`BackendManifest` (running its own capability validators)
+from a validated ``BackendManifestV2Model`` so the plan-inspection CLI can plan
+against an externally supplied manifest. Realization-envelope-bearing manifests
+fail closed because a v2 payload carries only the envelope identity, not the full
+digest-checked declaration the planner needs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aces_backend_protocols.manifest import (
+    backend_manifest_from_v2_model,
+    backend_manifest_v2_model,
+)
+from aces_backend_stubs.manifest import create_stub_manifest
+from aces_contracts.contracts import BackendManifestV2Model
+
+
+def test_round_trips_the_full_stub_manifest() -> None:
+    original = create_stub_manifest()
+    v2_model = backend_manifest_v2_model(original)
+
+    reconstructed = backend_manifest_from_v2_model(v2_model)
+
+    assert reconstructed == original
+
+
+@pytest.mark.parametrize(
+    ("with_participant_runtime", "with_observation"),
+    [(False, True), (True, False), (False, False)],
+)
+def test_round_trips_reduced_capability_stub_manifests(with_participant_runtime: bool, with_observation: bool) -> None:
+    original = create_stub_manifest(
+        with_participant_runtime=with_participant_runtime,
+        with_observation=with_observation,
+    )
+
+    reconstructed = backend_manifest_from_v2_model(backend_manifest_v2_model(original))
+
+    assert reconstructed == original
+    assert (reconstructed.participant_runtime is not None) == with_participant_runtime
+    assert (reconstructed.observation is not None) == with_observation
+
+
+def test_round_trip_reconstructs_via_serialized_payload() -> None:
+    """A payload that survives JSON serialization + revalidation still round-trips."""
+
+    original = create_stub_manifest()
+    payload = backend_manifest_v2_model(original).model_dump(mode="json")
+
+    revalidated = BackendManifestV2Model.model_validate(payload)
+    reconstructed = backend_manifest_from_v2_model(revalidated)
+
+    assert reconstructed == original
+
+
+def test_envelope_bearing_manifest_fails_closed() -> None:
+    stub_payload = backend_manifest_v2_model(create_stub_manifest()).model_dump(mode="json")
+    stub_payload["supported_contract_versions"].append("realization-envelope-v1")
+    stub_payload["realization_envelope"] = {
+        "contract_id": "realization-envelope-v1",
+        "envelope_id": "example-envelope",
+        "schema_version": "realization-envelope/v1",
+        "digest": "sha256:" + "0" * 64,
+        "configuration_digest": "sha256:" + "1" * 64,
+    }
+    envelope_model = BackendManifestV2Model.model_validate(stub_payload)
+
+    with pytest.raises(ValueError, match="realization envelope"):
+        backend_manifest_from_v2_model(envelope_model)

--- a/implementations/python/tests/test_plan_inspection_cli.py
+++ b/implementations/python/tests/test_plan_inspection_cli.py
@@ -1,0 +1,181 @@
+"""Tests for the ``aces processor plan`` plan-inspection CLI (issue #609)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aces_backend_protocols.manifest import backend_manifest_payload
+from aces_backend_stubs.manifest import create_stub_manifest
+from aces_cli.main import app
+from aces_cli.processor import _sdl_error_summary
+from aces_contracts.contracts import (
+    EvaluationPlanModel,
+    OrchestrationPlanModel,
+    ProvisioningPlanModel,
+)
+from aces_sdl._errors import (
+    SDLInstantiationError,
+    SDLParseDiagnostic,
+    SDLParseError,
+    SDLSourcePosition,
+    SDLSourceRange,
+    SDLValidationError,
+)
+from paths import EXAMPLES_DIR
+from typer.testing import CliRunner
+
+_SCENARIO = EXAMPLES_DIR / "techvault-defensive-min.sdl.yaml"
+_ENVELOPE_IDENTITY = {
+    "contract_id": "realization-envelope-v1",
+    "envelope_id": "example-envelope",
+    "schema_version": "realization-envelope/v1",
+    "digest": "sha256:" + "0" * 64,
+    "configuration_digest": "sha256:" + "1" * 64,
+}
+
+
+def _invoke(*args: str):
+    return CliRunner().invoke(app, ["processor", "plan", *args])
+
+
+def test_plan_default_manifest_emits_contract_json() -> None:
+    result = _invoke(str(_SCENARIO), "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert set(payload) == {"scenario_name", "provisioning", "orchestration", "evaluation", "diagnostics"}
+    assert payload["scenario_name"] == "techvault-defensive-min"
+
+    # Each domain member independently validates against its published plan contract
+    # -- the same models that admit contracts/fixtures/plans/*.
+    ProvisioningPlanModel.model_validate(payload["provisioning"])
+    OrchestrationPlanModel.model_validate(payload["orchestration"])
+    EvaluationPlanModel.model_validate(payload["evaluation"])
+    provisioning_ops = payload["provisioning"]["operations"]
+    assert provisioning_ops, "expected provisioning operations for defensive-min"
+    # Operation payload content -- the field real backends consume -- survives
+    # end-to-end through the CLI, not just the operations list being non-empty.
+    assert any(op["payload"] for op in provisioning_ops)
+
+
+def test_plan_output_is_deterministic() -> None:
+    first = _invoke(str(_SCENARIO), "--format", "json")
+    second = _invoke(str(_SCENARIO), "--format", "json")
+
+    assert first.exit_code == 0
+    assert first.stdout == second.stdout
+
+
+def test_plan_accepts_supplied_backend_manifest(tmp_path: Path) -> None:
+    manifest_file = tmp_path / "stub-manifest.json"
+    manifest_file.write_text(json.dumps(backend_manifest_payload(create_stub_manifest())), encoding="utf-8")
+
+    result = _invoke(str(_SCENARIO), "--manifest", str(manifest_file), "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    ProvisioningPlanModel.model_validate(payload["provisioning"])
+
+
+def test_plan_emits_full_json_and_nonzero_exit_on_error_diagnostics(tmp_path: Path) -> None:
+    payload = backend_manifest_payload(create_stub_manifest())
+    # A manifest that cannot provision VMs turns the scenario's VM nodes into a
+    # capability gap: the planner reports error diagnostics rather than raising.
+    payload["capabilities"]["provisioner"]["supported_node_types"] = ["switch"]
+    manifest_file = tmp_path / "no-vm-manifest.json"
+    manifest_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _invoke(str(_SCENARIO), "--manifest", str(manifest_file), "--format", "json")
+
+    assert result.exit_code == 1
+    emitted = json.loads(result.stdout)  # the full plan is still emitted
+    error_codes = {diagnostic["code"] for diagnostic in emitted["diagnostics"] if diagnostic["severity"] == "error"}
+    assert "provisioner.unsupported-node-type" in error_codes
+
+
+def test_plan_invalid_sdl_fails_without_partial_json(tmp_path: Path) -> None:
+    bad = tmp_path / "broken.sdl.yaml"
+    bad.write_text("name: [unclosed\n", encoding="utf-8")
+
+    result = _invoke(str(bad), "--format", "json")
+
+    assert result.exit_code == 1
+    assert result.stdout.strip() == ""
+    assert "could not compile" in result.stderr
+    # Sanitized single-line summary, not a raw multi-line exception dump.
+    assert result.stderr.count("\n") <= 1
+    assert "Traceback" not in result.stderr
+
+
+def test_sdl_error_summary_redacts_message_and_source() -> None:
+    source = Path("scenario.sdl.yaml")
+    parse_error = SDLParseError(
+        "boom SECRETMARKER",
+        diagnostics=[
+            SDLParseDiagnostic(
+                code="sdl.duplicate-key",
+                message="rejected value SECRETMARKER",
+                pointer="/nodes",
+                primary_range=SDLSourceRange(SDLSourcePosition(3, 5), SDLSourcePosition(3, 9)),
+            )
+        ],
+    )
+    parse_summary = _sdl_error_summary(source, parse_error)
+    assert "SECRETMARKER" not in parse_summary
+    assert "sdl.duplicate-key@3:5" in parse_summary
+
+    validation_summary = _sdl_error_summary(
+        source, SDLValidationError(errors=["undefined node SECRETMARKER", "bad ref SECRETMARKER"])
+    )
+    assert "SECRETMARKER" not in validation_summary
+    assert "2 SDL validation errors" in validation_summary
+
+    instantiation_summary = _sdl_error_summary(source, SDLInstantiationError(errors=["unbound parameter SECRETMARKER"]))
+    assert "SECRETMARKER" not in instantiation_summary
+    assert "1 SDL instantiation error" in instantiation_summary
+
+
+def test_plan_invalid_manifest_does_not_leak_rejected_value(tmp_path: Path) -> None:
+    payload = backend_manifest_payload(create_stub_manifest())
+    # A rejected controlled-vocabulary value must not escape into stderr/logs.
+    payload["capabilities"]["provisioner"]["supported_node_types"] = ["ZZLEAKMARKER99"]
+    manifest_file = tmp_path / "leaky-manifest.json"
+    manifest_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _invoke(str(_SCENARIO), "--manifest", str(manifest_file), "--format", "json")
+
+    assert result.exit_code != 0
+    assert result.stdout.strip() == ""
+    assert "ZZLEAKMARKER99" not in result.stderr
+    assert "backend-manifest-v2" in result.stderr
+
+
+def test_plan_manifest_with_realization_envelope_fails_closed(tmp_path: Path) -> None:
+    payload = backend_manifest_payload(create_stub_manifest())
+    payload["supported_contract_versions"].append("realization-envelope-v1")
+    payload["realization_envelope"] = dict(_ENVELOPE_IDENTITY)
+    manifest_file = tmp_path / "envelope-manifest.json"
+    manifest_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = _invoke(str(_SCENARIO), "--manifest", str(manifest_file), "--format", "json")
+
+    assert result.exit_code != 0
+    assert result.stdout.strip() == ""
+    assert "realization envelope" in result.stderr
+
+
+def test_plan_rejects_non_json_manifest(tmp_path: Path) -> None:
+    manifest_file = tmp_path / "not-json.json"
+    manifest_file.write_text("this is not json", encoding="utf-8")
+
+    result = _invoke(str(_SCENARIO), "--manifest", str(manifest_file), "--format", "json")
+
+    assert result.exit_code != 0
+    assert result.stdout.strip() == ""
+
+
+def test_plan_requires_explicit_format() -> None:
+    result = _invoke(str(_SCENARIO))
+
+    assert result.exit_code != 0

--- a/implementations/python/tests/test_plan_projection.py
+++ b/implementations/python/tests/test_plan_projection.py
@@ -1,0 +1,165 @@
+"""Tests for the internal-plan -> published-contract projector (issue #609)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from aces_backend_stubs.manifest import create_stub_manifest
+from aces_contracts.contracts import (
+    EvaluationPlanModel,
+    OrchestrationPlanModel,
+    ProvisioningPlanModel,
+    RealizationEnvelopeIdentityModel,
+)
+from aces_contracts.diagnostics import Diagnostic, Severity
+from aces_contracts.plan_projection import (
+    evaluation_plan_model,
+    orchestration_plan_model,
+    provisioning_plan_model,
+)
+from aces_contracts.planning import ProvisioningPlan
+from aces_processor.reference import run_reference_processor
+from paths import EXAMPLES_DIR, REPO_ROOT
+
+_PLAN_FIXTURES = REPO_ROOT / "contracts" / "fixtures" / "plans"
+_SCENARIO = EXAMPLES_DIR / "techvault-defensive-min.sdl.yaml"
+
+
+def test_empty_plans_project_to_minimal_contract_shape() -> None:
+    provisioning = provisioning_plan_model(ProvisioningPlan())
+    assert provisioning.operations == []
+    assert provisioning.diagnostics == []
+    assert provisioning.realization_envelope is None
+
+
+def test_diagnostics_are_projected_json_safe() -> None:
+    plan = ProvisioningPlan(
+        operations=[],
+        diagnostics=[
+            Diagnostic(
+                code="planner.capability-gap",
+                domain="provisioning",
+                address="runtime.provisioning",
+                message="node type unsupported",
+                severity=Severity.WARNING,
+            )
+        ],
+    )
+
+    projected = provisioning_plan_model(plan)
+    dumped = json.loads(projected.model_dump_json())
+
+    assert dumped["diagnostics"] == [
+        {
+            "code": "planner.capability-gap",
+            "domain": "provisioning",
+            "address": "runtime.provisioning",
+            "message": "node type unsupported",
+            "severity": "warning",
+        }
+    ]
+
+
+def test_real_execution_plan_projects_and_round_trips() -> None:
+    result = run_reference_processor(_SCENARIO, create_stub_manifest())
+    execution_plan = result.execution_plan
+
+    provisioning = provisioning_plan_model(execution_plan.provisioning)
+    orchestration = orchestration_plan_model(execution_plan.orchestration)
+    evaluation = evaluation_plan_model(execution_plan.evaluation)
+
+    assert provisioning.operations, "expected the defensive-min scenario to yield provisioning operations"
+    # The per-field comparison below is only a real regression detector if the
+    # fixture actually populates payload and refresh_dependencies.
+    assert any(op.payload for op in execution_plan.provisioning.operations)
+    assert any(op.refresh_dependencies for op in execution_plan.provisioning.operations)
+
+    # Every projected operation matches its source operation field-for-field,
+    # across all three domains that share _plan_operation_model.
+    for projected_plan, source_plan in (
+        (provisioning, execution_plan.provisioning),
+        (orchestration, execution_plan.orchestration),
+        (evaluation, execution_plan.evaluation),
+    ):
+        assert len(projected_plan.operations) == len(source_plan.operations)
+        for projected_op, source_op in zip(projected_plan.operations, source_plan.operations, strict=True):
+            assert projected_op.action == source_op.action.value
+            assert projected_op.address == source_op.address
+            assert projected_op.resource_type == source_op.resource_type
+            assert projected_op.payload == dict(source_op.payload)
+            assert projected_op.ordering_dependencies == list(source_op.ordering_dependencies)
+            assert projected_op.refresh_dependencies == list(source_op.refresh_dependencies)
+
+    # startup_order threads through the orchestration/evaluation wrappers.
+    assert orchestration.startup_order == list(execution_plan.orchestration.startup_order)
+    assert evaluation.startup_order == list(execution_plan.evaluation.startup_order)
+
+    # Each domain member independently validates against its published model and
+    # its JSON serialization is stable under re-parse + re-serialize.
+    for model, cls in (
+        (provisioning, ProvisioningPlanModel),
+        (orchestration, OrchestrationPlanModel),
+        (evaluation, EvaluationPlanModel),
+    ):
+        dumped = json.loads(model.model_dump_json())
+        revalidated = cls.model_validate(dumped)
+        assert json.loads(revalidated.model_dump_json()) == dumped
+
+
+def test_projection_excludes_internal_resources() -> None:
+    result = run_reference_processor(_SCENARIO, create_stub_manifest())
+    provisioning = provisioning_plan_model(result.execution_plan.provisioning)
+
+    # The internal resources map must not leak into the published contract.
+    assert "resources" not in provisioning.model_dump()
+
+
+def test_operation_projection_maps_every_field() -> None:
+    # Fixture-independent: a no-op drop of ANY of the six mapped fields must fail.
+    # Reuse a real operation's validated address/resource_type, then set every
+    # other field to a known, distinct value the projection must reflect exactly.
+    operations = run_reference_processor(_SCENARIO, create_stub_manifest()).execution_plan.provisioning.operations
+    addresses = [op.address for op in operations]
+    source = replace(
+        operations[0],
+        payload={"marker": "value", "count": 3, "nested": {"k": "v"}},
+        ordering_dependencies=(addresses[1],),
+        refresh_dependencies=(addresses[2],),
+    )
+
+    projected = provisioning_plan_model(ProvisioningPlan(operations=[source])).operations[0]
+
+    assert projected.action == source.action.value
+    assert projected.address == source.address
+    assert projected.resource_type == source.resource_type
+    assert projected.payload == {"marker": "value", "count": 3, "nested": {"k": "v"}}
+    assert projected.ordering_dependencies == [addresses[1]]
+    assert projected.refresh_dependencies == [addresses[2]]
+
+
+def test_realization_envelope_threads_through_projection() -> None:
+    # The optional provisioning realization-envelope identity must survive the
+    # projection, not only the trivial None -> None case.
+    identity = RealizationEnvelopeIdentityModel(
+        envelope_id="cli-test-envelope",
+        digest="sha256:" + "a" * 64,
+        configuration_digest="sha256:" + "b" * 64,
+    )
+
+    projected = provisioning_plan_model(ProvisioningPlan(realization_envelope=identity))
+
+    assert projected.realization_envelope == identity
+
+
+def test_published_plan_fixtures_validate_against_the_same_models() -> None:
+    # The projector's target models are exactly the ones that admit the published
+    # plan fixtures, so CLI output shares the fixtures' contract shape.
+    for family, cls in (
+        ("provisioning-plan-v1", ProvisioningPlanModel),
+        ("orchestration-plan-v1", OrchestrationPlanModel),
+        ("evaluation-plan-v1", EvaluationPlanModel),
+    ):
+        fixture = _PLAN_FIXTURES / family / "valid" / "minimal.json"
+        cls.model_validate(json.loads(Path(fixture).read_text(encoding="utf-8")))

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -200,6 +200,8 @@ module_boundaries:
     - id: aces_cli
       root: implementations/python/packages/aces_cli
       allowed_top_level_imports:
+        - aces_backend_protocols
+        - aces_backend_stubs
         - aces_contracts
         - aces_conformance
         - aces_operations
@@ -208,6 +210,13 @@ module_boundaries:
       forbidden_import_prefixes:
         - aces_runtime
       public_import_prefixes:
+        # Plan-inspection CLI (issue #609): the backend-manifest-v2 adapter and
+        # the pure stub-manifest declaration seam only -- never the stub runtime
+        # components (aces_backend_stubs.stubs pulls aces_runtime).
+        aces_backend_protocols:
+          - aces_backend_protocols.manifest
+        aces_backend_stubs:
+          - aces_backend_stubs.manifest
         aces_operations:
           - aces_operations.libvirt_evidence_run
           - aces_operations.cross_backend_corpus
@@ -215,6 +224,7 @@ module_boundaries:
         aces_processor:
           - aces_processor.manifest
           - aces_processor.models
+          - aces_processor.reference
     - id: aces_mcp
       root: implementations/python/packages/aces_mcp
       allowed_top_level_imports:

--- a/tools/policy/oversized_allowlist.yaml
+++ b/tools/policy/oversized_allowlist.yaml
@@ -10,7 +10,6 @@ files:
   - implementations/python/packages/aces_backend_libvirt/drivers/libvirt.py
   - implementations/python/packages/aces_backend_libvirt/realization.py
   - implementations/python/packages/aces_backend_libvirt/techvault_native.py
-  - implementations/python/packages/aces_backend_stubs/stubs.py
   - implementations/python/packages/aces_conformance/conformance.py
   - implementations/python/packages/aces_contracts/contracts.py
   - implementations/python/packages/aces_contracts/workflow.py


### PR DESCRIPTION
## Summary

Adds `aces processor plan <sdl> [--manifest <m>] --format json`, a read-only CLI that compiles an SDL scenario through the existing reference-processor path and emits its provisioning, orchestration, and evaluation plans as published-contract JSON. Closes the tooling gap where a compiled plan was only inspectable via library calls (`compile_runtime_model` + `plan`). Each domain member independently validates against the published plan contracts (round-trips against `contracts/fixtures/plans/*`); the top-level object is a CLI presentation envelope, not a new contract.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #609

## ADR Impact

- ADR-021
- ADR-036

## Changes

- `aces_cli/processor.py`: new `plan` command — compile+plan via `run_reference_processor`, emit a deterministic JSON envelope (scenario_name + provisioning/orchestration/evaluation + aggregate diagnostics); sanitized stderr (codes + line:col, never source/manifest text) and non-zero exit on failure or error diagnostics.
- `aces_contracts/plan_projection.py` (new): projector from in-memory plan dataclasses to the published `ProvisioningPlanModel`/`OrchestrationPlanModel`/`EvaluationPlanModel`, excluding internal resources/model/manifest/snapshot state.
- `aces_backend_protocols/manifest.py`: `backend_manifest_from_v2_model` reverse adapter (inverse of `backend_manifest_v2_model`), failing closed on realization-envelope-bearing manifests via `BackendManifestEnvelopeUnsupportedError`.
- `aces_backend_stubs/manifest.py` (new) + `stubs.py`: extract a pure stub-manifest declaration seam so the default dry-run manifest does not pull `aces_runtime` into the CLI; `stubs.py` re-exports the factory and `REFERENCE_*` constants for back-compat.
- `aces_contracts/diagnostics.py`: add `diagnostic_payload` JSON-render helper, reused by the projector and CLI.
- `tools/policy/adr_policy.yaml`: narrowly allow `aces_cli` to import `aces_backend_protocols.manifest`, `aces_backend_stubs.manifest`, and `aces_processor.reference`; drain the now-287-line `stubs.py` from the oversized allowlist.
- `docs/explain/getting-started.md`: add an `aces processor plan` usage example (CLI reference auto-documents the command via `automodule`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
