### PR TITLE
feat: add typed exploit-path analysis

### DIFF
--- a/contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/invalid/cross-outcome-payload.json
+++ b/contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/invalid/cross-outcome-payload.json
@@ -1,0 +1,184 @@
+{
+  "analysis_profile": "aces-exploit-path-analysis-v1",
+  "authored_digest": {
+    "algorithm": "sha256",
+    "profile": "aces-sdl-semantic/v1",
+    "value": "sha256:1dd6f51fcf01986275edb0c8fa6f75d163a9e5e097c6729d1f5447ec03cbfc10"
+  },
+  "diagnostics": [],
+  "failure": null,
+  "normalized_graph": {
+    "binding_profile": "aces-sdl-snapshot-attack-binding/v1",
+    "bindings": [
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-attacker-foothold",
+        "concept_kind": "scenario-node",
+        "target_id": "attacker-foothold",
+        "target_kind": "state-fact"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-data-access",
+        "concept_kind": "scenario-node",
+        "target_id": "data-access",
+        "target_kind": "state-fact"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-exploit-web",
+        "concept_kind": "participant-action",
+        "target_id": "exploit-web",
+        "target_kind": "transition"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-read-data",
+        "concept_kind": "participant-action",
+        "target_id": "read-data",
+        "target_kind": "transition"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-web-shell",
+        "concept_kind": "scenario-node",
+        "target_id": "web-shell",
+        "target_kind": "state-fact"
+      }
+    ],
+    "profile": "aces-attack-graph/v1",
+    "snapshot_digest": "sha256:4d49022a2c6f04058552ea9ef79b05a26b2ee3ffc3a91f85d977b5b0d6e3127b",
+    "state_facts": [
+      {
+        "fact_id": "attacker-foothold",
+        "kind": "access",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      },
+      {
+        "fact_id": "data-access",
+        "kind": "data-state",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      },
+      {
+        "fact_id": "web-shell",
+        "kind": "execution",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      }
+    ],
+    "transition_semantics_profile": "aces-monotonic-attack-transition/v1",
+    "transitions": [
+      {
+        "effects": [
+          "web-shell"
+        ],
+        "kind": "exploit-step",
+        "observations": [
+          {
+            "kind": "participant-observation",
+            "observation_id": "web-shell-observed",
+            "source_address": "/nodes/target"
+          }
+        ],
+        "prerequisites": [
+          "attacker-foothold"
+        ],
+        "semantics": "monotonic-additive/v1",
+        "transition_id": "exploit-web"
+      },
+      {
+        "effects": [
+          "data-access"
+        ],
+        "kind": "postcondition-step",
+        "observations": [],
+        "prerequisites": [
+          "web-shell"
+        ],
+        "semantics": "monotonic-additive/v1",
+        "transition_id": "read-data"
+      }
+    ]
+  },
+  "normalized_graph_digest": "sha256:8d5735dbed3247af815b54f8f763c59ee2c0b1823361d121ee6e8ff53cbd54d0",
+  "outcome": "invalid-path",
+  "profile": "exploit-path-analysis-evidence/v1",
+  "query": {
+    "allowed_transition_semantics": [
+      "monotonic-additive/v1"
+    ],
+    "goal_check": "before-and-after-transition",
+    "goal_facts": [
+      "data-access"
+    ],
+    "max_depth": 4,
+    "participant_perspective": "attacker",
+    "profile": "aces-exploit-path-query/v1",
+    "query_id": "attacker-data-path",
+    "start_facts": [
+      "attacker-foothold"
+    ]
+  },
+  "query_digest": "sha256:a9483aa194eed2ca368b372866d437de88262f126f77f58c9db67a650e4eeac3",
+  "search_configuration": {
+    "goal_check": "before-and-after-transition",
+    "max_depth": 4,
+    "profile": "aces-deterministic-attack-graph-search/v1",
+    "strategy": "breadth-first-canonical",
+    "transition_semantics": "monotonic-additive/v1"
+  },
+  "search_configuration_digest": "sha256:fca04e68d5277c7d4b2e939bee3e0d43f607cccc4e63bddfce2bcb0977626a86",
+  "snapshot_digest": "sha256:4d49022a2c6f04058552ea9ef79b05a26b2ee3ffc3a91f85d977b5b0d6e3127b",
+  "source": {
+    "byte_digest": "sha256:0f7e0fb521139d81f28dcbf9d6423f5f194487d8cbe36679d200c6a34199397b",
+    "source_id": "valid-path.input.json"
+  },
+  "unsupported": null,
+  "witness": {
+    "final_state": [
+      "attacker-foothold",
+      "data-access",
+      "web-shell"
+    ],
+    "final_state_digest": "sha256:82c0bf6b436c72ca524a0245dc14ed5ed2eb9a16f54425bb3ede4f07dfb9e713",
+    "goal_facts": [
+      "data-access"
+    ],
+    "initial_state": [
+      "attacker-foothold"
+    ],
+    "profile": "aces-exploit-path-witness/v1",
+    "steps": [
+      {
+        "applied_effects": [
+          "web-shell"
+        ],
+        "emitted_observations": [
+          "web-shell-observed"
+        ],
+        "satisfied_prerequisites": [
+          "attacker-foothold"
+        ],
+        "state_after_digest": "sha256:acf65b80f7fd24008df8164114136549aba1485a3faa86ca7a220db93212b87e",
+        "state_before_digest": "sha256:78aa42c9f17373d5803ec3049c04c66609250ce3e7afd016b7fe012d3aa4222c",
+        "step_index": 0,
+        "transition_id": "exploit-web"
+      },
+      {
+        "applied_effects": [
+          "data-access"
+        ],
+        "emitted_observations": [],
+        "satisfied_prerequisites": [
+          "web-shell"
+        ],
+        "state_after_digest": "sha256:82c0bf6b436c72ca524a0245dc14ed5ed2eb9a16f54425bb3ede4f07dfb9e713",
+        "state_before_digest": "sha256:acf65b80f7fd24008df8164114136549aba1485a3faa86ca7a220db93212b87e",
+        "step_index": 1,
+        "transition_id": "read-data"
+      }
+    ]
+  }
+}

--- a/contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/valid/valid-path.json
+++ b/contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/valid/valid-path.json
@@ -1,0 +1,184 @@
+{
+  "analysis_profile": "aces-exploit-path-analysis-v1",
+  "authored_digest": {
+    "algorithm": "sha256",
+    "profile": "aces-sdl-semantic/v1",
+    "value": "sha256:1dd6f51fcf01986275edb0c8fa6f75d163a9e5e097c6729d1f5447ec03cbfc10"
+  },
+  "diagnostics": [],
+  "failure": null,
+  "normalized_graph": {
+    "binding_profile": "aces-sdl-snapshot-attack-binding/v1",
+    "bindings": [
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-attacker-foothold",
+        "concept_kind": "scenario-node",
+        "target_id": "attacker-foothold",
+        "target_kind": "state-fact"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-data-access",
+        "concept_kind": "scenario-node",
+        "target_id": "data-access",
+        "target_kind": "state-fact"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-exploit-web",
+        "concept_kind": "participant-action",
+        "target_id": "exploit-web",
+        "target_kind": "transition"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-read-data",
+        "concept_kind": "participant-action",
+        "target_id": "read-data",
+        "target_kind": "transition"
+      },
+      {
+        "aces_address": "/nodes/target",
+        "binding_id": "bind-web-shell",
+        "concept_kind": "scenario-node",
+        "target_id": "web-shell",
+        "target_kind": "state-fact"
+      }
+    ],
+    "profile": "aces-attack-graph/v1",
+    "snapshot_digest": "sha256:4d49022a2c6f04058552ea9ef79b05a26b2ee3ffc3a91f85d977b5b0d6e3127b",
+    "state_facts": [
+      {
+        "fact_id": "attacker-foothold",
+        "kind": "access",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      },
+      {
+        "fact_id": "data-access",
+        "kind": "data-state",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      },
+      {
+        "fact_id": "web-shell",
+        "kind": "execution",
+        "object_ref": "/nodes/target",
+        "subject": "attacker"
+      }
+    ],
+    "transition_semantics_profile": "aces-monotonic-attack-transition/v1",
+    "transitions": [
+      {
+        "effects": [
+          "web-shell"
+        ],
+        "kind": "exploit-step",
+        "observations": [
+          {
+            "kind": "participant-observation",
+            "observation_id": "web-shell-observed",
+            "source_address": "/nodes/target"
+          }
+        ],
+        "prerequisites": [
+          "attacker-foothold"
+        ],
+        "semantics": "monotonic-additive/v1",
+        "transition_id": "exploit-web"
+      },
+      {
+        "effects": [
+          "data-access"
+        ],
+        "kind": "postcondition-step",
+        "observations": [],
+        "prerequisites": [
+          "web-shell"
+        ],
+        "semantics": "monotonic-additive/v1",
+        "transition_id": "read-data"
+      }
+    ]
+  },
+  "normalized_graph_digest": "sha256:8d5735dbed3247af815b54f8f763c59ee2c0b1823361d121ee6e8ff53cbd54d0",
+  "outcome": "valid-path",
+  "profile": "exploit-path-analysis-evidence/v1",
+  "query": {
+    "allowed_transition_semantics": [
+      "monotonic-additive/v1"
+    ],
+    "goal_check": "before-and-after-transition",
+    "goal_facts": [
+      "data-access"
+    ],
+    "max_depth": 4,
+    "participant_perspective": "attacker",
+    "profile": "aces-exploit-path-query/v1",
+    "query_id": "attacker-data-path",
+    "start_facts": [
+      "attacker-foothold"
+    ]
+  },
+  "query_digest": "sha256:a9483aa194eed2ca368b372866d437de88262f126f77f58c9db67a650e4eeac3",
+  "search_configuration": {
+    "goal_check": "before-and-after-transition",
+    "max_depth": 4,
+    "profile": "aces-deterministic-attack-graph-search/v1",
+    "strategy": "breadth-first-canonical",
+    "transition_semantics": "monotonic-additive/v1"
+  },
+  "search_configuration_digest": "sha256:fca04e68d5277c7d4b2e939bee3e0d43f607cccc4e63bddfce2bcb0977626a86",
+  "snapshot_digest": "sha256:4d49022a2c6f04058552ea9ef79b05a26b2ee3ffc3a91f85d977b5b0d6e3127b",
+  "source": {
+    "byte_digest": "sha256:0f7e0fb521139d81f28dcbf9d6423f5f194487d8cbe36679d200c6a34199397b",
+    "source_id": "valid-path.input.json"
+  },
+  "unsupported": null,
+  "witness": {
+    "final_state": [
+      "attacker-foothold",
+      "data-access",
+      "web-shell"
+    ],
+    "final_state_digest": "sha256:82c0bf6b436c72ca524a0245dc14ed5ed2eb9a16f54425bb3ede4f07dfb9e713",
+    "goal_facts": [
+      "data-access"
+    ],
+    "initial_state": [
+      "attacker-foothold"
+    ],
+    "profile": "aces-exploit-path-witness/v1",
+    "steps": [
+      {
+        "applied_effects": [
+          "web-shell"
+        ],
+        "emitted_observations": [
+          "web-shell-observed"
+        ],
+        "satisfied_prerequisites": [
+          "attacker-foothold"
+        ],
+        "state_after_digest": "sha256:acf65b80f7fd24008df8164114136549aba1485a3faa86ca7a220db93212b87e",
+        "state_before_digest": "sha256:78aa42c9f17373d5803ec3049c04c66609250ce3e7afd016b7fe012d3aa4222c",
+        "step_index": 0,
+        "transition_id": "exploit-web"
+      },
+      {
+        "applied_effects": [
+          "data-access"
+        ],
+        "emitted_observations": [],
+        "satisfied_prerequisites": [
+          "web-shell"
+        ],
+        "state_after_digest": "sha256:82c0bf6b436c72ca524a0245dc14ed5ed2eb9a16f54425bb3ede4f07dfb9e713",
+        "state_before_digest": "sha256:acf65b80f7fd24008df8164114136549aba1485a3faa86ca7a220db93212b87e",
+        "step_index": 1,
+        "transition_id": "read-data"
+      }
+    ]
+  }
+}

--- a/contracts/schema-publication/entries/exploit-path-analysis-evidence-v1.json
+++ b/contracts/schema-publication/entries/exploit-path-analysis-evidence-v1.json
@@ -1,0 +1,10 @@
+{
+  "contract_id": "exploit-path-analysis-evidence-v1",
+  "schema_path": "contracts/schemas/exploit-path-analysis/exploit-path-analysis-evidence-v1.json",
+  "stability": "draft",
+  "content_hash": "881cf0171e0f689ff88fd4be278f7bad835cbd4d0ed384842a7e4ad2491edd84",
+  "last_change": {
+    "summary": "Publish the typed exploit-path analysis evidence contract for governed attack-transition graph queries.",
+    "content_hash": "881cf0171e0f689ff88fd4be278f7bad835cbd4d0ed384842a7e4ad2491edd84"
+  }
+}

