### PR TITLE
feat: define participant decision surface semantics

### DIFF
--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/invalid/presentation-as-outcome.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/invalid/presentation-as-outcome.json
@@ -1,0 +1,31 @@
+{
+  "surface_id": "decision-surfaces.red.invalid.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.agent.v1",
+  "decision_control_mode": "autonomous",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [],
+  "affordance_refs": [],
+  "form": {
+    "surface_form": "candidate_action_set",
+    "selection_meaning_ref": "selection-meaning.candidate.v1",
+    "candidate_entry_ids": ["participant.action-contract.scan"]
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.order-4"],
+  "marking_definition_refs": [],
+  "redaction_policy_ref": null,
+  "semantic_limitations": ["invalid fixture"],
+  "selected_action_contract_address": "participant.action-contract.scan",
+  "outcome": "succeeded"
+}

--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/invalid/undisclosed-form-loss.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/invalid/undisclosed-form-loss.json
@@ -1,0 +1,50 @@
+{
+  "surface_id": "decision-surfaces.red.invalid-form.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.script.v1",
+  "decision_control_mode": "scripted",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [
+    {
+      "entry_id": "participant.action-contract.scan",
+      "action_contract_address": "participant.action-contract.scan",
+      "presentation_basis_ref": "projection-policy.red.v1",
+      "visibility": "observable",
+      "eligibility": "eligible",
+      "eligibility_reason_refs": [],
+      "constraint_refs": ["participant.action-contract.scan.preconditions"],
+      "selection_shape_ref": "selection-shapes.scan.v1",
+      "support": "supported",
+      "support_refs": ["participant-implementations.script.scan"],
+      "affordance_refs": [],
+      "realization_refs": ["realizations.script.v1"]
+    }
+  ],
+  "affordance_refs": [],
+  "form": {
+    "surface_form": "constrained_form",
+    "selection_meaning_ref": "selection-meaning.form.v1",
+    "action_entry_id": "participant.action-contract.scan",
+    "argument_shape_ref": "selection-shapes.scan.v1",
+    "validation_policy_ref": "validation-policies.sem220.v1",
+    "constraint_refs": ["forms.scan.constraints.v1"],
+    "default_disclosure_refs": ["forms.scan.defaults.v1"],
+    "normalization_disclosure_refs": ["forms.scan.normalization.v1"],
+    "omission_disclosure_refs": ["forms.scan.omission.v1"]
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.script.order-4"],
+  "marking_definition_refs": [],
+  "redaction_policy_ref": null,
+  "semantic_limitations": ["invalid fixture"]
+}

--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/human-candidate.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/human-candidate.json
@@ -1,0 +1,45 @@
+{
+  "surface_id": "decision-surfaces.red.human.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.human.v1",
+  "decision_control_mode": "human-supervised",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [
+    {
+      "entry_id": "participant.action-contract.scan",
+      "action_contract_address": "participant.action-contract.scan",
+      "presentation_basis_ref": "projection-policy.red.v1",
+      "visibility": "observable",
+      "eligibility": "ineligible",
+      "eligibility_reason_refs": ["sem211.precondition.authority.out-of-scope"],
+      "constraint_refs": ["participant.action-contract.scan.preconditions"],
+      "selection_shape_ref": "selection-shapes.scan.v1",
+      "support": "supported",
+      "support_refs": ["participant-implementations.human-proxy.scan"],
+      "affordance_refs": ["participant.behavior-specification.red-surface.tool-affordance.scanner"],
+      "realization_refs": ["realizations.human-proxy.v1"]
+    }
+  ],
+  "affordance_refs": ["participant.behavior-specification.red-surface.tool-affordance.scanner"],
+  "form": {
+    "surface_form": "candidate_action_set",
+    "selection_meaning_ref": "selection-meaning.candidate.v1",
+    "candidate_entry_ids": ["participant.action-contract.scan"],
+    "open_extension_binding_ref": null
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.human.order-4"],
+  "marking_definition_refs": ["markings.participant-visible.v1"],
+  "redaction_policy_ref": "redaction.red.v1",
+  "semantic_limitations": ["Candidate membership does not imply eligibility or admission"]
+}

--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/llm-open.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/llm-open.json
@@ -1,0 +1,47 @@
+{
+  "surface_id": "decision-surfaces.red.llm.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.llm-agent.v1",
+  "decision_control_mode": "autonomous",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [
+    {
+      "entry_id": "participant.action-contract.scan",
+      "action_contract_address": "participant.action-contract.scan",
+      "presentation_basis_ref": "projection-policy.red.v1",
+      "visibility": "observable",
+      "eligibility": "eligible",
+      "eligibility_reason_refs": [],
+      "constraint_refs": ["participant.action-contract.scan.preconditions"],
+      "selection_shape_ref": "selection-shapes.scan.v1",
+      "support": "supported",
+      "support_refs": ["participant-implementations.llm-agent.scan"],
+      "affordance_refs": [],
+      "realization_refs": ["realizations.llm-agent.v1"]
+    }
+  ],
+  "affordance_refs": [],
+  "form": {
+    "surface_form": "open_ended_generation",
+    "selection_meaning_ref": "selection-meaning.open.v1",
+    "proposal_binding_ref": "proposal-bindings.governed-action.v1",
+    "argument_shape_ref": "selection-shapes.scan.v1",
+    "validation_policy_ref": "validation-policies.sem220.v1",
+    "allowed_action_contract_addresses": ["participant.action-contract.scan"]
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.llm.order-4"],
+  "marking_definition_refs": ["markings.participant-visible.v1"],
+  "redaction_policy_ref": "redaction.red.v1",
+  "semantic_limitations": ["Generated proposals require governed shape validation and independent admission"]
+}

--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/rl-candidate.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/rl-candidate.json
@@ -1,0 +1,45 @@
+{
+  "surface_id": "decision-surfaces.red.rl.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.rl-agent.v1",
+  "decision_control_mode": "autonomous",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [
+    {
+      "entry_id": "participant.action-contract.scan",
+      "action_contract_address": "participant.action-contract.scan",
+      "presentation_basis_ref": "projection-policy.red.v1",
+      "visibility": "observable",
+      "eligibility": "eligible",
+      "eligibility_reason_refs": [],
+      "constraint_refs": ["participant.action-contract.scan.preconditions"],
+      "selection_shape_ref": "selection-shapes.scan.v1",
+      "support": "supported",
+      "support_refs": ["participant-implementations.rl-agent.scan"],
+      "affordance_refs": [],
+      "realization_refs": ["realizations.rl-agent.v1"]
+    }
+  ],
+  "affordance_refs": [],
+  "form": {
+    "surface_form": "candidate_action_set",
+    "selection_meaning_ref": "selection-meaning.candidate.v1",
+    "candidate_entry_ids": ["participant.action-contract.scan"],
+    "open_extension_binding_ref": null
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.rl.order-4"],
+  "marking_definition_refs": ["markings.participant-visible.v1"],
+  "redaction_policy_ref": "redaction.red.v1",
+  "semantic_limitations": ["RL realization changes apparatus only, not action or selection meaning"]
+}

--- a/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/script-form.json
+++ b/contracts/fixtures/control-plane/participant-decision-surface-v1/valid/script-form.json
@@ -1,0 +1,51 @@
+{
+  "surface_id": "decision-surfaces.red.script.order-4",
+  "participant_address": "participant.behavior.red-agent",
+  "episode_id": "episode-1",
+  "observation_point": "behavior-history:4",
+  "observation_order": 4,
+  "behavior_specification_address": "participant.behavior-specification.red-surface",
+  "observation_boundary_address": "participant.observation-boundary.red-view",
+  "context_view_ref": "context-views.red.episode-1.order-4",
+  "implementation_selection_ref": "participant-selections.red.script.v1",
+  "decision_control_mode": "scripted",
+  "projection_policy_ref": "projection-policy.red.v1",
+  "projection_policy_revision": "1",
+  "exposure_policy_ref": "exposure-policy.red.v1",
+  "visibility_projection_ref": "visibility-projection.red.order-4",
+  "visible_context_refs": ["context.public"],
+  "action_entries": [
+    {
+      "entry_id": "participant.action-contract.scan",
+      "action_contract_address": "participant.action-contract.scan",
+      "presentation_basis_ref": "projection-policy.red.v1",
+      "visibility": "observable",
+      "eligibility": "eligible",
+      "eligibility_reason_refs": [],
+      "constraint_refs": ["participant.action-contract.scan.preconditions"],
+      "selection_shape_ref": "selection-shapes.scan.v1",
+      "support": "supported",
+      "support_refs": ["participant-implementations.script.scan"],
+      "affordance_refs": [],
+      "realization_refs": ["realizations.script.v1"]
+    }
+  ],
+  "affordance_refs": [],
+  "form": {
+    "surface_form": "constrained_form",
+    "selection_meaning_ref": "selection-meaning.form.v1",
+    "action_entry_id": "participant.action-contract.scan",
+    "argument_shape_ref": "selection-shapes.scan.v1",
+    "validation_policy_ref": "validation-policies.sem220.v1",
+    "constraint_refs": ["forms.scan.constraints.v1"],
+    "default_disclosure_refs": ["forms.scan.defaults.v1"],
+    "normalization_disclosure_refs": ["forms.scan.normalization.v1"],
+    "omission_disclosure_refs": ["forms.scan.omission.v1"],
+    "loss_disclosure_refs": ["forms.scan.loss.none.v1"]
+  },
+  "evidence_refs": ["evidence.surface.red.order-4"],
+  "provenance_refs": ["provenance.surface.red.script.order-4"],
+  "marking_definition_refs": ["markings.participant-visible.v1"],
+  "redaction_policy_ref": "redaction.red.v1",
+  "semantic_limitations": ["Form presentation does not imply selection, admission, or outcome"]
+}

--- a/contracts/schema-publication/entries/participant-decision-surface-v1.json
+++ b/contracts/schema-publication/entries/participant-decision-surface-v1.json
@@ -1,0 +1,10 @@
+{
+  "contract_id": "participant-decision-surface-v1",
+  "schema_path": "contracts/schemas/control-plane/participant-decision-surface-v1.json",
+  "stability": "draft",
+  "content_hash": "5cd19386eec34eb5cfaa70f65c441ecfc743f1637a874dcecb62e02f7f59eee0",
+  "last_change": {
+    "summary": "Initial publication of the SEM-220 participant-local decision-surface payload with discriminated open-ended, constrained-form, and candidate-set selection meaning; explicit visibility, eligibility, constraint, support, evidence, provenance, and lifecycle-separation invariants.",
+    "content_hash": "5cd19386eec34eb5cfaa70f65c441ecfc743f1637a874dcecb62e02f7f59eee0"
+  }
+}

--- a/contracts/schemas/control-plane/participant-decision-surface-v1.json
+++ b/contracts/schemas/control-plane/participant-decision-surface-v1.json
@@ -1,0 +1,569 @@
+{
+  "$defs": {
+    "ParticipantDecisionSurfaceActionEntryModel": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "eligibility": {
+                "enum": [
+                  "ineligible",
+                  "unknown",
+                  "unsupported"
+                ]
+              }
+            },
+            "required": [
+              "eligibility"
+            ]
+          },
+          "then": {
+            "properties": {
+              "eligibility_reason_refs": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "support": {
+                "const": "supported"
+              }
+            },
+            "required": [
+              "support"
+            ]
+          },
+          "then": {
+            "properties": {
+              "support_refs": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
+      "description": "One presented or generable action without lifecycle implications.",
+      "properties": {
+        "action_contract_address": {
+          "minLength": 1,
+          "title": "Action Contract Address",
+          "type": "string"
+        },
+        "affordance_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Affordance Refs",
+          "type": "array"
+        },
+        "constraint_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Constraint Refs",
+          "type": "array"
+        },
+        "eligibility": {
+          "enum": [
+            "eligible",
+            "ineligible",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Eligibility",
+          "type": "string"
+        },
+        "eligibility_reason_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Eligibility Reason Refs",
+          "type": "array"
+        },
+        "entry_id": {
+          "minLength": 1,
+          "title": "Entry Id",
+          "type": "string"
+        },
+        "presentation_basis_ref": {
+          "minLength": 1,
+          "title": "Presentation Basis Ref",
+          "type": "string"
+        },
+        "realization_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Realization Refs",
+          "type": "array"
+        },
+        "selection_shape_ref": {
+          "minLength": 1,
+          "title": "Selection Shape Ref",
+          "type": "string"
+        },
+        "support": {
+          "enum": [
+            "supported",
+            "unsupported",
+            "unknown"
+          ],
+          "title": "Support",
+          "type": "string"
+        },
+        "support_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Support Refs",
+          "type": "array"
+        },
+        "visibility": {
+          "enum": [
+            "observable",
+            "discovered",
+            "inferred",
+            "disclosed",
+            "deceptive"
+          ],
+          "title": "Visibility",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entry_id",
+        "action_contract_address",
+        "presentation_basis_ref",
+        "visibility",
+        "eligibility",
+        "constraint_refs",
+        "selection_shape_ref",
+        "support"
+      ],
+      "title": "ParticipantDecisionSurfaceActionEntryModel",
+      "type": "object"
+    },
+    "ParticipantDecisionSurfaceCandidateSetFormModel": {
+      "additionalProperties": false,
+      "properties": {
+        "candidate_entry_ids": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Candidate Entry Ids",
+          "type": "array"
+        },
+        "open_extension_binding_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Open Extension Binding Ref"
+        },
+        "selection_meaning_ref": {
+          "minLength": 1,
+          "title": "Selection Meaning Ref",
+          "type": "string"
+        },
+        "surface_form": {
+          "const": "candidate_action_set",
+          "title": "Surface Form",
+          "type": "string"
+        }
+      },
+      "required": [
+        "surface_form",
+        "selection_meaning_ref",
+        "candidate_entry_ids"
+      ],
+      "title": "ParticipantDecisionSurfaceCandidateSetFormModel",
+      "type": "object"
+    },
+    "ParticipantDecisionSurfaceConstrainedFormModel": {
+      "additionalProperties": false,
+      "properties": {
+        "action_entry_id": {
+          "minLength": 1,
+          "title": "Action Entry Id",
+          "type": "string"
+        },
+        "argument_shape_ref": {
+          "minLength": 1,
+          "title": "Argument Shape Ref",
+          "type": "string"
+        },
+        "constraint_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Constraint Refs",
+          "type": "array"
+        },
+        "default_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Default Disclosure Refs",
+          "type": "array"
+        },
+        "loss_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss Disclosure Refs",
+          "type": "array"
+        },
+        "normalization_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Normalization Disclosure Refs",
+          "type": "array"
+        },
+        "omission_disclosure_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Omission Disclosure Refs",
+          "type": "array"
+        },
+        "selection_meaning_ref": {
+          "minLength": 1,
+          "title": "Selection Meaning Ref",
+          "type": "string"
+        },
+        "surface_form": {
+          "const": "constrained_form",
+          "title": "Surface Form",
+          "type": "string"
+        },
+        "validation_policy_ref": {
+          "minLength": 1,
+          "title": "Validation Policy Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "surface_form",
+        "selection_meaning_ref",
+        "action_entry_id",
+        "argument_shape_ref",
+        "validation_policy_ref",
+        "constraint_refs",
+        "default_disclosure_refs",
+        "normalization_disclosure_refs",
+        "omission_disclosure_refs",
+        "loss_disclosure_refs"
+      ],
+      "title": "ParticipantDecisionSurfaceConstrainedFormModel",
+      "type": "object"
+    },
+    "ParticipantDecisionSurfaceOpenEndedFormModel": {
+      "additionalProperties": false,
+      "properties": {
+        "allowed_action_contract_addresses": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Allowed Action Contract Addresses",
+          "type": "array"
+        },
+        "argument_shape_ref": {
+          "minLength": 1,
+          "title": "Argument Shape Ref",
+          "type": "string"
+        },
+        "proposal_binding_ref": {
+          "minLength": 1,
+          "title": "Proposal Binding Ref",
+          "type": "string"
+        },
+        "selection_meaning_ref": {
+          "minLength": 1,
+          "title": "Selection Meaning Ref",
+          "type": "string"
+        },
+        "surface_form": {
+          "const": "open_ended_generation",
+          "title": "Surface Form",
+          "type": "string"
+        },
+        "validation_policy_ref": {
+          "minLength": 1,
+          "title": "Validation Policy Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "surface_form",
+        "selection_meaning_ref",
+        "proposal_binding_ref",
+        "argument_shape_ref",
+        "validation_policy_ref",
+        "allowed_action_contract_addresses"
+      ],
+      "title": "ParticipantDecisionSurfaceOpenEndedFormModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://aces.dev/schemas/participant-decision-surface-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One participant-local decision projection at one episode order point.",
+  "properties": {
+    "action_entries": {
+      "items": {
+        "$ref": "#/$defs/ParticipantDecisionSurfaceActionEntryModel"
+      },
+      "minItems": 1,
+      "title": "Action Entries",
+      "type": "array"
+    },
+    "affordance_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Affordance Refs",
+      "type": "array"
+    },
+    "behavior_specification_address": {
+      "minLength": 1,
+      "title": "Behavior Specification Address",
+      "type": "string"
+    },
+    "context_view_ref": {
+      "minLength": 1,
+      "title": "Context View Ref",
+      "type": "string"
+    },
+    "decision_control_mode": {
+      "minLength": 1,
+      "title": "Decision Control Mode",
+      "type": "string"
+    },
+    "episode_id": {
+      "minLength": 1,
+      "title": "Episode Id",
+      "type": "string"
+    },
+    "evidence_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Evidence Refs",
+      "type": "array"
+    },
+    "exposure_policy_ref": {
+      "minLength": 1,
+      "title": "Exposure Policy Ref",
+      "type": "string"
+    },
+    "form": {
+      "discriminator": {
+        "mapping": {
+          "candidate_action_set": "#/$defs/ParticipantDecisionSurfaceCandidateSetFormModel",
+          "constrained_form": "#/$defs/ParticipantDecisionSurfaceConstrainedFormModel",
+          "open_ended_generation": "#/$defs/ParticipantDecisionSurfaceOpenEndedFormModel"
+        },
+        "propertyName": "surface_form"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/ParticipantDecisionSurfaceOpenEndedFormModel"
+        },
+        {
+          "$ref": "#/$defs/ParticipantDecisionSurfaceConstrainedFormModel"
+        },
+        {
+          "$ref": "#/$defs/ParticipantDecisionSurfaceCandidateSetFormModel"
+        }
+      ],
+      "title": "Form"
+    },
+    "implementation_selection_ref": {
+      "minLength": 1,
+      "title": "Implementation Selection Ref",
+      "type": "string"
+    },
+    "marking_definition_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "title": "Marking Definition Refs",
+      "type": "array"
+    },
+    "observation_boundary_address": {
+      "minLength": 1,
+      "title": "Observation Boundary Address",
+      "type": "string"
+    },
+    "observation_order": {
+      "minimum": 0,
+      "title": "Observation Order",
+      "type": "integer"
+    },
+    "observation_point": {
+      "minLength": 1,
+      "title": "Observation Point",
+      "type": "string"
+    },
+    "participant_address": {
+      "minLength": 1,
+      "title": "Participant Address",
+      "type": "string"
+    },
+    "projection_policy_ref": {
+      "minLength": 1,
+      "title": "Projection Policy Ref",
+      "type": "string"
+    },
+    "projection_policy_revision": {
+      "minLength": 1,
+      "title": "Projection Policy Revision",
+      "type": "string"
+    },
+    "provenance_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Provenance Refs",
+      "type": "array"
+    },
+    "redaction_policy_ref": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Redaction Policy Ref"
+    },
+    "semantic_limitations": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Semantic Limitations",
+      "type": "array"
+    },
+    "surface_id": {
+      "minLength": 1,
+      "title": "Surface Id",
+      "type": "string"
+    },
+    "visibility_projection_ref": {
+      "minLength": 1,
+      "title": "Visibility Projection Ref",
+      "type": "string"
+    },
+    "visible_context_refs": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Visible Context Refs",
+      "type": "array"
+    }
+  },
+  "required": [
+    "surface_id",
+    "participant_address",
+    "episode_id",
+    "observation_point",
+    "observation_order",
+    "behavior_specification_address",
+    "observation_boundary_address",
+    "context_view_ref",
+    "implementation_selection_ref",
+    "decision_control_mode",
+    "projection_policy_ref",
+    "projection_policy_revision",
+    "exposure_policy_ref",
+    "visibility_projection_ref",
+    "visible_context_refs",
+    "action_entries",
+    "form",
+    "evidence_refs",
+    "provenance_refs",
+    "semantic_limitations"
+  ],
+  "title": "ParticipantDecisionSurfaceModel",
+  "type": "object",
+  "x-aces-invariants": [
+    {
+      "description": "Candidate, constrained-form, and open-ended action references must resolve to action entries and their governed selection shapes.",
+      "id": "decision-surface-entry-reference-agreement",
+      "inputs": [
+        {
+          "contract_id": "participant-decision-surface-v1",
+          "instance_path": "#"
+        }
+      ],
+      "level": "error",
+      "validator": "aces_contracts.contracts.ParticipantDecisionSurfaceModel._validate_surface_relations"
+    },
+    {
+      "description": "Surface membership or presentation carries no selection, admission, execution, result, or outcome fact; those facts remain in their existing lifecycle contracts.",
+      "id": "decision-surface-presentation-not-lifecycle-evidence",
+      "inputs": [
+        {
+          "contract_id": "participant-decision-surface-v1",
+          "instance_path": "#"
+        }
+      ],
+      "level": "error",
+      "validator": "aces_contracts.contracts.ParticipantDecisionSurfaceModel"
+    }
+  ],
+  "x-aces-semantic-profile": {
+    "contract_id": "participant-decision-surface-v1",
+    "entry_schema_contract_id": "aces-semantic-invariants-v1",
+    "entry_schema_pointer": "#/$defs/AcesSemanticInvariantEntryModel",
+    "id": "aces-semantic-invariants-v1",
+    "keyword": "x-aces-invariants",
+    "required": true,
+    "uri": "https://aces.dev/schemas/semantic-invariants/v1"
+  }
+}

