### PR TITLE
fix: restore Ground Control project binding

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-project: raes-sdl
+project: aces-sdl
 github_repo: RAESystem/rae
 workflow:
   test_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify

--- a/tools/policy/historical_identity_records.json
+++ b/tools/policy/historical_identity_records.json
@@ -3,6 +3,13 @@
   "hash_algorithm": "sha256",
   "operational_bindings": [
     {
+      "path": ".ground-control.yaml",
+      "binding_class": "external-service-project-key",
+      "rationale": "Retains the existing service-owned Ground Control project designation without treating it as current RAES product identity.",
+      "occurrences": 1,
+      "content_sha256": "e0596809035a079630de05e4d350ed27fac0675526b247c3b069627ca4abe267"
+    },
+    {
       "path": "sonar-project.properties",
       "binding_class": "external-service-project-key",
       "rationale": "Retains the existing service-owned SonarCloud project designation without treating it as current RAES product identity.",


### PR DESCRIPTION
## Summary

Restore `.ground-control.yaml` to the existing service-owned `aces-sdl` project identifier. The MCP resolves GOV-944 under `aces-sdl`; `raes-sdl` returns project not found.

Record this as a single exact, content-hashed operational binding so the RAES identity-cutover gate remains fail-closed everywhere else.

## Verification

- `RAES_REQUIREMENT_UID=GOV-944 make policy`
- `implementations/python/.venv/bin/python -m pytest implementations/python/tests/test_identity_cutover_policy.py -q` (8 passed)
- `git diff --check`

Related to #908.