### PR TITLE
ci: allow publishing an existing release tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,12 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag to publish (for example, v1.0.0)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -28,6 +34,7 @@ concurrency:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write        # create/maintain the release PR, tag, and Release
@@ -45,16 +52,32 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      always()
+      && (needs.release-please.outputs.release_created == 'true'
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
       contents: write   # upload the built distributions to the Release
       id-token: write   # OIDC trusted publishing to PyPI (no stored token)
     steps:
+      - name: Validate manual release tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          case "${TAG}" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "Expected a release tag such as v1.0.0, got '${TAG}'" >&2; exit 1 ;;
+          esac
+          gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.sha }}
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -97,7 +120,7 @@ jobs:
       - name: Attach the distributions to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || needs.release-please.outputs.tag_name }}
         run: gh release upload "${TAG}" dist/* --clobber
 
   # After a release is cut, the version bump + CHANGELOG land on `main`, so `dev`


### PR DESCRIPTION
## Summary

Add a narrowly scoped manual dispatch path for publishing an existing GitHub release tag through the established PyPI OIDC job. Normal Release Please behavior on pushes to `main` is unchanged.

## Related Issues

- Follow-up to #884

## Requirement Context

- Requirement UID: N/A — release workflow recovery
- ADRs touched: None
- Ground Control project: `aces-sdl`

## Changes

- Add a required manual `tag` input.
- Validate that the requested GitHub release exists.
- Check out that tag and reuse the existing build, PyPI publish, and release-asset upload steps.
- Keep Release Please and dev synchronization restricted to the normal push-triggered release path.

## Test Plan

- [x] `git diff --check`
- [ ] Local test suite not run, per explicit request
- [ ] CI

## Checklist

- [x] Change is limited to `.github/workflows/release-please.yml`
- [x] PR title is a non-releasing Conventional Commit
- [x] No branch merge or history rewrite performed

## Notes for Review

This PR targets `dev`. After it reaches `main` through the repository’s normal promotion workflow, dispatch `Release Please` with tag `v1.0.0` to publish the already-created release.