--- a/contracts/schemas/exploit-path-analysis/exploit-path-analysis-evidence-v1.json
+++ b/contracts/schemas/exploit-path-analysis/exploit-path-analysis-evidence-v1.json
@@ -1,0 +1,968 @@
+{
+  "$defs": {
+    "AttackGraphBindingModel": {
+      "additionalProperties": false,
+      "description": "Governed binding from an admitted ACES snapshot concept to graph content.",
+      "properties": {
+        "aces_address": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Aces Address",
+          "type": "string"
+        },
+        "binding_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Binding Id",
+          "type": "string"
+        },
+        "concept_kind": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "title": "Concept Kind",
+          "type": "string"
+        },
+        "target_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Target Id",
+          "type": "string"
+        },
+        "target_kind": {
+          "enum": [
+            "state-fact",
+            "transition"
+          ],
+          "title": "Target Kind",
+          "type": "string"
+        }
+      },
+      "required": [
+        "binding_id",
+        "concept_kind",
+        "aces_address",
+        "target_kind",
+        "target_id"
+      ],
+      "title": "AttackGraphBindingModel",
+      "type": "object"
+    },
+    "AttackObservationModel": {
+      "additionalProperties": false,
+      "description": "Observation emitted by a transition, without promoting it to hidden truth.",
+      "properties": {
+        "kind": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "title": "Kind",
+          "type": "string"
+        },
+        "observation_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "source_address": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Source Address",
+          "type": "string"
+        }
+      },
+      "required": [
+        "observation_id",
+        "kind",
+        "source_address"
+      ],
+      "title": "AttackObservationModel",
+      "type": "object"
+    },
+    "AttackStateFactKind": {
+      "description": "Closed v1 attack-state fact families.",
+      "enum": [
+        "access",
+        "capability",
+        "data-state",
+        "execution",
+        "observation",
+        "objective-state"
+      ],
+      "title": "AttackStateFactKind",
+      "type": "string"
+    },
+    "AttackStateFactModel": {
+      "additionalProperties": false,
+      "description": "One typed fact in the normalized attack state space.",
+      "properties": {
+        "fact_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/AttackStateFactKind"
+        },
+        "object_ref": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Object Ref",
+          "type": "string"
+        },
+        "subject": {
+          "maxLength": 256,
+          "minLength": 1,
+          "pattern": "^[^\\r\\n]+$",
+          "title": "Subject",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fact_id",
+        "kind",
+        "subject",
+        "object_ref"
+      ],
+      "title": "AttackStateFactModel",
+      "type": "object"
+    },
+    "AttackTransitionKind": {
+      "description": "Closed v1 attack-transition families.",
+      "enum": [
+        "exploit-step",
+        "observation-step",
+        "postcondition-step"
+      ],
+      "title": "AttackTransitionKind",
+      "type": "string"
+    },
+    "AttackTransitionModel": {
+      "additionalProperties": false,
+      "description": "One typed attack transition with explicit prerequisites and effects.",
+      "properties": {
+        "effects": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "title": "Effects",
+          "type": "array"
+        },
+        "kind": {
+          "$ref": "#/$defs/AttackTransitionKind"
+        },
+        "observations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/AttackObservationModel"
+          },
+          "maxItems": 64,
+          "title": "Observations",
+          "type": "array"
+        },
+        "prerequisites": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "title": "Prerequisites",
+          "type": "array"
+        },
+        "semantics": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-z][a-z0-9-]*/v[0-9]+$",
+          "title": "Semantics",
+          "type": "string"
+        },
+        "transition_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Transition Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "transition_id",
+        "kind",
+        "semantics",
+        "prerequisites",
+        "effects"
+      ],
+      "title": "AttackTransitionModel",
+      "type": "object"
+    },
+    "BlockedTransitionModel": {
+      "additionalProperties": false,
+      "description": "One transition blocked at a reached state.",
+      "properties": {
+        "missing_prerequisites": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Missing Prerequisites",
+          "type": "array"
+        },
+        "state_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "State Digest",
+          "type": "string"
+        },
+        "transition_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Transition Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "transition_id",
+        "state_digest",
+        "missing_prerequisites"
+      ],
+      "title": "BlockedTransitionModel",
+      "type": "object"
+    },
+    "DiagnosticModel": {
+      "additionalProperties": false,
+      "description": "Closed portable diagnostic shape for published contracts.",
+      "properties": {
+        "address": {
+          "maxLength": 4096,
+          "pattern": "^(?:/(?:[^~/]|~[01])*)*$",
+          "title": "Address",
+          "type": "string"
+        },
+        "code": {
+          "maxLength": 128,
+          "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+          "title": "Code",
+          "type": "string"
+        },
+        "domain": {
+          "maxLength": 64,
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+          "title": "Domain",
+          "type": "string"
+        },
+        "message": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Message",
+          "type": "string"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity",
+          "default": "error"
+        }
+      },
+      "required": [
+        "code",
+        "domain",
+        "address",
+        "message"
+      ],
+      "title": "DiagnosticModel",
+      "type": "object"
+    },
+    "ExploitPathOutcome": {
+      "description": "Completed exploit-path analysis outcomes.",
+      "enum": [
+        "valid-path",
+        "invalid-path",
+        "unsupported"
+      ],
+      "title": "ExploitPathOutcome",
+      "type": "string"
+    },
+    "ExploitPathQueryModel": {
+      "additionalProperties": false,
+      "description": "Closed path query contract.",
+      "properties": {
+        "allowed_transition_semantics": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "title": "Allowed Transition Semantics",
+          "type": "array"
+        },
+        "goal_check": {
+          "const": "before-and-after-transition",
+          "title": "Goal Check",
+          "type": "string"
+        },
+        "goal_facts": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Goal Facts",
+          "type": "array"
+        },
+        "max_depth": {
+          "maximum": 64,
+          "minimum": 0,
+          "title": "Max Depth",
+          "type": "integer"
+        },
+        "participant_perspective": {
+          "maxLength": 256,
+          "minLength": 1,
+          "pattern": "^[^\\r\\n]+$",
+          "title": "Participant Perspective",
+          "type": "string"
+        },
+        "profile": {
+          "const": "aces-exploit-path-query/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "query_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Query Id",
+          "type": "string"
+        },
+        "start_facts": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Start Facts",
+          "type": "array"
+        }
+      },
+      "required": [
+        "profile",
+        "query_id",
+        "participant_perspective",
+        "start_facts",
+        "goal_facts",
+        "allowed_transition_semantics",
+        "max_depth",
+        "goal_check"
+      ],
+      "title": "ExploitPathQueryModel",
+      "type": "object"
+    },
+    "ExploitPathSearchConfigurationModel": {
+      "additionalProperties": false,
+      "description": "Complete output-affecting v1 search configuration.",
+      "properties": {
+        "goal_check": {
+          "const": "before-and-after-transition",
+          "title": "Goal Check",
+          "type": "string"
+        },
+        "max_depth": {
+          "maximum": 64,
+          "minimum": 0,
+          "title": "Max Depth",
+          "type": "integer"
+        },
+        "profile": {
+          "const": "aces-deterministic-attack-graph-search/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "strategy": {
+          "const": "breadth-first-canonical",
+          "title": "Strategy",
+          "type": "string"
+        },
+        "transition_semantics": {
+          "const": "monotonic-additive/v1",
+          "title": "Transition Semantics",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile",
+        "strategy",
+        "transition_semantics",
+        "goal_check",
+        "max_depth"
+      ],
+      "title": "ExploitPathSearchConfigurationModel",
+      "type": "object"
+    },
+    "ExploitPathStepModel": {
+      "additionalProperties": false,
+      "description": "One replayable witness step.",
+      "properties": {
+        "applied_effects": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "title": "Applied Effects",
+          "type": "array"
+        },
+        "emitted_observations": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "title": "Emitted Observations",
+          "type": "array"
+        },
+        "satisfied_prerequisites": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "title": "Satisfied Prerequisites",
+          "type": "array"
+        },
+        "state_after_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "State After Digest",
+          "type": "string"
+        },
+        "state_before_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "State Before Digest",
+          "type": "string"
+        },
+        "step_index": {
+          "maximum": 64,
+          "minimum": 0,
+          "title": "Step Index",
+          "type": "integer"
+        },
+        "transition_id": {
+          "maxLength": 256,
+          "pattern": "^[a-z][a-z0-9._:-]*$",
+          "title": "Transition Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "step_index",
+        "transition_id",
+        "state_before_digest",
+        "satisfied_prerequisites",
+        "applied_effects",
+        "emitted_observations",
+        "state_after_digest"
+      ],
+      "title": "ExploitPathStepModel",
+      "type": "object"
+    },
+    "InvalidPathEvidenceModel": {
+      "additionalProperties": false,
+      "description": "Structured evidence for an invalid path query.",
+      "properties": {
+        "blocked_transitions": {
+          "items": {
+            "$ref": "#/$defs/BlockedTransitionModel"
+          },
+          "maxItems": 256,
+          "title": "Blocked Transitions",
+          "type": "array"
+        },
+        "exhausted_depth": {
+          "title": "Exhausted Depth",
+          "type": "boolean"
+        },
+        "explored_state_count": {
+          "maximum": 4096,
+          "minimum": 1,
+          "title": "Explored State Count",
+          "type": "integer"
+        },
+        "impossible_transitions": {
+          "default": [],
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "title": "Impossible Transitions",
+          "type": "array"
+        },
+        "profile": {
+          "const": "aces-exploit-path-invalid/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "unsatisfied_goal": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Unsatisfied Goal",
+          "type": "array"
+        }
+      },
+      "required": [
+        "profile",
+        "explored_state_count",
+        "exhausted_depth",
+        "blocked_transitions",
+        "unsatisfied_goal"
+      ],
+      "title": "InvalidPathEvidenceModel",
+      "type": "object"
+    },
+    "NormalizedAttackGraphModel": {
+      "additionalProperties": false,
+      "description": "Closed normalized attack graph derived from governed ACES bindings.",
+      "properties": {
+        "binding_profile": {
+          "const": "aces-sdl-snapshot-attack-binding/v1",
+          "title": "Binding Profile",
+          "type": "string"
+        },
+        "bindings": {
+          "items": {
+            "$ref": "#/$defs/AttackGraphBindingModel"
+          },
+          "maxItems": 1024,
+          "title": "Bindings",
+          "type": "array"
+        },
+        "profile": {
+          "const": "aces-attack-graph/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "snapshot_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Snapshot Digest",
+          "type": "string"
+        },
+        "state_facts": {
+          "items": {
+            "$ref": "#/$defs/AttackStateFactModel"
+          },
+          "maxItems": 512,
+          "minItems": 1,
+          "title": "State Facts",
+          "type": "array"
+        },
+        "transition_semantics_profile": {
+          "const": "aces-monotonic-attack-transition/v1",
+          "title": "Transition Semantics Profile",
+          "type": "string"
+        },
+        "transitions": {
+          "items": {
+            "$ref": "#/$defs/AttackTransitionModel"
+          },
+          "maxItems": 512,
+          "title": "Transitions",
+          "type": "array"
+        }
+      },
+      "required": [
+        "profile",
+        "binding_profile",
+        "transition_semantics_profile",
+        "snapshot_digest",
+        "state_facts",
+        "transitions",
+        "bindings"
+      ],
+      "title": "NormalizedAttackGraphModel",
+      "type": "object"
+    },
+    "SemanticDigest": {
+      "additionalProperties": false,
+      "description": "Profile-labelled digest of one expanded authoring scenario.",
+      "properties": {
+        "algorithm": {
+          "const": "sha256",
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "profile": {
+          "const": "aces-sdl-semantic/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "value": {
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile",
+        "algorithm",
+        "value"
+      ],
+      "title": "SemanticDigest",
+      "type": "object"
+    },
+    "Severity": {
+      "description": "Diagnostic severity level.",
+      "enum": [
+        "error",
+        "warning",
+        "info"
+      ],
+      "title": "Severity",
+      "type": "string"
+    },
+    "SourceArtifactIdentityModel": {
+      "additionalProperties": false,
+      "description": "Portable identity and exact-byte digest for the root SDL source.",
+      "properties": {
+        "byte_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Byte Digest",
+          "type": "string"
+        },
+        "source_id": {
+          "maxLength": 256,
+          "minLength": 1,
+          "pattern": "^[^\\r\\n]+$",
+          "title": "Source Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id",
+        "byte_digest"
+      ],
+      "title": "SourceArtifactIdentityModel",
+      "type": "object"
+    },
+    "UnsupportedExploitPathAnalysisModel": {
+      "additionalProperties": false,
+      "description": "Fail-closed unsupported reason set.",
+      "properties": {
+        "profile": {
+          "const": "aces-exploit-path-unsupported/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "reason_codes": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Reason Codes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "profile",
+        "reason_codes"
+      ],
+      "title": "UnsupportedExploitPathAnalysisModel",
+      "type": "object"
+    },
+    "ValidPathWitnessModel": {
+      "additionalProperties": false,
+      "description": "Replayable valid path witness for the exact graph and query.",
+      "properties": {
+        "final_state": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "minItems": 1,
+          "title": "Final State",
+          "type": "array"
+        },
+        "final_state_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Final State Digest",
+          "type": "string"
+        },
+        "goal_facts": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "minItems": 1,
+          "title": "Goal Facts",
+          "type": "array"
+        },
+        "initial_state": {
+          "items": {
+            "maxLength": 256,
+            "pattern": "^[a-z][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "minItems": 1,
+          "title": "Initial State",
+          "type": "array"
+        },
+        "profile": {
+          "const": "aces-exploit-path-witness/v1",
+          "title": "Profile",
+          "type": "string"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/$defs/ExploitPathStepModel"
+          },
+          "maxItems": 64,
+          "title": "Steps",
+          "type": "array"
+        }
+      },
+      "required": [
+        "profile",
+        "initial_state",
+        "goal_facts",
+        "steps",
+        "final_state",
+        "final_state_digest"
+      ],
+      "title": "ValidPathWitnessModel",
+      "type": "object"
+    }
+  },
+  "$id": "https://aces.dev/schemas/exploit-path-analysis-evidence-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Closed evidence envelope binding source, snapshot, graph, query, and result.",
+  "oneOf": [
+    {
+      "properties": {
+        "failure": {
+          "type": "null"
+        },
+        "outcome": {
+          "const": "valid-path"
+        },
+        "unsupported": {
+          "type": "null"
+        },
+        "witness": {
+          "not": {
+            "type": "null"
+          }
+        }
+      },
+      "required": [
+        "outcome",
+        "witness"
+      ]
+    },
+    {
+      "properties": {
+        "failure": {
+          "not": {
+            "type": "null"
+          }
+        },
+        "outcome": {
+          "const": "invalid-path"
+        },
+        "unsupported": {
+          "type": "null"
+        },
+        "witness": {
+          "type": "null"
+        }
+      },
+      "required": [
+        "outcome",
+        "failure"
+      ]
+    },
+    {
+      "properties": {
+        "failure": {
+          "type": "null"
+        },
+        "outcome": {
+          "const": "unsupported"
+        },
+        "unsupported": {
+          "not": {
+            "type": "null"
+          }
+        },
+        "witness": {
+          "type": "null"
+        }
+      },
+      "required": [
+        "outcome",
+        "unsupported"
+      ]
+    }
+  ],
+  "properties": {
+    "analysis_profile": {
+      "const": "aces-exploit-path-analysis-v1",
+      "title": "Analysis Profile",
+      "type": "string"
+    },
+    "authored_digest": {
+      "$ref": "#/$defs/SemanticDigest"
+    },
+    "diagnostics": {
+      "items": {
+        "$ref": "#/$defs/DiagnosticModel"
+      },
+      "maxItems": 64,
+      "title": "Diagnostics",
+      "type": "array"
+    },
+    "failure": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/InvalidPathEvidenceModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "normalized_graph": {
+      "$ref": "#/$defs/NormalizedAttackGraphModel"
+    },
+    "normalized_graph_digest": {
+      "minLength": 1,
+      "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+      "title": "Normalized Graph Digest",
+      "type": "string"
+    },
+    "outcome": {
+      "$ref": "#/$defs/ExploitPathOutcome"
+    },
+    "profile": {
+      "const": "exploit-path-analysis-evidence/v1",
+      "title": "Profile",
+      "type": "string"
+    },
+    "query": {
+      "$ref": "#/$defs/ExploitPathQueryModel"
+    },
+    "query_digest": {
+      "minLength": 1,
+      "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+      "title": "Query Digest",
+      "type": "string"
+    },
+    "search_configuration": {
+      "$ref": "#/$defs/ExploitPathSearchConfigurationModel"
+    },
+    "search_configuration_digest": {
+      "minLength": 1,
+      "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+      "title": "Search Configuration Digest",
+      "type": "string"
+    },
+    "snapshot_digest": {
+      "minLength": 1,
+      "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+      "title": "Snapshot Digest",
+      "type": "string"
+    },
+    "source": {
+      "$ref": "#/$defs/SourceArtifactIdentityModel"
+    },
+    "unsupported": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UnsupportedExploitPathAnalysisModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "witness": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ValidPathWitnessModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "profile",
+    "analysis_profile",
+    "source",
+    "authored_digest",
+    "snapshot_digest",
+    "normalized_graph",
+    "normalized_graph_digest",
+    "query",
+    "query_digest",
+    "search_configuration",
+    "search_configuration_digest",
+    "outcome",
+    "diagnostics"
+  ],
+  "title": "ExploitPathAnalysisEvidenceModel",
+  "type": "object",
+  "x-aces-invariants": [
+    {
+      "description": "The snapshot, normalized graph, query, search configuration, witness final state, and unsupported reason code joins must validate against their canonical contract digests and diagnostics.",
+      "id": "exploit-path-evidence-digest-joins",
+      "inputs": [
+        {
+          "contract_id": "exploit-path-analysis-evidence-v1",
+          "instance_path": "#"
+        }
+      ],
+      "level": "error",
+      "validator": "aces_contracts.exploit_path.ExploitPathAnalysisEvidenceModel._validate_evidence_joins"
+    }
+  ],
+  "x-aces-semantic-profile": {
+    "contract_id": "exploit-path-analysis-evidence-v1",
+    "entry_schema_contract_id": "aces-semantic-invariants-v1",
+    "entry_schema_pointer": "#/$defs/AcesSemanticInvariantEntryModel",
+    "id": "aces-semantic-invariants-v1",
+    "keyword": "x-aces-invariants",
+    "required": true,
+    "uri": "https://aces.dev/schemas/semantic-invariants/v1"
+  }
+}

--- a/docs/api/processor.rst
+++ b/docs/api/processor.rst
@@ -76,3 +76,9 @@ Capabilities
 
 .. automodule:: aces_processor.capabilities
    :members:
+
+Exploit-Path Analysis
+---------------------
+
+.. automodule:: aces_processor.exploit_path
+   :members:

--- a/docs/decisions/issue-827-typed-exploit-path-semantics-preflight.md
+++ b/docs/decisions/issue-827-typed-exploit-path-semantics-preflight.md
@@ -1,0 +1,290 @@
+# Issue 827 Typed Exploit-Path Semantics Preflight
+
+Date: 2026-07-20
+
+Issue: #827. Requirement: none; the issue title, body, and acceptance criteria
+are the delivery contract.
+
+This note records repository-wide architecture guardrails for typed
+exploit-path semantics and executable path analysis. It does not implement the
+analyzer, publish schemas or fixtures, define final field names, add CLI
+commands, or provide an implementation plan.
+
+## Decision Boundary
+
+Issue #827 is an FM2 semantic graph and query surface. It asks whether a path
+exists in one governed attack-transition graph under one declared query and
+transition-semantics profile.
+
+The capability must not be implemented as a renamed reachability check. These
+claims stay separate:
+
+- schema/Pydantic acceptance proves shape, not exploitability;
+- `SemanticValidator` proves existing static SDL invariants, not attack
+  transition validity;
+- topology links, ACLs, route bindings, listeners, and service declarations are
+  inputs or binding facts, not exploit transitions by themselves;
+- vulnerability, CVE, CWE, ATT&CK, tactic, tool, or action labels are concept
+  evidence, not successful exploitation;
+- workflow reachability and planner ordering are properties of their owning
+  graphs, not attack paths;
+- scenario satisfiability proves only its finite variable-domain profile, not
+  exploitability;
+- backend realization, conformance, provisioning, and deployment success do not
+  prove exploit paths; and
+- objective success, proposition truth, participant-local action success, and
+  runtime observation remain distinct from attack-graph goal satisfaction unless
+  a governed binding says exactly how they relate.
+
+The normative theory should live under a focused
+`specs/formal/exploit-path-analysis/` artifact and must define typed attack
+states, transition prerequisites/effects/observations, query semantics, result
+semantics, and explicit exclusions. Existing ADRs already cover authority,
+claim evidence, validation strength, formal-methods classification, concept
+governance, phase contracts, provenance, participant behavior, and
+satisfiability boundaries. A new ADR is only warranted if implementation
+changes those authorities, adds an external solver/engine dependency, exposes a
+remote service boundary, or changes validation-strength semantics.
+
+## Analyzer Authority And Package Boundary
+
+The production analyzer belongs to the processor analysis layer. The expected
+ownership split is:
+
+| Concern | Required boundary |
+| --- | --- |
+| Normative semantics | `specs/formal/exploit-path-analysis/`; not code comments, CLI help, or tests. |
+| Portable contracts | `aces_contracts` closed models plus published schemas and fixtures if an exchange result is published. |
+| Graph derivation and analysis | `aces_processor` public analysis surface; no analyzer logic in `aces_sdl`, `aces_runtime`, `tools/`, or compatibility wrappers. |
+| CLI exposure | Existing `aces processor` Typer group, matching the `satisfiability` command style. |
+| SDL ingestion and admission | Existing parser, composition, instantiation/admission, semantic validation, canonical digest, and phase contracts. |
+
+The analyzer input should be a concrete, semantically admitted scenario
+surface: either an `InstantiatedScenarioSnapshot` or an entrypoint that first
+uses the existing parse/instantiate/admit path and then binds the produced
+snapshot. Evidence still binds the authored source and expanded semantic
+digest through existing instantiation provenance. Raw YAML dictionaries,
+direct model construction, `skip_semantic_validation`, and test-local graph
+fixtures cannot be the production acceptance path.
+
+The normalized attack graph is a derived artifact. It must not become a new SDL
+authoring section unless the SDL language itself is intentionally extended by a
+separate design. The graph may reference ACES scenario concepts, but every
+scenario-to-graph node or edge binding must be governed, typed, versioned, and
+fail closed when missing, ambiguous, lossy, unsupported, or conflicting.
+
+## Required Semantic Shape
+
+The normative model must define, at minimum:
+
+- typed attack-state node kinds, with stable identities and source bindings;
+- typed transition edge kinds, each with explicit prerequisites, effects,
+  observations, and unsupported conditions;
+- a closed query contract with start state, goal condition, participant
+  perspective, allowed transition semantics, and analysis profile;
+- transition firing semantics: which prerequisites are required, how effects
+  update state, whether observations are emitted, and how ordering is handled;
+- goal-check semantics, including whether the goal is evaluated before any
+  transition, after each transition, or both;
+- path witness semantics: ordered states/transitions plus satisfied
+  prerequisites, applied effects, emitted observations, and source/provenance
+  joins;
+- failure semantics: structured evidence for missing prerequisites,
+  impossible transitions, ambiguous bindings, unsupported semantics, exhausted
+  search bounds, and unsatisfied goals; and
+- explicit nonclaims for network reachability, vulnerability presence,
+  topology connectivity, action applicability, deployment success, runtime
+  behavior, and external exploit feasibility.
+
+Do not let the query be an open expression language. A query's start, goal,
+participant perspective, transition filter, and bounds must be governed
+contract fields with stable profile ids. No arbitrary Python, JSONPath,
+regular-expression predicate, shell command, SMT text, or plugin callback
+belongs in the portable query contract.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and required reuse |
+| --- | --- |
+| Prior finding and claim boundary | Issue #168 preflight and `docs/research/formal-semantic-validation/`; preserve the old unsupported/untested record and add new evidence rather than rewriting it. |
+| Authority and assurance | ADR-007, ADR-009, ADR-019, ADR-021, ADR-072, ADR-081, ADR-086, `specs/formal/assurance-policy.yaml`, and validation-profile terminology. |
+| SDL phases and provenance | ADR-078, `parse_sdl_file()`, `instantiate_scenario()`, `admit_instantiated_scenario()`, `InstantiatedScenarioSnapshot`, `canonical_sdl_digest()`, `canonical_instantiated_sdl_digest()`, and `InstantiationProvenance`. |
+| Static semantics and references | `SemanticValidator`, `build_declaration_index`, `specs/sdl/references.md`, `specs/sdl/diagnostics.md`, `_validate_named_ref()` patterns, and collect-all `SDLValidationError` behavior. |
+| Canonical addresses | ADR-076 and `aces_processor.compiler.addresses`; attack graph bindings should carry typed canonical addresses or safe JSON Pointers, not delimiter guesses. |
+| Concept governance | ADR-012, ADR-062, `contracts/concept-authority/`, controlled vocabularies, reference models, semantic profiles, and `BehavioralClaimBindingModel` where claim discipline is needed. |
+| Participant semantics | ADR-022, ADR-054, ADR-067, ADR-083, `specs/formal/participant-semantics/`, action contracts, observation boundaries, participant views, preconditions, effects, failure classes, and attribution boundaries. |
+| Objectives and truth | `aces_sdl.semantics.objectives`, `objective_semantics`, `propositions`, and `proposition-truth-result-v1`; reuse goal/proposition meaning only through an explicit binding. |
+| Satisfiability pattern | ADR-086, `specs/formal/scenario-satisfiability/`, `aces_contracts.satisfiability`, `aces_processor.satisfiability`, deterministic evidence/replay, and unsupported-versus-operational-failure separation. |
+| Contracts and schemas | `ContractModel(extra="forbid")`, `DiagnosticModel`, `PrefixedDigestString`, RFC 8785/JCS digests, `schema_bundle()`, `contracts/schemas/`, `contracts/fixtures/`, schema publication entries, and generated-schema parity. |
+| CLI and result errors | `aces_cli.processor`, `_sdl_error_summary()`, value-free stderr, JSON to stdout, exit `0` for completed supported analysis, exit `2` for typed unsupported results, and exit `1` for input/operational failure. |
+| Policy and workflow | `.ground-control.yaml`, `.gc/plan-rules.md`, ADR-014, ADR-015, `noxfile.py`, `SessionReporter`, `tools/verify_all.py`, repo policy, requirement governance, schema publication, JSON artifact, concept authority, assurance, semantic coverage, OSV, gitleaks, and docs checks. |
+
+Do not add a second graph registry, reference resolver, controlled vocabulary
+loader, schema publication manifest, diagnostic envelope, exception hierarchy,
+canonical digest shape, conformance runner, persistence store, logger, or CI
+workflow.
+
+## Cross-Cutting Security And Validation Layers
+
+The intended design passes every layer below.
+
+1. **SDL source/parser gate.** Source input uses existing bounded SDL reading,
+   UTF-8/YAML validation, duplicate-key and mapping-key checks, closed models,
+   composition/import path confinement, semantic validation, instantiation, and
+   admission. The analyzer must never repair malformed SDL or accept a
+   semantic-validation bypass as proof input.
+2. **Scenario phase gate.** Attack graph derivation consumes a concrete
+   admitted scenario or canonical snapshot and binds the authored semantic
+   digest, import/instantiation provenance, snapshot digest, and normalized
+   graph digest. Provenance uses portable source ids and digests, not absolute
+   checkout paths.
+3. **Binding gate.** Governed bindings from ACES concepts to attack graph nodes
+   and edges resolve through declaration indexes, canonical addresses,
+   reference models, controlled vocabularies, semantic profiles, and explicit
+   binding profiles. Missing, ambiguous, stale, lossy, conflicting, or
+   unsupported mappings fail closed with stable diagnostics.
+4. **Query/config gate.** The query and analysis profile are closed contract
+   inputs. Unknown fields, unknown profile ids, duplicate ids, dangling start
+   states, ill-typed goal predicates, unsupported transition semantics,
+   unsupported participant perspectives, and excessive search bounds are
+   rejected or reported as typed unsupported outcomes. Profiles are selected by
+   explicit input, not environment variables or open option maps.
+5. **Transition-semantics gate.** Each transition kind has one typed evaluator
+   for prerequisites, effects, observations, and state update. Unsupported
+   prerequisites or effects are not ignored, downgraded to warnings, or treated
+   as already satisfied. Ordering and goal checks are load-bearing semantics,
+   not traversal details.
+6. **Analyzer execution gate.** Prefer a deterministic in-process graph search
+   over adding a dependency. If a solver or graph engine is added, equality-pin
+   the dependency, record the exact profile/options, review license and OSV,
+   disable plugins/network access, bound work deterministically, and keep
+   timeout/unknown as operational failure unless the normative profile defines a
+   typed unsupported case.
+7. **Authentication/authorization gate.** The normal design is a local,
+   read-only analysis command and adds no auth surface. A later HTTP or MCP
+   adapter must reuse `ControlPlaneSecurityConfig.strict_defaults()`, verified
+   identity, role/target authorization, request-size guards, idempotency and
+   fingerprinting for mutations, audit summaries, and the redacted
+   internal-error handler. A research analyzer is not an auth bypass.
+8. **Secret and sensitivity gate.** Scenarios may contain exploit-relevant
+   credentials and hidden assets. Diagnostics, logs, CLI stderr, fixtures,
+   committed evidence, audit records, and result summaries must not render raw
+   source bodies, credential values, parameter maps, full domains, raw exploit
+   material, command output, solver/native objects, backend payloads, trust
+   policy contents, Pydantic input, environment dumps, process argv, or
+   tracebacks.
+9. **OS/process gate.** Do not pass raw scenario text, query JSON, bindings,
+   credentials, witnesses, or evidence in process argv. If a future external
+   engine is unavoidable, use fixed argv, `shell=False`, bounded stdin, no
+   network fetches, no ambient solver path from environment, and no privileged
+   namespace, firewall, backend apply, or exploit execution.
+10. **Error-envelope gate.** Use `SDLParseError`, `SDLValidationError`,
+    `SDLInstantiationError`, `Diagnostic`/`Severity`, `DiagnosticModel`, and
+    bounded `PolicyFailure` patterns. Invalid paths and unsupported semantics
+    are completed analyzer results; malformed input and internal failures are
+    operational failures. Public envelopes expose stable codes, domains, safe
+    addresses, and bounded messages only.
+11. **Persistence/observability gate.** The durable artifact is the closed
+    evidence JSON or checked-in research snapshot selected by the caller. Do
+    not write to `ControlPlaneStore`, runtime snapshots, experiment archives,
+    audit blobs, logs, caches, databases, or free-form metadata as part of this
+    capability.
+12. **Contract publication gate.** Published schemas under `contracts/schemas/`
+    are authority. Any new normalized graph, query, or evidence schema requires
+    the hand-governed schema, schema publication entry/ledger, `schema_bundle()`
+    parity, valid and single-defect invalid fixtures, JSON artifact validation,
+    and generated-schema drift checks.
+
+## Extensibility Seam
+
+Use one governed analysis profile that maps to a compatible tuple:
+
+```text
+(binding_profile, transition_semantics_profile, query_semantics_profile,
+ search_profile)
+```
+
+Callers select only the analysis profile. They do not freely combine arbitrary
+binding, semantics, query, and search profiles. The normalized graph and result
+contracts stay search-engine neutral so a later engine, broader transition
+family, participant perspective, scenario-variation input, or differential
+checker can add a new profile without changing SDL syntax or weakening v1.
+
+The next reasonable variation is adding a transition family or binding scope.
+That variation should add governed vocabulary/reference-model rows, one
+translation/binding disposition, fixtures, replay evidence, and mutation tests.
+It must not require editing unrelated planner topology, satisfiability,
+runtime, backend, or objective semantics.
+
+## Required Evidence Discipline
+
+Acceptance evidence must prove the semantics are load-bearing:
+
+- positive controls produce a replayable valid-path witness;
+- single-defect negatives isolate one missing prerequisite, impossible
+  transition, ordering violation, ambiguous binding, unsupported semantic, or
+  failed goal check at a time;
+- invalid-path results carry structured failure evidence, not only prose;
+- unsupported and ambiguous mappings fail closed with stable diagnostics;
+- mutation tests demonstrate that prerequisites, effects, ordering, and goal
+  checks change outcomes when weakened or removed;
+- replay rejects stale source, graph, query, result, witness, failure evidence,
+  profile, and digest joins; and
+- validation-profile documentation states that weaker reachability,
+  vulnerability, topology, deployment, or action-applicability evidence cannot
+  be promoted to exploit-path proof.
+
+Positive examples in `examples/` are not invalid corpora. Normative fixtures
+belong under `contracts/fixtures/` only when the result contract is published.
+Research evidence should follow the issue #168 protocol/snapshot/analysis
+bundle pattern and preserve prior records unchanged.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- proving exploit paths from topology links, ACLs, listeners, route bindings,
+  vulnerability refs, CWE/CVE/ATT&CK labels, tool names, offensive behavior
+  terms, action names, objective success, scanner output, or deployment success;
+- treating network reachability, service reachability, route targetability,
+  workflow reachability, planner ordering, whole-scenario satisfiability, or
+  realization-envelope membership as exploit-path validity;
+- deriving transitions from English descriptions, tags, free-form metadata,
+  raw commands, hidden answers, backend-native logs, or successful provisioner
+  output;
+- using participant-visible observations as hidden truth, or hidden truth as
+  participant-visible state, without a governed observation boundary;
+- treating a failed exploit-path query as proof that no real-world exploit is
+  possible outside the normalized graph and profile;
+- treating a valid witness as proof that a backend, network, tool, or attacker
+  can execute the path in reality;
+- allowing unsupported transition semantics to silently drop edges or
+  prerequisites;
+- giving ambiguous bindings a first-match, declaration-order, shortest-path, or
+  longest-name resolution;
+- embedding arbitrary predicate languages, shell commands, solver text,
+  callbacks, plugins, or environment-selected options in the query;
+- emitting raw scenario values, credentials, exploit text, solver dumps,
+  backend objects, tracebacks, or absolute host paths in diagnostics/evidence;
+- adding implementation logic under `implementations/python/src/aces/`; and
+- adding a parallel schema registry, graph/query DSL, exception tree,
+  diagnostic envelope, persistence store, remote service, or CI graph.
+
+## Non-Goals And Implementation Boundaries
+
+- This preflight does not implement issue #827 or define final contract fields.
+- It does not add SDL syntax, attack graph authoring sections, public schemas,
+  fixtures, examples, CLI commands, HTTP/MCP endpoints, runtime persistence, or
+  backend behavior.
+- It does not perform network scanning, vulnerability exploitation,
+  penetration testing, command execution, malware/tool invocation, provisioning,
+  deployment, observation capture, or runtime validation.
+- It does not prove real-world exploitability, arbitrary-SDL exploitability,
+  backend realizability, network reachability, service reachability, objective
+  success, attacker skill, or counterfactual necessity.
+- It does not replace participant action semantics, proposition truth,
+  workflow semantics, planner semantics, scenario satisfiability, behavioral
+  relations, validation-profile disclosure, or concept-authority governance.
+- Any supported result is valid only for the exact authored source/snapshot,
+  normalized graph, query, profiles, analyzer version, and evidence it binds.
+  Any change requires re-analysis.

