### PR TITLE
docs: clarify RAES ecosystem naming boundaries

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -1,5 +1,7 @@
 schema_version: 1
-project: raes-sdl
+# Ground Control still owns the pre-cutover project identifier. ADR-096
+# requires external provisioning before this binding can move.
+project: aces-sdl
 github_repo: RAESystem/rae
 workflow:
   test_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify

--- a/docs/decisions/issue-907-raes-env-packs-naming-preflight.md
+++ b/docs/decisions/issue-907-raes-env-packs-naming-preflight.md
@@ -1,0 +1,150 @@
+# Issue 907 RAES and Environment-Packs Naming Preflight
+
+Date: 2026-07-27
+
+Issue: #907. Requirement: none. The GitHub issue is the authoritative delivery
+contract.
+
+This note fixes the architecture boundaries for implementation. It does not
+publish a package, mutate a PyPI project, define a downstream pack format, or
+add a compatibility mode.
+
+## Base-Synchronization Correction
+
+The first preflight pass occurred before PR #921 merged. That merge completed
+issue #908 / GOV-944 and accepted ADR-096, which supersedes the earlier
+assumption that current ACES-bearing contract and wire identifiers would remain
+unchanged. The implementation for issue #907 treats the merged identity
+cutover as authoritative.
+
+The resulting downstream sequence is release-bounded:
+
+1. Consumers pinned to RAES 1.1.0 continue to use that release's ACES-bearing
+   contract, schema, wire, workflow, runtime, and host values.
+2. Consumers migrate those values atomically when adopting the next breaking
+   RAES release containing PR #921, targeted as 2.0.0.
+3. Consumers do not guess `raes-*` translations, combine values from both
+   release lines, or add aliases, fallback reads, and last-one-wins rules.
+
+The release's normative schemas, fixtures, and migration evidence define the
+new values. This note records sequencing; it does not create a second identity
+inventory.
+
+Ground Control's project identifier is an external service-owned operational
+binding, not a repository-owned product identity. The service currently exposes
+only its pre-cutover project record. ADR-096 requires replacement provisioning
+before repository configuration points to a new external identifier, so the
+existing logical binding remains registered as an exact content-bound
+operational binding until that provisioning occurs. This is the same bounded
+class of exception as the retained SonarCloud project key; it does not authorize
+a runtime alias or a general naming fallback.
+
+## Architecture Decisions
+
+### Scenario remains the SDL term; environment pack is a packaging term
+
+`Scenario` remains the RAES SDL authored-content concept, and
+`instantiate_scenario()` remains the operation that binds its variables into an
+instantiated scenario. The normative SDL document phases and contract names
+continue to use *scenario*.
+
+An **environment pack** is a downstream packaging and distribution unit. It may
+contain SDL scenarios and other reusable assets. It is not:
+
+- an alias or replacement for `Scenario`;
+- a new SDL document phase, schema, model, parser entry point, or validator;
+- equivalent to an agentic environment or realized environment; or
+- authority to restate upstream scenario, concept, or trust-policy semantics.
+
+The downstream pack owner may define pack layout and release mechanics. This
+repository remains the authority for the contained SDL and governed contract
+meanings.
+
+### Retire the `aces-sdl` PyPI project with a final pointer and archival
+
+The `aces-sdl` PyPI project is end-of-life. Its replacement is `raes`; migration
+is directly to RAES imports and commands. No removed import shim or compatibility
+package is restored.
+
+Close the old project with one final 0.23.2 legacy-line release whose code
+behavior is unchanged from 0.23.1 and whose distribution metadata and long
+description state that:
+
+- the project is retired and receives no further fixes;
+- `raes` is the replacement distribution;
+- old imports do not carry forward; and
+- consumers must follow `docs/migration/raes-rename.md`.
+
+The EOL release must not depend on `raes`, provide aliases, or install an empty
+placeholder. After its metadata and artifacts are verified on PyPI, archive the
+project. Do not delete or broadly yank historical releases.
+
+The current release path remains exclusively for `raes`. The one-time legacy
+publication is a separate protected action: it must build from immutable
+reviewed source, use the protected PyPI environment and short-lived OIDC
+credentials, and retain no token. Issue #907 records this decision but does not
+authorize the upload or archival action.
+
+## Canonical Incumbents To Reuse
+
+- **Identity cutover:** ADR-096,
+  `docs/decisions/issue-908-raes-identity-cutover-preflight.md`,
+  `docs/migration/raes-rename.md`, `tools/check_identity_cutover.py`, and
+  `tools/policy/historical_identity_records.json`.
+- **Normative authority and contract evolution:** ADR-009, ADR-019, ADR-061,
+  `contracts/schema-publication-manifest.json`,
+  `contracts/schema-publication/entries/`, `schema_bundle()`,
+  `tools/check_schema_publication.py`, and
+  `tools/check_generated_schemas.py`.
+- **Compatibility and lifecycle:** ADR-075,
+  `specs/evolution/versioning-deprecation-and-migration.md`,
+  `specs/evolution/deprecation-records.yaml`, and
+  `tools/check_deprecation_lifecycle.py`.
+- **SDL vocabulary and phases:** ADR-001, `specs/sdl/`,
+  `docs/explain/reference/glossary.md`, `raes.scenario.Scenario`,
+  `raes.instantiate.instantiate_scenario`, parser and semantic validators, and
+  the authored and instantiated schemas and fixtures.
+- **Concept and reusable-asset authority:** ADR-012, ADR-062, ADR-071,
+  `specs/concept-authority/`, `contracts/concept-authority/`, and
+  `specs/supply-chain/reusable-asset-trust-integrity.md`. Environment packs
+  consume these surfaces; they do not clone them.
+- **Release and verification:** release-please configuration,
+  `.github/workflows/release-please.yml`, the pinned PyPI publish action,
+  protected `pypi` environment, OIDC trusted publishing, ADR-014,
+  `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`,
+  `tools/check_repo_policy.py`, and `tools/verify_all.py`.
+
+## Cross-Cutting Boundaries
+
+| Layer | Required behavior |
+|---|---|
+| Contracts and schemas | PR #921 remains the sole identity-cutover implementation. Issue #907 adds sequencing guidance, not aliases, schema edits, or a parallel identifier inventory. |
+| SDL parse and instantiation | `Scenario` and `instantiate_scenario()` remain canonical. Pack metadata does not enter an SDL model merely because a pack contains SDL. |
+| Concept and trust policy | Environment packs reference the upstream authorities and validators. They do not copy schemas or create a pack-local trust model. |
+| Authentication and authorization | No runtime auth surface changes. Existing strict defaults and denial behavior remain in force. |
+| Secrets and publication | No credential is added to source, docs, fixtures, logs, environment dumps, or process arguments. The future protected publication uses short-lived OIDC. |
+| Persistence and host state | No read-time rewrite, cleanup service, or migration store is introduced. Operators migrate persisted values and resources at the breaking-release boundary. |
+| Historical evidence | This dated correction retains exact pre-cutover naming only through ADR-096's content-bound historical-record manifest. |
+| Lifecycle evidence | The legacy distribution name remains readable only in its exact content-bound ADR-075 lifecycle record; code and tests use the neutral record id `legacy-python-distribution`. |
+
+## Extensibility Seams
+
+- A future contract change extends its owning schema-publication entry,
+  fixtures, validators, compatibility record, and versioned reader boundary.
+- A future pack format extends the downstream pack manifest and containment
+  references; it does not extend `Scenario` with package metadata.
+- A future distribution retirement adds an exact `python-distribution`
+  lifecycle record. It does not make the RAES publisher accept an arbitrary
+  project name.
+
+## Non-Goals And Anti-Patterns
+
+- No additional contract, schema, profile, discriminator, URI, auth header,
+  workflow key, host identifier, or persisted artifact rename.
+- No SDL model/API rename and no `EnvironmentPack` model in this repository.
+- No compatibility shim, alias registry, automatic source migrator, generic
+  rename service, new exception hierarchy, or migration database.
+- No downstream pack implementation.
+- No package publication, PyPI project mutation, or release-workflow change.
+- No mixed old/new identity handling, global replacement, copied authority,
+  stored publication token, or deletion of sound historical releases.