--- a/docs/decisions/issue-119-sem-219-220-226-participant-decision-surface-preflight.md
+++ b/docs/decisions/issue-119-sem-219-220-226-participant-decision-surface-preflight.md
@@ -139,19 +139,65 @@ Do not rename or overload `behavior_mode`,
 action lists, tool instances, prompts, instructions, observations, or policy
 bodies.
 
-### Reuse a view carrier before publishing another DTO
+### Issue #295 reuse verdict: keep the envelope, not the generic producer
 
-If later implementation needs a portable retrieval/exchange carrier, first test
-whether `ParticipantContextViewModel` can express it through participant and
-episode scope, observation point, governed source layers, transformation,
-`payload_ref`, visibility projection, markings, redaction policy, evidence,
-provenance, limitations, and comparability. Stable action-contract and
-affordance refs may remain referenced content rather than duplicated payloads.
+The current `ParticipantContextViewModel` passes the ADR-083 reuse-first test as
+the outer portable envelope. It already owns participant/episode scope,
+observation point, governed source layers, transformation, `payload_ref`,
+visibility projection, markings, redaction policy, evidence, provenance,
+limitations, and comparability. Issue #295 must reuse those fields rather than
+publish a second context/audience envelope.
 
-A new published decision-surface contract is justified only if an independently
-portable payload cannot be represented without weakening those context-view
-invariants. It must not duplicate action-contract, observation-boundary,
-exposure-policy, status/history-view, or participant implementation fields.
+The existing `ParticipantRetrievalMixin.get_participant_context_view()` producer
+does **not** pass the semantic-projection test for `D(p,e,o)`. It accepts
+caller-supplied `view_ref`, `derivation_basis_ref`, and `payload_ref`; permits
+an absent episode; substitutes an episode id or `runtime.snapshot.current` for an
+observation point; and projects the current snapshot without proving the
+effective view relation at an order/event anchor. It remains a valid generic
+API-408 reference-view producer, but issue #295 must not reuse it as proof of a
+time-indexed decision surface or allow query parameters to manufacture semantic
+refs.
+
+A single new closed decision-surface payload contract is therefore justified.
+`ParticipantContextViewModel.payload_ref` references that typed payload; it does
+not embed a free-form map. The payload must be independently portable and carry
+the required `D(p,e,o)` identity and surface facts, while a relational validator
+or projection boundary verifies that its participant, episode, observation/order
+point, derivation basis, visibility projection, evidence, and provenance agree
+with the enclosing context view. Cross-contract obligations that JSON Schema
+cannot express must use the existing `x-aces-invariants` convention. The payload
+composes stable action-contract, affordance, observation-boundary,
+implementation-selection, exposure-policy, evidence, and provenance refs; it
+must not duplicate the referenced contracts.
+
+The payload must use one discriminated surface-form union so open-ended,
+constrained-form, and candidate-set selection meaning cannot be combined into an
+ambiguous bag. Common surface and action-entry facts remain common; form-specific
+defaults, normalization, omission, loss, membership, and open-extension meaning
+live only on the applicable variant. These form values are not additions to
+`participant-decision-surface-modes`.
+
+Two current capability limits must remain explicit:
+
+- `participant_action_admission_request_violations()` validates
+  implementation selection, exposure-policy consistency, and result identity;
+  it does not evaluate every SEM-211 precondition and does not validate action
+  arguments. `ParticipantActionResult` and
+  `validate_participant_action_result_contract()` enforce reported SEM-211
+  precondition/effect/result consistency after an attempt. A surface must not
+  rename either fact as pre-selection eligibility. It needs an order-scoped,
+  fail-closed eligibility state with reason refs to the existing SEM-211
+  precondition classes, and every selection still enters the existing admission
+  path.
+- No governed participant-action argument/parameter schema exists in the current
+  action contract. Issue #295 must not claim argument-shape validation by using
+  arbitrary dictionaries, SDL variables, experiment parameters, backend
+  command shapes, or `ParticipantExposurePolicyModel.constraints`. The minimum
+  missing seam is a governed selection/argument-shape reference plus a resolver
+  that validates proposals before admission; unresolved shape, default,
+  normalization, omission, or loss meaning fails closed or is explicitly
+  `unsupported`/`unknown`. This seam maps selection to an existing action
+  contract and does not redefine that contract's action meaning.
 
 ## Required Incumbents
 
@@ -167,13 +213,18 @@ exposure-policy, status/history-view, or participant implementation fields.
 - Compiled semantic addresses: `ParticipantBehaviorRuntime`,
   `ParticipantBehaviorSpecificationRuntime`,
   `ParticipantActionContractRuntime`,
-  `ParticipantObservationBoundaryRuntime`, and the existing
-  `participant.*` address families produced by `aces_processor.compiler`.
+  `ParticipantObservationBoundaryRuntime`, `ParticipantToolAffordanceRuntime`,
+  and the existing `participant.*` address families produced by
+  `aces_processor.compiler`.
 - Visibility and audience projections: `ParticipantViewRule`,
   `ParticipantViewTransition`, `view_relation_timeline`,
+  `_compile_view_relation_timeline()`,
+  `_participant_behavior_observation_effective_relation()`,
   `ParticipantObservationEnvelopeModel`, `ParticipantContextViewModel`,
   `ParticipantStatusViewModel`, `ParticipantHistoryViewModel`, and the SEM-216
-  audience-boundary validators.
+  audience-boundary validators. The existing effective-relation logic is the
+  incumbent to expose/factor for reuse; a decision-surface projector must not
+  copy its transition ordering and anchor-resolution algorithm.
 - Apparatus and selection: `ParticipantImplementationManifestModel`,
   `ParticipantImplementationCapabilitiesModel`,
   `ParticipantImplementationSelectionModel`, `ParticipantExposurePolicyModel`,
@@ -181,13 +232,16 @@ exposure-policy, status/history-view, or participant implementation fields.
   `validate_experiment_apparatus_context_against_manifests()`, and
   `participant_action_admission_request_violations()`.
 - Runtime admission and evidence: `ParticipantActionAdmissionRequest`,
-  `RuntimeControlPlane`, `ParticipantRuntime.admit_action()`,
+  `participant_action_admission_request_violations()`, `RuntimeControlPlane`,
+  `ParticipantRuntime.admit_action()`, `ParticipantActionPreconditionResult`,
+  `ParticipantActionResult`, `validate_participant_action_result_contract()`,
   `ParticipantBehaviorHistoryEventModel`, `ParticipantActionResultModel`,
   `RuntimeSnapshot`, participant episode/behavior/history validators,
   shared-state and concurrency validators, and runtime conformance diagnostics.
 - Contract and concept authority: `ContractModel`, `schema_bundle()`,
   `contracts/schemas/`, `contracts/fixtures/`,
   `contracts/schema-publication-manifest.json`,
+  `contracts/schema-publication/entries/`,
   `controlled-vocabularies-v1`, concept bindings,
   `validate_controlled_vocabulary_scope_values()`, and governed
   `x-<owner>:<term>` extensions.
@@ -200,14 +254,21 @@ exposure-policy, status/history-view, or participant implementation fields.
 - Verification patterns: the existing participant semantic invariant oracle,
   SEM-208/210 and SEM-216 negative leakage tests, participant-manifest fixtures,
   participant-backend contract fixtures, control-plane authorization tests,
-  runtime snapshot/conformance tests, and controlled-vocabulary tests.
+  runtime snapshot/conformance tests, RUN-306 lifecycle separation tests, and
+  controlled-vocabulary tests. Human, script, LLM, and RL fixtures reuse stable
+  semantic refs: LLM/RL are realization variants of the governed `agent`
+  implementation kind, not new action or surface semantics.
 - Repository policy: `.ground-control.yaml`, `.gc/plan-rules.md`,
   `noxfile.py`, `tools/check_repo_policy.py`,
   `tools/check_requirement_governance.py`,
   `tools/check_concept_authority_governance.py`,
   `tools/check_generated_schemas.py`, `tools/check_schema_publication.py`,
   `tools/check_json_artifacts.py`, `tools/check_semantic_coverage.py`, and
-  `tools/verify_all.py`.
+  `tools/verify_all.py`. The participant section of `docs/explain/sdl/lineage.md`
+  records SEM-220's exact ACES mappings, delivery status, evidence, and
+  nonclaims. `contracts/provenance/sdl-lineage-ledger-v1.json` and
+  `docs/research/lineage/source-audit-2026-07-12.md` change only if implementation
+  changes a normative external derivation or compatibility claim.
 
 ## Cross-Cutting Layers
 
@@ -224,18 +285,26 @@ exposure-policy, status/history-view, or participant implementation fields.
 - **Contract/schema shape:** portable payloads must be closed `ContractModel`
   descendants and pass model plus JSON Schema validation. Published schema
   changes require normative schema review, reference `schema_bundle()` parity,
-  valid/invalid fixtures, a publication-manifest change-ledger entry, and
-  compatibility classification under ADR-061.
+  valid/invalid fixtures, a v2 record under
+  `contracts/schema-publication/entries/` with a current `last_change` hash, and
+  compatibility classification under ADR-061. Adding a contract to a backend,
+  processor, or participant-implementation support allowlist is a separate
+  capability claim and occurs only when that component really consumes or
+  produces the contract.
 - **Participant visibility:** every participant-visible item must resolve at the
   relevant observation/order point through the compiled observation boundary,
   `V_p,t` timeline, exposure policy, source-layer transformation, audience
   scope, marking, redaction policy, evidence/provenance basis, and any disclosed
-  weakening. Future visibility cannot justify earlier exposure.
+  weakening. Factor/reuse the effective-relation selector already embodied by
+  `_participant_behavior_observation_effective_relation()`; do not implement a
+  second timeline walk. Future visibility cannot justify earlier exposure.
 - **Action admission:** a visible action or affordance is not necessarily
   eligible. Any admission path must reuse compiled action-contract addresses and
   SEM-211 authority, capability, target, knowledge, resource, temporal,
   interaction, and realization checks, then emit existing behavior-history and
-  action-result records.
+  action-result records. `ParticipantAdmissionDisposition` describes an
+  admission decision, not candidate eligibility, and the current admission
+  request helper is not an argument or full-precondition validator.
 - **Apparatus and provenance:** manifest support, selected mode, configuration
   ref/digest, and exposure policy must validate through the existing participant
   implementation and experiment apparatus/run models. Capability claims do not
@@ -246,7 +315,10 @@ exposure-policy, status/history-view, or participant implementation fields.
   bearer/proxy identity validation, read-versus-mutating role dependencies,
   target binding, request-size limits, idempotency/request fingerprints for
   mutations, and audit recording. Participant authority, surface visibility,
-  and control-plane caller authorization remain three different checks.
+  and control-plane caller authorization remain three different checks. Issue
+  #295 requires no new HTTP endpoint; if the existing context route later
+  returns a decision-surface ref, authenticated caller-supplied query values
+  must never become the surface's semantic or derivation authority.
 - **Secret handling and error envelopes:** credentials, bearer tokens, private
   keys, hidden prompts, answer keys, canaries, raw policy/configuration bodies,
   raw evidence payloads, environment dumps, backend-native object reprs, and
@@ -268,8 +340,12 @@ exposure-policy, status/history-view, or participant implementation fields.
   archival claims remain in participant implementation and experiment-run
   provenance contracts. Reuse behavior history, observation envelopes,
   diagnostics, audit events, and evidence records for observability. Do not add
-  a decision-surface store, cache, audit channel, log schema, or metadata/details
-  side channel, and do not treat raw logs as participant-visible evidence.
+  a decision-surface store, authoritative current-surface cache, audit channel,
+  log schema, or metadata/details side channel, and do not treat raw logs as
+  participant-visible evidence. Historical claims must remain derivable from or
+  referenced by the existing time-indexed behavior/visibility history and
+  evidence; a final `RuntimeSnapshot` projection alone cannot prove an earlier
+  surface after exposure changed.
 - **Package and policy boundary:** authored semantics stay in `aces_sdl`,
   compiled projections in `aces_processor`, neutral DTOs in `aces_contracts`,
   live control/persistence/security in `aces_runtime`, protocols in
@@ -283,7 +359,9 @@ backend-specific runner or UI model. Its semantic inputs are:
 
 - participant address and episode id;
 - observation/order point and time/clock basis where relevant;
+- surface form, projection-policy ref/revision, and selection-meaning ref;
 - behavior-specification and action-contract refs;
+- governed selection/argument-shape and constraint refs;
 - observation-boundary/view-relation ref;
 - participant implementation selection and decision-control mode;
 - exposure-policy ref/version/digest and realized affordance refs;
@@ -293,7 +371,10 @@ The next reasonable variants should fit by changing those parameters: another
 participant implementation, a per-phase surface, a new governed affordance
 category, a weaker backend realization, or another audience projection. A
 per-phase or per-action surface should add an explicit selection-context
-parameter, not overload the mode vocabulary or fork the visibility model.
+parameter, not overload the mode vocabulary or fork the visibility model. The
+order-relative view selector must remain one shared incumbent used by behavior
+history validation and surface projection, so a new clock/order basis extends
+one selector rather than creating divergent visibility algorithms.
 
 ## Gotchas And Anti-Patterns
 
@@ -307,6 +388,13 @@ Avoid:
   interaction topology, authority, or control-plane permission;
 - treating a visible action as currently applicable, authorized, supported, or
   successfully admitted;