--- a/docs/research/formal-semantic-validation/index.md
+++ b/docs/research/formal-semantic-validation/index.md
@@ -15,9 +15,12 @@ The immutable issue-168 v1 record keeps whole-scenario satisfiability,
 exploit-path validity, and counterfactual necessity `untested` at its pinned
 revision. ADR-086 and issue #826 add a revisioned satisfiability supplement:
 the exact finite-domain profile is now `demonstrated` by production
-satisfiable, unsatisfiable, and fail-closed unsupported controls. Exploit-path
-validity and counterfactual necessity remain `untested`, and the supplement
-does not generalize beyond its named profile.
+satisfiable, unsatisfiable, and fail-closed unsupported controls. Issue #827
+adds a bounded typed exploit-path analyzer and published evidence contract for
+`aces-exploit-path-analysis-v1`; that result is valid only for its admitted
+snapshot, normalized attack graph, query, and search profile. It does not
+demonstrate arbitrary-SDL or real-world exploit validity, and counterfactual
+necessity remains `untested`.
 
 ## Bundle
 

--- a/docs/specs/formal.md
+++ b/docs/specs/formal.md
@@ -32,6 +32,10 @@ formal artifacts are warranted.
   realization boundaries, backend realization support, and proposed
   realization-envelope membership, subsumption, witness, and negative
   conformance semantics
+- **Exploit-Path Analysis** (`specs/formal/exploit-path-analysis/`) -- Typed
+  attack-state graph, transition, query, witness, and failure-evidence
+  semantics with explicit nonclaims for weaker reachability and vulnerability
+  evidence
 - **Behavioral Relations** (`specs/formal/behavioral-relations/`) -- Revisioned
   validity, conformance, trace, simulation, refinement, bisimulation,
   participant-projection, strategic, probabilistic, statistical, and empirical

--- a/implementations/python/packages/aces_cli/processor.py
+++ b/implementations/python/packages/aces_cli/processor.py
@@ -21,6 +21,13 @@ from aces_contracts.plan_projection import (
     orchestration_plan_model,
     provisioning_plan_model,
 )
+from aces_processor.exploit_path import (
+    ANALYSIS_PROFILE as EXPLOIT_PATH_ANALYSIS_PROFILE,
+)
+from aces_processor.exploit_path import (
+    ExploitPathOperationalError,
+    analyze_exploit_path_file,
+)
 from aces_processor.manifest import reference_processor_manifest_payload
 from aces_processor.models import ExecutionPlan
 from aces_processor.reference import run_reference_processor
@@ -207,6 +214,33 @@ def satisfiability(
     except SatisfiabilityOperationalError as exc:
         # The service deliberately exposes value-free operational messages.
         typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(json.dumps(evidence.model_dump(mode="json"), indent=2, sort_keys=True))
+    if evidence.outcome.value == "unsupported":
+        raise typer.Exit(code=2)
+
+
+@app.command("exploit-path")
+def exploit_path(
+    input_json: Path = typer.Argument(..., exists=True, readable=True, help="Exploit-path analysis input JSON."),
+    profile: str = typer.Option(
+        EXPLOIT_PATH_ANALYSIS_PROFILE,
+        "--profile",
+        help="Closed governed exploit-path analysis profile.",
+    ),
+) -> None:
+    """Emit replayable typed exploit-path analysis evidence as JSON.
+
+    Exit status 0 means the supported query completed with a valid or invalid
+    path result, 2 means typed unsupported input, and 1 means malformed input
+    or operational failure.
+    """
+
+    try:
+        evidence = analyze_exploit_path_file(input_json, profile=profile)
+    except ExploitPathOperationalError as exc:
+        typer.echo(f"error: exploit-path input was rejected ({exc})", err=True)
         raise typer.Exit(code=1) from exc
 
     typer.echo(json.dumps(evidence.model_dump(mode="json"), indent=2, sort_keys=True))

--- a/implementations/python/packages/aces_contracts/contracts/bundle.py
+++ b/implementations/python/packages/aces_contracts/contracts/bundle.py
@@ -94,6 +94,7 @@ def _raw_schema_bundle() -> dict[str, dict[str, Any]]:
     from aces_contracts.realization_envelope import BackendRealizationEnvelopeModel
 
     from ..behavioral_relations import BehavioralRelationCatalogModel
+    from ..exploit_path import ExploitPathAnalysisEvidenceModel
     from ..provenance import SDLLineageLedgerModel
     from ..satisfiability import ScenarioSatisfiabilityEvidenceModel
     from ..scientific_completeness import (
@@ -107,6 +108,7 @@ def _raw_schema_bundle() -> dict[str, dict[str, Any]]:
         "instantiated-scenario-v1": InstantiatedScenario.model_json_schema(),
         "instantiated-scenario-snapshot-v1": InstantiatedScenarioSnapshot.model_json_schema(),
         "scenario-instantiation-request-v1": InstantiationRequestModel.model_json_schema(),
+        "exploit-path-analysis-evidence-v1": ExploitPathAnalysisEvidenceModel.model_json_schema(),
         "scenario-satisfiability-evidence-v1": ScenarioSatisfiabilityEvidenceModel.model_json_schema(),
         "backend-manifest-v2": BackendManifestV2Model.model_json_schema(),
         "realization-envelope-v1": BackendRealizationEnvelopeModel.model_json_schema(),

--- a/implementations/python/packages/aces_contracts/exploit_path.py
+++ b/implementations/python/packages/aces_contracts/exploit_path.py
@@ -1,0 +1,401 @@
+"""Portable contracts for typed exploit-path analysis evidence."""
+
+from __future__ import annotations
+
+import hashlib
+from enum import Enum
+from typing import Annotated, Literal
+
+import rfc8785
+from aces_sdl.canonical import InstantiatedScenarioSnapshot, canonical_instantiated_sdl_digest
+from aces_sdl.phase_contracts import SemanticDigest
+from pydantic import Field, GetJsonSchemaHandler, model_validator
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+
+from .contracts.base import ContractModel, PrefixedDigestString
+from .contracts.schema_invariants import _add_aces_invariant
+from .diagnostics import DiagnosticModel
+from .satisfiability import SourceArtifactIdentityModel, canonical_contract_digest
+
+ExploitPathId = Annotated[str, Field(pattern=r"^[a-z][a-z0-9._:-]*$", max_length=256)]
+JsonPointer = Annotated[str, Field(pattern=r"^(?:/(?:[^~/]|~[01])*)*$", max_length=4096)]
+MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS = 256
+MAX_EXPLOIT_PATH_DIAGNOSTICS = 64
+MAX_EXPLOIT_PATH_EXPLORED_STATES = 4096
+MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS = 512
+
+
+class AttackStateFactKind(str, Enum):
+    """Closed v1 attack-state fact families."""
+
+    ACCESS = "access"
+    CAPABILITY = "capability"
+    DATA_STATE = "data-state"
+    EXECUTION = "execution"
+    OBSERVATION = "observation"
+    OBJECTIVE_STATE = "objective-state"
+
+
+class AttackTransitionKind(str, Enum):
+    """Closed v1 attack-transition families."""
+
+    EXPLOIT_STEP = "exploit-step"
+    OBSERVATION_STEP = "observation-step"
+    POSTCONDITION_STEP = "postcondition-step"
+
+
+class ExploitPathOutcome(str, Enum):
+    """Completed exploit-path analysis outcomes."""
+
+    VALID_PATH = "valid-path"
+    INVALID_PATH = "invalid-path"
+    UNSUPPORTED = "unsupported"
+
+
+class AttackStateFactModel(ContractModel):
+    """One typed fact in the normalized attack state space."""
+
+    fact_id: ExploitPathId
+    kind: AttackStateFactKind
+    subject: str = Field(min_length=1, max_length=256, pattern=r"^[^\r\n]+$")
+    object_ref: JsonPointer
+
+
+class AttackObservationModel(ContractModel):
+    """Observation emitted by a transition, without promoting it to hidden truth."""
+
+    observation_id: ExploitPathId
+    kind: str = Field(min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9-]*$")
+    source_address: JsonPointer
+
+
+class AttackTransitionModel(ContractModel):
+    """One typed attack transition with explicit prerequisites and effects."""
+
+    transition_id: ExploitPathId
+    kind: AttackTransitionKind
+    semantics: str = Field(min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9-]*/v[0-9]+$")
+    prerequisites: tuple[ExploitPathId, ...] = Field(max_length=64)
+    effects: tuple[ExploitPathId, ...] = Field(max_length=64)
+    observations: tuple[AttackObservationModel, ...] = Field(default=(), max_length=64)
+
+    @model_validator(mode="after")
+    def _validate_canonical_members(self) -> AttackTransitionModel:
+        _require_sorted_unique(self.prerequisites, "transition prerequisites")
+        _require_sorted_unique(self.effects, "transition effects")
+        observation_ids = tuple(item.observation_id for item in self.observations)
+        _require_sorted_unique(observation_ids, "transition observations")
+        return self
+
+
+class AttackGraphBindingModel(ContractModel):
+    """Governed binding from an admitted ACES snapshot concept to graph content."""
+
+    binding_id: ExploitPathId
+    concept_kind: str = Field(min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9-]*$")
+    aces_address: JsonPointer
+    target_kind: Literal["state-fact", "transition"]
+    target_id: ExploitPathId
+
+
+class NormalizedAttackGraphModel(ContractModel):
+    """Closed normalized attack graph derived from governed ACES bindings."""
+
+    profile: Literal["aces-attack-graph/v1"]
+    binding_profile: Literal["aces-sdl-snapshot-attack-binding/v1"]
+    transition_semantics_profile: Literal["aces-monotonic-attack-transition/v1"]
+    snapshot_digest: PrefixedDigestString
+    state_facts: tuple[AttackStateFactModel, ...] = Field(min_length=1, max_length=512)
+    transitions: tuple[AttackTransitionModel, ...] = Field(max_length=512)
+    bindings: tuple[AttackGraphBindingModel, ...] = Field(max_length=1024)
+
+    @model_validator(mode="after")
+    def _validate_graph_shape(self) -> NormalizedAttackGraphModel:
+        fact_ids = tuple(item.fact_id for item in self.state_facts)
+        transition_ids = tuple(item.transition_id for item in self.transitions)
+        binding_ids = tuple(item.binding_id for item in self.bindings)
+        _require_sorted_unique(fact_ids, "state facts")
+        _require_sorted_unique(transition_ids, "transitions")
+        _require_sorted_unique(binding_ids, "bindings")
+
+        fact_set = set(fact_ids)
+        for transition in self.transitions:
+            for fact_id in (*transition.prerequisites, *transition.effects):
+                if fact_id not in fact_set:
+                    raise ValueError("transition prerequisites and effects must reference declared state facts")
+        return self
+
+
+class ExploitPathQueryModel(ContractModel):
+    """Closed path query contract."""
+
+    profile: Literal["aces-exploit-path-query/v1"]
+    query_id: ExploitPathId
+    participant_perspective: str = Field(min_length=1, max_length=256, pattern=r"^[^\r\n]+$")
+    start_facts: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=64)
+    goal_facts: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=64)
+    allowed_transition_semantics: tuple[str, ...] = Field(min_length=1, max_length=16)
+    max_depth: int = Field(ge=0, le=64)
+    goal_check: Literal["before-and-after-transition"]
+
+    @model_validator(mode="after")
+    def _validate_query_order(self) -> ExploitPathQueryModel:
+        _require_sorted_unique(self.start_facts, "start facts")
+        _require_sorted_unique(self.goal_facts, "goal facts")
+        _require_sorted_unique(self.allowed_transition_semantics, "allowed transition semantics")
+        return self
+
+
+class ExploitPathAnalysisInputModel(ContractModel):
+    """Production input: an admitted snapshot plus normalized graph and query."""
+
+    profile: Literal["exploit-path-analysis-input/v1"]
+    analysis_profile: Literal["aces-exploit-path-analysis-v1"]
+    snapshot: InstantiatedScenarioSnapshot
+    snapshot_digest: PrefixedDigestString
+    normalized_graph: NormalizedAttackGraphModel
+    query: ExploitPathQueryModel
+
+    @model_validator(mode="after")
+    def _validate_snapshot_join(self) -> ExploitPathAnalysisInputModel:
+        actual = canonical_instantiated_sdl_digest(self.snapshot.scenario).value
+        if self.snapshot_digest != actual:
+            raise ValueError("snapshot_digest must bind the admitted instantiated snapshot")
+        if self.normalized_graph.snapshot_digest != self.snapshot_digest:
+            raise ValueError("normalized graph snapshot digest must match the input snapshot")
+        return self
+
+
+class ExploitPathSearchConfigurationModel(ContractModel):
+    """Complete output-affecting v1 search configuration."""
+
+    profile: Literal["aces-deterministic-attack-graph-search/v1"]
+    strategy: Literal["breadth-first-canonical"]
+    transition_semantics: Literal["monotonic-additive/v1"]
+    goal_check: Literal["before-and-after-transition"]
+    max_depth: int = Field(ge=0, le=64)
+
+
+class ExploitPathStepModel(ContractModel):
+    """One replayable witness step."""
+
+    step_index: int = Field(ge=0, le=64)
+    transition_id: ExploitPathId
+    state_before_digest: PrefixedDigestString
+    satisfied_prerequisites: tuple[ExploitPathId, ...] = Field(max_length=64)
+    applied_effects: tuple[ExploitPathId, ...] = Field(max_length=64)
+    emitted_observations: tuple[ExploitPathId, ...] = Field(max_length=64)
+    state_after_digest: PrefixedDigestString
+
+    @model_validator(mode="after")
+    def _validate_step_order(self) -> ExploitPathStepModel:
+        _require_sorted_unique(self.satisfied_prerequisites, "satisfied prerequisites")
+        _require_sorted_unique(self.applied_effects, "applied effects")
+        _require_sorted_unique(self.emitted_observations, "emitted observations")
+        return self
+
+
+class ValidPathWitnessModel(ContractModel):
+    """Replayable valid path witness for the exact graph and query."""
+
+    profile: Literal["aces-exploit-path-witness/v1"]
+    initial_state: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=512)
+    goal_facts: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=64)
+    steps: tuple[ExploitPathStepModel, ...] = Field(max_length=64)
+    final_state: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=512)
+    final_state_digest: PrefixedDigestString
+
+    @model_validator(mode="after")
+    def _validate_witness_state(self) -> ValidPathWitnessModel:
+        _require_sorted_unique(self.initial_state, "initial state")
+        _require_sorted_unique(self.goal_facts, "goal facts")
+        _require_sorted_unique(self.final_state, "final state")
+        if self.final_state_digest != canonical_state_digest(self.final_state):
+            raise ValueError("final_state_digest must bind the final state")
+        if any(fact not in set(self.final_state) for fact in self.goal_facts):
+            raise ValueError("valid path witness final state must satisfy the goal")
+        return self
+
+
+class BlockedTransitionModel(ContractModel):
+    """One transition blocked at a reached state."""
+
+    transition_id: ExploitPathId
+    state_digest: PrefixedDigestString
+    missing_prerequisites: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def _validate_missing_order(self) -> BlockedTransitionModel:
+        _require_sorted_unique(self.missing_prerequisites, "missing prerequisites")
+        return self
+
+
+class InvalidPathEvidenceModel(ContractModel):
+    """Structured evidence for an invalid path query."""
+
+    profile: Literal["aces-exploit-path-invalid/v1"]
+    explored_state_count: int = Field(ge=1, le=MAX_EXPLOIT_PATH_EXPLORED_STATES)
+    exhausted_depth: bool
+    blocked_transitions: tuple[BlockedTransitionModel, ...] = Field(max_length=MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS)
+    impossible_transitions: tuple[ExploitPathId, ...] = Field(
+        default=(), max_length=MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS
+    )
+    unsatisfied_goal: tuple[ExploitPathId, ...] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def _validate_failure_order(self) -> InvalidPathEvidenceModel:
+        _require_sorted_unique(self.impossible_transitions, "impossible transitions")
+        _require_sorted_unique(self.unsatisfied_goal, "unsatisfied goal")
+        return self
+
+
+class UnsupportedExploitPathAnalysisModel(ContractModel):
+    """Fail-closed unsupported reason set."""
+
+    profile: Literal["aces-exploit-path-unsupported/v1"]
+    reason_codes: tuple[str, ...] = Field(min_length=1, max_length=64)
+
+    @model_validator(mode="after")
+    def _validate_reasons(self) -> UnsupportedExploitPathAnalysisModel:
+        _require_sorted_unique(self.reason_codes, "unsupported reason codes")
+        return self
+
+
+class ExploitPathAnalysisEvidenceModel(ContractModel):
+    """Closed evidence envelope binding source, snapshot, graph, query, and result."""
+
+    profile: Literal["exploit-path-analysis-evidence/v1"]
+    analysis_profile: Literal["aces-exploit-path-analysis-v1"]
+    source: SourceArtifactIdentityModel
+    authored_digest: SemanticDigest
+    snapshot_digest: PrefixedDigestString
+    normalized_graph: NormalizedAttackGraphModel
+    normalized_graph_digest: PrefixedDigestString
+    query: ExploitPathQueryModel
+    query_digest: PrefixedDigestString
+    search_configuration: ExploitPathSearchConfigurationModel
+    search_configuration_digest: PrefixedDigestString
+    outcome: ExploitPathOutcome
+    diagnostics: tuple[DiagnosticModel, ...] = Field(max_length=MAX_EXPLOIT_PATH_DIAGNOSTICS)
+    witness: ValidPathWitnessModel | None = None
+    failure: InvalidPathEvidenceModel | None = None
+    unsupported: UnsupportedExploitPathAnalysisModel | None = None
+
+    @model_validator(mode="after")
+    def _validate_evidence_joins(self) -> ExploitPathAnalysisEvidenceModel:
+        if self.snapshot_digest != self.normalized_graph.snapshot_digest:
+            raise ValueError("normalized graph snapshot digest must match the evidence snapshot")
+        if self.normalized_graph_digest != canonical_contract_digest(self.normalized_graph):
+            raise ValueError("normalized_graph_digest must bind the normalized graph")
+        if self.query_digest != canonical_contract_digest(self.query):
+            raise ValueError("query_digest must bind the query")
+        if self.search_configuration_digest != canonical_contract_digest(self.search_configuration):
+            raise ValueError("search_configuration_digest must bind the search configuration")
+        _validate_outcome_payload(self)
+        _validate_unsupported_reasons(self)
+        return self
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        core_schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.setdefault("oneOf", []).extend(
+            [
+                {
+                    "required": ["outcome", "witness"],
+                    "properties": {
+                        "outcome": {"const": ExploitPathOutcome.VALID_PATH.value},
+                        "witness": {"not": {"type": "null"}},
+                        "failure": {"type": "null"},
+                        "unsupported": {"type": "null"},
+                    },
+                },
+                {
+                    "required": ["outcome", "failure"],
+                    "properties": {
+                        "outcome": {"const": ExploitPathOutcome.INVALID_PATH.value},
+                        "witness": {"type": "null"},
+                        "failure": {"not": {"type": "null"}},
+                        "unsupported": {"type": "null"},
+                    },
+                },
+                {
+                    "required": ["outcome", "unsupported"],
+                    "properties": {
+                        "outcome": {"const": ExploitPathOutcome.UNSUPPORTED.value},
+                        "witness": {"type": "null"},
+                        "failure": {"type": "null"},
+                        "unsupported": {"not": {"type": "null"}},
+                    },
+                },
+            ]
+        )
+        _add_aces_invariant(
+            json_schema,
+            "exploit-path-evidence-digest-joins",
+            "The snapshot, normalized graph, query, search configuration, witness final state, and unsupported "
+            "reason code joins must validate against their canonical contract digests and diagnostics.",
+            validator="aces_contracts.exploit_path.ExploitPathAnalysisEvidenceModel._validate_evidence_joins",
+            inputs=[{"contract_id": "exploit-path-analysis-evidence-v1", "instance_path": "#"}],
+        )
+        return json_schema
+
+
+def canonical_state_digest(state_facts: tuple[str, ...]) -> str:
+    """Return a JCS SHA-256 digest for one canonical sorted state fact set."""
+
+    payload = rfc8785.dumps(tuple(state_facts))
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _validate_outcome_payload(evidence: ExploitPathAnalysisEvidenceModel) -> None:
+    payloads = {
+        ExploitPathOutcome.VALID_PATH: evidence.witness,
+        ExploitPathOutcome.INVALID_PATH: evidence.failure,
+        ExploitPathOutcome.UNSUPPORTED: evidence.unsupported,
+    }
+    if payloads[evidence.outcome] is None or sum(item is not None for item in payloads.values()) != 1:
+        raise ValueError("outcome must select exactly one matching payload")
+
+
+def _validate_unsupported_reasons(evidence: ExploitPathAnalysisEvidenceModel) -> None:
+    if evidence.unsupported is None:
+        return
+    diagnostic_codes = tuple(sorted({item.code for item in evidence.diagnostics}))
+    if evidence.unsupported.reason_codes != diagnostic_codes:
+        raise ValueError("unsupported reason codes must match diagnostic codes")
+
+
+def _require_sorted_unique(values: tuple[str, ...], label: str) -> None:
+    if values != tuple(sorted(set(values))):
+        raise ValueError(f"{label} must be unique and sorted")
+
+
+__all__ = (
+    "AttackGraphBindingModel",
+    "AttackObservationModel",
+    "AttackStateFactKind",
+    "AttackStateFactModel",
+    "AttackTransitionKind",
+    "AttackTransitionModel",
+    "BlockedTransitionModel",
+    "ExploitPathAnalysisEvidenceModel",
+    "ExploitPathAnalysisInputModel",
+    "ExploitPathOutcome",
+    "ExploitPathQueryModel",
+    "ExploitPathSearchConfigurationModel",
+    "InvalidPathEvidenceModel",
+    "MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS",
+    "MAX_EXPLOIT_PATH_DIAGNOSTICS",
+    "MAX_EXPLOIT_PATH_EXPLORED_STATES",
+    "MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS",
+    "NormalizedAttackGraphModel",
+    "UnsupportedExploitPathAnalysisModel",
+    "ValidPathWitnessModel",
+    "canonical_state_digest",
+)

--- a/implementations/python/packages/aces_processor/exploit_path/__init__.py
+++ b/implementations/python/packages/aces_processor/exploit_path/__init__.py
@@ -1,0 +1,19 @@
+"""Governed typed exploit-path analysis."""
+
+from ._service import (
+    ANALYSIS_PROFILE,
+    ExploitPathEvidenceError,
+    ExploitPathOperationalError,
+    analyze_exploit_path_file,
+    analyze_exploit_path_input,
+    replay_exploit_path_evidence,
+)
+
+__all__ = (
+    "ANALYSIS_PROFILE",
+    "ExploitPathEvidenceError",
+    "ExploitPathOperationalError",
+    "analyze_exploit_path_file",
+    "analyze_exploit_path_input",
+    "replay_exploit_path_evidence",
+)

--- a/implementations/python/packages/aces_processor/exploit_path/_diagnostics.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_diagnostics.py
@@ -1,0 +1,61 @@
+"""Shared diagnostics for exploit-path analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from aces_contracts.diagnostics import DiagnosticModel
+from aces_contracts.exploit_path import MAX_EXPLOIT_PATH_DIAGNOSTICS
+
+SUPPORTED_TRANSITION_SEMANTICS = "monotonic-additive/v1"
+BOUND_EXCEEDED_CODE = "exploit-path.analysis-bound-exceeded"
+BINDING_AMBIGUOUS_CODE = "exploit-path.binding-ambiguous"
+BINDING_MISSING_CODE = "exploit-path.binding-missing"
+BINDING_TARGET_DANGLING_CODE = "exploit-path.binding-target-dangling"
+MISSING_PREREQUISITE_CODE = "exploit-path.missing-prerequisite"
+IMPOSSIBLE_TRANSITION_CODE = "exploit-path.impossible-transition"
+QUERY_DANGLING_FACT_CODE = "exploit-path.query-dangling-fact"
+UNSATISFIED_GOAL_CODE = "exploit-path.unsatisfied-goal"
+UNSUPPORTED_SEMANTICS_CODE = "exploit-path.unsupported-semantics"
+FAIL_CLOSED_CODES = frozenset(
+    {
+        BOUND_EXCEEDED_CODE,
+        BINDING_AMBIGUOUS_CODE,
+        BINDING_MISSING_CODE,
+        BINDING_TARGET_DANGLING_CODE,
+        QUERY_DANGLING_FACT_CODE,
+        UNSUPPORTED_SEMANTICS_CODE,
+    }
+)
+
+
+def bounded_fail_closed_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
+    diagnostics = dedupe_diagnostics(items)
+    if len(diagnostics) <= MAX_EXPLOIT_PATH_DIAGNOSTICS:
+        return diagnostics
+    return (
+        diagnostic(
+            BOUND_EXCEEDED_CODE,
+            "/diagnostics",
+            "The analysis produced more fail-closed diagnostics than the evidence contract can carry.",
+        ),
+    )
+
+
+def diagnostic(code: str, address: str, message: str) -> DiagnosticModel:
+    return DiagnosticModel(
+        code=code,
+        domain="exploit-path",
+        address=address,
+        message=message,
+        severity="error",
+    )
+
+
+def dedupe_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
+    keyed = {(item.address, item.code): item for item in items}
+    return tuple(sorted(keyed.values(), key=lambda item: (item.address, item.code)))
+
+
+def pointer(value: str) -> str:
+    return value.replace("~", "~0").replace("/", "~1")

--- a/implementations/python/packages/aces_processor/exploit_path/_preflight.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_preflight.py
@@ -1,0 +1,164 @@
+"""Fail-closed exploit-path input preflight checks."""
+
+from __future__ import annotations
+
+from aces_contracts.diagnostics import DiagnosticModel
+from aces_contracts.exploit_path import (
+    AttackTransitionModel,
+    ExploitPathAnalysisInputModel,
+    ExploitPathQueryModel,
+)
+
+from ._diagnostics import (
+    BINDING_AMBIGUOUS_CODE,
+    BINDING_MISSING_CODE,
+    BINDING_TARGET_DANGLING_CODE,
+    QUERY_DANGLING_FACT_CODE,
+    SUPPORTED_TRANSITION_SEMANTICS,
+    UNSUPPORTED_SEMANTICS_CODE,
+    dedupe_diagnostics,
+    diagnostic,
+    pointer,
+)
+
+JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+_GraphTarget = tuple[str, str]
+
+
+def preflight_diagnostics(request: ExploitPathAnalysisInputModel) -> tuple[DiagnosticModel, ...]:
+    fact_ids, expected_targets = _graph_targets(request)
+    snapshot_payload = request.snapshot.scenario.model_dump(mode="json", by_alias=True)
+    binding_targets, binding_diagnostics = _binding_diagnostics(request, expected_targets, snapshot_payload)
+    diagnostics = (
+        *binding_diagnostics,
+        *_required_binding_diagnostics(expected_targets, binding_targets),
+        *_semantics_diagnostics(request.query, request.normalized_graph.transitions),
+        *_query_fact_diagnostics(request.query, fact_ids),
+    )
+    return dedupe_diagnostics(diagnostics)
+
+
+def _graph_targets(request: ExploitPathAnalysisInputModel) -> tuple[set[str], set[_GraphTarget]]:
+    fact_ids = {item.fact_id for item in request.normalized_graph.state_facts}
+    expected_targets = {("state-fact", fact_id) for fact_id in fact_ids} | {
+        ("transition", item.transition_id) for item in request.normalized_graph.transitions
+    }
+    return fact_ids, expected_targets
+
+
+def _binding_diagnostics(
+    request: ExploitPathAnalysisInputModel,
+    expected_targets: set[_GraphTarget],
+    snapshot_payload: JSONValue,
+) -> tuple[dict[_GraphTarget, list[str]], tuple[DiagnosticModel, ...]]:
+    binding_targets: dict[_GraphTarget, list[str]] = {}
+    diagnostics: list[DiagnosticModel] = []
+
+    for binding in request.normalized_graph.bindings:
+        target = (binding.target_kind, binding.target_id)
+        binding_targets.setdefault(target, []).append(binding.binding_id)
+        if target not in expected_targets:
+            diagnostics.append(
+                diagnostic(
+                    BINDING_TARGET_DANGLING_CODE,
+                    f"/normalized_graph/bindings/{pointer(binding.binding_id)}/target_id",
+                    "The binding target does not resolve in the normalized attack graph.",
+                )
+            )
+        if not _pointer_resolves(snapshot_payload, binding.aces_address):
+            diagnostics.append(
+                diagnostic(
+                    BINDING_MISSING_CODE,
+                    f"/normalized_graph/bindings/{pointer(binding.binding_id)}/aces_address",
+                    "The binding address does not resolve in the admitted scenario snapshot.",
+                )
+            )
+    return binding_targets, tuple(diagnostics)
+
+
+def _required_binding_diagnostics(
+    expected_targets: set[_GraphTarget],
+    binding_targets: dict[_GraphTarget, list[str]],
+) -> tuple[DiagnosticModel, ...]:
+    diagnostics: list[DiagnosticModel] = []
+    for target_kind, target_id in sorted(expected_targets):
+        ids = binding_targets.get((target_kind, target_id), [])
+        if not ids:
+            diagnostics.append(
+                diagnostic(
+                    BINDING_MISSING_CODE,
+                    f"/normalized_graph/{target_kind}s/{pointer(target_id)}",
+                    "The normalized graph target lacks a governed ACES binding.",
+                )
+            )
+        elif len(ids) > 1:
+            diagnostics.append(
+                diagnostic(
+                    BINDING_AMBIGUOUS_CODE,
+                    f"/normalized_graph/bindings/{pointer(ids[0])}",
+                    "The normalized graph target has multiple governed ACES bindings.",
+                )
+            )
+    return tuple(diagnostics)
+
+
+def _semantics_diagnostics(
+    query: ExploitPathQueryModel,
+    transitions: tuple[AttackTransitionModel, ...],
+) -> tuple[DiagnosticModel, ...]:
+    diagnostics: list[DiagnosticModel] = []
+    if any(item != SUPPORTED_TRANSITION_SEMANTICS for item in query.allowed_transition_semantics):
+        diagnostics.append(
+            diagnostic(
+                UNSUPPORTED_SEMANTICS_CODE,
+                "/query/allowed_transition_semantics",
+                "The query requests transition semantics outside the analysis profile.",
+            )
+        )
+    for transition in transitions:
+        if transition.semantics != SUPPORTED_TRANSITION_SEMANTICS:
+            diagnostics.append(
+                diagnostic(
+                    UNSUPPORTED_SEMANTICS_CODE,
+                    f"/normalized_graph/transitions/{pointer(transition.transition_id)}/semantics",
+                    "The normalized graph contains transition semantics outside the analysis profile.",
+                )
+            )
+    return tuple(diagnostics)
+
+
+def _query_fact_diagnostics(query: ExploitPathQueryModel, fact_ids: set[str]) -> tuple[DiagnosticModel, ...]:
+    diagnostics: list[DiagnosticModel] = []
+    for fact_id in (*query.start_facts, *query.goal_facts):
+        if fact_id not in fact_ids:
+            diagnostics.append(
+                diagnostic(
+                    QUERY_DANGLING_FACT_CODE,
+                    f"/query/facts/{pointer(fact_id)}",
+                    "The query references a state fact outside the normalized graph.",
+                )
+            )
+    return tuple(diagnostics)
+
+
+def _pointer_resolves(payload: JSONValue, pointer_value: str) -> bool:
+    try:
+        _resolve_pointer(payload, pointer_value)
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _resolve_pointer(payload: JSONValue, pointer_value: str) -> JSONValue:
+    if pointer_value == "":
+        return payload
+    current = payload
+    for raw_part in pointer_value.split("/")[1:]:
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict):
+            current = current[part]
+        elif isinstance(current, list):
+            current = current[int(part)]
+        else:
+            raise TypeError("pointer cannot descend into scalar")
+    return current

--- a/implementations/python/packages/aces_processor/exploit_path/_search.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_search.py
@@ -52,23 +52,37 @@ class _SearchAccumulator:
     exhausted_depth: bool = False
 
 
+@dataclass(frozen=True)
+class _SearchContext:
+    query: ExploitPathQueryModel
+    transitions: tuple[AttackTransitionModel, ...]
+    goal: frozenset[str]
+    initial: frozenset[str]
+
+
 def search(request: ExploitPathAnalysisInputModel) -> SearchResult:
-    query = request.query
-    transitions = _allowed_transitions(request)
-    goal = frozenset(query.goal_facts)
-    initial = frozenset(query.start_facts)
-    result = _initial_goal_result(query, goal, initial)
+    context = _search_context(request)
+    result = _initial_goal_result(context)
     if result is None:
         accumulator = _SearchAccumulator(
-            visited={initial},
-            queue=deque([(initial, ())]),
+            visited={context.initial},
+            queue=deque([(context.initial, ())]),
             blocked={},
             impossible=set(),
         )
-        result = _run_bounded_search(query, transitions, goal, initial, accumulator)
+        result = _run_bounded_search(context, accumulator)
         if result is None:
-            result = _invalid_search_result(goal, accumulator)
+            result = _invalid_search_result(context.goal, accumulator)
     return result
+
+
+def _search_context(request: ExploitPathAnalysisInputModel) -> _SearchContext:
+    return _SearchContext(
+        query=request.query,
+        transitions=_allowed_transitions(request),
+        goal=frozenset(request.query.goal_facts),
+        initial=frozenset(request.query.start_facts),
+    )
 
 
 def _allowed_transitions(request: ExploitPathAnalysisInputModel) -> tuple[AttackTransitionModel, ...]:
@@ -76,57 +90,45 @@ def _allowed_transitions(request: ExploitPathAnalysisInputModel) -> tuple[Attack
     return tuple(transition for transition in request.normalized_graph.transitions if transition.semantics in allowed)
 
 
-def _initial_goal_result(
-    query: ExploitPathQueryModel,
-    goal: frozenset[str],
-    initial: frozenset[str],
-) -> SearchResult | None:
+def _initial_goal_result(context: _SearchContext) -> SearchResult | None:
     result = None
-    if goal.issubset(initial):
-        result = _valid_search_result(query, initial, (), final_state=initial)
+    if context.goal.issubset(context.initial):
+        result = _valid_search_result(context.query, context.initial, (), final_state=context.initial)
     return result
 
 
 def _run_bounded_search(
-    query: ExploitPathQueryModel,
-    transitions: tuple[AttackTransitionModel, ...],
-    goal: frozenset[str],
-    initial: frozenset[str],
+    context: _SearchContext,
     accumulator: _SearchAccumulator,
 ) -> SearchResult | None:
     while accumulator.queue:
         state, steps = accumulator.queue.popleft()
-        if len(steps) >= query.max_depth:
+        if len(steps) >= context.query.max_depth:
             accumulator.exhausted_depth = True
             continue
-        result = _advance_from_state(query, transitions, goal, initial, accumulator, state, steps)
+        result = _advance_from_state(context, accumulator, state, steps)
         if result is not None:
             return result
     return _diagnostic_cap_result(accumulator)
 
 
 def _advance_from_state(
-    query: ExploitPathQueryModel,
-    transitions: tuple[AttackTransitionModel, ...],
-    goal: frozenset[str],
-    initial: frozenset[str],
+    context: _SearchContext,
     accumulator: _SearchAccumulator,
     state: frozenset[str],
     steps: tuple[ExploitPathStepModel, ...],
 ) -> SearchResult | None:
     result = None
-    for transition in transitions:
-        result = _advance_transition(query, transition, goal, initial, accumulator, state, steps)
+    for transition in context.transitions:
+        result = _advance_transition(context, transition, accumulator, state, steps)
         if result is not None:
             break
     return result
 
 
 def _advance_transition(
-    query: ExploitPathQueryModel,
+    context: _SearchContext,
     transition: AttackTransitionModel,
-    goal: frozenset[str],
-    initial: frozenset[str],
     accumulator: _SearchAccumulator,
     state: frozenset[str],
     steps: tuple[ExploitPathStepModel, ...],
@@ -138,9 +140,7 @@ def _advance_transition(
     applied = tuple(sorted(set(transition.effects) - set(state)))
     if not applied:
         return _record_impossible_transition(accumulator, transition.transition_id)
-    return _record_transition_progress(
-        query, transition, goal, initial, accumulator, state, steps, before_digest, applied
-    )
+    return _record_transition_progress(context, transition, accumulator, state, steps, before_digest, applied)
 
 
 def _record_blocked_transition(
@@ -183,10 +183,8 @@ def _record_impossible_transition(
 
 
 def _record_transition_progress(
-    query: ExploitPathQueryModel,
+    context: _SearchContext,
     transition: AttackTransitionModel,
-    goal: frozenset[str],
-    initial: frozenset[str],
     accumulator: _SearchAccumulator,
     state: frozenset[str],
     steps: tuple[ExploitPathStepModel, ...],
@@ -196,8 +194,8 @@ def _record_transition_progress(
     result = None
     next_state = frozenset((*state, *transition.effects))
     next_steps = (*steps, _step(transition, len(steps), before_digest, next_state, applied))
-    if goal.issubset(next_state):
-        result = _valid_search_result(query, initial, next_steps, final_state=next_state)
+    if context.goal.issubset(next_state):
+        result = _valid_search_result(context.query, context.initial, next_steps, final_state=next_state)
     elif next_state not in accumulator.visited:
         result = _queue_next_state(accumulator, next_state, next_steps)
     return result

--- a/implementations/python/packages/aces_processor/exploit_path/_search.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_search.py
@@ -1,0 +1,348 @@
+"""Deterministic exploit-path graph search."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+from aces_contracts.diagnostics import DiagnosticModel
+from aces_contracts.exploit_path import (
+    MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS,
+    MAX_EXPLOIT_PATH_DIAGNOSTICS,
+    MAX_EXPLOIT_PATH_EXPLORED_STATES,
+    MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS,
+    AttackTransitionModel,
+    BlockedTransitionModel,
+    ExploitPathAnalysisInputModel,
+    ExploitPathOutcome,
+    ExploitPathQueryModel,
+    ExploitPathStepModel,
+    InvalidPathEvidenceModel,
+    UnsupportedExploitPathAnalysisModel,
+    ValidPathWitnessModel,
+    canonical_state_digest,
+)
+
+from ._diagnostics import (
+    BOUND_EXCEEDED_CODE,
+    IMPOSSIBLE_TRANSITION_CODE,
+    MISSING_PREREQUISITE_CODE,
+    UNSATISFIED_GOAL_CODE,
+    dedupe_diagnostics,
+    diagnostic,
+    pointer,
+)
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    outcome: ExploitPathOutcome
+    witness: ValidPathWitnessModel | None
+    failure: InvalidPathEvidenceModel | None
+    unsupported: UnsupportedExploitPathAnalysisModel | None
+    diagnostics: tuple[DiagnosticModel, ...]
+
+
+@dataclass
+class _SearchAccumulator:
+    visited: set[frozenset[str]]
+    queue: deque[tuple[frozenset[str], tuple[ExploitPathStepModel, ...]]]
+    blocked: dict[tuple[str, str], BlockedTransitionModel]
+    impossible: set[str]
+    exhausted_depth: bool = False
+
+
+def search(request: ExploitPathAnalysisInputModel) -> SearchResult:
+    query = request.query
+    transitions = _allowed_transitions(request)
+    goal = frozenset(query.goal_facts)
+    initial = frozenset(query.start_facts)
+    result = _initial_goal_result(query, goal, initial)
+    if result is None:
+        accumulator = _SearchAccumulator(
+            visited={initial},
+            queue=deque([(initial, ())]),
+            blocked={},
+            impossible=set(),
+        )
+        result = _run_bounded_search(query, transitions, goal, initial, accumulator)
+        if result is None:
+            result = _invalid_search_result(goal, accumulator)
+    return result
+
+
+def _allowed_transitions(request: ExploitPathAnalysisInputModel) -> tuple[AttackTransitionModel, ...]:
+    allowed = set(request.query.allowed_transition_semantics)
+    return tuple(transition for transition in request.normalized_graph.transitions if transition.semantics in allowed)
+
+
+def _initial_goal_result(
+    query: ExploitPathQueryModel,
+    goal: frozenset[str],
+    initial: frozenset[str],
+) -> SearchResult | None:
+    result = None
+    if goal.issubset(initial):
+        result = _valid_search_result(query, initial, (), final_state=initial)
+    return result
+
+
+def _run_bounded_search(
+    query: ExploitPathQueryModel,
+    transitions: tuple[AttackTransitionModel, ...],
+    goal: frozenset[str],
+    initial: frozenset[str],
+    accumulator: _SearchAccumulator,
+) -> SearchResult | None:
+    while accumulator.queue:
+        state, steps = accumulator.queue.popleft()
+        if len(steps) >= query.max_depth:
+            accumulator.exhausted_depth = True
+            continue
+        result = _advance_from_state(query, transitions, goal, initial, accumulator, state, steps)
+        if result is not None:
+            return result
+    return _diagnostic_cap_result(accumulator)
+
+
+def _advance_from_state(
+    query: ExploitPathQueryModel,
+    transitions: tuple[AttackTransitionModel, ...],
+    goal: frozenset[str],
+    initial: frozenset[str],
+    accumulator: _SearchAccumulator,
+    state: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+) -> SearchResult | None:
+    result = None
+    for transition in transitions:
+        result = _advance_transition(query, transition, goal, initial, accumulator, state, steps)
+        if result is not None:
+            break
+    return result
+
+
+def _advance_transition(
+    query: ExploitPathQueryModel,
+    transition: AttackTransitionModel,
+    goal: frozenset[str],
+    initial: frozenset[str],
+    accumulator: _SearchAccumulator,
+    state: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+) -> SearchResult | None:
+    before_digest = canonical_state_digest(tuple(sorted(state)))
+    missing = tuple(sorted(set(transition.prerequisites) - set(state)))
+    if missing:
+        return _record_blocked_transition(accumulator, transition, before_digest, missing)
+    applied = tuple(sorted(set(transition.effects) - set(state)))
+    if not applied:
+        return _record_impossible_transition(accumulator, transition.transition_id)
+    return _record_transition_progress(
+        query, transition, goal, initial, accumulator, state, steps, before_digest, applied
+    )
+
+
+def _record_blocked_transition(
+    accumulator: _SearchAccumulator,
+    transition: AttackTransitionModel,
+    before_digest: str,
+    missing: tuple[str, ...],
+) -> SearchResult | None:
+    result = None
+    blocked_key = (transition.transition_id, before_digest)
+    if blocked_key not in accumulator.blocked:
+        if len(accumulator.blocked) >= MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS:
+            result = _unsupported_search_result(
+                "/search/blocked_transitions",
+                "The bounded search produced more blocked-transition evidence than the contract can carry.",
+            )
+        else:
+            accumulator.blocked[blocked_key] = BlockedTransitionModel(
+                transition_id=transition.transition_id,
+                state_digest=before_digest,
+                missing_prerequisites=missing,
+            )
+    return result
+
+
+def _record_impossible_transition(
+    accumulator: _SearchAccumulator,
+    transition_id: str,
+) -> SearchResult | None:
+    result = None
+    if transition_id not in accumulator.impossible:
+        if len(accumulator.impossible) >= MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS:
+            result = _unsupported_search_result(
+                "/search/impossible_transitions",
+                "The bounded search produced more impossible-transition evidence than the contract can carry.",
+            )
+        else:
+            accumulator.impossible.add(transition_id)
+    return result
+
+
+def _record_transition_progress(
+    query: ExploitPathQueryModel,
+    transition: AttackTransitionModel,
+    goal: frozenset[str],
+    initial: frozenset[str],
+    accumulator: _SearchAccumulator,
+    state: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+    before_digest: str,
+    applied: tuple[str, ...],
+) -> SearchResult | None:
+    result = None
+    next_state = frozenset((*state, *transition.effects))
+    next_steps = (*steps, _step(transition, len(steps), before_digest, next_state, applied))
+    if goal.issubset(next_state):
+        result = _valid_search_result(query, initial, next_steps, final_state=next_state)
+    elif next_state not in accumulator.visited:
+        result = _queue_next_state(accumulator, next_state, next_steps)
+    return result
+
+
+def _queue_next_state(
+    accumulator: _SearchAccumulator,
+    next_state: frozenset[str],
+    next_steps: tuple[ExploitPathStepModel, ...],
+) -> SearchResult | None:
+    if len(accumulator.visited) >= MAX_EXPLOIT_PATH_EXPLORED_STATES:
+        return _unsupported_search_result(
+            "/search/explored_state_count",
+            "The bounded search reached more attack states than the evidence contract can carry.",
+        )
+    accumulator.visited.add(next_state)
+    accumulator.queue.append((next_state, next_steps))
+    return None
+
+
+def _step(
+    transition: AttackTransitionModel,
+    step_index: int,
+    before_digest: str,
+    next_state: frozenset[str],
+    applied: tuple[str, ...],
+) -> ExploitPathStepModel:
+    return ExploitPathStepModel(
+        step_index=step_index,
+        transition_id=transition.transition_id,
+        state_before_digest=before_digest,
+        satisfied_prerequisites=tuple(sorted(transition.prerequisites)),
+        applied_effects=applied,
+        emitted_observations=tuple(sorted(item.observation_id for item in transition.observations)),
+        state_after_digest=canonical_state_digest(tuple(sorted(next_state))),
+    )
+
+
+def _valid_search_result(
+    query: ExploitPathQueryModel,
+    initial: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+    *,
+    final_state: frozenset[str],
+) -> SearchResult:
+    return SearchResult(
+        outcome=ExploitPathOutcome.VALID_PATH,
+        witness=_witness(query.goal_facts, initial, steps, final_state=final_state),
+        failure=None,
+        unsupported=None,
+        diagnostics=(),
+    )
+
+
+def _diagnostic_cap_result(accumulator: _SearchAccumulator) -> SearchResult | None:
+    result = None
+    if len(accumulator.blocked) + len(accumulator.impossible) + 1 > MAX_EXPLOIT_PATH_DIAGNOSTICS:
+        result = _unsupported_search_result(
+            "/diagnostics",
+            "The bounded search produced more diagnostics than the evidence contract can carry.",
+        )
+    return result
+
+
+def _invalid_search_result(goal: frozenset[str], accumulator: _SearchAccumulator) -> SearchResult:
+    diagnostics = _invalid_path_diagnostics(accumulator)
+    return SearchResult(
+        outcome=ExploitPathOutcome.INVALID_PATH,
+        witness=None,
+        failure=InvalidPathEvidenceModel(
+            profile="aces-exploit-path-invalid/v1",
+            explored_state_count=len(accumulator.visited),
+            exhausted_depth=accumulator.exhausted_depth,
+            blocked_transitions=tuple(
+                sorted(accumulator.blocked.values(), key=lambda item: (item.transition_id, item.state_digest))
+            ),
+            impossible_transitions=tuple(sorted(accumulator.impossible)),
+            unsatisfied_goal=_unsatisfied_goal(goal, accumulator.visited),
+        ),
+        unsupported=None,
+        diagnostics=dedupe_diagnostics(diagnostics),
+    )
+
+
+def _invalid_path_diagnostics(accumulator: _SearchAccumulator) -> tuple[DiagnosticModel, ...]:
+    diagnostics = [
+        diagnostic(
+            MISSING_PREREQUISITE_CODE,
+            f"/normalized_graph/transitions/{pointer(item.transition_id)}",
+            "A transition was blocked because at least one prerequisite was absent from the reached state.",
+        )
+        for item in accumulator.blocked.values()
+    ]
+    diagnostics.extend(
+        diagnostic(
+            IMPOSSIBLE_TRANSITION_CODE,
+            f"/normalized_graph/transitions/{pointer(transition_id)}",
+            "A transition could not advance the attack state under monotonic-additive semantics.",
+        )
+        for transition_id in sorted(accumulator.impossible)
+    )
+    diagnostics.append(
+        diagnostic(
+            UNSATISFIED_GOAL_CODE,
+            "/query/goal_facts",
+            "The search exhausted the bounded transition space without satisfying the goal.",
+        )
+    )
+    return tuple(diagnostics)
+
+
+def _unsatisfied_goal(goal: frozenset[str], visited: set[frozenset[str]]) -> tuple[str, ...]:
+    unsatisfied = tuple(sorted(goal - frozenset().union(*visited)))
+    if not unsatisfied:
+        unsatisfied = tuple(sorted(goal - set(max(visited, key=len))))
+    return unsatisfied
+
+
+def _witness(
+    goal_facts: tuple[str, ...],
+    initial_state: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+    *,
+    final_state: frozenset[str] | None = None,
+) -> ValidPathWitnessModel:
+    state = tuple(sorted(final_state if final_state is not None else initial_state))
+    return ValidPathWitnessModel(
+        profile="aces-exploit-path-witness/v1",
+        initial_state=tuple(sorted(initial_state)),
+        goal_facts=tuple(sorted(goal_facts)),
+        steps=steps,
+        final_state=state,
+        final_state_digest=canonical_state_digest(state),
+    )
+
+
+def _unsupported_search_result(address: str, message: str) -> SearchResult:
+    diagnostic_item = diagnostic(BOUND_EXCEEDED_CODE, address, message)
+    return SearchResult(
+        outcome=ExploitPathOutcome.UNSUPPORTED,
+        witness=None,
+        failure=None,
+        unsupported=UnsupportedExploitPathAnalysisModel(
+            profile="aces-exploit-path-unsupported/v1",
+            reason_codes=(BOUND_EXCEEDED_CODE,),
+        ),
+        diagnostics=(diagnostic_item,),
+    )

