### PR TITLE
ci: configure Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: uv
+      command: sync
+      path: implementations/python
+      extras:
+        - docs


### PR DESCRIPTION
## Summary

Add the repository-root Read the Docs v2 configuration for the existing Sphinx documentation tree.

- Use Ubuntu 24.04 and Python 3.13.
- Build directly from `docs/conf.py` with warnings treated as errors.
- Install the existing locked `implementations/python` project through Read the Docs native `uv sync` support with the `docs` extra.
- Preserve every existing documentation source and path; no source generation, copying, movement, or reorganization is part of this slice.
- Keep GitHub Pages deployment intact until the Read the Docs production site is confirmed healthy.

## Verification

- Parsed and asserted the full `.readthedocs.yaml` structure.
- Confirmed a local Python 3.13 interpreter.
- `uv sync --project implementations/python --extra docs --frozen`
- `implementations/python/.venv/bin/sphinx-build -W --keep-going -b html docs docs/_build/readthedocs-validation` — 327 sources, build succeeded.
- `RAES_REQUIREMENT_UID=GOV-944 make policy`
- `git diff --check`

Refs #925.