+- treating `ParticipantAdmissionDisposition` or a successful historical
+  `ParticipantActionResult` as the candidate's pre-selection eligibility state;
+- treating `participant_action_admission_request_violations()` as argument-shape
+  validation or as the complete SEM-211 applicability evaluator;
+- treating caller-supplied `view_ref`, `payload_ref`, an episode id, or
+  `runtime.snapshot.current` from the generic context-view producer as a proved
+  decision-surface order/derivation anchor;
 - treating network reachability, `operating_scope`, backend sandboxing, control
   plane authorization, and information visibility as equivalent boundaries;
 - collapsing `hidden`, `withheld`, `evidence_only`, `concealed`, `unsupported`,
@@ -318,6 +406,12 @@ Avoid:
   participant decision surface;
 - turning `ParticipantExposurePolicyModel.constraints`, snapshot `metadata`,
   history `details`, audit details, or logs into an untyped policy/surface bag;
+- placing raw proposal arguments, JSON Schema bodies, form defaults,
+  normalization rules, or lossy mappings in those bags instead of resolving a
+  governed selection-shape reference;
+- adding `llm`, `rl`, or UI-specific participant semantics when the existing
+  `agent`, `human-control-proxy`, `script`, decision-control mode, configuration,
+  provenance, and realization disclosures already express the variation;
 - duplicating action, affordance, visibility, exposure, mode, failure, or
   support vocabularies in Python, schemas, docs, CLI, API, or backend code;
 - adding a second DTO layer, schema registry, validator stack, exception
@@ -334,6 +428,10 @@ Avoid:
   fixtures, APIs, adapters, storage, conformance, or tests in this preflight.
 - Designing a participant UI, agent framework, shell/RPC protocol, generic tool
   runner, prompt format, policy engine, credential broker, or OS sandbox.
+- Designing a general action-parameter language or changing governed action
+  meaning. SEM-220 owns the minimum selection/argument-shape binding needed to
+  map a surface choice to an existing action contract; it does not turn UI,
+  prompt, command, or backend-native schemas into action authority.
 - Replacing participant action contracts, SEM-210 visibility, SEM-211
   applicability/failure, SEM-214 context views, SEM-216 audience boundaries,
   participant implementation provenance, or backend feature support.

--- a/docs/explain/sdl/lineage.md
+++ b/docs/explain/sdl/lineage.md
@@ -843,6 +843,34 @@ which dynamic queue/log/config details remain evidence or bounded settings.
   or evidence merely from authored presence. The lineage ledger and source
   audit remain unchanged because this implementation adds no normative
   external derivation or compatibility claim.
+- SEM-220's executable participant decision surface adopts the existing
+  action/observation-interface lineage above without importing a UI, prompt,
+  command, or backend-native parameter language. ACES maps one participant,
+  episode, and behavior-history order point to
+  `ParticipantDecisionSurfaceModel`; maps the three portable selection forms
+  to its discriminated open-ended, constrained-form, and candidate-set
+  payloads; maps governed action meaning to compiled
+  `ParticipantActionContractRuntime` addresses; maps participant-local
+  presentation to the shared observation-boundary effective-view selector;
+  maps candidate applicability to explicit SEM-211 eligibility state and
+  reason refs; maps apparatus variation to implementation-selection, support,
+  and realization refs; and maps a chosen proposal through governed
+  argument-shape resolution before the existing
+  `ParticipantActionAdmissionRequest` path. Delivery is implemented for the
+  published closed contract and fixtures, compiled-runtime projection,
+  context-envelope agreement, proposal binding, runtime admission routing,
+  schema publication, and adversarial ordering/bypass checks. Evidence is
+  `participant-decision-surface-v1`, `project_participant_decision_surface()`,
+  `bind_participant_decision_surface_selection()`, and
+  `implementations/python/tests/test_sem_220_participant_decision_surface.py`.
+  Human proxy, script, LLM-agent, and RL-agent fixtures retain identical stable
+  action and selection-meaning refs while disclosing apparatus differences.
+  This mapping does not claim that presentation proves eligibility, selection,
+  admission, execution, result, outcome, historical exposure from a final
+  snapshot, backend support, UI behavior, prompt semantics, or complete
+  SEM-211 precondition evaluation. The lineage ledger and source audit remain
+  unchanged because the implementation adds no normative external derivation
+  or compatibility claim.
 - CALDERA adversary-emulation research informs the action semantics: cyber
   actions can change foothold, knowledge, observations, detection surface, and
   downstream outcomes under uncertainty.

--- a/implementations/python/packages/aces_contracts/contracts/__init__.py
+++ b/implementations/python/packages/aces_contracts/contracts/__init__.py
@@ -182,6 +182,15 @@ from .manifests import (
     ProcessorManifestV2Model,
 )
 from .participant_context import ParticipantContextViewModel