--- a/implementations/python/packages/aces_processor/exploit_path/_service.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_service.py
@@ -4,45 +4,29 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections import deque
-from collections.abc import Iterable
-from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any
 
-from aces_contracts.diagnostics import DiagnosticModel
 from aces_contracts.exploit_path import (
-    MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS,
-    MAX_EXPLOIT_PATH_DIAGNOSTICS,
-    MAX_EXPLOIT_PATH_EXPLORED_STATES,
-    MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS,
-    BlockedTransitionModel,
     ExploitPathAnalysisEvidenceModel,
     ExploitPathAnalysisInputModel,
     ExploitPathOutcome,
     ExploitPathSearchConfigurationModel,
-    ExploitPathStepModel,
-    InvalidPathEvidenceModel,
     UnsupportedExploitPathAnalysisModel,
-    ValidPathWitnessModel,
-    canonical_state_digest,
 )
 from aces_contracts.satisfiability import SourceArtifactIdentityModel, canonical_contract_digest
 from pydantic import ValidationError
 
+from ._diagnostics import (
+    FAIL_CLOSED_CODES,
+    SUPPORTED_TRANSITION_SEMANTICS,
+    bounded_fail_closed_diagnostics,
+)
+from ._preflight import preflight_diagnostics
+from ._search import search
+
 ANALYSIS_PROFILE = "aces-exploit-path-analysis-v1"
-SUPPORTED_TRANSITION_SEMANTICS = "monotonic-additive/v1"
 _MAX_INPUT_BYTES = 2 * 1024 * 1024
-_BOUND_EXCEEDED_CODE = "exploit-path.analysis-bound-exceeded"
-_FAIL_CLOSED_CODES = {
-    _BOUND_EXCEEDED_CODE,
-    "exploit-path.binding-ambiguous",
-    "exploit-path.binding-missing",
-    "exploit-path.binding-target-dangling",
-    "exploit-path.query-dangling-fact",
-    "exploit-path.unsupported-semantics",
-}
 
 
 class ExploitPathEvidenceError(ValueError):
@@ -51,15 +35,6 @@ class ExploitPathEvidenceError(ValueError):
 
 class ExploitPathOperationalError(RuntimeError):
     """The analyzer failed outside the typed outcome domain."""