--- a/docs/migration/raes-rename.md
+++ b/docs/migration/raes-rename.md
@@ -52,3 +52,44 @@ The hard cut does not automatically rewrite persisted artifacts or clean
 resources created under an earlier identity. Operators should complete any
 required environment cleanup before deploying the cutover release; the
 repository does not discover or destroy old-name resources.
+
+## Downstream Cutover Sequencing
+
+Issue #908 migrated current contract, schema, wire, workflow, runtime, and host
+identities together. Consumers pinned to RAES 1.1.0 continue to use that
+release's pre-cutover values. They must switch all affected values atomically
+when adopting the next breaking RAES release that contains the identity
+cutover, targeted as 2.0.0.
+
+Consumers must not guess replacement spellings, mix identities from the two
+release lines, or introduce aliases and fallback reads. The release's schemas,
+fixtures, and migration evidence are the source of truth for the new values.
+
+## Scenario And Environment-Pack Vocabulary
+
+`Scenario` remains the RAES SDL authored-content concept, and
+`instantiate_scenario()` continues to produce an instantiated scenario. An
+**environment pack** is a downstream packaging and distribution unit that may
+contain SDL scenarios and other reusable assets. It is not another name for a
+scenario, an SDL document phase or model, or a realized environment.
+
+The intended split is therefore: packs are environment packs; the SDL content
+they carry remains scenarios. A pack repository owns its layout and release
+mechanics, while this repository remains authoritative for SDL, concept, and
+reusable-asset trust-policy meanings.
+
+## Legacy PyPI Distribution Retirement
+
+The legacy PyPI distribution named in issue #907 is end-of-life, and `raes` is
+its replacement. One final 0.23.2 release will be cut from the immutable 0.23.1
+legacy lineage with unchanged code behavior and an updated long description
+that points consumers to `raes` and this migration guide. It will not depend on
+`raes`, install a placeholder, or restore retired import aliases.
+
+After the final artifact name, version, contents, metadata, and replacement
+links are verified on PyPI, the legacy project will be archived. Existing
+historical releases will remain available rather than being deleted or broadly
+yanked. The current release-please workflow remains exclusive to `raes`; the
+one-time legacy publication requires an immutable reviewed source, the
+protected PyPI environment, and short-lived OIDC credentials rather than a
+stored token.