+from .participant_decision_surface import (
+    ParticipantDecisionSurfaceActionEntryModel,
+    ParticipantDecisionSurfaceCandidateSetFormModel,
+    ParticipantDecisionSurfaceConstrainedFormModel,
+    ParticipantDecisionSurfaceModel,
+    ParticipantDecisionSurfaceOpenEndedFormModel,
+    ParticipantDecisionSurfaceSelectionModel,
+    validate_participant_decision_surface_context,
+)
 from .participant_envelopes import (
     EventClassificationModel,
     ParticipantJointActionAccessSetModel,
@@ -338,7 +347,11 @@ __all__ = [
     "ParticipantActionPreconditionResultModel", "ParticipantActionResultModel",
     "ParticipantAttributionCandidateModel", "ParticipantAttributionEdgeModel",
     "ParticipantAttributionEvidenceBasisModel", "ParticipantAttributionOrderingBasisModel",
-    "ParticipantBehaviorHistoryEventModel", "ParticipantContextViewModel", "ParticipantEpisodeHistoryEventModel",
+    "ParticipantBehaviorHistoryEventModel", "ParticipantContextViewModel",
+    "ParticipantDecisionSurfaceActionEntryModel", "ParticipantDecisionSurfaceCandidateSetFormModel",
+    "ParticipantDecisionSurfaceConstrainedFormModel", "ParticipantDecisionSurfaceModel",
+    "ParticipantDecisionSurfaceOpenEndedFormModel", "ParticipantDecisionSurfaceSelectionModel",
+    "validate_participant_decision_surface_context", "ParticipantEpisodeHistoryEventModel",
     "ParticipantEpisodeStateModel", "ParticipantExposurePolicyModel", "ParticipantFeatureSupportLevel",
     "ParticipantFeatureSupportModel", "ParticipantHistoryViewBehaviorEventModel",
     "ParticipantHistoryViewEpisodeEventModel", "ParticipantHistoryViewModel",

--- a/implementations/python/packages/aces_contracts/contracts/bundle.py
+++ b/implementations/python/packages/aces_contracts/contracts/bundle.py
@@ -31,6 +31,7 @@ from .experiment_run import ExperimentRunModel
 from .experiment_spec import ExperimentSpecModel, ExperimentStudyModel
 from .manifests import ProcessorManifestV2Model
 from .participant_context import ParticipantContextViewModel
+from .participant_decision_surface import ParticipantDecisionSurfaceModel
 from .participant_envelopes import (
     ParticipantJointActionRecordModel,
     ParticipantLifecycleEventModel,
@@ -168,6 +169,7 @@ def _raw_schema_bundle() -> dict[str, dict[str, Any]]:
         "participant-status-view-v1": ParticipantStatusViewModel.model_json_schema(),
         "participant-history-view-v1": ParticipantHistoryViewModel.model_json_schema(),
         "participant-context-view-v1": ParticipantContextViewModel.model_json_schema(),
+        "participant-decision-surface-v1": ParticipantDecisionSurfaceModel.model_json_schema(),
         "operation-receipt-v1": OperationReceiptModel.model_json_schema(),
         "operation-status-v1": OperationStatusModel.model_json_schema(),
         "associated-artifact-manifest-v1": AssociatedArtifactManifestModel.model_json_schema(),

--- a/implementations/python/packages/aces_contracts/contracts/participant_decision_surface.py
+++ b/implementations/python/packages/aces_contracts/contracts/participant_decision_surface.py
@@ -150,6 +150,83 @@ ParticipantDecisionSurfaceFormModel = Annotated[
 ]
 
 
+def _surface_entry_indexes(
+    entries: list[ParticipantDecisionSurfaceActionEntryModel],
+) -> tuple[
+    dict[str, ParticipantDecisionSurfaceActionEntryModel],
+    dict[str, ParticipantDecisionSurfaceActionEntryModel],
+]:
+    entries_by_id = {entry.entry_id: entry for entry in entries}
+    entries_by_address = {entry.action_contract_address: entry for entry in entries}
+    _require_unique([entry.entry_id for entry in entries], "action_entries.entry_id")
+    _require_unique(
+        [entry.action_contract_address for entry in entries],
+        "action_entries.action_contract_address",
+    )
+    return entries_by_id, entries_by_address
+
+
+def _validate_candidate_form_relations(
+    form: ParticipantDecisionSurfaceCandidateSetFormModel,
+    entries_by_id: dict[str, ParticipantDecisionSurfaceActionEntryModel],
+) -> None:
+    unknown = sorted(set(form.candidate_entry_ids) - entries_by_id.keys())
+    if unknown:
+        raise ValueError("candidate_entry_ids must reference action_entries: " + ", ".join(unknown))
+
+
+def _validate_constrained_form_relations(
+    form: ParticipantDecisionSurfaceConstrainedFormModel,
+    entries_by_id: dict[str, ParticipantDecisionSurfaceActionEntryModel],
+) -> None:
+    entry = entries_by_id.get(form.action_entry_id)
+    if entry is None:
+        raise ValueError("constrained form action_entry_id must reference action_entries")
+    if entry.selection_shape_ref != form.argument_shape_ref:
+        raise ValueError("constrained form argument_shape_ref must match the selected action entry")
+
+
+def _validate_open_ended_form_relations(
+    form: ParticipantDecisionSurfaceOpenEndedFormModel,
+    entries_by_address: dict[str, ParticipantDecisionSurfaceActionEntryModel],
+) -> None:
+    unknown = sorted(set(form.allowed_action_contract_addresses) - entries_by_address.keys())
+    if unknown:
+        raise ValueError(
+            "open-ended allowed_action_contract_addresses must reference action_entries: " + ", ".join(unknown)
+        )
+    mismatched = sorted(
+        address
+        for address in form.allowed_action_contract_addresses
+        if entries_by_address[address].selection_shape_ref != form.argument_shape_ref
+    )
+    if mismatched:
+        raise ValueError("open-ended argument_shape_ref must match allowed action entries: " + ", ".join(mismatched))
+
+
+def _validate_surface_form_relations(
+    form: ParticipantDecisionSurfaceFormModel,
+    entries_by_id: dict[str, ParticipantDecisionSurfaceActionEntryModel],
+    entries_by_address: dict[str, ParticipantDecisionSurfaceActionEntryModel],
+) -> None:
+    if isinstance(form, ParticipantDecisionSurfaceCandidateSetFormModel):
+        _validate_candidate_form_relations(form, entries_by_id)
+    elif isinstance(form, ParticipantDecisionSurfaceConstrainedFormModel):
+        _validate_constrained_form_relations(form, entries_by_id)
+    else:
+        _validate_open_ended_form_relations(form, entries_by_address)
+
+
+def _validate_surface_affordances(
+    affordance_refs: list[str],
+    entries: list[ParticipantDecisionSurfaceActionEntryModel],
+) -> None:
+    entry_affordances = {ref for entry in entries for ref in entry.affordance_refs}
+    unknown = sorted(set(affordance_refs) - entry_affordances)
+    if unknown:
+        raise ValueError("affordance_refs must be carried by action_entries: " + ", ".join(unknown))
+
+
 class ParticipantDecisionSurfaceModel(ContractModel):
     """One participant-local decision projection at one episode order point."""
 
@@ -188,42 +265,9 @@ class ParticipantDecisionSurfaceModel(ContractModel):
             "semantic_limitations",
         ):
             _require_unique(getattr(self, field_name), field_name)
-        entry_ids = [entry.entry_id for entry in self.action_entries]
-        _require_unique(entry_ids, "action_entries.entry_id")
-        action_addresses = [entry.action_contract_address for entry in self.action_entries]
-        _require_unique(action_addresses, "action_entries.action_contract_address")
-        entry_id_set = set(entry_ids)
-        action_address_set = set(action_addresses)
-        if isinstance(self.form, ParticipantDecisionSurfaceCandidateSetFormModel):
-            unknown = sorted(set(self.form.candidate_entry_ids) - entry_id_set)
-            if unknown:
-                raise ValueError("candidate_entry_ids must reference action_entries: " + ", ".join(unknown))
-        elif isinstance(self.form, ParticipantDecisionSurfaceConstrainedFormModel):
-            if self.form.action_entry_id not in entry_id_set:
-                raise ValueError("constrained form action_entry_id must reference action_entries")
-            entry = next(item for item in self.action_entries if item.entry_id == self.form.action_entry_id)
-            if entry.selection_shape_ref != self.form.argument_shape_ref:
-                raise ValueError("constrained form argument_shape_ref must match the selected action entry")
-        else:
-            unknown = sorted(set(self.form.allowed_action_contract_addresses) - action_address_set)
-            if unknown:
-                raise ValueError(
-                    "open-ended allowed_action_contract_addresses must reference action_entries: " + ", ".join(unknown)
-                )
-            mismatched = sorted(
-                entry.action_contract_address
-                for entry in self.action_entries
-                if entry.action_contract_address in self.form.allowed_action_contract_addresses
-                and entry.selection_shape_ref != self.form.argument_shape_ref
-            )
-            if mismatched:
-                raise ValueError(
-                    "open-ended argument_shape_ref must match allowed action entries: " + ", ".join(mismatched)
-                )
-        entry_affordances = {ref for entry in self.action_entries for ref in entry.affordance_refs}
-        unknown_affordances = sorted(set(self.affordance_refs) - entry_affordances)
-        if unknown_affordances:
-            raise ValueError("affordance_refs must be carried by action_entries: " + ", ".join(unknown_affordances))
+        entries_by_id, entries_by_address = _surface_entry_indexes(self.action_entries)
+        _validate_surface_form_relations(self.form, entries_by_id, entries_by_address)
+        _validate_surface_affordances(self.affordance_refs, self.action_entries)
         return self
 
     @classmethod

--- a/implementations/python/packages/aces_contracts/contracts/participant_decision_surface.py
+++ b/implementations/python/packages/aces_contracts/contracts/participant_decision_surface.py
@@ -1,0 +1,289 @@
+"""Portable SEM-220 participant decision-surface contracts."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field, GetJsonSchemaHandler, StrictInt, model_validator
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+
+from .base import ContractModel, NonEmptyString
+from .participant_context import ParticipantContextViewModel
+from .schema_invariants import _add_aces_invariant
+
+ParticipantDecisionSurfaceVisibility = Literal[
+    "observable",
+    "discovered",
+    "inferred",
+    "disclosed",
+    "deceptive",
+]
+ParticipantDecisionSurfaceEligibility = Literal["eligible", "ineligible", "unknown", "unsupported"]
+ParticipantDecisionSurfaceSupport = Literal["supported", "unsupported", "unknown"]
+
+
+def _require_unique(values: list[str], field_name: str) -> None:
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} must not contain duplicates")
+
+
+class ParticipantDecisionSurfaceActionEntryModel(ContractModel):
+    """One presented or generable action without lifecycle implications."""
+
+    entry_id: NonEmptyString
+    action_contract_address: NonEmptyString
+    presentation_basis_ref: NonEmptyString
+    visibility: ParticipantDecisionSurfaceVisibility
+    eligibility: ParticipantDecisionSurfaceEligibility
+    eligibility_reason_refs: list[NonEmptyString] = Field(default_factory=list)
+    constraint_refs: list[NonEmptyString] = Field(min_length=1)
+    selection_shape_ref: NonEmptyString
+    support: ParticipantDecisionSurfaceSupport
+    support_refs: list[NonEmptyString] = Field(default_factory=list)
+    affordance_refs: list[NonEmptyString] = Field(default_factory=list)
+    realization_refs: list[NonEmptyString] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_entry_facts(self) -> ParticipantDecisionSurfaceActionEntryModel:
+        for field_name in (
+            "eligibility_reason_refs",
+            "constraint_refs",
+            "support_refs",
+            "affordance_refs",
+            "realization_refs",
+        ):
+            _require_unique(getattr(self, field_name), field_name)
+        if self.eligibility != "eligible" and not self.eligibility_reason_refs:
+            raise ValueError("eligibility_reason_refs are required unless eligibility is eligible")
+        if self.eligibility == "eligible" and self.eligibility_reason_refs:
+            raise ValueError("eligible action entries must not carry eligibility_reason_refs")
+        if self.support == "supported" and not self.support_refs:
+            raise ValueError("support_refs are required when support is supported")
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.setdefault("allOf", []).extend(
+            [
+                {
+                    "if": {
+                        "properties": {"eligibility": {"enum": ["ineligible", "unknown", "unsupported"]}},
+                        "required": ["eligibility"],
+                    },
+                    "then": {"properties": {"eligibility_reason_refs": {"minItems": 1}}},
+                },
+                {
+                    "if": {
+                        "properties": {"support": {"const": "supported"}},
+                        "required": ["support"],
+                    },
+                    "then": {"properties": {"support_refs": {"minItems": 1}}},
+                },
+            ]
+        )
+        return json_schema
+
+
+class ParticipantDecisionSurfaceOpenEndedFormModel(ContractModel):
+    surface_form: Literal["open_ended_generation"]
+    selection_meaning_ref: NonEmptyString
+    proposal_binding_ref: NonEmptyString
+    argument_shape_ref: NonEmptyString
+    validation_policy_ref: NonEmptyString
+    allowed_action_contract_addresses: list[NonEmptyString] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_allowed_actions(self) -> ParticipantDecisionSurfaceOpenEndedFormModel:
+        _require_unique(self.allowed_action_contract_addresses, "allowed_action_contract_addresses")
+        return self
+
+
+class ParticipantDecisionSurfaceConstrainedFormModel(ContractModel):
+    surface_form: Literal["constrained_form"]
+    selection_meaning_ref: NonEmptyString
+    action_entry_id: NonEmptyString
+    argument_shape_ref: NonEmptyString
+    validation_policy_ref: NonEmptyString
+    constraint_refs: list[NonEmptyString] = Field(min_length=1)
+    default_disclosure_refs: list[NonEmptyString] = Field(min_length=1)
+    normalization_disclosure_refs: list[NonEmptyString] = Field(min_length=1)
+    omission_disclosure_refs: list[NonEmptyString] = Field(min_length=1)
+    loss_disclosure_refs: list[NonEmptyString] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_mapping_disclosures(self) -> ParticipantDecisionSurfaceConstrainedFormModel:
+        for field_name in (
+            "constraint_refs",
+            "default_disclosure_refs",
+            "normalization_disclosure_refs",
+            "omission_disclosure_refs",
+            "loss_disclosure_refs",
+        ):
+            _require_unique(getattr(self, field_name), field_name)
+        return self
+
+
+class ParticipantDecisionSurfaceCandidateSetFormModel(ContractModel):
+    surface_form: Literal["candidate_action_set"]
+    selection_meaning_ref: NonEmptyString
+    candidate_entry_ids: list[NonEmptyString] = Field(min_length=1)
+    open_extension_binding_ref: NonEmptyString | None = None
+
+    @model_validator(mode="after")
+    def _validate_candidate_ids(self) -> ParticipantDecisionSurfaceCandidateSetFormModel:
+        _require_unique(self.candidate_entry_ids, "candidate_entry_ids")
+        return self
+
+
+ParticipantDecisionSurfaceFormModel = Annotated[
+    ParticipantDecisionSurfaceOpenEndedFormModel
+    | ParticipantDecisionSurfaceConstrainedFormModel
+    | ParticipantDecisionSurfaceCandidateSetFormModel,
+    Field(discriminator="surface_form"),
+]
+
+
+class ParticipantDecisionSurfaceModel(ContractModel):
+    """One participant-local decision projection at one episode order point."""
+
+    surface_id: NonEmptyString
+    participant_address: NonEmptyString
+    episode_id: NonEmptyString
+    observation_point: NonEmptyString
+    observation_order: StrictInt = Field(ge=0)
+    behavior_specification_address: NonEmptyString
+    observation_boundary_address: NonEmptyString
+    context_view_ref: NonEmptyString
+    implementation_selection_ref: NonEmptyString
+    decision_control_mode: NonEmptyString
+    projection_policy_ref: NonEmptyString
+    projection_policy_revision: NonEmptyString
+    exposure_policy_ref: NonEmptyString
+    visibility_projection_ref: NonEmptyString
+    visible_context_refs: list[NonEmptyString] = Field(min_length=1)
+    action_entries: list[ParticipantDecisionSurfaceActionEntryModel] = Field(min_length=1)
+    affordance_refs: list[NonEmptyString] = Field(default_factory=list)
+    form: ParticipantDecisionSurfaceFormModel
+    evidence_refs: list[NonEmptyString] = Field(min_length=1)
+    provenance_refs: list[NonEmptyString] = Field(min_length=1)
+    marking_definition_refs: list[NonEmptyString] = Field(default_factory=list)
+    redaction_policy_ref: NonEmptyString | None = None
+    semantic_limitations: list[NonEmptyString] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_surface_relations(self) -> ParticipantDecisionSurfaceModel:
+        for field_name in (
+            "visible_context_refs",
+            "affordance_refs",
+            "evidence_refs",
+            "provenance_refs",
+            "marking_definition_refs",
+            "semantic_limitations",
+        ):
+            _require_unique(getattr(self, field_name), field_name)
+        entry_ids = [entry.entry_id for entry in self.action_entries]
+        _require_unique(entry_ids, "action_entries.entry_id")
+        action_addresses = [entry.action_contract_address for entry in self.action_entries]
+        _require_unique(action_addresses, "action_entries.action_contract_address")
+        entry_id_set = set(entry_ids)
+        action_address_set = set(action_addresses)
+        if isinstance(self.form, ParticipantDecisionSurfaceCandidateSetFormModel):
+            unknown = sorted(set(self.form.candidate_entry_ids) - entry_id_set)
+            if unknown:
+                raise ValueError("candidate_entry_ids must reference action_entries: " + ", ".join(unknown))
+        elif isinstance(self.form, ParticipantDecisionSurfaceConstrainedFormModel):
+            if self.form.action_entry_id not in entry_id_set:
+                raise ValueError("constrained form action_entry_id must reference action_entries")
+            entry = next(item for item in self.action_entries if item.entry_id == self.form.action_entry_id)
+            if entry.selection_shape_ref != self.form.argument_shape_ref:
+                raise ValueError("constrained form argument_shape_ref must match the selected action entry")
+        else:
+            unknown = sorted(set(self.form.allowed_action_contract_addresses) - action_address_set)
+            if unknown:
+                raise ValueError(
+                    "open-ended allowed_action_contract_addresses must reference action_entries: " + ", ".join(unknown)
+                )
+            mismatched = sorted(
+                entry.action_contract_address
+                for entry in self.action_entries
+                if entry.action_contract_address in self.form.allowed_action_contract_addresses
+                and entry.selection_shape_ref != self.form.argument_shape_ref
+            )
+            if mismatched:
+                raise ValueError(
+                    "open-ended argument_shape_ref must match allowed action entries: " + ", ".join(mismatched)
+                )
+        entry_affordances = {ref for entry in self.action_entries for ref in entry.affordance_refs}
+        unknown_affordances = sorted(set(self.affordance_refs) - entry_affordances)
+        if unknown_affordances:
+            raise ValueError("affordance_refs must be carried by action_entries: " + ", ".join(unknown_affordances))
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        _add_aces_invariant(
+            json_schema,
+            "decision-surface-entry-reference-agreement",
+            "Candidate, constrained-form, and open-ended action references must resolve to action entries and "
+            "their governed selection shapes.",
+            validator="aces_contracts.contracts.ParticipantDecisionSurfaceModel._validate_surface_relations",
+            inputs=[{"contract_id": "participant-decision-surface-v1", "instance_path": "#"}],
+        )
+        _add_aces_invariant(
+            json_schema,
+            "decision-surface-presentation-not-lifecycle-evidence",
+            "Surface membership or presentation carries no selection, admission, execution, result, or outcome fact; "
+            "those facts remain in their existing lifecycle contracts.",
+            validator="aces_contracts.contracts.ParticipantDecisionSurfaceModel",
+            inputs=[{"contract_id": "participant-decision-surface-v1", "instance_path": "#"}],
+        )
+        return json_schema
+
+
+class ParticipantDecisionSurfaceSelectionModel(ContractModel):
+    """A referenced proposal selected from one surface, before admission."""
+
+    surface_id: NonEmptyString
+    observation_order: StrictInt = Field(ge=0)
+    action_contract_address: NonEmptyString
+    argument_shape_ref: NonEmptyString
+    proposal_ref: NonEmptyString
+
+
+def validate_participant_decision_surface_context(
+    surface: ParticipantDecisionSurfaceModel,
+    context: ParticipantContextViewModel,
+) -> None:
+    """Require the typed payload to agree with its SEM-214/216 envelope."""
+
+    comparisons: tuple[tuple[str, object, object], ...] = (
+        ("context_view_ref", surface.context_view_ref, context.view_id),
+        ("participant_address", surface.participant_address, context.participant_address),
+        ("episode_id", surface.episode_id, context.episode_id),
+        ("observation_point", surface.observation_point, context.observation_point),
+        ("surface_id/payload_ref", surface.surface_id, context.payload_ref),
+        ("projection_policy_ref", surface.projection_policy_ref, context.derivation_basis_ref),
+        ("transformation_rule_ref", surface.projection_policy_ref, context.transformation.transformation_rule_ref),
+        ("visibility_projection_ref", surface.visibility_projection_ref, context.visibility_projection_ref),
+        ("evidence_refs", surface.evidence_refs, context.evidence_refs),
+        ("provenance_refs", surface.provenance_refs, context.provenance_refs),
+        ("marking_definition_refs", surface.marking_definition_refs, context.marking_definition_refs),
+        ("redaction_policy_ref", surface.redaction_policy_ref, context.redaction_policy_ref),
+        ("semantic_limitations", surface.semantic_limitations, context.semantic_limitations),
+    )
+    mismatched = [name for name, surface_value, context_value in comparisons if surface_value != context_value]
+    if mismatched:
+        raise ValueError("decision surface and context view disagree on: " + ", ".join(mismatched))

--- a/implementations/python/packages/aces_contracts/participant_binding.py
+++ b/implementations/python/packages/aces_contracts/participant_binding.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Protocol
 
 from .contracts import (
     ParticipantActionResultModel,
     ParticipantBehaviorHistoryEventModel,
+    ParticipantDecisionSurfaceCandidateSetFormModel,
+    ParticipantDecisionSurfaceConstrainedFormModel,
+    ParticipantDecisionSurfaceModel,
+    ParticipantDecisionSurfaceSelectionModel,
     ParticipantImplementationManifestModel,
     ParticipantImplementationSelectionModel,
     ParticipantObservationDetailsModel,
@@ -22,6 +27,29 @@ from .participant_behavior import (
 
 _ACTION_CONTRACT_PREFIX = "participant.action-contract."
 _OBSERVATION_BOUNDARY_PREFIX = "participant.observation-boundary."
+
+
+class ParticipantDecisionSurfaceArgumentShapeResolver(Protocol):
+    """Resolve a governed argument shape and validate one referenced proposal."""
+
+    def __call__(
+        self,
+        *,
+        action_contract_address: str,
+        argument_shape_ref: str,
+        proposal_ref: str,
+    ) -> bool: ...
+
+
+class ParticipantDecisionSurfaceApparatusResolver(Protocol):
+    """Resolve the run selection and exposure policy referenced by one surface."""
+
+    def __call__(
+        self,
+        *,
+        implementation_selection_ref: str,
+        exposure_policy_ref: str,
+    ) -> ParticipantImplementationSelectionModel | None: ...
 
 
 @dataclass(frozen=True)
@@ -94,6 +122,81 @@ def participant_action_admission_request_violations(
         *_exposure_policy_violations(request),
         *_action_result_violations(request),
     )
+
+
+def bind_participant_decision_surface_selection(
+    *,
+    surface: ParticipantDecisionSurfaceModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+    admission_request: ParticipantActionAdmissionRequest,
+    argument_shape_resolver: ParticipantDecisionSurfaceArgumentShapeResolver,
+    apparatus_resolver: ParticipantDecisionSurfaceApparatusResolver,
+) -> ParticipantActionAdmissionRequest:
+    """Validate SEM-220 selection meaning before the existing admission path."""
+
+    if selection.surface_id != surface.surface_id:
+        raise ValueError("selection surface_id must match the participant decision surface")
+    if selection.observation_order != surface.observation_order:
+        raise ValueError("selection observation_order must match the participant decision surface")
+    entries = {entry.action_contract_address: entry for entry in surface.action_entries}
+    entry = entries.get(selection.action_contract_address)
+    if entry is None:
+        raise ValueError("selection action_contract_address is not carried by the participant decision surface")
+    if entry.eligibility != "eligible":
+        raise ValueError("participant decision surface selection is not eligible")
+    if entry.support != "supported":
+        raise ValueError("participant decision surface selection is not supported")
+    if entry.selection_shape_ref != selection.argument_shape_ref:
+        raise ValueError("selection argument_shape_ref must match the participant decision surface action entry")
+
+    form = surface.form
+    if isinstance(form, ParticipantDecisionSurfaceCandidateSetFormModel):
+        if entry.entry_id not in form.candidate_entry_ids:
+            raise ValueError("selection action is not a member of the participant candidate-action set")
+    elif isinstance(form, ParticipantDecisionSurfaceConstrainedFormModel):
+        if entry.entry_id != form.action_entry_id or selection.argument_shape_ref != form.argument_shape_ref:
+            raise ValueError("selection does not match the constrained-form action and argument shape")
+    else:
+        if selection.action_contract_address not in form.allowed_action_contract_addresses:
+            raise ValueError("open-ended proposal does not bind to an allowed governed action contract")
+        if selection.argument_shape_ref != form.argument_shape_ref:
+            raise ValueError("open-ended proposal does not bind to the governed argument shape")
+
+    if admission_request.participant_address != surface.participant_address:
+        raise ValueError("admission request participant_address must match the participant decision surface")
+    if admission_request.action_contract_address != selection.action_contract_address:
+        raise ValueError("admission request action_contract_address must match the validated selection")
+    if admission_request.observation_boundary_address != surface.observation_boundary_address:
+        raise ValueError("admission request observation_boundary_address must match the participant decision surface")
+    if admission_request.implementation_selection.selected_decision_surface_mode != surface.decision_control_mode:
+        raise ValueError("admission request decision-control mode must match the participant decision surface")
+    try:
+        surface_implementation_selection = apparatus_resolver(
+            implementation_selection_ref=surface.implementation_selection_ref,
+            exposure_policy_ref=surface.exposure_policy_ref,
+        )
+    except Exception as exc:
+        raise ValueError("participant decision surface apparatus resolution failed") from exc
+    if surface_implementation_selection is None:
+        raise ValueError("participant decision surface apparatus refs did not resolve")
+    if surface_implementation_selection.model_dump(
+        mode="json"
+    ) != admission_request.implementation_selection.model_dump(mode="json"):
+        raise ValueError("admission request implementation selection and exposure policy must match the surface refs")
+    try:
+        valid_arguments = argument_shape_resolver(
+            action_contract_address=selection.action_contract_address,
+            argument_shape_ref=selection.argument_shape_ref,
+            proposal_ref=selection.proposal_ref,
+        )
+    except Exception as exc:
+        raise ValueError("participant decision surface argument-shape resolution failed") from exc
+    if valid_arguments is not True:
+        raise ValueError("participant decision surface proposal failed governed argument-shape validation")
+    violations = participant_action_admission_request_violations(admission_request)
+    if violations:
+        raise ValueError(violations[0])
+    return admission_request
 
 
 def _implementation_selection_violations(request: ParticipantActionAdmissionRequest) -> tuple[str, ...]:
@@ -271,6 +374,8 @@ def _string_tuple(value: Iterable[str], field_name: str) -> tuple[str, ...]:
 
 __all__ = (
     "ParticipantActionAdmissionRequest",
+    "ParticipantDecisionSurfaceArgumentShapeResolver",
+    "bind_participant_decision_surface_selection",
     "participant_action_admission_request_violations",
     "participant_action_binding_events",
     "participant_behavior_event_payload",

--- a/implementations/python/packages/aces_contracts/participant_binding.py
+++ b/implementations/python/packages/aces_contracts/participant_binding.py
@@ -9,9 +9,11 @@ from typing import Protocol
 from .contracts import (
     ParticipantActionResultModel,
     ParticipantBehaviorHistoryEventModel,
+    ParticipantDecisionSurfaceActionEntryModel,
     ParticipantDecisionSurfaceCandidateSetFormModel,
     ParticipantDecisionSurfaceConstrainedFormModel,
     ParticipantDecisionSurfaceModel,
+    ParticipantDecisionSurfaceOpenEndedFormModel,
     ParticipantDecisionSurfaceSelectionModel,
     ParticipantImplementationManifestModel,
     ParticipantImplementationSelectionModel,
@@ -50,6 +52,14 @@ class ParticipantDecisionSurfaceApparatusResolver(Protocol):
         implementation_selection_ref: str,
         exposure_policy_ref: str,
     ) -> ParticipantImplementationSelectionModel | None: ...
+
+
+@dataclass(frozen=True)
+class ParticipantDecisionSurfaceBindingResolvers:
+    """Governed dependencies used to validate one decision-surface selection."""
+
+    argument_shape: ParticipantDecisionSurfaceArgumentShapeResolver
+    apparatus: ParticipantDecisionSurfaceApparatusResolver
 
 
 @dataclass(frozen=True)
@@ -134,14 +144,42 @@ def bind_participant_decision_surface_selection(
 ) -> ParticipantActionAdmissionRequest:
     """Validate SEM-220 selection meaning before the existing admission path."""
 
+    _validate_selection_surface_identity(surface, selection)
+    entry = _selected_surface_entry(surface, selection)
+    _validate_selected_entry(entry, selection)
+    _validate_surface_form_selection(surface.form, entry, selection)
+    _validate_admission_surface_agreement(surface, selection, admission_request)
+    _validate_surface_apparatus(surface, admission_request, apparatus_resolver)
+    _validate_proposal_arguments(selection, argument_shape_resolver)
+    _validate_bound_admission_request(admission_request)
+    return admission_request
+
+
+def _validate_selection_surface_identity(
+    surface: ParticipantDecisionSurfaceModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+) -> None:
     if selection.surface_id != surface.surface_id:
         raise ValueError("selection surface_id must match the participant decision surface")
     if selection.observation_order != surface.observation_order:
         raise ValueError("selection observation_order must match the participant decision surface")
+
+
+def _selected_surface_entry(
+    surface: ParticipantDecisionSurfaceModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+) -> ParticipantDecisionSurfaceActionEntryModel:
     entries = {entry.action_contract_address: entry for entry in surface.action_entries}
     entry = entries.get(selection.action_contract_address)
     if entry is None:
         raise ValueError("selection action_contract_address is not carried by the participant decision surface")
+    return entry
+
+
+def _validate_selected_entry(
+    entry: ParticipantDecisionSurfaceActionEntryModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+) -> None:
     if entry.eligibility != "eligible":
         raise ValueError("participant decision surface selection is not eligible")
     if entry.support != "supported":
@@ -149,7 +187,14 @@ def bind_participant_decision_surface_selection(
     if entry.selection_shape_ref != selection.argument_shape_ref:
         raise ValueError("selection argument_shape_ref must match the participant decision surface action entry")
 
-    form = surface.form
+
+def _validate_surface_form_selection(
+    form: ParticipantDecisionSurfaceCandidateSetFormModel
+    | ParticipantDecisionSurfaceConstrainedFormModel
+    | ParticipantDecisionSurfaceOpenEndedFormModel,
+    entry: ParticipantDecisionSurfaceActionEntryModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+) -> None:
     if isinstance(form, ParticipantDecisionSurfaceCandidateSetFormModel):
         if entry.entry_id not in form.candidate_entry_ids:
             raise ValueError("selection action is not a member of the participant candidate-action set")
@@ -162,6 +207,12 @@ def bind_participant_decision_surface_selection(
         if selection.argument_shape_ref != form.argument_shape_ref:
             raise ValueError("open-ended proposal does not bind to the governed argument shape")
 
+
+def _validate_admission_surface_agreement(
+    surface: ParticipantDecisionSurfaceModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+    admission_request: ParticipantActionAdmissionRequest,
+) -> None:
     if admission_request.participant_address != surface.participant_address:
         raise ValueError("admission request participant_address must match the participant decision surface")
     if admission_request.action_contract_address != selection.action_contract_address:
@@ -170,6 +221,13 @@ def bind_participant_decision_surface_selection(
         raise ValueError("admission request observation_boundary_address must match the participant decision surface")
     if admission_request.implementation_selection.selected_decision_surface_mode != surface.decision_control_mode:
         raise ValueError("admission request decision-control mode must match the participant decision surface")
+
+
+def _validate_surface_apparatus(
+    surface: ParticipantDecisionSurfaceModel,
+    admission_request: ParticipantActionAdmissionRequest,
+    apparatus_resolver: ParticipantDecisionSurfaceApparatusResolver,
+) -> None:
     try:
         surface_implementation_selection = apparatus_resolver(
             implementation_selection_ref=surface.implementation_selection_ref,
@@ -183,6 +241,12 @@ def bind_participant_decision_surface_selection(
         mode="json"
     ) != admission_request.implementation_selection.model_dump(mode="json"):
         raise ValueError("admission request implementation selection and exposure policy must match the surface refs")
+
+
+def _validate_proposal_arguments(
+    selection: ParticipantDecisionSurfaceSelectionModel,
+    argument_shape_resolver: ParticipantDecisionSurfaceArgumentShapeResolver,
+) -> None:
     try:
         valid_arguments = argument_shape_resolver(
             action_contract_address=selection.action_contract_address,
@@ -193,10 +257,12 @@ def bind_participant_decision_surface_selection(
         raise ValueError("participant decision surface argument-shape resolution failed") from exc
     if valid_arguments is not True:
         raise ValueError("participant decision surface proposal failed governed argument-shape validation")
+
+
+def _validate_bound_admission_request(admission_request: ParticipantActionAdmissionRequest) -> None:
     violations = participant_action_admission_request_violations(admission_request)
     if violations:
         raise ValueError(violations[0])
-    return admission_request
 
 
 def _implementation_selection_violations(request: ParticipantActionAdmissionRequest) -> tuple[str, ...]:
@@ -375,6 +441,7 @@ def _string_tuple(value: Iterable[str], field_name: str) -> tuple[str, ...]:
 __all__ = (
     "ParticipantActionAdmissionRequest",
     "ParticipantDecisionSurfaceArgumentShapeResolver",
+    "ParticipantDecisionSurfaceBindingResolvers",
     "bind_participant_decision_surface_selection",
     "participant_action_admission_request_violations",
     "participant_action_binding_events",

--- a/implementations/python/packages/aces_processor/models/__init__.py
+++ b/implementations/python/packages/aces_processor/models/__init__.py
@@ -125,6 +125,11 @@ from .behavior_resources import (
     WorkflowStepStatePredicateRuntime,
     WorkflowSwitchCaseRuntime,
 )
+from .decision_surface import (
+    ParticipantDecisionSurfaceActionAssessment,
+    ParticipantDecisionSurfaceProjectionInput,
+    project_participant_decision_surface,
+)
 from .history_event import (
     ParticipantBehaviorHistoryEvent,
 )
@@ -219,6 +224,8 @@ __all__ = [
     "ParticipantAttributionOrderingBasis",
     "ParticipantBehaviorHistoryEvent",
     "ParticipantBehaviorHistoryEventType",
+    "ParticipantDecisionSurfaceActionAssessment",
+    "ParticipantDecisionSurfaceProjectionInput",
     "ParticipantBehaviorRuntime",
     "ParticipantBehaviorSpecificationRuntime",
     "ParticipantInteractiveAccessRuntime",
@@ -243,6 +250,7 @@ __all__ = [
     "ParticipantOutcomeTargetRecord",
     "ParticipantPhaseRealization",
     "ParticipantRuntimeLifecyclePhase",
+    "project_participant_decision_surface",
     "ParticipantTemporalRuntimeContext",
     "ParticipantTemporalState",
     "ParticipantTemporalStateTransition",

--- a/implementations/python/packages/aces_processor/models/behavior_anchor_checks.py
+++ b/implementations/python/packages/aces_processor/models/behavior_anchor_checks.py
@@ -171,7 +171,7 @@ def _participant_behavior_episode_closed_ids(
     return closed_episode_ids
 
 
-def _participant_behavior_observation_effective_relation(
+def participant_observation_effective_relation(
     *,
     observation_index: int,
     boundary_address: str,
@@ -238,7 +238,7 @@ def _participant_behavior_observation_visibility_violations(
             continue
         if not any(detail_refs.values()):
             continue
-        relation, effective_order = _participant_behavior_observation_effective_relation(
+        relation, effective_order = participant_observation_effective_relation(
             observation_index=index,
             boundary_address=boundary_address,
             boundary=boundary,
@@ -271,7 +271,7 @@ def _participant_behavior_action_result_ref_authorization_violations_for_events(
         if boundary is None:
             continue
         locator = f"{_PARTICIPANT_BEHAVIOR_HISTORY_KEY}[{index}]"
-        relation, effective_order = _participant_behavior_observation_effective_relation(
+        relation, effective_order = participant_observation_effective_relation(
             observation_index=index,
             boundary_address=boundary_address,
             boundary=boundary,

--- a/implementations/python/packages/aces_processor/models/decision_surface.py
+++ b/implementations/python/packages/aces_processor/models/decision_surface.py
@@ -9,7 +9,11 @@ from aces_contracts.contracts import ParticipantDecisionSurfaceModel
 
 from .behavior_anchor_checks import participant_observation_effective_relation
 from .behavior_anchor_index import _participant_behavior_history_anchor_indexes
-from .behavior_resources import _PARTICIPANT_VISIBLE_VIEW_DISPOSITIONS
+from .behavior_resources import (
+    _PARTICIPANT_VISIBLE_VIEW_DISPOSITIONS,
+    ParticipantBehaviorSpecificationRuntime,
+    ParticipantObservationBoundaryRuntime,
+)
 from .history_event import ParticipantBehaviorHistoryEvent
 from .runtime_model import RuntimeModel
 
@@ -130,14 +134,10 @@ def _validate_context_visibility(
         )
 
 
-def project_participant_decision_surface(
-    runtime_model: RuntimeModel,
-    *,
+def _validate_projection_history(
     history_events: Sequence[ParticipantBehaviorHistoryEvent],
     projection: ParticipantDecisionSurfaceProjectionInput,
-) -> ParticipantDecisionSurfaceModel:
-    """Derive one surface from compiled meaning and one scoped history prefix."""
-
+) -> None:
     if not history_events:
         raise ValueError("participant decision surfaces require time-indexed history; a final snapshot is insufficient")
     if projection.observation_order < 0 or projection.observation_order >= len(history_events):
@@ -148,6 +148,11 @@ def project_participant_decision_surface(
     ):
         raise ValueError("participant decision surface history must contain one participant and episode")
 
+
+def _resolve_projection_scope(
+    runtime_model: RuntimeModel,
+    projection: ParticipantDecisionSurfaceProjectionInput,
+) -> tuple[ParticipantBehaviorSpecificationRuntime, ParticipantObservationBoundaryRuntime]:
     behavior = runtime_model.behavior_specifications.get(projection.behavior_specification_address)
     if behavior is None:
         raise ValueError("behavior_specification_address does not resolve in the compiled runtime model")
@@ -158,7 +163,14 @@ def project_participant_decision_surface(
     boundary = runtime_model.observation_boundaries.get(projection.observation_boundary_address)
     if boundary is None:
         raise ValueError("observation_boundary_address does not resolve in the compiled runtime model")
+    return behavior, boundary
 
+
+def _projection_visibility_relation(
+    history_events: Sequence[ParticipantBehaviorHistoryEvent],
+    projection: ParticipantDecisionSurfaceProjectionInput,
+    boundary: ParticipantObservationBoundaryRuntime,
+) -> Mapping[str, str]:
     action_attempts, state_transitions, observations = _participant_behavior_history_anchor_indexes(history_events)
     relation, _ = participant_observation_effective_relation(
         observation_index=projection.observation_order,
@@ -168,75 +180,121 @@ def project_participant_decision_surface(
         state_transitions=state_transitions,
         observations=observations,
     )
+    return relation
+
+
+def _project_surface_action(
+    runtime_model: RuntimeModel,
+    behavior: ParticipantBehaviorSpecificationRuntime,
+    relation: Mapping[str, str],
+    projection: ParticipantDecisionSurfaceProjectionInput,
+    action_address: str,
+) -> tuple[dict[str, object], tuple[str, ...]]:
+    if action_address not in behavior.action_contract_addresses:
+        raise ValueError(f"action {action_address!r} is outside the compiled behavior specification")
+    if action_address not in runtime_model.action_contracts:
+        raise ValueError(f"action {action_address!r} does not resolve in the compiled runtime model")
+    assessment = projection.action_assessments.get(action_address)
+    if assessment is None or assessment.action_contract_address != action_address:
+        raise ValueError(f"action {action_address!r} lacks a matching order-scoped assessment")
+    affordance_addresses = _action_affordance_addresses(
+        runtime_model,
+        behavior_affordance_addresses=behavior.tool_affordance_addresses,
+        action_address=action_address,
+    )
+    visibility = _participant_visible_disposition(
+        relation,
+        action_address=action_address,
+        affordance_addresses=affordance_addresses,
+        observation_order=projection.observation_order,
+    )
+    return (
+        {
+            "entry_id": action_address,
+            "action_contract_address": action_address,
+            "presentation_basis_ref": assessment.presentation_basis_ref,
+            "visibility": visibility,
+            "eligibility": assessment.eligibility,
+            "eligibility_reason_refs": list(assessment.eligibility_reason_refs),
+            "constraint_refs": list(assessment.constraint_refs),
+            "selection_shape_ref": assessment.selection_shape_ref,
+            "support": assessment.support,
+            "support_refs": list(assessment.support_refs),
+            "affordance_refs": list(affordance_addresses),
+            "realization_refs": list(assessment.realization_refs),
+        },
+        affordance_addresses,
+    )
+
+
+def _project_surface_actions(
+    runtime_model: RuntimeModel,
+    behavior: ParticipantBehaviorSpecificationRuntime,
+    relation: Mapping[str, str],
+    projection: ParticipantDecisionSurfaceProjectionInput,
+) -> tuple[list[dict[str, object]], list[str]]:
+    entries: list[dict[str, object]] = []
+    surface_affordances: list[str] = []
+    for action_address in _surface_action_addresses(projection.form):
+        entry, affordance_addresses = _project_surface_action(
+            runtime_model,
+            behavior,
+            relation,
+            projection,
+            action_address,
+        )
+        entries.append(entry)
+        surface_affordances.extend(affordance_addresses)
+    return entries, surface_affordances
+
+
+def _surface_payload(
+    projection: ParticipantDecisionSurfaceProjectionInput,
+    entries: list[dict[str, object]],
+    surface_affordances: list[str],
+) -> dict[str, object]:
+    return {
+        "surface_id": projection.surface_id,
+        "participant_address": projection.participant_address,
+        "episode_id": projection.episode_id,
+        "observation_point": projection.observation_point,
+        "observation_order": projection.observation_order,
+        "behavior_specification_address": projection.behavior_specification_address,
+        "observation_boundary_address": projection.observation_boundary_address,
+        "context_view_ref": projection.context_view_ref,
+        "implementation_selection_ref": projection.implementation_selection_ref,
+        "decision_control_mode": projection.decision_control_mode,
+        "projection_policy_ref": projection.projection_policy_ref,
+        "projection_policy_revision": projection.projection_policy_revision,
+        "exposure_policy_ref": projection.exposure_policy_ref,
+        "visibility_projection_ref": projection.visibility_projection_ref,
+        "visible_context_refs": list(projection.visible_context_refs),
+        "action_entries": entries,
+        "affordance_refs": list(dict.fromkeys(surface_affordances)),
+        "form": dict(projection.form),
+        "evidence_refs": list(projection.evidence_refs),
+        "provenance_refs": list(projection.provenance_refs),
+        "marking_definition_refs": list(projection.marking_definition_refs),
+        "redaction_policy_ref": projection.redaction_policy_ref,
+        "semantic_limitations": list(projection.semantic_limitations),
+    }
+
+
+def project_participant_decision_surface(
+    runtime_model: RuntimeModel,
+    *,
+    history_events: Sequence[ParticipantBehaviorHistoryEvent],
+    projection: ParticipantDecisionSurfaceProjectionInput,
+) -> ParticipantDecisionSurfaceModel:
+    """Derive one surface from compiled meaning and one scoped history prefix."""
+
+    _validate_projection_history(history_events, projection)
+    behavior, boundary = _resolve_projection_scope(runtime_model, projection)
+    relation = _projection_visibility_relation(history_events, projection, boundary)
     _validate_context_visibility(
         relation,
         refs=projection.visible_context_refs,
         observation_order=projection.observation_order,
     )
-
-    entries: list[dict[str, object]] = []
-    surface_affordances: list[str] = []
-    for action_address in _surface_action_addresses(projection.form):
-        if action_address not in behavior.action_contract_addresses:
-            raise ValueError(f"action {action_address!r} is outside the compiled behavior specification")
-        if action_address not in runtime_model.action_contracts:
-            raise ValueError(f"action {action_address!r} does not resolve in the compiled runtime model")
-        assessment = projection.action_assessments.get(action_address)
-        if assessment is None or assessment.action_contract_address != action_address:
-            raise ValueError(f"action {action_address!r} lacks a matching order-scoped assessment")
-        affordance_addresses = _action_affordance_addresses(
-            runtime_model,
-            behavior_affordance_addresses=behavior.tool_affordance_addresses,
-            action_address=action_address,
-        )
-        visibility = _participant_visible_disposition(
-            relation,
-            action_address=action_address,
-            affordance_addresses=affordance_addresses,
-            observation_order=projection.observation_order,
-        )
-        surface_affordances.extend(affordance_addresses)
-        entries.append(
-            {
-                "entry_id": action_address,
-                "action_contract_address": action_address,
-                "presentation_basis_ref": assessment.presentation_basis_ref,
-                "visibility": visibility,
-                "eligibility": assessment.eligibility,
-                "eligibility_reason_refs": list(assessment.eligibility_reason_refs),
-                "constraint_refs": list(assessment.constraint_refs),
-                "selection_shape_ref": assessment.selection_shape_ref,
-                "support": assessment.support,
-                "support_refs": list(assessment.support_refs),
-                "affordance_refs": list(affordance_addresses),
-                "realization_refs": list(assessment.realization_refs),
-            }
-        )
-
-    return ParticipantDecisionSurfaceModel.model_validate(
-        {
-            "surface_id": projection.surface_id,
-            "participant_address": projection.participant_address,
-            "episode_id": projection.episode_id,
-            "observation_point": projection.observation_point,
-            "observation_order": projection.observation_order,
-            "behavior_specification_address": projection.behavior_specification_address,
-            "observation_boundary_address": projection.observation_boundary_address,
-            "context_view_ref": projection.context_view_ref,
-            "implementation_selection_ref": projection.implementation_selection_ref,
-            "decision_control_mode": projection.decision_control_mode,
-            "projection_policy_ref": projection.projection_policy_ref,
-            "projection_policy_revision": projection.projection_policy_revision,
-            "exposure_policy_ref": projection.exposure_policy_ref,
-            "visibility_projection_ref": projection.visibility_projection_ref,
-            "visible_context_refs": list(projection.visible_context_refs),
-            "action_entries": entries,
-            "affordance_refs": list(dict.fromkeys(surface_affordances)),
-            "form": dict(projection.form),
-            "evidence_refs": list(projection.evidence_refs),
-            "provenance_refs": list(projection.provenance_refs),
-            "marking_definition_refs": list(projection.marking_definition_refs),
-            "redaction_policy_ref": projection.redaction_policy_ref,
-            "semantic_limitations": list(projection.semantic_limitations),
-        }
-    )
+    entries, surface_affordances = _project_surface_actions(runtime_model, behavior, relation, projection)
+    return ParticipantDecisionSurfaceModel.model_validate(_surface_payload(projection, entries, surface_affordances))

--- a/implementations/python/packages/aces_processor/models/decision_surface.py
+++ b/implementations/python/packages/aces_processor/models/decision_surface.py
@@ -1,0 +1,242 @@
+"""Time-indexed SEM-220 participant decision-surface projection."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from aces_contracts.contracts import ParticipantDecisionSurfaceModel
+
+from .behavior_anchor_checks import participant_observation_effective_relation
+from .behavior_anchor_index import _participant_behavior_history_anchor_indexes
+from .behavior_resources import _PARTICIPANT_VISIBLE_VIEW_DISPOSITIONS
+from .history_event import ParticipantBehaviorHistoryEvent
+from .runtime_model import RuntimeModel
+
+
+@dataclass(frozen=True)
+class ParticipantDecisionSurfaceActionAssessment:
+    """Order-scoped eligibility/support facts supplied by their owning gates."""
+
+    action_contract_address: str
+    presentation_basis_ref: str
+    eligibility: str
+    eligibility_reason_refs: tuple[str, ...]
+    constraint_refs: tuple[str, ...]
+    selection_shape_ref: str
+    support: str
+    support_refs: tuple[str, ...]
+    realization_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ParticipantDecisionSurfaceProjectionInput:
+    """Governed projection inputs that are not authored by the payload itself."""
+
+    surface_id: str
+    participant_address: str
+    episode_id: str
+    observation_order: int
+    observation_point: str
+    behavior_specification_address: str
+    observation_boundary_address: str
+    context_view_ref: str
+    implementation_selection_ref: str
+    decision_control_mode: str
+    projection_policy_ref: str
+    projection_policy_revision: str
+    exposure_policy_ref: str
+    visibility_projection_ref: str
+    visible_context_refs: tuple[str, ...]
+    action_assessments: Mapping[str, ParticipantDecisionSurfaceActionAssessment]
+    form: Mapping[str, object]
+    evidence_refs: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+    marking_definition_refs: tuple[str, ...]
+    redaction_policy_ref: str | None
+    semantic_limitations: tuple[str, ...]
+
+
+def _surface_action_addresses(form: Mapping[str, object]) -> tuple[str, ...]:
+    surface_form = form.get("surface_form")
+    if surface_form == "candidate_action_set":
+        raw = form.get("candidate_entry_ids")
+    elif surface_form == "constrained_form":
+        raw = [form.get("action_entry_id")]
+    elif surface_form == "open_ended_generation":
+        raw = form.get("allowed_action_contract_addresses")
+    else:
+        raise ValueError(f"unsupported participant decision surface form {surface_form!r}")
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+        raise ValueError("participant decision surface form must declare action references")
+    addresses = tuple(item for item in raw if isinstance(item, str) and item)
+    if len(addresses) != len(raw) or not addresses or len(set(addresses)) != len(addresses):
+        raise ValueError("participant decision surface action references must be unique non-empty strings")
+    return addresses
+
+
+def _action_affordance_addresses(
+    runtime_model: RuntimeModel,
+    *,
+    behavior_affordance_addresses: tuple[str, ...],
+    action_address: str,
+) -> tuple[str, ...]:
+    return tuple(
+        affordance_address
+        for affordance_address in behavior_affordance_addresses
+        if affordance_address in runtime_model.tool_affordances
+        and action_address in runtime_model.tool_affordances[affordance_address].action_contract_addresses
+    )
+
+
+def _participant_visible_disposition(
+    relation: Mapping[str, str],
+    *,
+    action_address: str,
+    affordance_addresses: tuple[str, ...],
+    observation_order: int,
+) -> str:
+    projected_refs = (action_address, *affordance_addresses)
+    missing = sorted(ref for ref in projected_refs if ref not in relation)
+    if missing:
+        raise ValueError(
+            "participant decision surface refs lack an effective view disposition at observation_order "
+            f"{observation_order}: {', '.join(missing)}"
+        )
+    classified = {relation[ref] for ref in projected_refs}
+    if len(classified) > 1:
+        raise ValueError(
+            f"action {action_address!r} has conflicting view dispositions at observation_order {observation_order}"
+        )
+    disposition = next(iter(classified), None)
+    if disposition not in _PARTICIPANT_VISIBLE_VIEW_DISPOSITIONS:
+        raise ValueError(
+            f"action {action_address!r} is not participant-visible at observation_order {observation_order}"
+        )
+    return disposition
+
+
+def _validate_context_visibility(
+    relation: Mapping[str, str],
+    *,
+    refs: tuple[str, ...],
+    observation_order: int,
+) -> None:
+    hidden = sorted(ref for ref in refs if relation.get(ref) not in _PARTICIPANT_VISIBLE_VIEW_DISPOSITIONS)
+    if hidden:
+        raise ValueError(
+            "visible_context_refs are not participant-visible at observation_order "
+            f"{observation_order}: {', '.join(hidden)}"
+        )
+
+
+def project_participant_decision_surface(
+    runtime_model: RuntimeModel,
+    *,
+    history_events: Sequence[ParticipantBehaviorHistoryEvent],
+    projection: ParticipantDecisionSurfaceProjectionInput,
+) -> ParticipantDecisionSurfaceModel:
+    """Derive one surface from compiled meaning and one scoped history prefix."""
+
+    if not history_events:
+        raise ValueError("participant decision surfaces require time-indexed history; a final snapshot is insufficient")
+    if projection.observation_order < 0 or projection.observation_order >= len(history_events):
+        raise ValueError("observation_order must identify an event in the supplied time-indexed history")
+    if any(
+        event.participant_address != projection.participant_address or event.episode_id != projection.episode_id
+        for event in history_events
+    ):
+        raise ValueError("participant decision surface history must contain one participant and episode")
+
+    behavior = runtime_model.behavior_specifications.get(projection.behavior_specification_address)
+    if behavior is None:
+        raise ValueError("behavior_specification_address does not resolve in the compiled runtime model")
+    if projection.participant_address not in behavior.participant_addresses:
+        raise ValueError("participant_address is outside the compiled behavior specification")
+    if projection.observation_boundary_address not in behavior.observation_boundary_addresses:
+        raise ValueError("observation_boundary_address is outside the compiled behavior specification")
+    boundary = runtime_model.observation_boundaries.get(projection.observation_boundary_address)
+    if boundary is None:
+        raise ValueError("observation_boundary_address does not resolve in the compiled runtime model")
+
+    action_attempts, state_transitions, observations = _participant_behavior_history_anchor_indexes(history_events)
+    relation, _ = participant_observation_effective_relation(
+        observation_index=projection.observation_order,
+        boundary_address=projection.observation_boundary_address,
+        boundary=boundary,
+        action_attempts=action_attempts,
+        state_transitions=state_transitions,
+        observations=observations,
+    )
+    _validate_context_visibility(
+        relation,
+        refs=projection.visible_context_refs,
+        observation_order=projection.observation_order,
+    )
+
+    entries: list[dict[str, object]] = []
+    surface_affordances: list[str] = []
+    for action_address in _surface_action_addresses(projection.form):
+        if action_address not in behavior.action_contract_addresses:
+            raise ValueError(f"action {action_address!r} is outside the compiled behavior specification")
+        if action_address not in runtime_model.action_contracts:
+            raise ValueError(f"action {action_address!r} does not resolve in the compiled runtime model")
+        assessment = projection.action_assessments.get(action_address)
+        if assessment is None or assessment.action_contract_address != action_address:
+            raise ValueError(f"action {action_address!r} lacks a matching order-scoped assessment")
+        affordance_addresses = _action_affordance_addresses(
+            runtime_model,
+            behavior_affordance_addresses=behavior.tool_affordance_addresses,
+            action_address=action_address,
+        )
+        visibility = _participant_visible_disposition(
+            relation,
+            action_address=action_address,
+            affordance_addresses=affordance_addresses,
+            observation_order=projection.observation_order,
+        )
+        surface_affordances.extend(affordance_addresses)
+        entries.append(
+            {
+                "entry_id": action_address,
+                "action_contract_address": action_address,
+                "presentation_basis_ref": assessment.presentation_basis_ref,
+                "visibility": visibility,
+                "eligibility": assessment.eligibility,
+                "eligibility_reason_refs": list(assessment.eligibility_reason_refs),
+                "constraint_refs": list(assessment.constraint_refs),
+                "selection_shape_ref": assessment.selection_shape_ref,
+                "support": assessment.support,
+                "support_refs": list(assessment.support_refs),
+                "affordance_refs": list(affordance_addresses),
+                "realization_refs": list(assessment.realization_refs),
+            }
+        )
+
+    return ParticipantDecisionSurfaceModel.model_validate(
+        {
+            "surface_id": projection.surface_id,
+            "participant_address": projection.participant_address,
+            "episode_id": projection.episode_id,
+            "observation_point": projection.observation_point,
+            "observation_order": projection.observation_order,
+            "behavior_specification_address": projection.behavior_specification_address,
+            "observation_boundary_address": projection.observation_boundary_address,
+            "context_view_ref": projection.context_view_ref,
+            "implementation_selection_ref": projection.implementation_selection_ref,
+            "decision_control_mode": projection.decision_control_mode,
+            "projection_policy_ref": projection.projection_policy_ref,
+            "projection_policy_revision": projection.projection_policy_revision,
+            "exposure_policy_ref": projection.exposure_policy_ref,
+            "visibility_projection_ref": projection.visibility_projection_ref,
+            "visible_context_refs": list(projection.visible_context_refs),
+            "action_entries": entries,
+            "affordance_refs": list(dict.fromkeys(surface_affordances)),
+            "form": dict(projection.form),
+            "evidence_refs": list(projection.evidence_refs),
+            "provenance_refs": list(projection.provenance_refs),
+            "marking_definition_refs": list(projection.marking_definition_refs),
+            "redaction_policy_ref": projection.redaction_policy_ref,
+            "semantic_limitations": list(projection.semantic_limitations),
+        }
+    )

--- a/implementations/python/packages/aces_runtime/participant_control.py
+++ b/implementations/python/packages/aces_runtime/participant_control.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+from aces_contracts.contracts import ParticipantDecisionSurfaceModel, ParticipantDecisionSurfaceSelectionModel
 from aces_contracts.diagnostics import Diagnostic
-from aces_contracts.participant_binding import ParticipantActionAdmissionRequest
+from aces_contracts.participant_binding import (
+    ParticipantActionAdmissionRequest,
+    ParticipantDecisionSurfaceApparatusResolver,
+    ParticipantDecisionSurfaceArgumentShapeResolver,
+    bind_participant_decision_surface_selection,
+)
 from aces_contracts.participant_episode import (
     ParticipantEpisodeInitializeRequest,
     ParticipantEpisodeResetRequest,
@@ -352,6 +358,51 @@ class ParticipantControlMixin:
             method=self._target.participant_runtime.admit_action,
             request=request,
             address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+        )
+
+    def admit_participant_decision_surface_selection(
+        self,
+        participant_behavior: ParticipantBehaviorRuntime,
+        *,
+        surface: ParticipantDecisionSurfaceModel,
+        selection: ParticipantDecisionSurfaceSelectionModel,
+        admission_request: ParticipantActionAdmissionRequest,
+        argument_shape_resolver: ParticipantDecisionSurfaceArgumentShapeResolver,
+        apparatus_resolver: ParticipantDecisionSurfaceApparatusResolver,
+        idempotency_key: str = "",
+        request_fingerprint: str = "",
+    ) -> OperationReceipt:
+        """Validate a SEM-220 selection before reusing normal action admission."""
+
+        if self._target.participant_runtime is None:
+            return self._reject_submission(
+                domain=RuntimeDomain.PARTICIPANT,
+                message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        try:
+            request = bind_participant_decision_surface_selection(
+                surface=surface,
+                selection=selection,
+                admission_request=admission_request,
+                argument_shape_resolver=argument_shape_resolver,
+                apparatus_resolver=apparatus_resolver,
+            )
+        except (TypeError, ValueError) as exc:
+            return self._reject_diagnostics(
+                domain=RuntimeDomain.PARTICIPANT,
+                diagnostics=[
+                    _participant_binding_diagnostic(_participant_binding_address(participant_behavior), str(exc))
+                ],
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+            )
+        return self.admit_participant_action(
+            participant_behavior,
+            request,
             idempotency_key=idempotency_key,
             request_fingerprint=request_fingerprint,
         )

--- a/implementations/python/packages/aces_runtime/participant_control.py
+++ b/implementations/python/packages/aces_runtime/participant_control.py
@@ -6,8 +6,7 @@ from aces_contracts.contracts import ParticipantDecisionSurfaceModel, Participan
 from aces_contracts.diagnostics import Diagnostic
 from aces_contracts.participant_binding import (
     ParticipantActionAdmissionRequest,
-    ParticipantDecisionSurfaceApparatusResolver,
-    ParticipantDecisionSurfaceArgumentShapeResolver,
+    ParticipantDecisionSurfaceBindingResolvers,
     bind_participant_decision_surface_selection,
 )
 from aces_contracts.participant_episode import (
@@ -369,8 +368,7 @@ class ParticipantControlMixin:
         surface: ParticipantDecisionSurfaceModel,
         selection: ParticipantDecisionSurfaceSelectionModel,
         admission_request: ParticipantActionAdmissionRequest,
-        argument_shape_resolver: ParticipantDecisionSurfaceArgumentShapeResolver,
-        apparatus_resolver: ParticipantDecisionSurfaceApparatusResolver,
+        resolvers: ParticipantDecisionSurfaceBindingResolvers,
         idempotency_key: str = "",
         request_fingerprint: str = "",
     ) -> OperationReceipt:
@@ -388,8 +386,8 @@ class ParticipantControlMixin:
                 surface=surface,
                 selection=selection,
                 admission_request=admission_request,
-                argument_shape_resolver=argument_shape_resolver,
-                apparatus_resolver=apparatus_resolver,
+                argument_shape_resolver=resolvers.argument_shape,
+                apparatus_resolver=resolvers.apparatus,
             )
         except (TypeError, ValueError) as exc:
             return self._reject_diagnostics(

--- a/implementations/python/tests/test_sem_220_participant_decision_surface.py
+++ b/implementations/python/tests/test_sem_220_participant_decision_surface.py
@@ -18,6 +18,7 @@ from aces_contracts.contracts import (
 )
 from aces_contracts.participant_binding import (
     ParticipantActionAdmissionRequest,
+    ParticipantDecisionSurfaceBindingResolvers,
     bind_participant_decision_surface_selection,
 )
 from aces_processor.models import (
@@ -435,9 +436,10 @@ def test_candidate_membership_does_not_bypass_entry_admissibility(
     payload = _surface_payload()
     payload["action_entries"][0].update(entry_updates)  # type: ignore[index,union-attr]
     surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+    selection = _surface_selection(surface)
 
     with pytest.raises(ValueError, match=message):
-        _bind_selection(surface, _surface_selection(surface))
+        _bind_selection(surface, selection)
 
 
 def test_selection_must_be_a_candidate_member() -> None:
@@ -456,9 +458,10 @@ def test_selection_must_be_a_candidate_member() -> None:
     payload["action_entries"].append(exfiltrate_entry)  # type: ignore[union-attr]
     payload["form"]["candidate_entry_ids"] = [EXFILTRATE]  # type: ignore[index]
     surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+    selection = _surface_selection(surface)
 
     with pytest.raises(ValueError, match="not a member"):
-        _bind_selection(surface, _surface_selection(surface))
+        _bind_selection(surface, selection)
 
 
 def test_constrained_form_selection_must_match_its_action_entry() -> None:
@@ -504,12 +507,13 @@ def test_constrained_form_requires_mapping_disclosures() -> None:
 def test_projection_uses_time_indexed_visibility_and_rejects_future_state() -> None:
     runtime_model = _runtime_model()
     history = _history()
+    hidden_projection = _projection_input(observation_order=0, action_address=EXFILTRATE)
 
     with pytest.raises(ValueError, match="not participant-visible at observation_order 0"):
         project_participant_decision_surface(
             runtime_model,
             history_events=history,
-            projection=_projection_input(observation_order=0, action_address=EXFILTRATE),
+            projection=hidden_projection,
         )
 
     surface = project_participant_decision_surface(
@@ -523,11 +527,15 @@ def test_projection_uses_time_indexed_visibility_and_rejects_future_state() -> N
 
 @pytest.mark.parametrize("omitted_ref", (SCAN, SCAN_AFFORDANCE))
 def test_projection_requires_visibility_proof_for_every_emitted_ref(omitted_ref: str) -> None:
+    runtime_model = _runtime_model(omitted_visibility_ref=omitted_ref)
+    history = _history()
+    projection = _projection_input(observation_order=0)
+
     with pytest.raises(ValueError, match="lack an effective view disposition"):
         project_participant_decision_surface(
-            _runtime_model(omitted_visibility_ref=omitted_ref),
-            history_events=_history(),
-            projection=_projection_input(observation_order=0),
+            runtime_model,
+            history_events=history,
+            projection=projection,
         )
 
 
@@ -542,17 +550,19 @@ def test_projection_rejects_global_history_and_final_snapshot_substitution() -> 
         action_contract_address=SCAN,
         actor_provenance="participant:blue-agent",
     )
+    global_history = (*_history(), foreign)
+    projection = _projection_input(observation_order=0)
     with pytest.raises(ValueError, match="one participant and episode"):
         project_participant_decision_surface(
             runtime_model,
-            history_events=(*_history(), foreign),
-            projection=_projection_input(observation_order=0),
+            history_events=global_history,
+            projection=projection,
         )
     with pytest.raises(ValueError, match="time-indexed history"):
         project_participant_decision_surface(
             runtime_model,
             history_events=(),
-            projection=_projection_input(observation_order=0),
+            projection=projection,
         )
 
 
@@ -697,8 +707,10 @@ def test_open_ended_proposal_validates_before_existing_admission_path() -> None:
         surface=surface,
         selection=selection,
         admission_request=request,
-        argument_shape_resolver=reject_shape,
-        apparatus_resolver=resolve_apparatus,
+        resolvers=ParticipantDecisionSurfaceBindingResolvers(
+            argument_shape=reject_shape,
+            apparatus=resolve_apparatus,
+        ),
     )
     assert rejected == "rejected"
     assert resolver_calls == ["proposals.scan.1"]
@@ -710,8 +722,10 @@ def test_open_ended_proposal_validates_before_existing_admission_path() -> None:
         surface=surface,
         selection=selection,
         admission_request=request,
-        argument_shape_resolver=lambda **_: True,
-        apparatus_resolver=resolve_apparatus,
+        resolvers=ParticipantDecisionSurfaceBindingResolvers(
+            argument_shape=lambda **_: True,
+            apparatus=resolve_apparatus,
+        ),
     )
     assert admitted == "admitted"
     assert control.admitted is request
@@ -741,8 +755,10 @@ def test_surface_apparatus_must_resolve_to_the_admission_selection() -> None:
         surface=surface,
         selection=selection,
         admission_request=request,
-        apparatus_resolver=lambda **_: mismatched_selection,
-        argument_shape_resolver=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+        resolvers=ParticipantDecisionSurfaceBindingResolvers(
+            argument_shape=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+            apparatus=lambda **_: mismatched_selection,
+        ),
     )
 
     assert rejected == "rejected"
@@ -755,8 +771,10 @@ def test_surface_apparatus_must_resolve_to_the_admission_selection() -> None:
         surface=mismatched_mode_surface,
         selection=selection,
         admission_request=request,
-        apparatus_resolver=lambda **_: request.implementation_selection,
-        argument_shape_resolver=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+        resolvers=ParticipantDecisionSurfaceBindingResolvers(
+            argument_shape=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+            apparatus=lambda **_: request.implementation_selection,
+        ),
     )
 
     assert rejected == "rejected"

--- a/implementations/python/tests/test_sem_220_participant_decision_surface.py
+++ b/implementations/python/tests/test_sem_220_participant_decision_surface.py
@@ -1,0 +1,772 @@
+"""SEM-220 participant decision-surface contract and projection tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from aces_contracts.contracts import (
+    ParticipantContextViewModel,
+    ParticipantDecisionSurfaceModel,
+    ParticipantDecisionSurfaceSelectionModel,
+    ParticipantImplementationManifestModel,
+    ParticipantImplementationSelectionModel,
+    schema_bundle,
+    validate_participant_decision_surface_context,
+)
+from aces_contracts.participant_binding import (
+    ParticipantActionAdmissionRequest,
+    bind_participant_decision_surface_selection,
+)
+from aces_processor.models import (
+    ParticipantActionContractRuntime,
+    ParticipantBehaviorHistoryEvent,
+    ParticipantBehaviorHistoryEventType,
+    ParticipantBehaviorSpecificationRuntime,
+    ParticipantDecisionSurfaceActionAssessment,
+    ParticipantDecisionSurfaceProjectionInput,
+    ParticipantObservationBoundaryRuntime,
+    ParticipantObservationStatus,
+    ParticipantToolAffordanceRuntime,
+    RuntimeModel,
+    project_participant_decision_surface,
+)
+from aces_runtime.participant_control import ParticipantControlMixin
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "contracts" / "fixtures" / "control-plane" / "participant-decision-surface-v1"
+
+PARTICIPANT = "participant.behavior.red-agent"
+EPISODE = "episode-1"
+BEHAVIOR = "participant.behavior-specification.red-surface"
+BOUNDARY = "participant.observation-boundary.red-view"
+SCAN = "participant.action-contract.scan"
+EXFILTRATE = "participant.action-contract.exfiltrate"
+SCAN_AFFORDANCE = f"{BEHAVIOR}.tool-affordance.scanner"
+EXFILTRATE_AFFORDANCE = f"{BEHAVIOR}.tool-affordance.exfiltration"
+
+
+def _surface_payload(*, surface_form: str = "candidate_action_set") -> dict[str, object]:
+    entry = {
+        "entry_id": SCAN,
+        "action_contract_address": SCAN,
+        "presentation_basis_ref": "projection-policy.red.v1",
+        "visibility": "observable",
+        "eligibility": "ineligible",
+        "eligibility_reason_refs": ["sem211.precondition.authority.out-of-scope"],
+        "constraint_refs": ["participant.action-contract.scan.preconditions"],
+        "selection_shape_ref": "selection-shapes.scan.v1",
+        "support": "supported",
+        "support_refs": ["participant-implementation.reference.scan"],
+        "affordance_refs": [SCAN_AFFORDANCE],
+        "realization_refs": ["realizations.scan.reference.v1"],
+    }
+    forms: dict[str, dict[str, object]] = {
+        "candidate_action_set": {
+            "surface_form": "candidate_action_set",
+            "selection_meaning_ref": "selection-meaning.candidate.v1",
+            "candidate_entry_ids": [SCAN],
+            "open_extension_binding_ref": None,
+        },
+        "open_ended_generation": {
+            "surface_form": "open_ended_generation",
+            "selection_meaning_ref": "selection-meaning.open.v1",
+            "proposal_binding_ref": "proposal-bindings.governed-action.v1",
+            "argument_shape_ref": "selection-shapes.scan.v1",
+            "validation_policy_ref": "validation-policies.sem220.v1",
+            "allowed_action_contract_addresses": [SCAN],
+        },
+        "constrained_form": {
+            "surface_form": "constrained_form",
+            "selection_meaning_ref": "selection-meaning.form.v1",
+            "action_entry_id": SCAN,
+            "argument_shape_ref": "selection-shapes.scan.v1",
+            "validation_policy_ref": "validation-policies.sem220.v1",
+            "constraint_refs": ["forms.scan.constraints.v1"],
+            "default_disclosure_refs": ["forms.scan.defaults.v1"],
+            "normalization_disclosure_refs": ["forms.scan.normalization.v1"],
+            "omission_disclosure_refs": ["forms.scan.omission.v1"],
+            "loss_disclosure_refs": ["forms.scan.loss.none.v1"],
+        },
+    }
+    return {
+        "surface_id": "decision-surfaces.red.episode-1.order-0",
+        "participant_address": PARTICIPANT,
+        "episode_id": EPISODE,
+        "observation_point": "behavior-history:0",
+        "observation_order": 0,
+        "behavior_specification_address": BEHAVIOR,
+        "observation_boundary_address": BOUNDARY,
+        "context_view_ref": "context-views.red.episode-1.order-0",
+        "implementation_selection_ref": "participant-selections.red.reference.v1",
+        "decision_control_mode": "autonomous",
+        "projection_policy_ref": "projection-policy.red.v1",
+        "projection_policy_revision": "1",
+        "exposure_policy_ref": "exposure-policy.red.v1",
+        "visibility_projection_ref": "visibility-projection.red.order-0",
+        "visible_context_refs": ["context.public"],
+        "action_entries": [entry],
+        "affordance_refs": [SCAN_AFFORDANCE],
+        "form": forms[surface_form],
+        "evidence_refs": ["evidence.surface.red.order-0"],
+        "provenance_refs": ["provenance.surface.red.order-0"],
+        "marking_definition_refs": ["markings.participant-visible.v1"],
+        "redaction_policy_ref": "redaction.red.v1",
+        "semantic_limitations": ["Presentation does not imply selection, admission, execution, result, or outcome"],
+    }
+
+
+def _runtime_model(*, omitted_visibility_ref: str | None = None) -> RuntimeModel:
+    initial_view_relation = {
+        "context.public": "observable",
+        SCAN: "observable",
+        EXFILTRATE: "hidden",
+        SCAN_AFFORDANCE: "observable",
+        EXFILTRATE_AFFORDANCE: "hidden",
+    }
+    revealed_view_relation = {
+        "context.public": "observable",
+        SCAN: "observable",
+        EXFILTRATE: "disclosed",
+        SCAN_AFFORDANCE: "observable",
+        EXFILTRATE_AFFORDANCE: "disclosed",
+    }
+    if omitted_visibility_ref is not None:
+        initial_view_relation.pop(omitted_visibility_ref, None)
+        revealed_view_relation.pop(omitted_visibility_ref, None)
+    boundary = ParticipantObservationBoundaryRuntime(
+        address=BOUNDARY,
+        name="red-view",
+        spec={},
+        boundary_name="red-view",
+        projection_basis="participant-local",
+        view_transitions=(
+            {
+                "transition_id": "reveal-exfiltration",
+                "history_event_type": "observation_emitted",
+                "action_instance_id": "reveal-1",
+                "information_ref": EXFILTRATE,
+                "from_disposition": "hidden",
+                "to_disposition": "disclosed",
+                "effective_order": 1,
+            },
+            {
+                "transition_id": "reveal-exfiltration-affordance",
+                "history_event_type": "observation_emitted",
+                "action_instance_id": "reveal-1",
+                "information_ref": EXFILTRATE_AFFORDANCE,
+                "from_disposition": "hidden",
+                "to_disposition": "disclosed",
+                "effective_order": 1,
+            },
+        ),
+        view_relation_timeline=(
+            {
+                "transition_id": "initial",
+                "effective_order": -1,
+                "view_relation": initial_view_relation,
+            },
+            {
+                "transition_id": "reveal-exfiltration",
+                "effective_order": 1,
+                "view_relation": revealed_view_relation,
+            },
+        ),
+    )
+    behavior = ParticipantBehaviorSpecificationRuntime(
+        address=BEHAVIOR,
+        name="red-surface",
+        spec={},
+        participant_addresses=(PARTICIPANT,),
+        action_contract_addresses=(SCAN, EXFILTRATE),
+        observation_boundary_addresses=(BOUNDARY,),
+        tool_affordance_addresses=(SCAN_AFFORDANCE, EXFILTRATE_AFFORDANCE),
+        behavior_mode="autonomous",
+    )
+    return RuntimeModel(
+        scenario_name="sem-220",
+        action_contracts={
+            SCAN: ParticipantActionContractRuntime(address=SCAN, name="scan", spec={}, action_name="scan"),
+            EXFILTRATE: ParticipantActionContractRuntime(
+                address=EXFILTRATE,
+                name="exfiltrate",
+                spec={},
+                action_name="exfiltrate",
+            ),
+        },
+        observation_boundaries={BOUNDARY: boundary},
+        behavior_specifications={BEHAVIOR: behavior},
+        tool_affordances={
+            SCAN_AFFORDANCE: ParticipantToolAffordanceRuntime(
+                address=SCAN_AFFORDANCE,
+                name="scanner",
+                spec={},
+                affordance_id="scanner",
+                behavior_specification_address=BEHAVIOR,
+                action_contract_addresses=(SCAN,),
+                observation_boundary_addresses=(BOUNDARY,),
+            ),
+            EXFILTRATE_AFFORDANCE: ParticipantToolAffordanceRuntime(
+                address=EXFILTRATE_AFFORDANCE,
+                name="exfiltration",
+                spec={},
+                affordance_id="exfiltration",
+                behavior_specification_address=BEHAVIOR,
+                action_contract_addresses=(EXFILTRATE,),
+                observation_boundary_addresses=(BOUNDARY,),
+            ),
+        },
+    )
+
+
+def _history() -> tuple[ParticipantBehaviorHistoryEvent, ...]:
+    return (
+        ParticipantBehaviorHistoryEvent(
+            event_type=ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED,
+            timestamp="2026-07-20T08:00:00Z",
+            participant_address=PARTICIPANT,
+            episode_id=EPISODE,
+            action_instance_id="setup-1",
+            action_contract_address=SCAN,
+            actor_provenance="participant:red-agent",
+        ),
+        ParticipantBehaviorHistoryEvent(
+            event_type=ParticipantBehaviorHistoryEventType.OBSERVATION_EMITTED,
+            timestamp="2026-07-20T08:00:01Z",
+            participant_address=PARTICIPANT,
+            episode_id=EPISODE,
+            action_instance_id="reveal-1",
+            action_contract_address=SCAN,
+            observation_boundary_address=BOUNDARY,
+            observation_status=ParticipantObservationStatus.TERMINAL,
+            post_state_digest="sha256:known-after-reveal",
+        ),
+    )
+
+
+def _assessment(action_address: str, *, eligibility: str = "eligible") -> ParticipantDecisionSurfaceActionAssessment:
+    return ParticipantDecisionSurfaceActionAssessment(
+        action_contract_address=action_address,
+        presentation_basis_ref="projection-policy.red.v1",
+        eligibility=eligibility,
+        eligibility_reason_refs=(() if eligibility == "eligible" else ("sem211.precondition.authority.out-of-scope",)),
+        constraint_refs=(f"{action_address}.preconditions",),
+        selection_shape_ref=f"selection-shapes.{action_address.rsplit('.', 1)[-1]}.v1",
+        support="supported",
+        support_refs=("participant-implementation.reference",),
+        realization_refs=("realization.reference",),
+    )
+
+
+def _projection_input(
+    *,
+    observation_order: int,
+    action_address: str = SCAN,
+    eligibility: str = "eligible",
+    implementation_selection_ref: str = "participant-selections.red.agent.v1",
+    decision_control_mode: str = "autonomous",
+) -> ParticipantDecisionSurfaceProjectionInput:
+    return ParticipantDecisionSurfaceProjectionInput(
+        surface_id=f"decision-surfaces.red.episode-1.order-{observation_order}",
+        participant_address=PARTICIPANT,
+        episode_id=EPISODE,
+        observation_order=observation_order,
+        observation_point=f"behavior-history:{observation_order}",
+        behavior_specification_address=BEHAVIOR,
+        observation_boundary_address=BOUNDARY,
+        context_view_ref=f"context-views.red.episode-1.order-{observation_order}",
+        implementation_selection_ref=implementation_selection_ref,
+        decision_control_mode=decision_control_mode,
+        projection_policy_ref="projection-policy.red.v1",
+        projection_policy_revision="1",
+        exposure_policy_ref="exposure-policy.red.v1",
+        visibility_projection_ref=f"visibility-projection.red.order-{observation_order}",
+        visible_context_refs=("context.public",),
+        action_assessments={action_address: _assessment(action_address, eligibility=eligibility)},
+        form={
+            "surface_form": "candidate_action_set",
+            "selection_meaning_ref": "selection-meaning.candidate.v1",
+            "candidate_entry_ids": [action_address],
+            "open_extension_binding_ref": None,
+        },
+        evidence_refs=(f"evidence.surface.red.order-{observation_order}",),
+        provenance_refs=(f"provenance.surface.red.order-{observation_order}",),
+        marking_definition_refs=("markings.participant-visible.v1",),
+        redaction_policy_ref="redaction.red.v1",
+        semantic_limitations=("Presentation does not imply selection, admission, execution, result, or outcome",),
+    )
+
+
+def _admission_request() -> ParticipantActionAdmissionRequest:
+    manifest_payload = json.loads(
+        (
+            REPO_ROOT
+            / "contracts"
+            / "fixtures"
+            / "participant-implementation-manifest"
+            / "participant-implementation-manifest-v1"
+            / "valid"
+            / "reference.json"
+        ).read_text(encoding="utf-8")
+    )
+    manifest = ParticipantImplementationManifestModel.model_validate(manifest_payload)
+    selection = ParticipantImplementationSelectionModel.model_validate(
+        {
+            "participant_address": PARTICIPANT,
+            "implementation_identity": manifest.identity.model_dump(mode="json"),
+            "manifest_ref": "participant-implementation-manifests.reference.v1",
+            "manifest_digest": "sha256:" + "1" * 64,
+            "configuration_ref": "participant-configurations.red.v1",
+            "configuration_digest": "sha256:" + "2" * 64,
+            "selected_decision_surface_mode": "autonomous",
+            "participant_contract_versions": ["participant-behavior-history-event-stream-v1"],
+            "exposure_policy": {
+                "policy_id": "red-policy",
+                "policy_version": "1",
+                "policy_digest": "sha256:" + "3" * 64,
+                "exposure_policy_kinds": ["task-statement"],
+                "disclosed_refs": ["context.public"],
+                "withheld_refs": [],
+                "tool_affordance_refs": [],
+                "visibility_scope_refs": [],
+                "constraints": {},
+            },
+        }
+    )
+    return ParticipantActionAdmissionRequest(
+        participant_address=PARTICIPANT,
+        action_contract_address=SCAN,
+        observation_boundary_address=BOUNDARY,
+        action_instance_id="scan-1",
+        implementation_manifest=manifest,
+        implementation_selection=selection,
+    )
+
+
+def _eligible_surface(*, surface_form: str = "candidate_action_set") -> ParticipantDecisionSurfaceModel:
+    payload = _surface_payload(surface_form=surface_form)
+    payload["action_entries"][0]["eligibility"] = "eligible"  # type: ignore[index]
+    payload["action_entries"][0]["eligibility_reason_refs"] = []  # type: ignore[index]
+    return ParticipantDecisionSurfaceModel.model_validate(payload)
+
+
+def _surface_selection(
+    surface: ParticipantDecisionSurfaceModel,
+    *,
+    action_contract_address: str = SCAN,
+    argument_shape_ref: str = "selection-shapes.scan.v1",
+) -> ParticipantDecisionSurfaceSelectionModel:
+    return ParticipantDecisionSurfaceSelectionModel(
+        surface_id=surface.surface_id,
+        observation_order=surface.observation_order,
+        action_contract_address=action_contract_address,
+        argument_shape_ref=argument_shape_ref,
+        proposal_ref="proposals.selection.1",
+    )
+
+
+def _bind_selection(
+    surface: ParticipantDecisionSurfaceModel,
+    selection: ParticipantDecisionSurfaceSelectionModel,
+) -> ParticipantActionAdmissionRequest:
+    request = _admission_request()
+    return bind_participant_decision_surface_selection(
+        surface=surface,
+        selection=selection,
+        admission_request=request,
+        argument_shape_resolver=lambda **_: True,
+        apparatus_resolver=lambda **_: request.implementation_selection,
+    )
+
+
+def test_decision_surface_schema_is_closed_discriminated_and_published() -> None:
+    surface = ParticipantDecisionSurfaceModel.model_validate(_surface_payload())
+    assert surface.form.surface_form == "candidate_action_set"
+
+    schema = schema_bundle()["participant-decision-surface-v1"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["form"]["discriminator"]["propertyName"] == "surface_form"
+    assert {entry["id"] for entry in schema["x-aces-invariants"]} >= {
+        "decision-surface-entry-reference-agreement",
+        "decision-surface-presentation-not-lifecycle-evidence",
+    }
+
+
+def test_decision_surface_valid_and_invalid_fixtures_match_model_and_schema() -> None:
+    validator = Draft202012Validator(schema_bundle()["participant-decision-surface-v1"])
+    valid_paths = sorted((FIXTURE_ROOT / "valid").glob("*.json"))
+    invalid_paths = sorted((FIXTURE_ROOT / "invalid").glob("*.json"))
+    assert {path.stem for path in valid_paths} >= {"human-candidate", "script-form", "llm-open", "rl-candidate"}
+    assert invalid_paths
+    for path in valid_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        validator.validate(payload)
+        ParticipantDecisionSurfaceModel.model_validate(payload)
+    for path in invalid_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert list(validator.iter_errors(payload)), path
+        with pytest.raises(ValidationError):
+            ParticipantDecisionSurfaceModel.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("entry_updates", "message"),
+    (
+        ({}, "not eligible"),
+        (
+            {
+                "eligibility": "eligible",
+                "eligibility_reason_refs": [],
+                "support": "unsupported",
+                "support_refs": [],
+            },
+            "not supported",
+        ),
+    ),
+)
+def test_candidate_membership_does_not_bypass_entry_admissibility(
+    entry_updates: dict[str, object],
+    message: str,
+) -> None:
+    payload = _surface_payload()
+    payload["action_entries"][0].update(entry_updates)  # type: ignore[index,union-attr]
+    surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+
+    with pytest.raises(ValueError, match=message):
+        _bind_selection(surface, _surface_selection(surface))
+
+
+def test_selection_must_be_a_candidate_member() -> None:
+    payload = _surface_payload()
+    payload["action_entries"][0]["eligibility"] = "eligible"  # type: ignore[index]
+    payload["action_entries"][0]["eligibility_reason_refs"] = []  # type: ignore[index]
+    exfiltrate_entry = dict(payload["action_entries"][0])  # type: ignore[index]
+    exfiltrate_entry.update(
+        {
+            "entry_id": EXFILTRATE,
+            "action_contract_address": EXFILTRATE,
+            "selection_shape_ref": "selection-shapes.exfiltrate.v1",
+            "affordance_refs": [EXFILTRATE_AFFORDANCE],
+        }
+    )
+    payload["action_entries"].append(exfiltrate_entry)  # type: ignore[union-attr]
+    payload["form"]["candidate_entry_ids"] = [EXFILTRATE]  # type: ignore[index]
+    surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+
+    with pytest.raises(ValueError, match="not a member"):
+        _bind_selection(surface, _surface_selection(surface))
+
+
+def test_constrained_form_selection_must_match_its_action_entry() -> None:
+    payload = _surface_payload(surface_form="constrained_form")
+    payload["action_entries"][0]["eligibility"] = "eligible"  # type: ignore[index]
+    payload["action_entries"][0]["eligibility_reason_refs"] = []  # type: ignore[index]
+    exfiltrate_entry = dict(payload["action_entries"][0])  # type: ignore[index]
+    exfiltrate_entry.update(
+        {
+            "entry_id": EXFILTRATE,
+            "action_contract_address": EXFILTRATE,
+            "selection_shape_ref": "selection-shapes.exfiltrate.v1",
+            "affordance_refs": [EXFILTRATE_AFFORDANCE],
+        }
+    )
+    payload["action_entries"].append(exfiltrate_entry)  # type: ignore[union-attr]
+    surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+
+    selection = _surface_selection(
+        surface,
+        action_contract_address=EXFILTRATE,
+        argument_shape_ref="selection-shapes.exfiltrate.v1",
+    )
+    with pytest.raises(ValueError, match="constrained-form action and argument shape"):
+        _bind_selection(surface, selection)
+
+
+def test_selection_shape_must_match_the_action_entry() -> None:
+    surface = _eligible_surface()
+    selection = _surface_selection(surface, argument_shape_ref="selection-shapes.other.v1")
+
+    with pytest.raises(ValueError, match="argument_shape_ref must match"):
+        _bind_selection(surface, selection)
+
+
+def test_constrained_form_requires_mapping_disclosures() -> None:
+    payload = _surface_payload(surface_form="constrained_form")
+    del payload["form"]["loss_disclosure_refs"]  # type: ignore[index]
+    with pytest.raises(ValidationError, match="loss_disclosure_refs"):
+        ParticipantDecisionSurfaceModel.model_validate(payload)
+
+
+def test_projection_uses_time_indexed_visibility_and_rejects_future_state() -> None:
+    runtime_model = _runtime_model()
+    history = _history()
+
+    with pytest.raises(ValueError, match="not participant-visible at observation_order 0"):
+        project_participant_decision_surface(
+            runtime_model,
+            history_events=history,
+            projection=_projection_input(observation_order=0, action_address=EXFILTRATE),
+        )
+
+    surface = project_participant_decision_surface(
+        runtime_model,
+        history_events=history,
+        projection=_projection_input(observation_order=1, action_address=EXFILTRATE),
+    )
+    assert surface.observation_order == 1
+    assert surface.action_entries[0].visibility == "disclosed"
+
+
+@pytest.mark.parametrize("omitted_ref", (SCAN, SCAN_AFFORDANCE))
+def test_projection_requires_visibility_proof_for_every_emitted_ref(omitted_ref: str) -> None:
+    with pytest.raises(ValueError, match="lack an effective view disposition"):
+        project_participant_decision_surface(
+            _runtime_model(omitted_visibility_ref=omitted_ref),
+            history_events=_history(),
+            projection=_projection_input(observation_order=0),
+        )
+
+
+def test_projection_rejects_global_history_and_final_snapshot_substitution() -> None:
+    runtime_model = _runtime_model()
+    foreign = ParticipantBehaviorHistoryEvent(
+        event_type=ParticipantBehaviorHistoryEventType.ACTION_ATTEMPTED,
+        timestamp="2026-07-20T08:00:00Z",
+        participant_address="participant.behavior.blue-agent",
+        episode_id=EPISODE,
+        action_instance_id="foreign-1",
+        action_contract_address=SCAN,
+        actor_provenance="participant:blue-agent",
+    )
+    with pytest.raises(ValueError, match="one participant and episode"):
+        project_participant_decision_surface(
+            runtime_model,
+            history_events=(*_history(), foreign),
+            projection=_projection_input(observation_order=0),
+        )
+    with pytest.raises(ValueError, match="time-indexed history"):
+        project_participant_decision_surface(
+            runtime_model,
+            history_events=(),
+            projection=_projection_input(observation_order=0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("implementation_selection_ref", "decision_control_mode"),
+    (
+        ("participant-selections.red.human.v1", "human-supervised"),
+        ("participant-selections.red.script.v1", "scripted"),
+        ("participant-selections.red.llm.v1", "autonomous"),
+        ("participant-selections.red.rl.v1", "autonomous"),
+    ),
+)
+def test_realization_kind_preserves_surface_semantic_refs(
+    implementation_selection_ref: str,
+    decision_control_mode: str,
+) -> None:
+    surface = project_participant_decision_surface(
+        _runtime_model(),
+        history_events=_history(),
+        projection=_projection_input(
+            observation_order=0,
+            implementation_selection_ref=implementation_selection_ref,
+            decision_control_mode=decision_control_mode,
+        ),
+    )
+    assert surface.action_entries[0].action_contract_address == SCAN
+    assert surface.action_entries[0].selection_shape_ref == "selection-shapes.scan.v1"
+    assert surface.form.selection_meaning_ref == "selection-meaning.candidate.v1"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "mismatched_value"),
+    (
+        ("observation_point", "behavior-history:99"),
+        ("evidence_refs", ["evidence.surface.other"]),
+        ("provenance_refs", ["provenance.surface.other"]),
+        ("marking_definition_refs", ["markings.other.v1"]),
+        ("redaction_policy_ref", "redaction.other.v1"),
+        ("semantic_limitations", ["Different limitation"]),
+    ),
+)
+def test_context_envelope_and_payload_must_agree(field_name: str, mismatched_value: object) -> None:
+    surface = ParticipantDecisionSurfaceModel.model_validate(_surface_payload())
+    context = ParticipantContextViewModel.model_validate(
+        {
+            "view_id": surface.context_view_ref,
+            "participant_address": PARTICIPANT,
+            "episode_id": EPISODE,
+            "generated_at": "2026-07-20T08:00:00Z",
+            "source_snapshot_ref": "snapshots.run-1.order-0",
+            "view_ref": "views.decision-surface.v1",
+            "meaning_ref": "semantics.decision-surface.v1",
+            "participant_scope": "participant_local",
+            "audience_scope": "participant_visible",
+            "observation_point": surface.observation_point,
+            "derived_from_refs": ["snapshots.run-1.order-0"],
+            "source_layers": [
+                {
+                    "source_id": "history-order-0",
+                    "source_layer": "participant_behavior_history",
+                    "ref": "snapshots.run-1.order-0",
+                    "temporal_relation": "same_observation_point",
+                    "observation_point": surface.observation_point,
+                    "evidence_refs": surface.evidence_refs,
+                    "provenance_refs": surface.provenance_refs,
+                }
+            ],
+            "transformation": {
+                "transformation_rule_ref": surface.projection_policy_ref,
+                "description": "Project one participant-local decision surface at one order point",
+                "input_source_ids": ["history-order-0"],
+                "output_semantics_ref": "semantics.decision-surface.v1",
+            },
+            "comparability": {
+                "comparability_class": "portable_equivalent",
+                "comparison_basis_ref": "comparability.decision-surface.v1",
+                "backend_disclosure_refs": [],
+                "limitations": surface.semantic_limitations,
+            },
+            "evidence_refs": surface.evidence_refs,
+            "provenance_refs": surface.provenance_refs,
+            "semantic_limitations": surface.semantic_limitations,
+            "derivation_basis_ref": surface.projection_policy_ref,
+            "payload_ref": surface.surface_id,
+            "visibility_projection_ref": surface.visibility_projection_ref,
+            "marking_definition_refs": surface.marking_definition_refs,
+            "redaction_policy_ref": surface.redaction_policy_ref,
+        }
+    )
+    validate_participant_decision_surface_context(surface, context)
+
+    mismatched = context.model_copy(update={field_name: mismatched_value})
+    with pytest.raises(ValueError, match=field_name):
+        validate_participant_decision_surface_context(surface, mismatched)
+
+
+class _RecordingControl(ParticipantControlMixin):
+    def __init__(self) -> None:
+        self._target = SimpleNamespace(participant_runtime=object())
+        self.admitted: ParticipantActionAdmissionRequest | None = None
+
+    def _reject_diagnostics(self, **kwargs: object) -> str:
+        return "rejected"
+
+    def admit_participant_action(
+        self,
+        participant_behavior: object,
+        admission_request: ParticipantActionAdmissionRequest,
+        **kwargs: object,
+    ) -> str:
+        self.admitted = admission_request
+        return "admitted"
+
+
+def test_open_ended_proposal_validates_before_existing_admission_path() -> None:
+    payload = _surface_payload(surface_form="open_ended_generation")
+    payload["action_entries"][0]["eligibility"] = "eligible"  # type: ignore[index]
+    payload["action_entries"][0]["eligibility_reason_refs"] = []  # type: ignore[index]
+    surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+    selection = ParticipantDecisionSurfaceSelectionModel(
+        surface_id=surface.surface_id,
+        observation_order=surface.observation_order,
+        action_contract_address=SCAN,
+        argument_shape_ref="selection-shapes.scan.v1",
+        proposal_ref="proposals.scan.1",
+    )
+    request = _admission_request()
+    control = _RecordingControl()
+    resolver_calls: list[str] = []
+    apparatus_calls: list[tuple[str, str]] = []
+
+    def resolve_apparatus(**kwargs: str) -> ParticipantImplementationSelectionModel:
+        apparatus_calls.append((kwargs["implementation_selection_ref"], kwargs["exposure_policy_ref"]))
+        return request.implementation_selection
+
+    def reject_shape(**kwargs: str) -> bool:
+        resolver_calls.append(kwargs["proposal_ref"])
+        return False
+
+    rejected = control.admit_participant_decision_surface_selection(
+        SimpleNamespace(address=PARTICIPANT),
+        surface=surface,
+        selection=selection,
+        admission_request=request,
+        argument_shape_resolver=reject_shape,
+        apparatus_resolver=resolve_apparatus,
+    )
+    assert rejected == "rejected"
+    assert resolver_calls == ["proposals.scan.1"]
+    assert apparatus_calls == [(surface.implementation_selection_ref, surface.exposure_policy_ref)]
+    assert control.admitted is None
+
+    admitted = control.admit_participant_decision_surface_selection(
+        SimpleNamespace(address=PARTICIPANT),
+        surface=surface,
+        selection=selection,
+        admission_request=request,
+        argument_shape_resolver=lambda **_: True,
+        apparatus_resolver=resolve_apparatus,
+    )
+    assert admitted == "admitted"
+    assert control.admitted is request
+
+
+def test_surface_apparatus_must_resolve_to_the_admission_selection() -> None:
+    payload = _surface_payload(surface_form="open_ended_generation")
+    payload["action_entries"][0]["eligibility"] = "eligible"  # type: ignore[index]
+    payload["action_entries"][0]["eligibility_reason_refs"] = []  # type: ignore[index]
+    surface = ParticipantDecisionSurfaceModel.model_validate(payload)
+    selection = ParticipantDecisionSurfaceSelectionModel(
+        surface_id=surface.surface_id,
+        observation_order=surface.observation_order,
+        action_contract_address=SCAN,
+        argument_shape_ref="selection-shapes.scan.v1",
+        proposal_ref="proposals.scan.1",
+    )
+    request = _admission_request()
+    mismatched_selection = request.implementation_selection.model_copy(
+        update={"configuration_ref": "participant-configurations.other.v1"}
+    )
+    control = _RecordingControl()
+    shape_calls: list[str] = []
+
+    rejected = control.admit_participant_decision_surface_selection(
+        SimpleNamespace(address=PARTICIPANT),
+        surface=surface,
+        selection=selection,
+        admission_request=request,
+        apparatus_resolver=lambda **_: mismatched_selection,
+        argument_shape_resolver=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+    )
+
+    assert rejected == "rejected"
+    assert shape_calls == []
+    assert control.admitted is None
+
+    mismatched_mode_surface = surface.model_copy(update={"decision_control_mode": "scripted"})
+    rejected = control.admit_participant_decision_surface_selection(
+        SimpleNamespace(address=PARTICIPANT),
+        surface=mismatched_mode_surface,
+        selection=selection,
+        admission_request=request,
+        apparatus_resolver=lambda **_: request.implementation_selection,
+        argument_shape_resolver=lambda **kwargs: shape_calls.append(kwargs["proposal_ref"]) or True,
+    )
+
+    assert rejected == "rejected"
+    assert shape_calls == []
+    assert control.admitted is None
+
+
+def test_presentation_cannot_be_encoded_as_selection_result_or_outcome() -> None:
+    payload = _surface_payload()
+    payload["selected_action_contract_address"] = SCAN
+    payload["outcome"] = "succeeded"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ParticipantDecisionSurfaceModel.model_validate(payload)


### PR DESCRIPTION
## Summary

Define a participant-local, time-indexed decision-surface contract and projection path for open-ended proposals, constrained forms, and candidate sets, with governed selection binding into the existing participant action-admission boundary.

## Requirement UIDs

- `SEM-220`

## Related Issues

Closes #295

## ADR Impact

- ADR-083

## Changes

- Add the closed participant-decision-surface contract, generated schema, publication entry, and human/script/LLM/RL fixtures.
- Project participant-visible actions and affordances from time-indexed context history while preserving identity, policy, evidence, provenance, markings, and limitations.
- Validate proposal/form/candidate selections against governed shapes and surface context before invoking the existing participant action-admission path.
- Document SEM-220 lineage and add negative coverage for hidden or future references, admission bypass, presentation-as-outcome, context disagreement, and lossy constrained forms.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`ACES_REQUIREMENT_UID=SEM-220 pre-commit run --all-files`; full `nox verify` (4,187 unit tests passed, 1 skipped; 39 integration tests passed, 2 skipped); explicit repository-policy, requirement-governance, and `verify_all` chain. The external governance lookup followed the repository checker's designed timeout/skip path.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SEM-220 ← implementations/python/packages/aces_contracts/contracts/participant_decision_surface.py, SEM-220 ← implementations/python/packages/aces_processor/models/decision_surface.py, SEM-220 ← implementations/python/packages/aces_contracts/participant_binding.py, SEM-220 ← implementations/python/packages/aces_runtime/participant_control.py
- TESTS: SEM-220 ← implementations/python/tests/test_sem_220_participant_decision_surface.py, SEM-220 ← contracts/fixtures/control-plane/participant-decision-surface-v1/

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed