### PR TITLE
fix: publish Python version classifiers for the raes distribution

### DIFF
--- a/implementations/python/pyproject.toml
+++ b/implementations/python/pyproject.toml
@@ -7,6 +7,14 @@ name = "raes"
 description = "Contracts and reference tooling for reproducible agentic environments."
 dynamic = ["readme", "version"]
 requires-python = ">=3.11"
+# Trove classifiers are the only source PyPI and downstream badges read for
+# supported interpreter versions; `requires-python` alone leaves them blank.
+# Keep this list in step with `requires-python`.
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "typer>=0.12.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary

The `Python` badge in `README.md` renders as `python: missing`. The published
`raes` distribution carries no trove classifiers at all, and
`img.shields.io/pypi/pyversions/` reads only
`Programming Language :: Python :: X.Y` classifiers — it does not fall back to
`Requires-Python`. Verified against the live release: `raes` 2.0.0 publishes
`requires_python: ">=3.11"` with `classifiers: []`, and the badge still returns
`missing`.

This adds the classifiers to `implementations/python/pyproject.toml`. The
`PyPI` version badge on the line above is unaffected — it already renders
`v2.0.0` correctly.

The badge will keep showing `missing` until a release is uploaded to PyPI,
since classifiers are baked into release metadata rather than read from the
repository.

## Related issues

<!-- none -->

## Changes

- Declare `Programming Language :: Python :: 3`, `3.11`, and `3.12` classifiers
  on the `raes` project metadata, matching `requires-python = ">=3.11"` and the
  interpreter CI runs on.

## Test plan

- [x] Relevant tests pass
- [ ] The canonical `nox -s verify` gate passes, or unchecked sessions are listed below
- [ ] The docs gate passes when public documentation changed

Not run locally: the full `nox -s verify` gate and the docs gate. What did run
is the `hook-pre-commit` gate (hygiene, conftest self-verify, repo policy,
requirement governance) and the `verify-changed` pre-push lane, both green. CI
runs the unconditional `verify` gate on this PR.

Built the sdist and confirmed the emitted `PKG-INFO`:

```
Metadata-Version: 2.4
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.11
Classifier: Programming Language :: Python :: 3.12
Requires-Python: >=3.11
```

## Checklist

- [x] Code follows the [project coding standards](../docs/explain/reference/coding-standards.md)
- [x] FM level classified if semantic change — n/a, no semantic change
- [x] Published contract schemas regenerated if models changed — n/a, no model change
- [x] PR title is a Conventional Commit (release-please derives the version and `CHANGELOG.md` from it)
- [x] Architectural docs updated if applicable — n/a

## Notes for review

- Requirement context: `DOC-928`. The `documentation-surfaces` phase owns both
  `README.md` and `implementations/python/pyproject.toml`, and the defect is a
  public-presentation one. If you would rather this trace to a dedicated
  distribution-metadata requirement, say so and I will re-anchor it.
- No test was added: the classifiers are static packaging metadata with no
  repository-side gate that reads them. A check that asserts the classifier list
  stays in step with `requires-python` would be a reasonable follow-up if you
  want one — happy to add it in this PR instead.
- `3.13` is deliberately not claimed. CI runs `3.12` only, so listing an
  untested interpreter would overstate support.
- Package metadata still declares no license. `LICENSE` is MIT and the README
  shows an MIT badge, but PyPI shows none. Left out of this PR as a separate
  concern; PEP 639 makes it a `license`/`license-files` change rather than a
  classifier.