-
-
-@dataclass(frozen=True)
-class _SearchResult:
-    outcome: ExploitPathOutcome
-    witness: ValidPathWitnessModel | None
-    failure: InvalidPathEvidenceModel | None
-    unsupported: UnsupportedExploitPathAnalysisModel | None
-    diagnostics: tuple[DiagnosticModel, ...]
 
 
 def analyze_exploit_path_file(
@@ -96,7 +71,7 @@ def analyze_exploit_path_input(
 ) -> ExploitPathAnalysisEvidenceModel:
     """Analyze an admitted snapshot, normalized graph, and closed query."""
 
-    diagnostics = _preflight_diagnostics(request)
+    diagnostics = preflight_diagnostics(request)
     search_configuration = ExploitPathSearchConfigurationModel(
         profile="aces-deterministic-attack-graph-search/v1",
         strategy="breadth-first-canonical",
@@ -117,7 +92,7 @@ def analyze_exploit_path_input(
         "search_configuration": search_configuration,
         "search_configuration_digest": canonical_contract_digest(search_configuration),
     }
-    fail_closed = _bounded_fail_closed_diagnostics(item for item in diagnostics if item.code in _FAIL_CLOSED_CODES)
+    fail_closed = bounded_fail_closed_diagnostics(item for item in diagnostics if item.code in FAIL_CLOSED_CODES)
     if fail_closed:
         return ExploitPathAnalysisEvidenceModel(
             **common,
@@ -129,14 +104,14 @@ def analyze_exploit_path_input(
             ),
         )
 
-    search = _search(request)
+    search_result = search(request)
     return ExploitPathAnalysisEvidenceModel(
         **common,
-        outcome=search.outcome,
-        diagnostics=search.diagnostics,
-        witness=search.witness,
-        failure=search.failure,
-        unsupported=search.unsupported,
+        outcome=search_result.outcome,
+        diagnostics=search_result.diagnostics,
+        witness=search_result.witness,
+        failure=search_result.failure,
+        unsupported=search_result.unsupported,
     )
 
 
@@ -156,248 +131,6 @@ def replay_exploit_path_evidence(
     return replayed
 
 
-def _preflight_diagnostics(request: ExploitPathAnalysisInputModel) -> tuple[DiagnosticModel, ...]:
-    diagnostics: list[DiagnosticModel] = []
-    fact_ids = {item.fact_id for item in request.normalized_graph.state_facts}
-    transition_ids = {item.transition_id for item in request.normalized_graph.transitions}
-    expected_targets = {("state-fact", item.fact_id) for item in request.normalized_graph.state_facts} | {
-        ("transition", item.transition_id) for item in request.normalized_graph.transitions
-    }
-    binding_targets: dict[tuple[str, str], list[str]] = {}
-    snapshot_payload = request.snapshot.scenario.model_dump(mode="json", by_alias=True)
-
-    for binding in request.normalized_graph.bindings:
-        target = (binding.target_kind, binding.target_id)
-        binding_targets.setdefault(target, []).append(binding.binding_id)
-        if target not in expected_targets:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.binding-target-dangling",
-                    f"/normalized_graph/bindings/{_pointer(binding.binding_id)}/target_id",
-                    "The binding target does not resolve in the normalized attack graph.",
-                )
-            )
-        if not _pointer_resolves(snapshot_payload, binding.aces_address):
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.binding-missing",
-                    f"/normalized_graph/bindings/{_pointer(binding.binding_id)}/aces_address",
-                    "The binding address does not resolve in the admitted scenario snapshot.",
-                )
-            )
-
-    for target_kind, target_id in sorted(expected_targets):
-        ids = binding_targets.get((target_kind, target_id), [])
-        if not ids:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.binding-missing",
-                    f"/normalized_graph/{target_kind}s/{_pointer(target_id)}",
-                    "The normalized graph target lacks a governed ACES binding.",
-                )
-            )
-        elif len(ids) > 1:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.binding-ambiguous",
-                    f"/normalized_graph/bindings/{_pointer(ids[0])}",
-                    "The normalized graph target has multiple governed ACES bindings.",
-                )
-            )
-
-    if any(item != SUPPORTED_TRANSITION_SEMANTICS for item in request.query.allowed_transition_semantics):
-        diagnostics.append(
-            _diagnostic(
-                "exploit-path.unsupported-semantics",
-                "/query/allowed_transition_semantics",
-                "The query requests transition semantics outside the analysis profile.",
-            )
-        )
-    for transition in request.normalized_graph.transitions:
-        if transition.semantics != SUPPORTED_TRANSITION_SEMANTICS:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.unsupported-semantics",
-                    f"/normalized_graph/transitions/{_pointer(transition.transition_id)}/semantics",
-                    "The normalized graph contains transition semantics outside the analysis profile.",
-                )
-            )
-
-    for fact_id in (*request.query.start_facts, *request.query.goal_facts):
-        if fact_id not in fact_ids:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.query-dangling-fact",
-                    f"/query/facts/{_pointer(fact_id)}",
-                    "The query references a state fact outside the normalized graph.",
-                )
-            )
-    for transition in request.normalized_graph.transitions:
-        if transition.transition_id not in transition_ids:
-            diagnostics.append(
-                _diagnostic(
-                    "exploit-path.binding-target-dangling",
-                    f"/normalized_graph/transitions/{_pointer(transition.transition_id)}",
-                    "The transition identity does not resolve.",
-                )
-            )
-    return _dedupe_diagnostics(diagnostics)
-
-
-def _search(request: ExploitPathAnalysisInputModel) -> _SearchResult:
-    query = request.query
-    transitions = tuple(
-        transition
-        for transition in request.normalized_graph.transitions
-        if transition.semantics in set(query.allowed_transition_semantics)
-    )
-    goal = frozenset(query.goal_facts)
-    initial = frozenset(query.start_facts)
-    if goal.issubset(initial):
-        return _SearchResult(
-            outcome=ExploitPathOutcome.VALID_PATH,
-            witness=_witness(query.goal_facts, initial, ()),
-            failure=None,
-            unsupported=None,
-            diagnostics=(),
-        )
-
-    visited: set[frozenset[str]] = {initial}
-    queue: deque[tuple[frozenset[str], tuple[ExploitPathStepModel, ...]]] = deque([(initial, ())])
-    blocked: dict[tuple[str, str], BlockedTransitionModel] = {}
-    impossible: set[str] = set()
-    exhausted_depth = False
-
-    while queue:
-        state, steps = queue.popleft()
-        if len(steps) >= query.max_depth:
-            exhausted_depth = True
-            continue
-        for transition in transitions:
-            missing = tuple(sorted(set(transition.prerequisites) - set(state)))
-            before_digest = canonical_state_digest(tuple(sorted(state)))
-            if missing:
-                blocked_key = (transition.transition_id, before_digest)
-                if blocked_key not in blocked:
-                    if len(blocked) >= MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS:
-                        return _unsupported_search_result(
-                            "/search/blocked_transitions",
-                            "The bounded search produced more blocked-transition evidence than the contract can carry.",
-                        )
-                    blocked[blocked_key] = BlockedTransitionModel(
-                        transition_id=transition.transition_id,
-                        state_digest=before_digest,
-                        missing_prerequisites=missing,
-                    )
-                continue
-            effects = set(transition.effects)
-            applied = tuple(sorted(effects - set(state)))
-            if not applied:
-                if (
-                    transition.transition_id not in impossible
-                    and len(impossible) >= MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS
-                ):
-                    return _unsupported_search_result(
-                        "/search/impossible_transitions",
-                        "The bounded search produced more impossible-transition evidence than the contract can carry.",
-                    )
-                impossible.add(transition.transition_id)
-                continue
-            next_state = frozenset((*state, *effects))
-            step = ExploitPathStepModel(
-                step_index=len(steps),
-                transition_id=transition.transition_id,
-                state_before_digest=before_digest,
-                satisfied_prerequisites=tuple(sorted(transition.prerequisites)),
-                applied_effects=applied,
-                emitted_observations=tuple(sorted(item.observation_id for item in transition.observations)),
-                state_after_digest=canonical_state_digest(tuple(sorted(next_state))),
-            )
-            next_steps = (*steps, step)
-            if goal.issubset(next_state):
-                return _SearchResult(
-                    outcome=ExploitPathOutcome.VALID_PATH,
-                    witness=_witness(query.goal_facts, initial, next_steps, final_state=next_state),
-                    failure=None,
-                    unsupported=None,
-                    diagnostics=(),
-                )
-            if next_state not in visited:
-                if len(visited) >= MAX_EXPLOIT_PATH_EXPLORED_STATES:
-                    return _unsupported_search_result(
-                        "/search/explored_state_count",
-                        "The bounded search reached more attack states than the evidence contract can carry.",
-                    )
-                visited.add(next_state)
-                queue.append((next_state, next_steps))
-
-    if len(blocked) + len(impossible) + 1 > MAX_EXPLOIT_PATH_DIAGNOSTICS:
-        return _unsupported_search_result(
-            "/diagnostics",
-            "The bounded search produced more diagnostics than the evidence contract can carry.",
-        )
-    unsatisfied = tuple(sorted(goal - frozenset().union(*visited)))
-    if not unsatisfied:
-        unsatisfied = tuple(sorted(goal - set(max(visited, key=len))))
-    diagnostics = [
-        _diagnostic(
-            "exploit-path.missing-prerequisite",
-            f"/normalized_graph/transitions/{_pointer(item.transition_id)}",
-            "A transition was blocked because at least one prerequisite was absent from the reached state.",
-        )
-        for item in blocked.values()
-    ]
-    diagnostics.extend(
-        _diagnostic(
-            "exploit-path.impossible-transition",
-            f"/normalized_graph/transitions/{_pointer(transition_id)}",
-            "A transition could not advance the attack state under monotonic-additive semantics.",
-        )
-        for transition_id in sorted(impossible)
-    )
-    diagnostics.append(
-        _diagnostic(
-            "exploit-path.unsatisfied-goal",
-            "/query/goal_facts",
-            "The search exhausted the bounded transition space without satisfying the goal.",
-        )
-    )
-    return _SearchResult(
-        outcome=ExploitPathOutcome.INVALID_PATH,
-        witness=None,
-        failure=InvalidPathEvidenceModel(
-            profile="aces-exploit-path-invalid/v1",
-            explored_state_count=len(visited),
-            exhausted_depth=exhausted_depth,
-            blocked_transitions=tuple(
-                sorted(blocked.values(), key=lambda item: (item.transition_id, item.state_digest))
-            ),
-            impossible_transitions=tuple(sorted(impossible)),
-            unsatisfied_goal=unsatisfied,
-        ),
-        unsupported=None,
-        diagnostics=_dedupe_diagnostics(diagnostics),
-    )
-
-
-def _witness(
-    goal_facts: tuple[str, ...],
-    initial_state: frozenset[str],
-    steps: tuple[ExploitPathStepModel, ...],
-    *,
-    final_state: frozenset[str] | None = None,
-) -> ValidPathWitnessModel:
-    state = tuple(sorted(final_state if final_state is not None else initial_state))
-    return ValidPathWitnessModel(
-        profile="aces-exploit-path-witness/v1",
-        initial_state=tuple(sorted(initial_state)),
-        goal_facts=tuple(sorted(goal_facts)),
-        steps=steps,
-        final_state=state,
-        final_state_digest=canonical_state_digest(state),
-    )
-
-
 def _read_bounded_bytes(path: Path) -> bytes:
     try:
         with path.open("rb") as handle:
@@ -407,72 +140,3 @@ def _read_bounded_bytes(path: Path) -> bytes:
     if len(payload) > _MAX_INPUT_BYTES:
         raise ExploitPathOperationalError("input exceeds the exploit-path size limit")
     return payload
-
-
-def _bounded_fail_closed_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
-    diagnostics = _dedupe_diagnostics(items)
-    if len(diagnostics) <= MAX_EXPLOIT_PATH_DIAGNOSTICS:
-        return diagnostics
-    return (
-        _diagnostic(
-            _BOUND_EXCEEDED_CODE,
-            "/diagnostics",
-            "The analysis produced more fail-closed diagnostics than the evidence contract can carry.",
-        ),
-    )
-
-
-def _unsupported_search_result(address: str, message: str) -> _SearchResult:
-    diagnostic = _diagnostic(_BOUND_EXCEEDED_CODE, address, message)
-    return _SearchResult(
-        outcome=ExploitPathOutcome.UNSUPPORTED,
-        witness=None,
-        failure=None,
-        unsupported=UnsupportedExploitPathAnalysisModel(
-            profile="aces-exploit-path-unsupported/v1",
-            reason_codes=(_BOUND_EXCEEDED_CODE,),
-        ),
-        diagnostics=(diagnostic,),
-    )
-
-
-def _pointer_resolves(payload: Any, pointer: str) -> bool:
-    try:
-        _resolve_pointer(payload, pointer)
-    except (KeyError, IndexError, TypeError, ValueError):
-        return False
-    return True
-
-
-def _resolve_pointer(payload: Any, pointer: str) -> Any:
-    if pointer == "":
-        return payload
-    current = payload
-    for raw_part in pointer.split("/")[1:]:
-        part = raw_part.replace("~1", "/").replace("~0", "~")
-        if isinstance(current, dict):
-            current = current[part]
-        elif isinstance(current, list):
-            current = current[int(part)]
-        else:
-            raise TypeError("pointer cannot descend into scalar")
-    return current
-
-
-def _diagnostic(code: str, address: str, message: str) -> DiagnosticModel:
-    return DiagnosticModel(
-        code=code,
-        domain="exploit-path",
-        address=address,
-        message=message,
-        severity="error",
-    )
-
-
-def _dedupe_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
-    keyed = {(item.address, item.code): item for item in items}
-    return tuple(sorted(keyed.values(), key=lambda item: (item.address, item.code)))
-
-
-def _pointer(value: str) -> str:
-    return value.replace("~", "~0").replace("/", "~1")

