### PR TITLE
chore: stop dependabot bumping the governed solver pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,17 @@ updates:
       python-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # z3-solver is pinned by a governed contract, not by ordinary dependency
+      # policy: the aces-z3-finite-domain/v1 profile fixes package_version
+      # 4.16.0.0 / engine_version 4.16.0 in SolverConfigurationModel, in the
+      # published scenario-satisfiability-evidence-v1 schema, and in its
+      # fixtures, so satisfiability evidence stays reproducible.
+      #
+      # An automated bump rewrites pyproject away from that authority while
+      # `uv --frozen` keeps resolving the locked 4.16.0.0, so CI stays green and
+      # the contradiction is invisible until someone regenerates the lock and
+      # the formal semantic-validation gate breaks. That has happened twice
+      # (#856, #872). Re-pinning the governed profile is a deliberate change
+      # with evidence to regenerate; it is not Dependabot's call.
+      - dependency-name: "z3-solver"


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` for `z3-solver`. One file, 14 lines, no code or dependency change.

## Requirement UIDs

- (none — maintenance run; see ADR-021 gated workflow)

## Related Issues

Refs #856, #872

## ADR Impact

- ADR-021 (no decision change)

## Changes

- `.github/dependabot.yml`: ignore `z3-solver` in the pip ecosystem, with the reason recorded inline.

`z3-solver` is pinned by a governed contract rather than by ordinary dependency policy. The `aces-z3-finite-domain/v1` profile fixes `package_version 4.16.0.0` / `engine_version 4.16.0` in three places — `SolverConfigurationModel`, the published `scenario-satisfiability-evidence-v1` schema, and its fixtures — so satisfiability evidence stays reproducible.

**Why this is worth a rule rather than a re-fix each time.** An automated bump rewrites `pyproject.toml` away from that authority, but every gate runs `uv --frozen`, which keeps resolving the locked `4.16.0.0`. CI therefore stays green while `pyproject.toml` and the lockfile disagree, and nothing surfaces the contradiction until someone regenerates the lock — at which point the `formal semantic-validation evidence` gate fails with `SatisfiabilityOperationalError`, because the installed solver no longer matches the governed profile. That failure mode is silent, delayed, and lands on whoever next touches the lock.

This has happened twice: #856 and #872.

Re-pinning the governed profile is a deliberate change that also requires regenerating the affected evidence, so it does not belong to Dependabot.

Note: Dependabot reads this file from the default branch, so the ignore takes effect once this reaches `main`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Config-only change; no source, dependency, schema, or lockfile edit. `dependabot.yml` parses and the existing `python-minor-patch` group is unchanged.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-021 ← .github/dependabot.yml
- TESTS: ADR-021 ← .github/dependabot.yml

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: the rationale is recorded inline in `dependabot.yml`, next to the rule it explains.
