### PR TITLE
fix: restore the raes-sdl distribution name and pin dependabot off the governed solver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,16 @@ updates:
       python-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # z3-solver is pinned by a governed contract, not by ordinary dependency
+      # policy: the aces-z3-finite-domain/v1 profile fixes package_version
+      # 4.16.0.0 / engine_version 4.16.0 in SolverConfigurationModel, in the
+      # published scenario-satisfiability-evidence-v1 schema, and in its
+      # fixtures, so satisfiability evidence stays reproducible. An automated
+      # bump desynchronizes pyproject from that authority while `uv --frozen`
+      # keeps resolving the locked 4.16.0.0, so CI stays green and the
+      # contradiction goes unnoticed until someone regenerates the lock and the
+      # formal semantic-validation gate breaks (#856, #872). Re-pinning the
+      # governed profile is a deliberate change with evidence to regenerate; it
+      # is not Dependabot's call.
+      - dependency-name: "z3-solver"

--- a/implementations/python/pyproject.toml
+++ b/implementations/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "raes"
+name = "raes-sdl"
 version = "0.24.0"
 description = "Backend-agnostic cyber range scenario description language and runtime."
 dynamic = ["readme"]

--- a/implementations/python/uv.lock
+++ b/implementations/python/uv.lock
@@ -1234,7 +1234,7 @@ wheels = [
 
 [[package]]
 name = "raes-sdl"
-version = "0.23.1"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncssh" },


### PR DESCRIPTION
## Summary

Two fixes to `dev`: the `[project] name` divergence that makes every `dev` → `main` promotion conflict (#877), and the Dependabot rule that keeps rewriting a governed solver pin.

## Requirement UIDs

- (none — maintenance run; see ADR-021 gated workflow)

## Related Issues

Refs #877

## ADR Impact

- ADR-021 (no decision change)

## Changes

### 1. Restore the `raes-sdl` distribution name

The #871 merge resolution left `[project] name = "raes"` on `dev`. Everything else in the repo says `raes-sdl`:

| Source | Name |
|---|---|
| `main` | `raes-sdl` |
| merge base `91b0ec5d` | `raes-sdl` |
| `release-please-config.json` `package-name` | `raes-sdl` |
| release-please branch component | `…components--raes-sdl` |
| `#870` RAES cutover | `raes-sdl` |
| `uv.lock` (never rewritten) | `raes-sdl` |
| `dev` `pyproject.toml` | **`raes`** ← the outlier |

No deliberate rename to `raes` exists on any branch, so this restores the name rather than choosing between two intents.

**Why it produced a conflict.** `name` (line 6) and `version` (line 7) are adjacent. `main` changed only `version` (release-please, 0.24.0); `dev` changed both. The two edit regions overlap with no unchanged line between them, so git conflicts even though the outcome is compatible. Verified with `git merge-tree`:

- `dev` vs `main` → conflict, three stages on `pyproject.toml`
- this branch vs `main` → clean tree, no conflict

Also syncs the `uv.lock` version entry (`0.23.1` → `0.24.0`) that release-please left stale — a one-line change.

### 2. Ignore `z3-solver` in Dependabot

`z3-solver` is pinned by a governed contract, not by ordinary dependency policy. The `aces-z3-finite-domain/v1` profile fixes `package_version 4.16.0.0` / `engine_version 4.16.0` in `SolverConfigurationModel`, in the published `scenario-satisfiability-evidence-v1` schema, and in its fixtures, so satisfiability evidence stays reproducible.

An automated bump rewrites `pyproject.toml` away from that authority while `uv --frozen` keeps resolving the locked `4.16.0.0` — so **CI stays green and the contradiction is invisible** until someone regenerates the lock, at which point the `formal semantic-validation evidence` gate breaks. This has now happened twice (#856, #872). Re-pinning the governed profile is a deliberate change with evidence to regenerate, so it does not belong to Dependabot.

Note: Dependabot reads this file from the default branch, so the ignore takes effect once this reaches `main`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`uv lock --check` passes. `dependabot.yml` and `pyproject.toml` both parse. The conflict resolution is verified structurally with `git merge-tree` against `main` (clean tree) rather than by assertion.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-021 ← implementations/python/pyproject.toml
- TESTS: ADR-021 ← .github/dependabot.yml

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no user-facing behavior changes; the rationale lives in the `pyproject.toml` and `dependabot.yml` comments next to the pins they govern.