--- a/implementations/python/packages/aces_processor/exploit_path/_service.py
+++ b/implementations/python/packages/aces_processor/exploit_path/_service.py
@@ -1,0 +1,478 @@
+"""Production orchestration and replay for exploit-path analysis evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import dataclass
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+from aces_contracts.diagnostics import DiagnosticModel
+from aces_contracts.exploit_path import (
+    MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS,
+    MAX_EXPLOIT_PATH_DIAGNOSTICS,
+    MAX_EXPLOIT_PATH_EXPLORED_STATES,
+    MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS,
+    BlockedTransitionModel,
+    ExploitPathAnalysisEvidenceModel,
+    ExploitPathAnalysisInputModel,
+    ExploitPathOutcome,
+    ExploitPathSearchConfigurationModel,
+    ExploitPathStepModel,
+    InvalidPathEvidenceModel,
+    UnsupportedExploitPathAnalysisModel,
+    ValidPathWitnessModel,
+    canonical_state_digest,
+)
+from aces_contracts.satisfiability import SourceArtifactIdentityModel, canonical_contract_digest
+from pydantic import ValidationError
+
+ANALYSIS_PROFILE = "aces-exploit-path-analysis-v1"
+SUPPORTED_TRANSITION_SEMANTICS = "monotonic-additive/v1"
+_MAX_INPUT_BYTES = 2 * 1024 * 1024
+_BOUND_EXCEEDED_CODE = "exploit-path.analysis-bound-exceeded"
+_FAIL_CLOSED_CODES = {
+    _BOUND_EXCEEDED_CODE,
+    "exploit-path.binding-ambiguous",
+    "exploit-path.binding-missing",
+    "exploit-path.binding-target-dangling",
+    "exploit-path.query-dangling-fact",
+    "exploit-path.unsupported-semantics",
+}
+
+
+class ExploitPathEvidenceError(ValueError):
+    """Stored exploit-path evidence does not replay against its governed input."""
+
+
+class ExploitPathOperationalError(RuntimeError):
+    """The analyzer failed outside the typed outcome domain."""
+
+
+@dataclass(frozen=True)
+class _SearchResult:
+    outcome: ExploitPathOutcome
+    witness: ValidPathWitnessModel | None
+    failure: InvalidPathEvidenceModel | None
+    unsupported: UnsupportedExploitPathAnalysisModel | None
+    diagnostics: tuple[DiagnosticModel, ...]
+
+
+def analyze_exploit_path_file(
+    path: Path,
+    *,
+    profile: str = ANALYSIS_PROFILE,
+) -> ExploitPathAnalysisEvidenceModel:
+    """Analyze one bounded exploit-path input JSON file."""
+
+    if profile != ANALYSIS_PROFILE:
+        raise ExploitPathOperationalError("unknown exploit-path analysis profile")
+    raw_bytes = _read_bounded_bytes(path)
+    try:
+        payload = json.loads(raw_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, JSONDecodeError) as exc:
+        raise ExploitPathOperationalError("input is not valid UTF-8 JSON") from exc
+    try:
+        request = ExploitPathAnalysisInputModel.model_validate(payload)
+    except ValidationError as exc:
+        raise ExploitPathOperationalError("input does not match the exploit-path contract") from exc
+    source_digest = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
+    return analyze_exploit_path_input(
+        request,
+        source_id=path.name,
+        source_digest=source_digest,
+    )
+
+
+def analyze_exploit_path_input(
+    request: ExploitPathAnalysisInputModel,
+    *,
+    source_id: str,
+    source_digest: str,
+) -> ExploitPathAnalysisEvidenceModel:
+    """Analyze an admitted snapshot, normalized graph, and closed query."""
+
+    diagnostics = _preflight_diagnostics(request)
+    search_configuration = ExploitPathSearchConfigurationModel(
+        profile="aces-deterministic-attack-graph-search/v1",
+        strategy="breadth-first-canonical",
+        transition_semantics=SUPPORTED_TRANSITION_SEMANTICS,
+        goal_check=request.query.goal_check,
+        max_depth=request.query.max_depth,
+    )
+    common = {
+        "profile": "exploit-path-analysis-evidence/v1",
+        "analysis_profile": ANALYSIS_PROFILE,
+        "source": SourceArtifactIdentityModel(source_id=source_id, byte_digest=source_digest),
+        "authored_digest": request.snapshot.scenario.instantiation_provenance.authored_digest,
+        "snapshot_digest": request.snapshot_digest,
+        "normalized_graph": request.normalized_graph,
+        "normalized_graph_digest": canonical_contract_digest(request.normalized_graph),
+        "query": request.query,
+        "query_digest": canonical_contract_digest(request.query),
+        "search_configuration": search_configuration,
+        "search_configuration_digest": canonical_contract_digest(search_configuration),
+    }
+    fail_closed = _bounded_fail_closed_diagnostics(item for item in diagnostics if item.code in _FAIL_CLOSED_CODES)
+    if fail_closed:
+        return ExploitPathAnalysisEvidenceModel(
+            **common,
+            outcome=ExploitPathOutcome.UNSUPPORTED,
+            diagnostics=tuple(sorted(fail_closed, key=lambda item: (item.address, item.code))),
+            unsupported=UnsupportedExploitPathAnalysisModel(
+                profile="aces-exploit-path-unsupported/v1",
+                reason_codes=tuple(sorted({item.code for item in fail_closed})),
+            ),
+        )
+
+    search = _search(request)
+    return ExploitPathAnalysisEvidenceModel(
+        **common,
+        outcome=search.outcome,
+        diagnostics=search.diagnostics,
+        witness=search.witness,
+        failure=search.failure,
+        unsupported=search.unsupported,
+    )
+
+
+def replay_exploit_path_evidence(
+    path: Path,
+    evidence: ExploitPathAnalysisEvidenceModel,
+) -> ExploitPathAnalysisEvidenceModel:
+    """Recompute and compare every source/graph/query/result evidence join."""
+
+    raw_bytes = _read_bounded_bytes(path)
+    source_digest = "sha256:" + hashlib.sha256(raw_bytes).hexdigest()
+    if source_digest != evidence.source.byte_digest:
+        raise ExploitPathEvidenceError("source digest does not match the evidence")
+    replayed = analyze_exploit_path_file(path, profile=evidence.analysis_profile)
+    if canonical_contract_digest(replayed) != canonical_contract_digest(evidence):
+        raise ExploitPathEvidenceError("exploit-path evidence replay did not reproduce")
+    return replayed
+
+
+def _preflight_diagnostics(request: ExploitPathAnalysisInputModel) -> tuple[DiagnosticModel, ...]:
+    diagnostics: list[DiagnosticModel] = []
+    fact_ids = {item.fact_id for item in request.normalized_graph.state_facts}
+    transition_ids = {item.transition_id for item in request.normalized_graph.transitions}
+    expected_targets = {("state-fact", item.fact_id) for item in request.normalized_graph.state_facts} | {
+        ("transition", item.transition_id) for item in request.normalized_graph.transitions
+    }
+    binding_targets: dict[tuple[str, str], list[str]] = {}
+    snapshot_payload = request.snapshot.scenario.model_dump(mode="json", by_alias=True)
+
+    for binding in request.normalized_graph.bindings:
+        target = (binding.target_kind, binding.target_id)
+        binding_targets.setdefault(target, []).append(binding.binding_id)
+        if target not in expected_targets:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.binding-target-dangling",
+                    f"/normalized_graph/bindings/{_pointer(binding.binding_id)}/target_id",
+                    "The binding target does not resolve in the normalized attack graph.",
+                )
+            )
+        if not _pointer_resolves(snapshot_payload, binding.aces_address):
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.binding-missing",
+                    f"/normalized_graph/bindings/{_pointer(binding.binding_id)}/aces_address",
+                    "The binding address does not resolve in the admitted scenario snapshot.",
+                )
+            )
+
+    for target_kind, target_id in sorted(expected_targets):
+        ids = binding_targets.get((target_kind, target_id), [])
+        if not ids:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.binding-missing",
+                    f"/normalized_graph/{target_kind}s/{_pointer(target_id)}",
+                    "The normalized graph target lacks a governed ACES binding.",
+                )
+            )
+        elif len(ids) > 1:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.binding-ambiguous",
+                    f"/normalized_graph/bindings/{_pointer(ids[0])}",
+                    "The normalized graph target has multiple governed ACES bindings.",
+                )
+            )
+
+    if any(item != SUPPORTED_TRANSITION_SEMANTICS for item in request.query.allowed_transition_semantics):
+        diagnostics.append(
+            _diagnostic(
+                "exploit-path.unsupported-semantics",
+                "/query/allowed_transition_semantics",
+                "The query requests transition semantics outside the analysis profile.",
+            )
+        )
+    for transition in request.normalized_graph.transitions:
+        if transition.semantics != SUPPORTED_TRANSITION_SEMANTICS:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.unsupported-semantics",
+                    f"/normalized_graph/transitions/{_pointer(transition.transition_id)}/semantics",
+                    "The normalized graph contains transition semantics outside the analysis profile.",
+                )
+            )
+
+    for fact_id in (*request.query.start_facts, *request.query.goal_facts):
+        if fact_id not in fact_ids:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.query-dangling-fact",
+                    f"/query/facts/{_pointer(fact_id)}",
+                    "The query references a state fact outside the normalized graph.",
+                )
+            )
+    for transition in request.normalized_graph.transitions:
+        if transition.transition_id not in transition_ids:
+            diagnostics.append(
+                _diagnostic(
+                    "exploit-path.binding-target-dangling",
+                    f"/normalized_graph/transitions/{_pointer(transition.transition_id)}",
+                    "The transition identity does not resolve.",
+                )
+            )
+    return _dedupe_diagnostics(diagnostics)
+
+
+def _search(request: ExploitPathAnalysisInputModel) -> _SearchResult:
+    query = request.query
+    transitions = tuple(
+        transition
+        for transition in request.normalized_graph.transitions
+        if transition.semantics in set(query.allowed_transition_semantics)
+    )
+    goal = frozenset(query.goal_facts)
+    initial = frozenset(query.start_facts)
+    if goal.issubset(initial):
+        return _SearchResult(
+            outcome=ExploitPathOutcome.VALID_PATH,
+            witness=_witness(query.goal_facts, initial, ()),
+            failure=None,
+            unsupported=None,
+            diagnostics=(),
+        )
+
+    visited: set[frozenset[str]] = {initial}
+    queue: deque[tuple[frozenset[str], tuple[ExploitPathStepModel, ...]]] = deque([(initial, ())])
+    blocked: dict[tuple[str, str], BlockedTransitionModel] = {}
+    impossible: set[str] = set()
+    exhausted_depth = False
+
+    while queue:
+        state, steps = queue.popleft()
+        if len(steps) >= query.max_depth:
+            exhausted_depth = True
+            continue
+        for transition in transitions:
+            missing = tuple(sorted(set(transition.prerequisites) - set(state)))
+            before_digest = canonical_state_digest(tuple(sorted(state)))
+            if missing:
+                blocked_key = (transition.transition_id, before_digest)
+                if blocked_key not in blocked:
+                    if len(blocked) >= MAX_EXPLOIT_PATH_BLOCKED_TRANSITIONS:
+                        return _unsupported_search_result(
+                            "/search/blocked_transitions",
+                            "The bounded search produced more blocked-transition evidence than the contract can carry.",
+                        )
+                    blocked[blocked_key] = BlockedTransitionModel(
+                        transition_id=transition.transition_id,
+                        state_digest=before_digest,
+                        missing_prerequisites=missing,
+                    )
+                continue
+            effects = set(transition.effects)
+            applied = tuple(sorted(effects - set(state)))
+            if not applied:
+                if (
+                    transition.transition_id not in impossible
+                    and len(impossible) >= MAX_EXPLOIT_PATH_IMPOSSIBLE_TRANSITIONS
+                ):
+                    return _unsupported_search_result(
+                        "/search/impossible_transitions",
+                        "The bounded search produced more impossible-transition evidence than the contract can carry.",
+                    )
+                impossible.add(transition.transition_id)
+                continue
+            next_state = frozenset((*state, *effects))
+            step = ExploitPathStepModel(
+                step_index=len(steps),
+                transition_id=transition.transition_id,
+                state_before_digest=before_digest,
+                satisfied_prerequisites=tuple(sorted(transition.prerequisites)),
+                applied_effects=applied,
+                emitted_observations=tuple(sorted(item.observation_id for item in transition.observations)),
+                state_after_digest=canonical_state_digest(tuple(sorted(next_state))),
+            )
+            next_steps = (*steps, step)
+            if goal.issubset(next_state):
+                return _SearchResult(
+                    outcome=ExploitPathOutcome.VALID_PATH,
+                    witness=_witness(query.goal_facts, initial, next_steps, final_state=next_state),
+                    failure=None,
+                    unsupported=None,
+                    diagnostics=(),
+                )
+            if next_state not in visited:
+                if len(visited) >= MAX_EXPLOIT_PATH_EXPLORED_STATES:
+                    return _unsupported_search_result(
+                        "/search/explored_state_count",
+                        "The bounded search reached more attack states than the evidence contract can carry.",
+                    )
+                visited.add(next_state)
+                queue.append((next_state, next_steps))
+
+    if len(blocked) + len(impossible) + 1 > MAX_EXPLOIT_PATH_DIAGNOSTICS:
+        return _unsupported_search_result(
+            "/diagnostics",
+            "The bounded search produced more diagnostics than the evidence contract can carry.",
+        )
+    unsatisfied = tuple(sorted(goal - frozenset().union(*visited)))
+    if not unsatisfied:
+        unsatisfied = tuple(sorted(goal - set(max(visited, key=len))))
+    diagnostics = [
+        _diagnostic(
+            "exploit-path.missing-prerequisite",
+            f"/normalized_graph/transitions/{_pointer(item.transition_id)}",
+            "A transition was blocked because at least one prerequisite was absent from the reached state.",
+        )
+        for item in blocked.values()
+    ]
+    diagnostics.extend(
+        _diagnostic(
+            "exploit-path.impossible-transition",
+            f"/normalized_graph/transitions/{_pointer(transition_id)}",
+            "A transition could not advance the attack state under monotonic-additive semantics.",
+        )
+        for transition_id in sorted(impossible)
+    )
+    diagnostics.append(
+        _diagnostic(
+            "exploit-path.unsatisfied-goal",
+            "/query/goal_facts",
+            "The search exhausted the bounded transition space without satisfying the goal.",
+        )
+    )
+    return _SearchResult(
+        outcome=ExploitPathOutcome.INVALID_PATH,
+        witness=None,
+        failure=InvalidPathEvidenceModel(
+            profile="aces-exploit-path-invalid/v1",
+            explored_state_count=len(visited),
+            exhausted_depth=exhausted_depth,
+            blocked_transitions=tuple(
+                sorted(blocked.values(), key=lambda item: (item.transition_id, item.state_digest))
+            ),
+            impossible_transitions=tuple(sorted(impossible)),
+            unsatisfied_goal=unsatisfied,
+        ),
+        unsupported=None,
+        diagnostics=_dedupe_diagnostics(diagnostics),
+    )
+
+
+def _witness(
+    goal_facts: tuple[str, ...],
+    initial_state: frozenset[str],
+    steps: tuple[ExploitPathStepModel, ...],
+    *,
+    final_state: frozenset[str] | None = None,
+) -> ValidPathWitnessModel:
+    state = tuple(sorted(final_state if final_state is not None else initial_state))
+    return ValidPathWitnessModel(
+        profile="aces-exploit-path-witness/v1",
+        initial_state=tuple(sorted(initial_state)),
+        goal_facts=tuple(sorted(goal_facts)),
+        steps=steps,
+        final_state=state,
+        final_state_digest=canonical_state_digest(state),
+    )
+
+
+def _read_bounded_bytes(path: Path) -> bytes:
+    try:
+        with path.open("rb") as handle:
+            payload = handle.read(_MAX_INPUT_BYTES + 1)
+    except OSError as exc:
+        raise ExploitPathOperationalError("input could not be read") from exc
+    if len(payload) > _MAX_INPUT_BYTES:
+        raise ExploitPathOperationalError("input exceeds the exploit-path size limit")
+    return payload
+
+
+def _bounded_fail_closed_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
+    diagnostics = _dedupe_diagnostics(items)
+    if len(diagnostics) <= MAX_EXPLOIT_PATH_DIAGNOSTICS:
+        return diagnostics
+    return (
+        _diagnostic(
+            _BOUND_EXCEEDED_CODE,
+            "/diagnostics",
+            "The analysis produced more fail-closed diagnostics than the evidence contract can carry.",
+        ),
+    )
+
+
+def _unsupported_search_result(address: str, message: str) -> _SearchResult:
+    diagnostic = _diagnostic(_BOUND_EXCEEDED_CODE, address, message)
+    return _SearchResult(
+        outcome=ExploitPathOutcome.UNSUPPORTED,
+        witness=None,
+        failure=None,
+        unsupported=UnsupportedExploitPathAnalysisModel(
+            profile="aces-exploit-path-unsupported/v1",
+            reason_codes=(_BOUND_EXCEEDED_CODE,),
+        ),
+        diagnostics=(diagnostic,),
+    )
+
+
+def _pointer_resolves(payload: Any, pointer: str) -> bool:
+    try:
+        _resolve_pointer(payload, pointer)
+    except (KeyError, IndexError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _resolve_pointer(payload: Any, pointer: str) -> Any:
+    if pointer == "":
+        return payload
+    current = payload
+    for raw_part in pointer.split("/")[1:]:
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict):
+            current = current[part]
+        elif isinstance(current, list):
+            current = current[int(part)]
+        else:
+            raise TypeError("pointer cannot descend into scalar")
+    return current
+
+
+def _diagnostic(code: str, address: str, message: str) -> DiagnosticModel:
+    return DiagnosticModel(
+        code=code,
+        domain="exploit-path",
+        address=address,
+        message=message,
+        severity="error",
+    )
+
+
+def _dedupe_diagnostics(items: Iterable[DiagnosticModel]) -> tuple[DiagnosticModel, ...]:
+    keyed = {(item.address, item.code): item for item in items}
+    return tuple(sorted(keyed.values(), key=lambda item: (item.address, item.code)))
+
+
+def _pointer(value: str) -> str:
+    return value.replace("~", "~0").replace("/", "~1")

--- a/implementations/python/tests/test_exploit_path_analysis.py
+++ b/implementations/python/tests/test_exploit_path_analysis.py
@@ -414,8 +414,9 @@ def test_published_valid_and_invalid_fixtures_enforce_outcome_joins() -> None:
     invalid = fixtures / "exploit-path-analysis-evidence-v1" / "invalid" / "cross-outcome-payload.json"
 
     ExploitPathAnalysisEvidenceModel.model_validate_json(valid.read_text(encoding="utf-8"))
+    invalid_payload = invalid.read_text(encoding="utf-8")
     with pytest.raises(ValidationError) as exc_info:
-        ExploitPathAnalysisEvidenceModel.model_validate_json(invalid.read_text(encoding="utf-8"))
+        ExploitPathAnalysisEvidenceModel.model_validate_json(invalid_payload)
 
     assert "outcome must select exactly one matching payload" in str(exc_info.value)
 

--- a/implementations/python/tests/test_exploit_path_analysis.py
+++ b/implementations/python/tests/test_exploit_path_analysis.py
@@ -1,0 +1,430 @@
+"""Typed exploit-path analysis semantics (issue #827)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from aces_contracts.contracts import schema_bundle
+from aces_contracts.exploit_path import (
+    ExploitPathAnalysisEvidenceModel,
+    ExploitPathAnalysisInputModel,
+    ExploitPathOutcome,
+)
+from aces_processor.exploit_path import (
+    ExploitPathEvidenceError,
+    analyze_exploit_path_file,
+    replay_exploit_path_evidence,
+)
+from aces_sdl.canonical import (
+    INSTANTIATED_SNAPSHOT_PROFILE,
+    InstantiatedScenarioSnapshot,
+    canonical_instantiated_sdl_digest,
+)
+from aces_sdl.instantiate import instantiate_scenario
+from aces_sdl.parser import parse_sdl
+from jsonschema import Draft202012Validator
+from pydantic import ValidationError
+
+_SDL = """\
+name: exploit-path-control
+nodes:
+  target:
+    type: vm
+    os: linux
+"""
+_PLACEHOLDER_DIGEST = "sha256:" + "0" * 64
+
+
+def _snapshot() -> InstantiatedScenarioSnapshot:
+    scenario = parse_sdl(_SDL)
+    instantiated = instantiate_scenario(
+        scenario,
+        parameters={},
+        profile="aces-exploit-path-fixture/v1",
+    )
+    return InstantiatedScenarioSnapshot(
+        profile=INSTANTIATED_SNAPSHOT_PROFILE,
+        scenario=instantiated,
+    )
+
+
+def _graph() -> dict:
+    return {
+        "profile": "aces-attack-graph/v1",
+        "binding_profile": "aces-sdl-snapshot-attack-binding/v1",
+        "transition_semantics_profile": "aces-monotonic-attack-transition/v1",
+        "snapshot_digest": _PLACEHOLDER_DIGEST,
+        "state_facts": [
+            {
+                "fact_id": "attacker-foothold",
+                "kind": "access",
+                "subject": "attacker",
+                "object_ref": "/nodes/target",
+            },
+            {
+                "fact_id": "data-access",
+                "kind": "data-state",
+                "subject": "attacker",
+                "object_ref": "/nodes/target",
+            },
+            {
+                "fact_id": "web-shell",
+                "kind": "execution",
+                "subject": "attacker",
+                "object_ref": "/nodes/target",
+            },
+        ],
+        "transitions": [
+            {
+                "transition_id": "exploit-web",
+                "kind": "exploit-step",
+                "semantics": "monotonic-additive/v1",
+                "prerequisites": ["attacker-foothold"],
+                "effects": ["web-shell"],
+                "observations": [
+                    {
+                        "observation_id": "web-shell-observed",
+                        "kind": "participant-observation",
+                        "source_address": "/nodes/target",
+                    }
+                ],
+            },
+            {
+                "transition_id": "read-data",
+                "kind": "postcondition-step",
+                "semantics": "monotonic-additive/v1",
+                "prerequisites": ["web-shell"],
+                "effects": ["data-access"],
+                "observations": [],
+            },
+        ],
+        "bindings": [
+            {
+                "binding_id": "bind-attacker-foothold",
+                "concept_kind": "scenario-node",
+                "aces_address": "/nodes/target",
+                "target_kind": "state-fact",
+                "target_id": "attacker-foothold",
+            },
+            {
+                "binding_id": "bind-data-access",
+                "concept_kind": "scenario-node",
+                "aces_address": "/nodes/target",
+                "target_kind": "state-fact",
+                "target_id": "data-access",
+            },
+            {
+                "binding_id": "bind-exploit-web",
+                "concept_kind": "participant-action",
+                "aces_address": "/nodes/target",
+                "target_kind": "transition",
+                "target_id": "exploit-web",
+            },
+            {
+                "binding_id": "bind-read-data",
+                "concept_kind": "participant-action",
+                "aces_address": "/nodes/target",
+                "target_kind": "transition",
+                "target_id": "read-data",
+            },
+            {
+                "binding_id": "bind-web-shell",
+                "concept_kind": "scenario-node",
+                "aces_address": "/nodes/target",
+                "target_kind": "state-fact",
+                "target_id": "web-shell",
+            },
+        ],
+    }
+
+
+def _blocked_graph(blocked_count: int) -> dict:
+    state_facts = [
+        {
+            "fact_id": "goal",
+            "kind": "objective-state",
+            "subject": "attacker",
+            "object_ref": "/nodes/target",
+        },
+        {
+            "fact_id": "start",
+            "kind": "access",
+            "subject": "attacker",
+            "object_ref": "/nodes/target",
+        },
+    ]
+    transitions = []
+    for index in range(blocked_count):
+        state_facts.extend(
+            [
+                {
+                    "fact_id": f"effect-{index:03}",
+                    "kind": "data-state",
+                    "subject": "attacker",
+                    "object_ref": "/nodes/target",
+                },
+                {
+                    "fact_id": f"missing-{index:03}",
+                    "kind": "capability",
+                    "subject": "attacker",
+                    "object_ref": "/nodes/target",
+                },
+            ]
+        )
+        transitions.append(
+            {
+                "transition_id": f"blocked-{index:03}",
+                "kind": "exploit-step",
+                "semantics": "monotonic-additive/v1",
+                "prerequisites": [f"missing-{index:03}"],
+                "effects": [f"effect-{index:03}"],
+                "observations": [],
+            }
+        )
+    bindings = [
+        {
+            "binding_id": f"bind-fact-{item['fact_id']}",
+            "concept_kind": "scenario-node",
+            "aces_address": "/nodes/target",
+            "target_kind": "state-fact",
+            "target_id": item["fact_id"],
+        }
+        for item in state_facts
+    ]
+    bindings.extend(
+        {
+            "binding_id": f"bind-transition-{item['transition_id']}",
+            "concept_kind": "participant-action",
+            "aces_address": "/nodes/target",
+            "target_kind": "transition",
+            "target_id": item["transition_id"],
+        }
+        for item in transitions
+    )
+    return {
+        "profile": "aces-attack-graph/v1",
+        "binding_profile": "aces-sdl-snapshot-attack-binding/v1",
+        "transition_semantics_profile": "aces-monotonic-attack-transition/v1",
+        "snapshot_digest": _PLACEHOLDER_DIGEST,
+        "state_facts": sorted(state_facts, key=lambda item: item["fact_id"]),
+        "transitions": sorted(transitions, key=lambda item: item["transition_id"]),
+        "bindings": sorted(bindings, key=lambda item: item["binding_id"]),
+    }
+
+
+def _query(*, max_depth: int = 4, goal_facts: list[str] | None = None) -> dict:
+    return {
+        "profile": "aces-exploit-path-query/v1",
+        "query_id": "attacker-data-path",
+        "participant_perspective": "attacker",
+        "start_facts": ["attacker-foothold"],
+        "goal_facts": goal_facts or ["data-access"],
+        "allowed_transition_semantics": ["monotonic-additive/v1"],
+        "max_depth": max_depth,
+        "goal_check": "before-and-after-transition",
+    }
+
+
+def _blocked_query() -> dict:
+    return {
+        "profile": "aces-exploit-path-query/v1",
+        "query_id": "blocked-path",
+        "participant_perspective": "attacker",
+        "start_facts": ["start"],
+        "goal_facts": ["goal"],
+        "allowed_transition_semantics": ["monotonic-additive/v1"],
+        "max_depth": 1,
+        "goal_check": "before-and-after-transition",
+    }
+
+
+def _analysis_input(*, graph: dict | None = None, query: dict | None = None) -> ExploitPathAnalysisInputModel:
+    snapshot = _snapshot()
+    snapshot_digest = canonical_instantiated_sdl_digest(snapshot.scenario).value
+    payload = {
+        "profile": "exploit-path-analysis-input/v1",
+        "analysis_profile": "aces-exploit-path-analysis-v1",
+        "snapshot": snapshot.model_dump(mode="json"),
+        "snapshot_digest": snapshot_digest,
+        "normalized_graph": graph or _graph(),
+        "query": query or _query(),
+    }
+    payload["normalized_graph"]["snapshot_digest"] = payload["snapshot_digest"]
+    return ExploitPathAnalysisInputModel.model_validate(payload)
+
+
+def _write_input(tmp_path: Path, payload: ExploitPathAnalysisInputModel) -> Path:
+    path = tmp_path / "exploit-path-input.json"
+    path.write_text(
+        json.dumps(payload.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_valid_path_emits_replayable_ordered_witness(tmp_path: Path) -> None:
+    source = _write_input(tmp_path, _analysis_input())
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.VALID_PATH
+    assert evidence.witness is not None
+    assert evidence.failure is None
+    assert evidence.unsupported is None
+    assert [step.transition_id for step in evidence.witness.steps] == ["exploit-web", "read-data"]
+    assert evidence.witness.final_state == ("attacker-foothold", "data-access", "web-shell")
+    assert replay_exploit_path_evidence(source, evidence) == evidence
+
+
+def test_missing_prerequisite_rejects_invalid_path_with_structured_failure(tmp_path: Path) -> None:
+    graph = _graph()
+    graph["transitions"][0]["effects"] = []
+    source = _write_input(tmp_path, _analysis_input(graph=graph))
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.INVALID_PATH
+    assert evidence.failure is not None
+    assert evidence.witness is None
+    assert "data-access" in evidence.failure.unsatisfied_goal
+    blocked = {item.transition_id: item.missing_prerequisites for item in evidence.failure.blocked_transitions}
+    assert blocked["read-data"] == ("web-shell",)
+    assert "exploit-path.missing-prerequisite" in {item.code for item in evidence.diagnostics}
+
+
+def test_impossible_transition_reports_stable_diagnostic(tmp_path: Path) -> None:
+    graph = _graph()
+    graph["transitions"][0]["effects"] = ["attacker-foothold"]
+    source = _write_input(tmp_path, _analysis_input(graph=graph))
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.INVALID_PATH
+    assert evidence.failure is not None
+    assert "exploit-path.impossible-transition" in {item.code for item in evidence.diagnostics}
+
+
+def test_search_fails_closed_before_exceeding_evidence_diagnostic_cap(tmp_path: Path) -> None:
+    source = _write_input(tmp_path, _analysis_input(graph=_blocked_graph(65), query=_blocked_query()))
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.UNSUPPORTED
+    assert evidence.failure is None
+    assert evidence.unsupported is not None
+    assert evidence.unsupported.reason_codes == ("exploit-path.analysis-bound-exceeded",)
+    assert [item.code for item in evidence.diagnostics] == ["exploit-path.analysis-bound-exceeded"]
+
+
+def test_ambiguous_binding_fails_closed_with_unsupported_diagnostic(tmp_path: Path) -> None:
+    graph = _graph()
+    graph["bindings"].append(
+        {
+            "binding_id": "bind-exploit-web-ambiguous",
+            "concept_kind": "runtime-service",
+            "aces_address": "/nodes/target/os",
+            "target_kind": "transition",
+            "target_id": "exploit-web",
+        }
+    )
+    graph["bindings"] = sorted(graph["bindings"], key=lambda item: item["binding_id"])
+    source = _write_input(tmp_path, _analysis_input(graph=graph))
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.UNSUPPORTED
+    assert evidence.unsupported is not None
+    assert evidence.unsupported.reason_codes == ("exploit-path.binding-ambiguous",)
+    assert evidence.witness is None
+    assert evidence.failure is None
+
+
+def test_unsupported_transition_semantics_fail_closed(tmp_path: Path) -> None:
+    graph = _graph()
+    graph["transitions"][0]["semantics"] = "external-engine/v1"
+    source = _write_input(tmp_path, _analysis_input(graph=graph))
+
+    evidence = analyze_exploit_path_file(source)
+
+    assert evidence.outcome is ExploitPathOutcome.UNSUPPORTED
+    assert evidence.unsupported is not None
+    assert evidence.unsupported.reason_codes == ("exploit-path.unsupported-semantics",)
+
+
+def test_replay_rejects_source_query_and_payload_mutations(tmp_path: Path) -> None:
+    source = _write_input(tmp_path, _analysis_input())
+    evidence = analyze_exploit_path_file(source)
+
+    mutated = _analysis_input(query=_query(goal_facts=["web-shell"]))
+    source.write_text(json.dumps(mutated.model_dump(mode="json"), sort_keys=True), encoding="utf-8")
+    with pytest.raises(ExploitPathEvidenceError, match="source digest"):
+        replay_exploit_path_evidence(source, evidence)
+
+    payload = evidence.model_dump(mode="json")
+    payload["query"]["max_depth"] = 1
+    with pytest.raises(ValidationError):
+        ExploitPathAnalysisEvidenceModel.model_validate(payload)
+
+    payload = evidence.model_dump(mode="json")
+    payload["witness"]["final_state_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(ValidationError):
+        ExploitPathAnalysisEvidenceModel.model_validate(payload)
+
+
+def test_prerequisites_effects_ordering_and_goal_checks_are_load_bearing(tmp_path: Path) -> None:
+    depth_limited = analyze_exploit_path_file(_write_input(tmp_path, _analysis_input(query=_query(max_depth=1))))
+    assert depth_limited.outcome is ExploitPathOutcome.INVALID_PATH
+
+    graph = _graph()
+    graph["transitions"][1]["prerequisites"] = []
+    no_ordering = analyze_exploit_path_file(
+        _write_input(tmp_path, _analysis_input(graph=graph, query=_query(max_depth=1)))
+    )
+    assert no_ordering.outcome is ExploitPathOutcome.VALID_PATH
+    assert no_ordering.witness is not None
+    assert [step.transition_id for step in no_ordering.witness.steps] == ["read-data"]
+
+    graph = _graph()
+    graph["transitions"][1]["effects"] = []
+    no_effect = analyze_exploit_path_file(_write_input(tmp_path, _analysis_input(graph=graph)))
+    assert no_effect.outcome is ExploitPathOutcome.INVALID_PATH
+
+    impossible_goal = analyze_exploit_path_file(
+        _write_input(tmp_path, _analysis_input(query=_query(goal_facts=["nonexistent-goal"])))
+    )
+    assert impossible_goal.outcome is ExploitPathOutcome.UNSUPPORTED
+    assert impossible_goal.unsupported is not None
+    assert impossible_goal.unsupported.reason_codes == ("exploit-path.query-dangling-fact",)
+
+
+def test_evidence_contract_rejects_cross_outcome_payloads(tmp_path: Path) -> None:
+    evidence = analyze_exploit_path_file(_write_input(tmp_path, _analysis_input()))
+    payload = evidence.model_dump(mode="json")
+    payload["outcome"] = "invalid-path"
+
+    with pytest.raises(ValidationError):
+        ExploitPathAnalysisEvidenceModel.model_validate(payload)
+
+
+def test_published_valid_and_invalid_fixtures_enforce_outcome_joins() -> None:
+    fixtures = Path(__file__).resolve().parents[3] / "contracts" / "fixtures" / "exploit-path-analysis"
+    valid = fixtures / "exploit-path-analysis-evidence-v1" / "valid" / "valid-path.json"
+    invalid = fixtures / "exploit-path-analysis-evidence-v1" / "invalid" / "cross-outcome-payload.json"
+
+    ExploitPathAnalysisEvidenceModel.model_validate_json(valid.read_text(encoding="utf-8"))
+    with pytest.raises(ValidationError) as exc_info:
+        ExploitPathAnalysisEvidenceModel.model_validate_json(invalid.read_text(encoding="utf-8"))
+
+    assert "outcome must select exactly one matching payload" in str(exc_info.value)
+
+
+def test_published_schema_enforces_outcome_payload_exclusivity() -> None:
+    fixtures = Path(__file__).resolve().parents[3] / "contracts" / "fixtures" / "exploit-path-analysis"
+    valid = fixtures / "exploit-path-analysis-evidence-v1" / "valid" / "valid-path.json"
+    invalid = fixtures / "exploit-path-analysis-evidence-v1" / "invalid" / "cross-outcome-payload.json"
+    validator = Draft202012Validator(schema_bundle()["exploit-path-analysis-evidence-v1"])
+
+    assert list(validator.iter_errors(json.loads(valid.read_text(encoding="utf-8")))) == []
+    assert list(validator.iter_errors(json.loads(invalid.read_text(encoding="utf-8"))))

--- a/implementations/python/tests/test_exploit_path_cli.py
+++ b/implementations/python/tests/test_exploit_path_cli.py
@@ -1,0 +1,61 @@
+"""Production CLI coverage for typed exploit-path analysis (issue #827)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aces_cli.main import app
+from test_exploit_path_analysis import _analysis_input, _graph, _write_input
+from typer.testing import CliRunner
+
+
+def _invoke(path: Path):
+    return CliRunner().invoke(
+        app,
+        [
+            "processor",
+            "exploit-path",
+            str(path),
+            "--profile",
+            "aces-exploit-path-analysis-v1",
+        ],
+    )
+
+
+def test_cli_emits_replayable_evidence_and_is_deterministic(tmp_path: Path) -> None:
+    source = _write_input(tmp_path, _analysis_input())
+
+    first = _invoke(source)
+    second = _invoke(source)
+
+    assert first.exit_code == 0, first.output
+    assert first.stdout == second.stdout
+    evidence = json.loads(first.stdout)
+    assert evidence["profile"] == "exploit-path-analysis-evidence/v1"
+    assert evidence["outcome"] == "valid-path"
+    assert [step["transition_id"] for step in evidence["witness"]["steps"]] == ["exploit-web", "read-data"]
+
+
+def test_cli_uses_exit_two_for_typed_unsupported_result(tmp_path: Path) -> None:
+    graph = _graph()
+    graph["transitions"][0]["semantics"] = "external-engine/v1"
+    source = _write_input(tmp_path, _analysis_input(graph=graph))
+
+    result = _invoke(source)
+
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["outcome"] == "unsupported"
+    assert result.stderr == ""
+
+
+def test_cli_sanitizes_malformed_input(tmp_path: Path) -> None:
+    source = tmp_path / "SECRET-MARKER.json"
+    source.write_text("{not-json", encoding="utf-8")
+
+    result = _invoke(source)
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Traceback" not in result.stderr
+    assert "SECRET-MARKER" not in result.stderr

--- a/specs/formal/README.md
+++ b/specs/formal/README.md
@@ -16,6 +16,7 @@ Examples:
 - `specs/formal/experiment-core/`
 - `specs/formal/scenario-variation-trial-realization/`
 - `specs/formal/scenario-satisfiability/`
+- `specs/formal/exploit-path-analysis/`
 - `specs/formal/validation-admission-profiles/`
 - `specs/formal/sdl-phases/`
 

--- a/specs/formal/assurance-fulfillment.yaml
+++ b/specs/formal/assurance-fulfillment.yaml
@@ -57,6 +57,9 @@ subsystems:
   - id: scenario-satisfiability
     path: specs/formal/scenario-satisfiability
     fm_level: FM2
+  - id: exploit-path-analysis
+    path: specs/formal/exploit-path-analysis
+    fm_level: FM2
   - id: runtime-contracts
     path: specs/formal/runtime-contracts
     fm_level: FM2
@@ -216,6 +219,18 @@ entries:
         path: contracts/schemas/satisfiability/scenario-satisfiability-evidence-v1.json
       - kind: property_based_or_differential_tests
         path: implementations/python/tests/test_scenario_satisfiability.py
+    waived_artifacts: []
+
+  - subsystem: exploit-path-analysis
+    delivered_artifacts:
+      - kind: invariant_list
+        path: specs/formal/exploit-path-analysis/README.md
+      - kind: unit_tests
+        path: implementations/python/tests/test_exploit_path_analysis.py
+      - kind: typed_ir_or_contract_coverage
+        path: contracts/schemas/exploit-path-analysis/exploit-path-analysis-evidence-v1.json
+      - kind: property_based_or_differential_tests
+        path: implementations/python/tests/test_exploit_path_analysis.py
     waived_artifacts: []
 
   - subsystem: runtime-contracts

--- a/specs/formal/exploit-path-analysis/README.md
+++ b/specs/formal/exploit-path-analysis/README.md
@@ -1,0 +1,160 @@
+# Exploit-Path Analysis
+
+This specification defines the normative v1 typed exploit-path analysis
+boundary for issue #827. The keywords MUST, MUST NOT, SHALL, and SHOULD are
+normative.
+
+## Scope
+
+The analysis profile `aces-exploit-path-analysis-v1` SHALL mean exactly:
+
+```text
+binding_profile              = aces-sdl-snapshot-attack-binding/v1
+transition_semantics_profile = aces-monotonic-attack-transition/v1
+query_semantics_profile      = aces-exploit-path-query/v1
+search_profile               = aces-deterministic-attack-graph-search/v1
+```
+
+The input SHALL be an admitted `InstantiatedScenarioSnapshot`, a normalized
+attack graph whose `snapshot_digest` binds that snapshot, and a closed query.
+The analyzer does not consume raw YAML dictionaries, skip semantic admission,
+or add SDL authoring syntax. The normalized graph is a derived artifact that
+binds ACES scenario concepts to attack-state facts and transitions.
+
+## Normalized Graph
+
+A normalized graph contains:
+
+- `state_facts`: typed facts with stable ids, a fact kind, participant or
+  actor subject, and an ACES snapshot JSON Pointer;
+- `transitions`: typed edges with stable ids, transition kind, transition
+  semantics id, prerequisite fact ids, effect fact ids, and emitted
+  observations;
+- `bindings`: governed mappings from ACES snapshot JSON Pointers to exactly
+  one graph state fact or transition target under the binding profile.
+
+State fact ids, transition ids, binding ids, prerequisite lists, effect lists,
+and observation ids MUST be unique and canonically sorted. Transition
+prerequisites and effects MUST reference declared state facts. Bindings are
+resolved against the admitted snapshot payload using RFC 6901 JSON Pointer
+semantics. Missing, dangling, or ambiguous bindings fail closed as
+`unsupported`; the analyzer MUST NOT first-match ambiguous bindings.
+
+The v1 state fact kinds are `access`, `capability`, `data-state`, `execution`,
+`observation`, and `objective-state`. The v1 transition kinds are
+`exploit-step`, `observation-step`, and `postcondition-step`.
+
+## Transition Semantics
+
+`monotonic-additive/v1` is the only supported v1 transition semantics.
+
+Let `S` be the current attack-state fact set and `t` a transition. The
+transition is enabled iff every prerequisite of `t` is in `S`. Firing `t`
+produces:
+
+```text
+S' = S union effects(t)
+```
+
+Emitted observations are recorded as witness evidence. They do not become
+hidden truth unless a transition effect explicitly adds a corresponding state
+fact. A transition with no newly applied effect under a state that satisfies
+its prerequisites is an impossible transition for v1 search and is recorded as
+structured invalid-path evidence.
+
+Unsupported transition semantics MUST fail closed as `unsupported`; they MUST
+NOT silently drop the transition or treat unsupported prerequisites/effects as
+already satisfied.
+
+## Query Semantics
+
+A query contains:
+
+- query profile and stable query id;
+- participant perspective;
+- start fact set;
+- goal fact set;
+- allowed transition semantics;
+- bounded maximum depth; and
+- goal-check mode `before-and-after-transition`.
+
+Start and goal facts MUST be non-empty, unique, and sorted. They MUST resolve
+to graph state facts. The query is not an expression language: no Python,
+JSONPath, regular expression predicate, shell command, SMT text, callback,
+plugin, or environment-selected option belongs in the portable query contract.
+
+The goal is satisfied when every goal fact is present in the current state. The
+analyzer checks the goal before any transition and after every fired
+transition. Search stops at the first valid path selected by deterministic
+breadth-first search over canonically ordered transitions and states. Exhausting
+the bounded search without reaching the goal yields `invalid-path`, not
+`unsupported`.
+
+## Evidence And Replay
+
+The published `exploit-path-analysis-evidence/v1` envelope SHALL bind:
+
+1. portable input source identity and SHA-256 byte digest;
+2. the authored scenario semantic digest carried by the instantiated snapshot;
+3. the instantiated snapshot digest;
+4. the normalized graph and its RFC 8785 SHA-256 digest;
+5. the query and its RFC 8785 SHA-256 digest;
+6. the search configuration and its RFC 8785 SHA-256 digest;
+7. completed outcome and value-free diagnostics; and
+8. exactly one outcome-specific payload.
+
+`valid-path` carries a replayable witness: initial state, ordered transition
+steps, state digests before and after each step, satisfied prerequisites,
+applied effects, emitted observations, final state, and final-state digest.
+
+`invalid-path` carries structured failure evidence: explored-state count,
+whether the depth bound was exhausted, blocked transitions with missing
+prerequisites at reached states, impossible transitions, and unsatisfied goal
+facts.
+
+`unsupported` carries stable reason codes matching the diagnostics. It is used
+for unsupported semantics, missing/dangling/ambiguous bindings, dangling query
+facts, or cases where the bounded search cannot fit complete evidence into the
+published evidence contract. Malformed JSON, contract validation failure,
+source read failure, and internal failures are operational failures outside the
+completed outcome vocabulary.
+
+Replay rereads the bounded input, verifies the source byte digest, recomputes
+the full evidence envelope using the evidence analysis profile, and requires
+canonical contract equality. Mutated source bytes, graph, query, search
+configuration, witness, failure evidence, unsupported reason codes, or digest
+joins fail closed.
+
+## Diagnostics
+
+Diagnostics SHALL use the shared closed `DiagnosticModel` shape with domain
+`exploit-path`, stable code, safe JSON Pointer address, bounded message, and
+severity `error`. They MUST NOT render raw scenario values, credentials, exploit
+payloads, command output, backend-native objects, environment values, full
+tracebacks, or absolute host paths.
+
+Required v1 diagnostic codes include:
+
+- `exploit-path.binding-missing`;
+- `exploit-path.binding-ambiguous`;
+- `exploit-path.binding-target-dangling`;
+- `exploit-path.unsupported-semantics`;
+- `exploit-path.query-dangling-fact`;
+- `exploit-path.analysis-bound-exceeded`;
+- `exploit-path.missing-prerequisite`;
+- `exploit-path.impossible-transition`; and
+- `exploit-path.unsatisfied-goal`.
+
+## Claims And Nonclaims
+
+Passing v1 evidence demonstrates only the result of the pinned graph/query
+profile for the exact snapshot, normalized graph, query, and analyzer version.
+
+It does not demonstrate network reachability, topology connectivity,
+vulnerability presence, CVE/CWE/ATT&CK applicability, participant action
+admission, objective success, proposition truth, backend realization,
+deployment success, runtime behavior, scanner findings, counterfactual
+necessity, real-world exploitability, attacker skill, or exploitability outside
+the normalized graph. New binding scopes, transition families, search
+strategies, query semantics, or evidence meaning require a new governed
+profile/version.

--- a/specs/formal/validation-admission-profiles/README.md
+++ b/specs/formal/validation-admission-profiles/README.md
@@ -238,3 +238,22 @@ translation coverage, replay rules, and nonclaims are normative in
 This profile does not upgrade the general validation strength of every
 scenario. Unsupported occurrences remain an explicit unsupported gate, and
 backend realization and runtime behavior remain separate gates.
+
+### Typed exploit-path analysis
+
+Issue #827 adds `aces-exploit-path-analysis-v1` as a concrete typed
+attack-transition graph/query boundary for an admitted instantiated scenario
+snapshot. Its `exploit-path-analysis-evidence/v1` envelope records the exact
+input source, authored digest, snapshot digest, normalized attack graph, query,
+search configuration, completed outcome, and one of witness, invalid-path
+failure evidence, or unsupported disclosure. The profile's transition,
+binding, query, replay, diagnostics, and nonclaims are normative in
+[`specs/formal/exploit-path-analysis/`](../exploit-path-analysis/README.md).
+
+This profile does not upgrade weaker evidence into exploit-path proof. Network
+reachability, topology connectivity, service/listener presence, vulnerability
+or ATT&CK labels, workflow reachability, scenario satisfiability, objective
+success, participant-local action success, backend realization, deployment
+success, scanner output, and runtime observation remain separate gates unless
+the exploit-path graph contains governed bindings and transitions that state
+exactly how those facts participate in the v1 path semantics.

--- a/tools/generate_contract_schemas.py
+++ b/tools/generate_contract_schemas.py
@@ -20,6 +20,8 @@ def _schema_output_path(schemas_dir: Path, name: str) -> Path:
         return schemas_dir / "sdl" / f"{name}.json"
     if name.startswith("scenario-satisfiability-evidence-v"):
         return schemas_dir / "satisfiability" / f"{name}.json"
+    if name.startswith("exploit-path-analysis-evidence-v"):
+        return schemas_dir / "exploit-path-analysis" / f"{name}.json"
     if name.startswith("backend-manifest-v"):
         return schemas_dir / "backend-manifest" / f"{name}.json"
     if name.startswith("realization-envelope-v"):

--- a/tools/policy/adr_policy.yaml
+++ b/tools/policy/adr_policy.yaml
@@ -224,6 +224,7 @@ module_boundaries:
           - aces_operations.cross_backend_corpus
           - aces_operations.techvault_live
         aces_processor:
+          - aces_processor.exploit_path
           - aces_processor.manifest
           - aces_processor.models
           - aces_processor.reference


### PR DESCRIPTION
## Summary

Add a governed typed exploit-path analysis profile that turns an admitted scenario snapshot, normalized attack graph, and closed path query into replayable valid, invalid, or fail-closed unsupported evidence.

## Requirement UIDs

- `ASR-530`

## Related Issues

Closes #827

## ADR Impact

- ADR-021
- ADR-036
- ADR-072
- ADR-086

## Changes

- Define the normative `aces-exploit-path-analysis-v1` graph, transition, query, replay, diagnostic, and nonclaim semantics under `specs/formal/exploit-path-analysis/`.
- Add closed portable exploit-path contracts, publish the evidence schema and schema-publication entry, and add valid plus single-defect invalid fixtures.
- Implement `aces_processor.exploit_path` with deterministic bounded monotonic-additive search, replay, value-free diagnostics, and evidence-cap fail-closed handling.
- Expose `aces processor exploit-path` with deterministic JSON output and typed unsupported exit status.
- Update validation-profile, formal evidence, API, assurance-fulfillment, and module-boundary documentation/policy surfaces.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Targeted exploit-path tests passed (`14 passed`). Full `ACES_REQUIREMENT_UID=ASR-530 implementations/python/.venv/bin/python tools/verify_all.py` passed after the pre-push review cycles. `gc_assert_quality_gates` returned ok=true for ASR-530 with no configured gates.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-530 ← specs/formal/exploit-path-analysis/README.md, ASR-530 ← implementations/python/packages/aces_contracts/exploit_path.py, ASR-530 ← implementations/python/packages/aces_processor/exploit_path/_service.py, ASR-530 ← implementations/python/packages/aces_cli/processor.py, ASR-530 ← contracts/schemas/exploit-path-analysis/exploit-path-analysis-evidence-v1.json
- TESTS: ASR-530 ← implementations/python/tests/test_exploit_path_analysis.py, ASR-530 ← implementations/python/tests/test_exploit_path_cli.py, ASR-530 ← contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/valid/valid-path.json, ASR-530 ← contracts/fixtures/exploit-path-analysis/exploit-path-analysis-evidence-v1/invalid/cross-outcome-payload.json

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