--- a/implementations/python/tests/test_deprecation_lifecycle.py
+++ b/implementations/python/tests/test_deprecation_lifecycle.py
@@ -34,7 +34,7 @@ from tools.check_deprecation_lifecycle import (  # noqa: E402
 
 
 def _good_ledger() -> dict:
-    # Includes the canonical retention-floor record so the positive case and
+    # Includes all canonical (retention-floor) records so the positive case and
     # every mutation starting point satisfies CANONICAL_DEPRECATION_RECORD_IDS.
     # records[0] is a canonical record; mutation tests operate on it.
     return {
@@ -65,6 +65,17 @@ def _good_ledger() -> dict:
                 "migration_reference": "docs/explain/sdl/parser.md",
                 "notice_window": "supported indefinitely as a backward-compatible alias",
                 "verification_evidence": "parser normalises the legacy field; tests exercise both forms",
+            },
+            {
+                "id": "legacy-python-distribution",
+                "surface_class": "python-distribution",
+                "identifier": "the legacy PyPI distribution",
+                "status": "deprecated",
+                "first_notice": "ADR-093 and issue #907",
+                "replacement": "the raes PyPI distribution",
+                "migration_reference": "docs/migration/raes-rename.md",
+                "notice_window": "publish the final pointer release, verify it, then archive the project",
+                "verification_evidence": "the current release path publishes only raes",
             },
         ],
     }
@@ -342,11 +353,11 @@ def test_empty_ledger_is_rejected(tmp_path: Path) -> None:
 
 
 def test_dropping_a_canonical_record_is_rejected(tmp_path: Path) -> None:
-    # Deleting an established record (leaving the other) must fail: an existing
+    # Deleting an established record (leaving the others) must fail: an existing
     # deprecation is permanent lifecycle history, not something a later diff can
     # silently remove.
     ledger = _good_ledger()
-    dropped = ledger["records"].pop()  # remove sdl-import-path-field
+    dropped = ledger["records"].pop()  # remove the legacy distribution record
     _write_repo(tmp_path, ledger)
     failures = evaluate_deprecation_records(tmp_path)
     assert any(f.rule_id == "deprecation-records-canonical-record-missing" for f in failures)
@@ -361,7 +372,10 @@ def test_dropping_a_canonical_record_is_rejected(tmp_path: Path) -> None:
 
 
 def test_canonical_record_ids_are_pinned() -> None:
-    assert {"sdl-import-path-field"} == CANONICAL_DEPRECATION_RECORD_IDS
+    assert {
+        "legacy-python-distribution",
+        "sdl-import-path-field",
+    } == CANONICAL_DEPRECATION_RECORD_IDS
 
 
 def test_surface_classes_cover_known_matrix_rows() -> None:

--- a/implementations/python/tests/test_deprecation_lifecycle.py
+++ b/implementations/python/tests/test_deprecation_lifecycle.py
@@ -372,10 +372,12 @@ def test_dropping_a_canonical_record_is_rejected(tmp_path: Path) -> None:
 
 
 def test_canonical_record_ids_are_pinned() -> None:
-    assert {
+    expected = {
         "legacy-python-distribution",
         "sdl-import-path-field",
-    } == CANONICAL_DEPRECATION_RECORD_IDS
+    }
+    actual = CANONICAL_DEPRECATION_RECORD_IDS
+    assert actual == expected
 
 
 def test_surface_classes_cover_known_matrix_rows() -> None:

--- a/implementations/python/tests/test_identity_cutover_policy.py
+++ b/implementations/python/tests/test_identity_cutover_policy.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import subprocess
 from pathlib import Path
 
+import pytest
 from tools.check_identity_cutover import evaluate_identity_cutover
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -31,10 +33,16 @@ def _git(repo_root: Path, *args: str) -> None:
     )
 
 
-def _record(path: str, content: bytes, *, occurrences: int = 1) -> dict[str, object]:
+def _record(
+    path: str,
+    content: bytes,
+    *,
+    occurrences: int = 1,
+    record_class: str = "dated-design-record",
+) -> dict[str, object]:
     return {
         "path": path,
-        "record_class": "dated-design-record",
+        "record_class": record_class,
         "rationale": "Preserves a dated design decision from before the identity cutover.",
         "occurrences": occurrences,
         "content_sha256": hashlib.sha256(content).hexdigest(),
@@ -74,8 +82,132 @@ def _seed_repo(
     _git(repo_root, "add", "-A")
 
 
+def _seed_manifest_fixture(repo_root: Path) -> dict[str, object]:
+    record_content = f"Historical {RETIRED_UPPER} record.\n".encode()
+    binding_content = f"projectKey=service_{RETIRED_LOWER}\n".encode()
+    record_path = "docs/decisions/issue-1-preflight.md"
+    binding_path = "service-project.properties"
+    _seed_repo(
+        repo_root,
+        files={
+            record_path: record_content,
+            binding_path: binding_content,
+        },
+        records=[_record(record_path, record_content)],
+        bindings=[_binding(binding_path, binding_content)],
+    )
+    return json.loads((repo_root / MANIFEST_PATH).read_text(encoding="utf-8"))
+
+
+def _write_manifest(repo_root: Path, manifest: object) -> None:
+    _write(
+        repo_root / MANIFEST_PATH,
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def _manifest_rule_ids(repo_root: Path) -> set[str]:
+    return {failure.rule_id for failure in evaluate_identity_cutover(repo_root)}
+
+
 def test_current_repository_satisfies_identity_cutover() -> None:
     assert evaluate_identity_cutover(REPO_ROOT) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("schema_version", "wrong-schema"),
+        ("hash_algorithm", "sha512"),
+        ("records", {}),
+        ("operational_bindings", {}),
+    ],
+)
+def test_invalid_manifest_top_level_fields_fail(tmp_path: Path, field: str, invalid_value: object) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    manifest[field] = invalid_value
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest" in _manifest_rule_ids(tmp_path)
+
+
+@pytest.mark.parametrize("collection", ["records", "operational_bindings"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "non-object",
+        "missing-key",
+        "extra-key",
+        "unknown-class",
+        "blank-rationale",
+        "bad-digest",
+    ],
+)
+def test_invalid_manifest_entry_shapes_fail(tmp_path: Path, collection: str, mutation: str) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    entries = manifest[collection]
+    assert isinstance(entries, list)
+    entry = entries[0]
+    assert isinstance(entry, dict)
+
+    if mutation == "non-object":
+        entries[0] = "not-an-object"
+    elif mutation == "missing-key":
+        del entry["content_sha256"]
+    elif mutation == "extra-key":
+        entry["unexpected"] = "field"
+    elif mutation == "unknown-class":
+        class_field = "record_class" if collection == "records" else "binding_class"
+        entry[class_field] = "unknown-class"
+    elif mutation == "blank-rationale":
+        entry["rationale"] = " "
+    else:
+        entry["content_sha256"] = "not-a-sha256"
+
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest" in _manifest_rule_ids(tmp_path)
+
+
+@pytest.mark.parametrize("collection", ["records", "operational_bindings"])
+@pytest.mark.parametrize("invalid_occurrences", [True, 0, -1, "1"])
+def test_invalid_manifest_occurrence_counts_fail(
+    tmp_path: Path,
+    collection: str,
+    invalid_occurrences: object,
+) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    entries = manifest[collection]
+    assert isinstance(entries, list)
+    entry = entries[0]
+    assert isinstance(entry, dict)
+    entry["occurrences"] = invalid_occurrences
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest" in _manifest_rule_ids(tmp_path)
+
+
+@pytest.mark.parametrize("collection", ["records", "operational_bindings"])
+def test_duplicate_manifest_paths_fail(tmp_path: Path, collection: str) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    entries = manifest[collection]
+    assert isinstance(entries, list)
+    entries.append(copy.deepcopy(entries[0]))
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest" in _manifest_rule_ids(tmp_path)
+
+
+def test_path_shared_between_record_and_binding_fails(tmp_path: Path) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    records = manifest["records"]
+    bindings = manifest["operational_bindings"]
+    assert isinstance(records, list) and isinstance(records[0], dict)
+    assert isinstance(bindings, list) and isinstance(bindings[0], dict)
+    bindings[0]["path"] = records[0]["path"]
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest" in _manifest_rule_ids(tmp_path)
 
 
 def test_live_retired_identity_fails_in_visible_hidden_and_binary_files(tmp_path: Path) -> None:
@@ -106,6 +238,18 @@ def test_exact_content_bound_historical_record_passes(tmp_path: Path) -> None:
         tmp_path,
         files={path: content},
         records=[_record(path, content)],
+    )
+
+    assert evaluate_identity_cutover(tmp_path) == []
+
+
+def test_exact_content_bound_lifecycle_record_passes(tmp_path: Path) -> None:
+    content = f'identifier: "retired {RETIRED_LOWER}-sdl distribution"\n'.encode()
+    path = "specs/evolution/deprecation-records.yaml"
+    _seed_repo(
+        tmp_path,
+        files={path: content},
+        records=[_record(path, content, record_class="lifecycle-record")],
     )
 
     assert evaluate_identity_cutover(tmp_path) == []
@@ -176,6 +320,16 @@ def test_unsafe_or_untracked_historical_path_fails_closed(tmp_path: Path) -> Non
     failures = evaluate_identity_cutover(tmp_path)
 
     assert any(failure.rule_id == "identity-cutover-manifest-path" for failure in failures)
+
+
+def test_unsafe_operational_binding_path_fails_closed(tmp_path: Path) -> None:
+    manifest = _seed_manifest_fixture(tmp_path)
+    bindings = manifest["operational_bindings"]
+    assert isinstance(bindings, list) and isinstance(bindings[0], dict)
+    bindings[0]["path"] = "../outside.properties"
+    _write_manifest(tmp_path, manifest)
+
+    assert "identity-cutover-manifest-path" in _manifest_rule_ids(tmp_path)
 
 
 def test_identity_cutover_check_is_registered_in_canonical_policy_graph() -> None:

--- a/specs/evolution/deprecation-records.yaml
+++ b/specs/evolution/deprecation-records.yaml
@@ -35,6 +35,19 @@ adr_refs:
 spec: specs/evolution/versioning-deprecation-and-migration.md
 
 records:
+  # The old PyPI project needs one final pointer release before archival. This
+  # is distribution lifecycle, not an import compatibility promise: the final
+  # release changes metadata and guidance only and does not restore old imports.
+  - id: legacy-python-distribution
+    surface_class: python-distribution
+    identifier: "the legacy `aces-sdl` PyPI distribution, with 0.23.1 as its latest published release before the EOL pointer"
+    status: deprecated
+    first_notice: "ADR-093 and issue #907 (RAES rename and environment-pack naming convergence)"
+    replacement: "the `raes` PyPI distribution and direct `raes` / `raes_*` imports"
+    migration_reference: "docs/migration/raes-rename.md"
+    notice_window: "Publish one final metadata-only 0.23.2 pointer release from the immutable 0.23.1 legacy lineage, verify it on PyPI, then archive the `aces-sdl` project. The archive is removal eligibility; no later fixes or releases are planned."
+    verification_evidence: "The current pyproject and release workflow publish only `raes`; version and packaging tests reject the old command/import surface. The final legacy artifact must be verified separately for its exact name, version, unchanged code payload, EOL description, and `raes` replacement link before archival."
+
   # The module-import `path:` field, superseded by `source:` in ADR-053. The
   # parser still accepts it as a backward-compatible alias, normalizing it to
   # the `local:{path}` source form.

--- a/tools/check_deprecation_lifecycle.py
+++ b/tools/check_deprecation_lifecycle.py
@@ -94,6 +94,7 @@ STATUSES: frozenset[str] = frozenset({"deprecated", "removed"})
 # this floor -- exactly the predictability GOV-902 requires.
 CANONICAL_DEPRECATION_RECORD_IDS: frozenset[str] = frozenset(
     {
+        "legacy-python-distribution",
         "sdl-import-path-field",
     }
 )

--- a/tools/check_identity_cutover.py
+++ b/tools/check_identity_cutover.py
@@ -37,6 +37,7 @@ RECORD_CLASSES = {
     "accepted-adr",
     "dated-design-record",
     "historical-index",
+    "lifecycle-record",
     "provenance-record",
     "release-history",
     "research-record",

--- a/tools/policy/historical_identity_records.json
+++ b/tools/policy/historical_identity_records.json
@@ -3,6 +3,13 @@
   "hash_algorithm": "sha256",
   "operational_bindings": [
     {
+      "path": ".ground-control.yaml",
+      "binding_class": "external-service-project-key",
+      "rationale": "Retains the existing service-owned Ground Control project identifier until its replacement is externally provisioned.",
+      "occurrences": 1,
+      "content_sha256": "f89fa216218b0c68786c464b7777ceb194e3c6aa0c3bc12a61a245068d967c7e"
+    },
+    {
       "path": "sonar-project.properties",
       "binding_class": "external-service-project-key",
       "rationale": "Retains the existing service-owned SonarCloud project designation without treating it as current RAES product identity.",
@@ -1279,6 +1286,13 @@
       "content_sha256": "3128021de32125f2d8ce6270e1386c2c8cc5dd3af45514fb8e335a17c9469940"
     },
     {
+      "path": "docs/decisions/issue-907-raes-env-packs-naming-preflight.md",
+      "record_class": "dated-design-record",
+      "rationale": "Preserves the dated issue preflight and its base-synchronization correction as historical identity-cutover evidence.",
+      "occurrences": 4,
+      "content_sha256": "82c441869cca975874236fa02946298bb4dbf70ecd04336550652193673e0022"
+    },
+    {
       "path": "docs/decisions/issue-97-asr-511-515-validation-strength-disclosure-preflight.md",
       "record_class": "dated-design-record",
       "rationale": "Preserves a completed, dated design or architecture-preflight record from before the RAES identity cutover.",
@@ -1788,6 +1802,13 @@
       "rationale": "Preserves preregistered, frozen, dated, or lineage-bearing research evidence from before the RAES identity cutover.",
       "occurrences": 4,
       "content_sha256": "778711fccb5b5912a6fd106d080b4eac9dd354e4ccd4574204274fea653fecbc"
+    },
+    {
+      "path": "specs/evolution/deprecation-records.yaml",
+      "record_class": "lifecycle-record",
+      "rationale": "Preserves the exact retired distribution identifier in its governed deprecation and removal record.",
+      "occurrences": 2,
+      "content_sha256": "eff30897103368c6583701e886078f810188bcc47f4d9183853faeb1739fbdcb"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Clarifies the naming and release boundaries environment-pack consumers need after the RAES identity cutover, while governing retirement of the legacy Python distribution through the existing lifecycle and identity-policy surfaces.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #907

## ADR Impact

- ADR-021
- ADR-075
- ADR-096

## Changes

- Document the atomic downstream transition from RAES 1.1.0 values to the identity-cutover release targeted as 2.0.0.
- Confirm that Scenario remains the SDL concept while environment pack names the downstream packaging unit.
- Record the legacy Python distribution's final metadata-only 0.23.2 pointer release and subsequent archival in the governed lifecycle ledger.
- Extend exact content-bound identity policy to lifecycle records and add negative coverage for malformed historical-record manifests.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

The configured completion command and `make policy` passed after the final synchronization with `dev`; focused lifecycle and identity-policy suites also passed.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #907 ← docs/decisions/issue-907-raes-env-packs-naming-preflight.md, Issue #907 ← docs/migration/raes-rename.md, Issue #907 ← specs/evolution/deprecation-records.yaml
- TESTS: Issue #907 ← implementations/python/tests/test_deprecation_lifecycle.py, ADR-096 ← implementations/python/tests/test_identity_cutover_policy.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.