### PR TITLE
feat: enforce participant information-flow policy

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -2,10 +2,12 @@ schema_version: 1
 project: aces-sdl
 github_repo: RAESystem/rae
 workflow:
-  test_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
-  completion_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
+  test_command: RAES_REQUIREMENT_UID="${RAES_REQUIREMENT_UID:-$(printenv A""CES_REQUIREMENT_UID)}" uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
+  completion_command: RAES_REQUIREMENT_UID="${RAES_REQUIREMENT_UID:-$(printenv A""CES_REQUIREMENT_UID)}" uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify
   lint_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s lint
   format_command: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s hygiene
+  policy_command: RAES_REQUIREMENT_UID="${RAES_REQUIREMENT_UID:-$(printenv A""CES_REQUIREMENT_UID)}" make policy
+  precommit_command: RAES_REQUIREMENT_UID="${RAES_REQUIREMENT_UID:-$(printenv A""CES_REQUIREMENT_UID)}" pre-commit run --all-files
   codex_review:
     pre_push_cap: 1
   test_quality_review:

--- a/contracts/fixtures/participant-runtime/participant-crossing-occurrence-v1/invalid/policy-bag.json
+++ b/contracts/fixtures/participant-runtime/participant-crossing-occurrence-v1/invalid/policy-bag.json
@@ -43,6 +43,8 @@
       "policy_id": "participant-crossing-policy:red",
       "policy_revision": "revision-3",
       "policy_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_decision_ref": "participant-crossing-policy-decision:red:episode-1:8",
+      "decision_cut_ref": "participant-policy-cut:red:episode-1:8",
       "effective_order": 8,
       "valid_from_order": 8,
       "valid_until_order": 20

--- a/contracts/fixtures/participant-runtime/participant-crossing-occurrence-v1/valid/request.json
+++ b/contracts/fixtures/participant-runtime/participant-crossing-occurrence-v1/valid/request.json
@@ -44,6 +44,8 @@
       "policy_id": "participant-crossing-policy:red",
       "policy_revision": "revision-3",
       "policy_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "policy_decision_ref": "participant-crossing-policy-decision:red:episode-1:8",
+      "decision_cut_ref": "participant-policy-cut:red:episode-1:8",
       "effective_order": 8,
       "valid_from_order": 8,
       "valid_until_order": 20

--- a/contracts/schema-publication/entries/participant-crossing-occurrence-v1.json
+++ b/contracts/schema-publication/entries/participant-crossing-occurrence-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "participant-crossing-occurrence-v1",
   "schema_path": "contracts/schemas/participant-runtime/participant-crossing-occurrence-v1.json",
   "stability": "draft",
-  "content_hash": "61b5963daceb11e2fe21d47d4c174db1bbfbdfafa3cd96fe263c4f0c4a88d7ff",
+  "content_hash": "ee1e52f8a680dd74d409adff6d8a28832774c83c4338e02ef505d4b64b3deffb",
   "last_change": {
-    "summary": "Repointed the published schema namespace from the uncontrolled raes.dev domain to the repository-owned https://raesystem.github.io/rae/schemas/ root for issue #908.",
-    "content_hash": "61b5963daceb11e2fe21d47d4c174db1bbfbdfafa3cd96fe263c4f0c4a88d7ff"
+    "summary": "Added exact policy-decision and participant-state-cut references required for RUN-319 policy resolution under #799, retaining the repository-owned schema namespace.",
+    "content_hash": "ee1e52f8a680dd74d409adff6d8a28832774c83c4338e02ef505d4b64b3deffb"
   }
 }

--- a/contracts/schema-publication/entries/runtime-snapshot-v1.json
+++ b/contracts/schema-publication/entries/runtime-snapshot-v1.json
@@ -2,9 +2,9 @@
   "contract_id": "runtime-snapshot-v1",
   "schema_path": "contracts/schemas/snapshots/runtime-snapshot-v1.json",
   "stability": "draft",
-  "content_hash": "42201288da8990fe0214a5f02fb53de7d2500dca86f42663ffbddd6823f03ffa",
+  "content_hash": "e6b06f8859f4343fd77803f5c92ffdae2c7d163137ee5348fa4ab914f1e927c2",
   "last_change": {
-    "summary": "Repointed the published schema namespace from the uncontrolled raes.dev domain to the repository-owned https://raesystem.github.io/rae/schemas/ root for issue #908.",
-    "content_hash": "42201288da8990fe0214a5f02fb53de7d2500dca86f42663ffbddd6823f03ffa"
+    "summary": "Added first-class append-only participant crossing history for RUN-319 enforcement evidence under #799, retaining the repository-owned schema namespace.",
+    "content_hash": "e6b06f8859f4343fd77803f5c92ffdae2c7d163137ee5348fa4ab914f1e927c2"
   }
 }

--- a/contracts/schemas/participant-runtime/participant-crossing-occurrence-v1.json
+++ b/contracts/schemas/participant-runtime/participant-crossing-occurrence-v1.json
@@ -1055,10 +1055,20 @@
       "additionalProperties": false,
       "description": "Exact revision and order interval for the policy used at a crossing.",
       "properties": {
+        "decision_cut_ref": {
+          "minLength": 1,
+          "title": "Decision Cut Ref",
+          "type": "string"
+        },
         "effective_order": {
           "minimum": 0,
           "title": "Effective Order",
           "type": "integer"
+        },
+        "policy_decision_ref": {
+          "minLength": 1,
+          "title": "Policy Decision Ref",
+          "type": "string"
         },
         "policy_digest": {
           "minLength": 1,
@@ -1091,6 +1101,8 @@
         "policy_id",
         "policy_revision",
         "policy_digest",
+        "policy_decision_ref",
+        "decision_cut_ref",
         "effective_order",
         "valid_from_order",
         "valid_until_order"

--- a/contracts/schemas/snapshots/runtime-snapshot-v1.json
+++ b/contracts/schemas/snapshots/runtime-snapshot-v1.json
@@ -2493,6 +2493,1857 @@
         }
       ]
     },
+    "ParticipantCrossingAuditModel": {
+      "additionalProperties": false,
+      "description": "Audit/evidence retention for a prior crossing fact, not participant egress.",
+      "properties": {
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "audit_record_ref": {
+          "minLength": 1,
+          "title": "Audit Record Ref",
+          "type": "string"
+        },
+        "audited_event_ref": {
+          "minLength": 1,
+          "title": "Audited Event Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "retained_evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Retained Evidence Refs",
+          "type": "array"
+        },
+        "stage": {
+          "const": "audited",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "audited_event_ref",
+        "audit_record_ref",
+        "retained_evidence_refs"
+      ],
+      "title": "ParticipantCrossingAuditModel",
+      "type": "object"
+    },
+    "ParticipantCrossingBackendPosture": {
+      "description": "Bounded backend-support posture without a realization claim.",
+      "enum": [
+        "exact",
+        "bounded",
+        "disclosed-weak",
+        "unsupported"
+      ],
+      "title": "ParticipantCrossingBackendPosture",
+      "type": "string"
+    },
+    "ParticipantCrossingDecisionDisposition": {
+      "description": "Overall policy disposition for one crossing request.",
+      "enum": [
+        "permit",
+        "deny",
+        "transform",
+        "withhold",
+        "unsupported"
+      ],
+      "title": "ParticipantCrossingDecisionDisposition",
+      "type": "string"
+    },
+    "ParticipantCrossingDecisionGatesModel": {
+      "additionalProperties": false,
+      "description": "Independent deny-first gates for one crossing decision.",
+      "properties": {
+        "action_admission": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "backend_support": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "caller_authorization": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "declassification": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "marking_authorization": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "participant_authority": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "target_authorization": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "transformation_validity": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        },
+        "visibility": {
+          "$ref": "#/$defs/ParticipantCrossingGateDisposition"
+        }
+      },
+      "required": [
+        "caller_authorization",
+        "target_authorization",
+        "participant_authority",
+        "action_admission",
+        "visibility",
+        "marking_authorization",
+        "declassification",
+        "backend_support",
+        "transformation_validity"
+      ],
+      "title": "ParticipantCrossingDecisionGatesModel",
+      "type": "object"
+    },
+    "ParticipantCrossingDecisionModel": {
+      "additionalProperties": false,
+      "description": "The deny-first policy decision for one exact crossing request.",
+      "properties": {
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_id": {
+          "minLength": 1,
+          "title": "Decision Id",
+          "type": "string"
+        },
+        "decision_revision": {
+          "minimum": 1,
+          "title": "Decision Revision",
+          "type": "integer"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "disposition": {
+          "$ref": "#/$defs/ParticipantCrossingDecisionDisposition"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "gates": {
+          "$ref": "#/$defs/ParticipantCrossingDecisionGatesModel"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "reason_code": {
+          "minLength": 1,
+          "title": "Reason Code",
+          "type": "string"
+        },
+        "request_ref": {
+          "minLength": 1,
+          "title": "Request Ref",
+          "type": "string"
+        },
+        "required_evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Required Evidence Refs",
+          "type": "array"
+        },
+        "required_operation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ParticipantCrossingOperation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stage": {
+          "const": "decided",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "request_ref",
+        "decision_id",
+        "decision_revision",
+        "gates",
+        "disposition",
+        "reason_code",
+        "required_evidence_refs"
+      ],
+      "title": "ParticipantCrossingDecisionModel",
+      "type": "object"
+    },
+    "ParticipantCrossingDeliveryAttemptModel": {
+      "additionalProperties": false,
+      "description": "An attempted participant delivery, distinct from scheduling and success.",
+      "properties": {
+        "attempt_id": {
+          "minLength": 1,
+          "title": "Attempt Id",
+          "type": "string"
+        },
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_ref": {
+          "minLength": 1,
+          "title": "Decision Ref",
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "disposition": {
+          "enum": [
+            "attempted",
+            "failed",
+            "withheld",
+            "unsupported"
+          ],
+          "title": "Disposition",
+          "type": "string"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "owning_occurrence_ref": {
+          "minLength": 1,
+          "title": "Owning Occurrence Ref",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "stage": {
+          "const": "delivery-attempted",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        },
+        "transformation_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transformation Ref"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "decision_ref",
+        "attempt_id",
+        "owning_occurrence_ref",
+        "disposition"
+      ],
+      "title": "ParticipantCrossingDeliveryAttemptModel",
+      "type": "object"
+    },
+    "ParticipantCrossingDeliveryModel": {
+      "additionalProperties": false,
+      "description": "A delivered participant-facing occurrence, distinct from observation.",
+      "properties": {
+        "attempt_ref": {
+          "minLength": 1,
+          "title": "Attempt Ref",
+          "type": "string"
+        },
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_ref": {
+          "minLength": 1,
+          "title": "Decision Ref",
+          "type": "string"
+        },
+        "delivery_id": {
+          "minLength": 1,
+          "title": "Delivery Id",
+          "type": "string"
+        },
+        "delivery_order": {
+          "minimum": 0,
+          "title": "Delivery Order",
+          "type": "integer"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "disposition": {
+          "enum": [
+            "delivered",
+            "failed",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Disposition",
+          "type": "string"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "owning_occurrence_ref": {
+          "minLength": 1,
+          "title": "Owning Occurrence Ref",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "stage": {
+          "const": "delivered",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "decision_ref",
+        "attempt_ref",
+        "delivery_id",
+        "owning_occurrence_ref",
+        "delivery_order",
+        "disposition"
+      ],
+      "title": "ParticipantCrossingDeliveryModel",
+      "type": "object"
+    },
+    "ParticipantCrossingDirection": {
+      "description": "Closed participant-boundary directions.",
+      "enum": [
+        "ingress",
+        "egress"
+      ],
+      "title": "ParticipantCrossingDirection",
+      "type": "string"
+    },
+    "ParticipantCrossingDisclosureModel": {
+      "additionalProperties": false,
+      "description": "An authorized disclosure or declassification decision, not delivery.",
+      "properties": {
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_ref": {
+          "minLength": 1,
+          "title": "Decision Ref",
+          "type": "string"
+        },
+        "declassification_basis_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Declassification Basis Ref"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "disclosure_id": {
+          "minLength": 1,
+          "title": "Disclosure Id",
+          "type": "string"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "operation": {
+          "enum": [
+            "disclosure",
+            "declassification"
+          ],
+          "title": "Operation",
+          "type": "string"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "result_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Result Marking Refs",
+          "type": "array"
+        },
+        "source_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Source Marking Refs",
+          "type": "array"
+        },
+        "stage": {
+          "const": "disclosed",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        },
+        "transformation_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Transformation Ref"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "decision_ref",
+        "disclosure_id",
+        "operation",
+        "source_marking_refs",
+        "result_marking_refs"
+      ],
+      "title": "ParticipantCrossingDisclosureModel",
+      "type": "object"
+    },
+    "ParticipantCrossingGateDisposition": {
+      "description": "One deny-first decision-gate result.",
+      "enum": [
+        "permit",
+        "deny",
+        "not-applicable",
+        "unknown",
+        "unsupported"
+      ],
+      "title": "ParticipantCrossingGateDisposition",
+      "type": "string"
+    },
+    "ParticipantCrossingInteractionKind": {
+      "description": "Closed incumbent carrier kinds that may cross a participant boundary.",
+      "enum": [
+        "action-proposal",
+        "constrained-form-submission",
+        "candidate-selection",
+        "approval",
+        "denial",
+        "external-direction",
+        "intervention",
+        "handoff",
+        "override",
+        "cancellation",
+        "participant-inject-delivery",
+        "observation",
+        "decision-surface-projection",
+        "redacted-output",
+        "disclosure",
+        "delivery-receipt",
+        "action-result",
+        "status-projection",
+        "history-projection"
+      ],
+      "title": "ParticipantCrossingInteractionKind",
+      "type": "string"
+    },
+    "ParticipantCrossingLossKind": {
+      "description": "Disclosed loss or guarantee weakening for a crossing fact.",
+      "enum": [
+        "none",
+        "fidelity-loss",
+        "guarantee-weakening",
+        "unknown",
+        "unsupported"
+      ],
+      "title": "ParticipantCrossingLossKind",
+      "type": "string"
+    },
+    "ParticipantCrossingLossModel": {
+      "additionalProperties": false,
+      "description": "One explicit fidelity loss or guarantee weakening.",
+      "properties": {
+        "affected_ref": {
+          "minLength": 1,
+          "title": "Affected Ref",
+          "type": "string"
+        },
+        "basis_ref": {
+          "minLength": 1,
+          "title": "Basis Ref",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/ParticipantCrossingLossKind"
+        },
+        "limitation_ref": {
+          "minLength": 1,
+          "title": "Limitation Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "basis_ref",
+        "affected_ref",
+        "limitation_ref"
+      ],
+      "title": "ParticipantCrossingLossModel",
+      "type": "object"
+    },
+    "ParticipantCrossingObservationModel": {
+      "additionalProperties": false,
+      "description": "Participant observation of a delivered fact through an incumbent carrier.",
+      "properties": {
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_ref": {
+          "minLength": 1,
+          "title": "Decision Ref",
+          "type": "string"
+        },
+        "delivery_ref": {
+          "minLength": 1,
+          "title": "Delivery Ref",
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "observation_id": {
+          "minLength": 1,
+          "title": "Observation Id",
+          "type": "string"
+        },
+        "observation_order": {
+          "minimum": 0,
+          "title": "Observation Order",
+          "type": "integer"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "owning_observation_ref": {
+          "minLength": 1,
+          "title": "Owning Observation Ref",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "stage": {
+          "const": "observed",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "decision_ref",
+        "delivery_ref",
+        "observation_id",
+        "owning_observation_ref",
+        "observation_order"
+      ],
+      "title": "ParticipantCrossingObservationModel",
+      "type": "object"
+    },
+    "ParticipantCrossingOccurrenceModel": {
+      "additionalProperties": false,
+      "description": "Closed participant-runtime carrier for one API-423 crossing fact.",
+      "properties": {
+        "actor_ref": {
+          "minLength": 1,
+          "title": "Actor Ref",
+          "type": "string"
+        },
+        "authorization_scope": {
+          "minLength": 1,
+          "title": "Authorization Scope",
+          "type": "string"
+        },
+        "clock_authority": {
+          "minLength": 1,
+          "title": "Clock Authority",
+          "type": "string"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "episode_id": {
+          "minLength": 1,
+          "title": "Episode Id",
+          "type": "string"
+        },
+        "event_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EventClassificationModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "event_id": {
+          "minLength": 1,
+          "title": "Event Id",
+          "type": "string"
+        },
+        "event_type": {
+          "const": "participant-crossing-occurrence",
+          "title": "Event Type",
+          "type": "string"
+        },
+        "evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "extension_policy": {
+          "const": "closed",
+          "title": "Extension Policy",
+          "type": "string"
+        },
+        "granular_markings": {
+          "additionalProperties": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "title": "Granular Markings",
+          "type": "object"
+        },
+        "ingested_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Ingested At",
+          "type": "string"
+        },
+        "logical_order_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logical Order Ref"
+        },
+        "marking_definition_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Marking Definition Refs",
+          "type": "array"
+        },
+        "markings": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Markings",
+          "type": "array"
+        },
+        "object_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Object Marking Refs",
+          "type": "array"
+        },
+        "occurred_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Occurred At",
+          "type": "string"
+        },
+        "occurrence": {
+          "discriminator": {
+            "mapping": {
+              "audited": "#/$defs/ParticipantCrossingAuditModel",
+              "decided": "#/$defs/ParticipantCrossingDecisionModel",
+              "delivered": "#/$defs/ParticipantCrossingDeliveryModel",
+              "delivery-attempted": "#/$defs/ParticipantCrossingDeliveryAttemptModel",
+              "disclosed": "#/$defs/ParticipantCrossingDisclosureModel",
+              "observed": "#/$defs/ParticipantCrossingObservationModel",
+              "requested": "#/$defs/ParticipantCrossingRequestModel",
+              "transformed": "#/$defs/ParticipantCrossingTransformationModel"
+            },
+            "propertyName": "stage"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ParticipantCrossingRequestModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingDecisionModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingTransformationModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingDisclosureModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingDeliveryAttemptModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingDeliveryModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingObservationModel"
+            },
+            {
+              "$ref": "#/$defs/ParticipantCrossingAuditModel"
+            }
+          ],
+          "title": "Occurrence"
+        },
+        "ordering_basis": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Ordering Basis",
+          "type": "string"
+        },
+        "participant_address": {
+          "minLength": 1,
+          "title": "Participant Address",
+          "type": "string"
+        },
+        "predecessor_event_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Predecessor Event Refs",
+          "type": "array"
+        },
+        "producer_ref": {
+          "minLength": 1,
+          "title": "Producer Ref",
+          "type": "string"
+        },
+        "provenance_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Provenance Refs",
+          "type": "array"
+        },
+        "raw_data_integrity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawDataIntegrityModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "recorded_at": {
+          "format": "date-time",
+          "minLength": 1,
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}[Tt](?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:[Zz]|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+          "title": "Recorded At",
+          "type": "string"
+        },
+        "redaction_policy_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Redaction Policy Ref"
+        },
+        "schema_name": {
+          "const": "participant-crossing-occurrence",
+          "title": "Schema Name",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "1.0.0",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "sequence_number": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sequence Number"
+        },
+        "source_pipeline": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourcePipelineModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_raw_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Raw Ref"
+        },
+        "source_record_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Record Ref"
+        },
+        "source_status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceStatusModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "source_system_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source System Ref"
+        },
+        "temporal_context": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temporal Context"
+        }
+      },
+      "required": [
+        "event_id",
+        "schema_name",
+        "schema_version",
+        "event_type",
+        "extension_policy",
+        "participant_address",
+        "episode_id",
+        "occurred_at",
+        "recorded_at",
+        "ingested_at",
+        "clock_authority",
+        "ordering_basis",
+        "actor_ref",
+        "producer_ref",
+        "provenance_refs",
+        "evidence_refs",
+        "object_marking_refs",
+        "authorization_scope",
+        "occurrence"
+      ],
+      "title": "ParticipantCrossingOccurrenceModel",
+      "type": "object",
+      "x-raes-invariants": [
+        {
+          "description": "Every crossing fact must resolve typed subjects, exact policy revisions, predecessor stages, evidence, markings, and order coordinates without retroactive authorization or identity reuse.",
+          "id": "participant-crossing-context-agreement",
+          "inputs": [
+            {
+              "contract_id": "participant-crossing-occurrence-v1",
+              "instance_path": "#"
+            }
+          ],
+          "level": "error",
+          "validator": "raes_contracts.contracts.validate_participant_crossing_occurrence_context"
+        },
+        {
+          "description": "Requested, decided, transformed, disclosed, attempted, delivered, observed, and audited facts remain independently addressable and do not imply one another.",
+          "id": "participant-crossing-stage-separation",
+          "inputs": [
+            {
+              "contract_id": "participant-crossing-occurrence-v1",
+              "instance_path": "#"
+            }
+          ],
+          "level": "error",
+          "validator": "raes_contracts.contracts.ParticipantCrossingOccurrenceModel"
+        }
+      ]
+    },
+    "ParticipantCrossingOperation": {
+      "description": "Semantically independent participant information-flow operations.",
+      "enum": [
+        "admission",
+        "withholding",
+        "projection",
+        "masking",
+        "redaction",
+        "transformation",
+        "declassification",
+        "disclosure",
+        "delivery",
+        "concealment",
+        "revocation",
+        "audit-retention"
+      ],
+      "title": "ParticipantCrossingOperation",
+      "type": "string"
+    },
+    "ParticipantCrossingPolicyReferenceModel": {
+      "additionalProperties": false,
+      "description": "Exact revision and order interval for the policy used at a crossing.",
+      "properties": {
+        "decision_cut_ref": {
+          "minLength": 1,
+          "title": "Decision Cut Ref",
+          "type": "string"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "policy_decision_ref": {
+          "minLength": 1,
+          "title": "Policy Decision Ref",
+          "type": "string"
+        },
+        "policy_digest": {
+          "minLength": 1,
+          "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+          "title": "Policy Digest",
+          "type": "string"
+        },
+        "policy_id": {
+          "minLength": 1,
+          "title": "Policy Id",
+          "type": "string"
+        },
+        "policy_revision": {
+          "minLength": 1,
+          "title": "Policy Revision",
+          "type": "string"
+        },
+        "valid_from_order": {
+          "minimum": 0,
+          "title": "Valid From Order",
+          "type": "integer"
+        },
+        "valid_until_order": {
+          "minimum": 0,
+          "title": "Valid Until Order",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "policy_id",
+        "policy_revision",
+        "policy_digest",
+        "policy_decision_ref",
+        "decision_cut_ref",
+        "effective_order",
+        "valid_from_order",
+        "valid_until_order"
+      ],
+      "title": "ParticipantCrossingPolicyReferenceModel",
+      "type": "object"
+    },
+    "ParticipantCrossingRequestModel": {
+      "additionalProperties": false,
+      "description": "A requested crossing or produced egress candidate, not a decision.",
+      "properties": {
+        "action_or_projection_ref": {
+          "minLength": 1,
+          "title": "Action Or Projection Ref",
+          "type": "string"
+        },
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "request_id": {
+          "minLength": 1,
+          "title": "Request Id",
+          "type": "string"
+        },
+        "requested_operation": {
+          "$ref": "#/$defs/ParticipantCrossingOperation"
+        },
+        "required_evidence_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Required Evidence Refs",
+          "type": "array"
+        },
+        "stage": {
+          "const": "requested",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "request_id",
+        "requested_operation",
+        "action_or_projection_ref",
+        "required_evidence_refs"
+      ],
+      "title": "ParticipantCrossingRequestModel",
+      "type": "object"
+    },
+    "ParticipantCrossingSubjectKind": {
+      "description": "Closed typed references to incumbent participant and evidence carriers.",
+      "enum": [
+        "participant-control-occurrence",
+        "participant-action-contract",
+        "participant-action-admission",
+        "participant-action-attempt",
+        "participant-action-result",
+        "participant-lifecycle-event",
+        "participant-observation",
+        "participant-decision-surface",
+        "participant-exposure",
+        "participant-inject-delivery",
+        "participant-context-view",
+        "participant-history-view",
+        "participant-status-view",
+        "experiment-evidence"
+      ],
+      "title": "ParticipantCrossingSubjectKind",
+      "type": "string"
+    },
+    "ParticipantCrossingSubjectReferenceModel": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "properties": {
+            "subject_revision": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "subject_revision"
+          ]
+        },
+        {
+          "properties": {
+            "subject_digest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "subject_digest"
+          ]
+        }
+      ],
+      "description": "Typed identity for an existing carrier without copying its payload.",
+      "properties": {
+        "contract_id": {
+          "minLength": 1,
+          "title": "Contract Id",
+          "type": "string"
+        },
+        "episode_id": {
+          "minLength": 1,
+          "title": "Episode Id",
+          "type": "string"
+        },
+        "participant_address": {
+          "minLength": 1,
+          "title": "Participant Address",
+          "type": "string"
+        },
+        "subject_digest": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "pattern": "^(?:sha256:[A-Fa-f0-9]{64}|sha384:[A-Fa-f0-9]{96}|sha512:[A-Fa-f0-9]{128}|blake3:[A-Fa-f0-9]{64})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subject Digest"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectKind"
+        },
+        "subject_ref": {
+          "minLength": 1,
+          "title": "Subject Ref",
+          "type": "string"
+        },
+        "subject_revision": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Subject Revision"
+        }
+      },
+      "required": [
+        "subject_kind",
+        "contract_id",
+        "subject_ref",
+        "participant_address",
+        "episode_id"
+      ],
+      "title": "ParticipantCrossingSubjectReferenceModel",
+      "type": "object"
+    },
+    "ParticipantCrossingTransformationModel": {
+      "additionalProperties": false,
+      "description": "A non-mutating transformation from one typed subject to a new subject.",
+      "properties": {
+        "audience_scope_ref": {
+          "minLength": 1,
+          "title": "Audience Scope Ref",
+          "type": "string"
+        },
+        "authority_basis_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authority Basis Refs",
+          "type": "array"
+        },
+        "backend_posture": {
+          "$ref": "#/$defs/ParticipantCrossingBackendPosture"
+        },
+        "controller_ref": {
+          "minLength": 1,
+          "title": "Controller Ref",
+          "type": "string"
+        },
+        "decision_ref": {
+          "minLength": 1,
+          "title": "Decision Ref",
+          "type": "string"
+        },
+        "declassification_basis_ref": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Declassification Basis Ref"
+        },
+        "direction": {
+          "$ref": "#/$defs/ParticipantCrossingDirection"
+        },
+        "effective_order": {
+          "minimum": 0,
+          "title": "Effective Order",
+          "type": "integer"
+        },
+        "interaction_kind": {
+          "$ref": "#/$defs/ParticipantCrossingInteractionKind"
+        },
+        "loss_and_limitations": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Loss And Limitations",
+          "type": "array"
+        },
+        "losses": {
+          "items": {
+            "$ref": "#/$defs/ParticipantCrossingLossModel"
+          },
+          "title": "Losses",
+          "type": "array"
+        },
+        "operation": {
+          "enum": [
+            "projection",
+            "masking",
+            "redaction",
+            "transformation",
+            "declassification"
+          ],
+          "title": "Operation",
+          "type": "string"
+        },
+        "order_model": {
+          "enum": [
+            "total_order",
+            "partial_order",
+            "simultaneous",
+            "serialized_backend_order",
+            "simulation_tick",
+            "control_plane_order",
+            "logical_clock",
+            "vector_clock",
+            "wall_clock_only",
+            "unknown",
+            "unsupported"
+          ],
+          "title": "Order Model",
+          "type": "string"
+        },
+        "policy": {
+          "$ref": "#/$defs/ParticipantCrossingPolicyReferenceModel"
+        },
+        "result_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Result Marking Refs",
+          "type": "array"
+        },
+        "result_subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        },
+        "rule_ref": {
+          "minLength": 1,
+          "title": "Rule Ref",
+          "type": "string"
+        },
+        "rule_revision": {
+          "minLength": 1,
+          "title": "Rule Revision",
+          "type": "string"
+        },
+        "source_marking_refs": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Source Marking Refs",
+          "type": "array"
+        },
+        "source_subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        },
+        "stage": {
+          "const": "transformed",
+          "title": "Stage",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/ParticipantCrossingSubjectReferenceModel"
+        },
+        "transformation_id": {
+          "minLength": 1,
+          "title": "Transformation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "direction",
+        "interaction_kind",
+        "audience_scope_ref",
+        "subject",
+        "controller_ref",
+        "authority_basis_refs",
+        "policy",
+        "effective_order",
+        "order_model",
+        "backend_posture",
+        "loss_and_limitations",
+        "stage",
+        "decision_ref",
+        "transformation_id",
+        "operation",
+        "source_subject",
+        "result_subject",
+        "rule_ref",
+        "rule_revision",
+        "source_marking_refs",
+        "result_marking_refs"
+      ],
+      "title": "ParticipantCrossingTransformationModel",
+      "type": "object"
+    },
     "ParticipantDenialOccurrenceModel": {
       "additionalProperties": false,
       "description": "Denial of exactly one proposal revision.",
@@ -8239,6 +10090,16 @@
         "type": "array"
       },
       "title": "Participant Control History",
+      "type": "object"
+    },
+    "participant_crossing_history": {
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/$defs/ParticipantCrossingOccurrenceModel"
+        },
+        "type": "array"
+      },
+      "title": "Participant Crossing History",
       "type": "object"
     },
     "participant_episode_history": {

--- a/docs/decisions/issue-799-run-319-participant-information-flow-policy-enforcement-preflight.md
+++ b/docs/decisions/issue-799-run-319-participant-information-flow-policy-enforcement-preflight.md
@@ -1,0 +1,452 @@
+# Issue 799 RUN-319 Participant Information-Flow Policy Enforcement Preflight
+
+Date: 2026-07-27
+
+Issue: #799.
+
+Requirement: RUN-319.
+
+This note records repository-wide architecture boundaries for reference-runtime
+participant crossing enforcement and evidence. It is guidance only. It does not
+implement a policy decision, transform content, change a backend claim, add a
+route, publish or revise a schema, migrate legacy records, or claim runtime
+realization or information-flow assurance.
+
+## Decisive Current-State Findings
+
+RUN-319 is an integration requirement over delivered incumbents, not a new
+policy-engine or carrier project:
+
+- ADR-085, as amended by ADR-095, and
+  `specs/formal/participant-semantics/information-flow-control.md` own the
+  deny-first semantics, distinct operations, exact-cut policy resolution,
+  participant-relative projection, ordering, and nonclaims.
+- API-423 already publishes the closed
+  `participant-crossing-occurrence-v1` relation and
+  `validate_participant_crossing_occurrence_context()`. It separates requested,
+  decided, transformed, disclosed, delivery-attempted, delivered, observed, and
+  audited facts.
+- API-407 already owns participant policy feature strength, limitations,
+  disclosure, evidence, required-contract mapping, and
+  `resolve_participant_feature_support()`.
+- SEM-226 already supplies deny-first exposure selection through the v2
+  exact-cut decision-surface/exposure resolvers. RUN-319 must invoke that logic
+  for applicable egress; it must not create another visibility selector.
+- RUN-310 already demonstrates authenticated participant/controller binding,
+  semantic fingerprints, scoped idempotency, immutable API-409 occurrences,
+  append-only snapshot history, expected-head atomic commit, safe diagnostics,
+  and audit correlation.
+- `RuntimeSnapshot`, its serializers, participant snapshot/transition
+  diagnostics, `ControlPlaneStore`, and `AuditEvent` do not yet carry a
+  first-class crossing history or a general atomic participant transition.
+- API-408 retrieval currently synthesizes visibility refs, empty markings, and
+  no redaction policy from the current snapshot. Its backend/operator/auditor
+  read authorization is not participant or audience authorization. It is not a
+  participant-safe egress path and cannot be grandfathered into one.
+- The reference-emulation manifest currently declares every participant-policy
+  feature `unsupported`. Contract publication and pure runtime logic cannot
+  silently upgrade that declaration.
+
+One dependency discrepancy must be resolved deliberately. SEM-230 revision 2
+and ADR-095 require the exact policy-decision identity and state-cut identity.
+The current API-423 `ParticipantCrossingPolicyReferenceModel` carries policy
+identity, revision, digest, effective order, and validity interval, but no
+general `decision_cut_ref` or exact policy-decision ref. Decision epoch,
+effective order, receipt order, timestamp, and state-cut identity are not
+interchangeable. RUN-319 must therefore either consume an existing exact-cut
+owning relation where one exists, such as SEM-226 v2, or evolve API-423 through
+its normal compatibility/publication process before claiming general SEM-230
+revision-2 enforcement. A runtime-only field, `RuntimeSnapshot.metadata`, or an
+audit detail is not an acceptable compatibility shim.
+
+Accepted ADRs and existing issue preflights settle the overall architecture. A
+new ADR is not warranted unless the exact-cut discrepancy requires a normative
+decision that cannot be resolved by compatible contract composition.
+
+## Architecture Decisions And Guardrails
+
+### Enforce at the existing runtime service boundary
+
+The enforcement owner remains `RuntimeControlPlane` through
+`ParticipantControlMixin`, `ParticipantRetrievalMixin`, and the existing
+participant action/lifecycle methods. HTTP handlers, in-process callers, and
+backend adapters must reach the same mediation path. Route-only middleware,
+response filtering, a participant gateway, or a backend-local check would
+leave bypasses.
+
+The runtime owns crossing event ids, decision and realization dispositions,
+effective policy/cut coordinates, safe reason codes, backend posture,
+predecessor links, evidence/provenance, and persistence status. A caller may
+provide a closed, bounded intent and typed subject reference; it must never
+submit a completed API-423 occurrence, choose its gates or disposition, assert
+declassification, or claim delivery/observation/audit.
+
+For every authenticated and subject-bound attempt, the runtime emits the
+minimum applicable API-423 stage facts. A request and deny/withhold/unsupported
+decision remain append-only evidence. Delivery, observation, and audit stages
+are appended only when their owning occurrence resolves; none is inferred from
+another. Failures before authenticated target/subject binding remain security
+audit denials and must not let untrusted input manufacture a participant fact.
+
+### Compose the existing gates deny-first
+
+The crossing mediator resolves one immutable state cut and evaluates:
+
+1. closed input shape and bounded transport values;
+2. authenticated caller and exact runtime target;
+3. trusted principal-to-participant/controller binding;
+4. participant authority, controller state, scope, and applicable policy;
+5. typed subject, interaction semantics, episode, markings, and order;
+6. SEM-211 applicability/admission for actionable ingress;
+7. SEM-226 audience, visibility, projection, marking, redaction, and
+   declassification for participant egress;
+8. API-407 required feature strength, contracts, evidence, and any explicitly
+   authorized downgrade;
+9. governed transformation result validity and fresh admission where
+   actionable; and
+10. append-only decision/realization/evidence commit before dispatch or
+    serialization.
+
+These are independent owners whose results populate the API-423 decision
+gates. A permit from one owner cannot widen a deny, unknown, unsupported, or
+unresolved result from another. Planner admission, a manifest declaration, a
+role, a visibility ref, a redaction, or a passing schema is never a substitute
+for the complete decision.
+
+Policy and subject resolution must occur while the relevant snapshot/history
+head is stable. The semantic fingerprint and commit precondition bind the same
+state cut; resolving policy before a concurrent handoff, policy change, reset,
+or prior crossing and committing afterward is a time-of-check/time-of-use
+bypass.
+
+### Keep ingress, egress, control, inject, and transformation owners distinct
+
+- Ordinary action ingress still terminates in
+  `ParticipantActionAdmissionRequest`,
+  `participant_action_admission_request_violations()`, and the existing
+  participant runtime apply/result-history checks.
+- Approval, denial, direction, intervention, handoff, override, and
+  cancellation still terminate in RUN-310/API-409 mediation. RUN-319 adds the
+  crossing decision relation around the attempt; it does not replace the
+  control state machine or dispatch directly from approval.
+- Decision-surface/context/history/status egress still uses the SEM-226
+  exact-cut exposure selector and existing typed views. RUN-319 records the
+  crossing decision and realization, then serializes only the governed result.
+- A participant-directed inject retains its compiled DSL-142 binding and
+  original DSL-111 occurrence identity. Schedule, attempted delivery,
+  delivery, observation, external direction, and action remain separate.
+- A transformation is non-mutating and creates a typed result identity with
+  rule/revision, source/result markings, authority, evidence, provenance, and
+  loss. Existing pure projection/exposure functions are the first incumbents.
+  Any additional operation must be a trusted, resolver-supplied, closed
+  operation keyed by governed rule identity/revision—not an executable policy
+  body, expression language, arbitrary callable from a request, or open plugin
+  bag.
+
+A transformed proposal re-enters the same ingress boundary as a new attempt.
+It receives a new subject identity, decision, semantic fingerprint, and full
+structural, semantic, capability, authority, and admission validation. Source
+approval, admission, execution, delivery, and idempotency state do not carry
+forward. API-423's transformation graph and contextual validator remain the
+cycle/source-mutation guard.
+
+### Project before serialization, never after
+
+Participant-facing views are constructed from authorized projected result
+carriers and validated as their existing closed response models before any
+serialization. The implementation must not serialize a snapshot/raw carrier
+and remove fields afterward, call `_project_scope()` as an authorization
+operation, or expose a response while decision persistence is still pending.
+
+The existing `/snapshot` route is an administrative control-plane view, not a
+participant view. Adding crossing history to snapshot state must not cause raw
+crossing history to appear in API-408 participant views. Any participant-facing
+status, context, history, result, inject, or error passes the same
+participant/audience projection. Operator/auditor access to an administrative
+surface does not make its contents participant-visible.
+
+### Make crossing history first-class and append-only
+
+Persist API-423 occurrences in a first-class typed
+`RuntimeSnapshot` participant crossing history, keyed consistently with the
+existing participant histories and retaining episode, audience, policy/cut,
+order, predecessor, evidence, provenance, marking, loss, and audit links in
+each record. Do not use `metadata`, generic event `details`, operation
+diagnostics, audit details, logs, an exposure cache, or a gateway-local file as
+the authoritative history.
+
+The new history must participate in all existing state paths:
+
+- `RuntimeSnapshot`, `with_entries()`, allowed update keys, and carrier-address
+  accounting;
+- runtime snapshot envelope/model serialization;
+- `_snapshot_payload()`, `_snapshot_from_payload()`, `_snapshot_model()`, and
+  local-store restart loading;
+- full-snapshot validation and API-423 resolver-backed contextual validation;
+- append-only transition validation on backend results and control-plane
+  commits; and
+- operational summaries and conformance evidence without payload disclosure.
+
+On restart or replay, closed models first validate each stored occurrence.
+Before the runtime serves or mutates participant state, the API-423 contextual
+validator must resolve the history against trusted typed subject, exact policy
+history/cut, authority, evidence, and predecessor indexes. Policy bodies and
+hidden subjects remain out of line; absence of the trusted resolution context
+fails closed rather than weakening validation.
+
+### Generalize the existing atomic participant commit seam
+
+`ControlPlaneStore`, `InMemoryControlPlaneStore`, and
+`LocalControlPlaneStore` remain the only persistence owners.
+`commit_control_transition()` is the incumbent transaction pattern. RUN-319
+must reuse or carefully generalize its expected-head semantics so one durable
+commit contains the applicable crossing facts, snapshot transition, operation
+record/idempotency outcome, and safe audit correlation. It must not introduce a
+crossing store or call `save_snapshot()`, `save_record()`, and `append_audit()`
+independently.
+
+The commit precondition covers every history head involved in the state cut,
+including control or behavior history when the crossing decision depends on
+it. Multi-stage writes that must be observed together use one write set; later
+realization stages use new append-only commits and predecessor refs. A failed
+commit returns no permitted output and performs no backend dispatch.
+
+The current lock and atomic file replacement support a declared single-process,
+single-writer reference-runtime bound only. They do not provide multi-process
+compare-and-swap, distributed linearizability, or crash-safe transactions
+across unrelated files. A later durable store implements the same expected-head
+write-set seam; it must not replace the policy or participant lifecycle.
+
+### Scope idempotency to policy-relevant semantics
+
+Reuse `Idempotency-Key`, `ControlPlaneOperationRecord`, store lookup, and
+semantic request fingerprints. The effective scope includes target,
+authenticated principal, operation/interaction kind, participant, episode,
+audience, client key, and typed subject identity.
+
+The fingerprint additionally binds subject revision/digest, controller and
+authority, exact policy decision/cut/revision, marking state, order/head,
+required and effective backend strength, downgrade authorization,
+transformation rule/result identity, and any owning proposal/control/inject
+revision. An exact retry returns the original result without another decision
+or realization. Reuse across changed semantics conflicts. A change in policy,
+controller, authority, subject, marking, capability posture, or relevant state
+requires a fresh decision even if raw request bytes are equal.
+
+### Keep capability and realization claims honest
+
+Runtime enforcement calls `resolve_participant_feature_support()` for the
+specific crossing kind and policy-required minimum strength. Planning-time
+feature checks are useful early rejection, not runtime authority. Method
+presence, contract ids, schema validity, or a non-null participant runtime
+cannot establish support.
+
+Map `ParticipantFeatureSupportLevel` to API-423 backend posture explicitly;
+do not compare incidental string spellings. A downgrade is accepted only when
+the already-resolved crossing policy authorizes the effective strength and the
+record carries the downgrade policy/provenance, constraints, limitations,
+disclosures, and evidence. The effective record drops the stronger claim.
+
+The shipped reference backend remains `unsupported` until actual backend or
+runtime behavior and bounded conformance evidence justify a changed manifest.
+RUN-319 may exercise fail-closed unsupported paths and bounded in-process
+reference-runtime logic without claiming backend realization. Any positive
+manifest change remains owned by API-407 manifest/conformance rules.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and required use |
+| --- | --- |
+| Normative semantics | ADR-085, ADR-095, SEM-230 revision 2, `Effective(rho,c)`, `MayCross`, and the distinct operation/claim tables. Do not add runtime-local policy meaning. |
+| Crossing contract | `ParticipantCrossingOccurrenceModel`, its closed stage models/vocabularies, `ParticipantRuntimeBaseEnvelopeModel`, and `validate_participant_crossing_occurrence_context()`. Emit and validate these; add no generic I/O event. |
+| Ingress/admission | `ParticipantActionAdmissionRequest`, `participant_action_admission_request_violations()`, decision-surface selection binding, `ParticipantControlMixin.admit_participant_action()`, and participant action result/history validation. |
+| Control | RUN-310 mediation, API-409 `ParticipantControlOccurrenceModel`, compiled ACT-617 controller states/transitions, `ControlPlaneIdentity.participant_control_subjects`, and `participant_control_history`. |
+| Egress/exposure | SEM-226 v2 projection/exposure resolvers and validators, `participant_observation_effective_relation()`, participant decision surfaces, context/history/status models, observation envelopes, and behavior histories. |
+| Directed injects | Compiled DSL-142 `ParticipantInjectDelivery`, original DSL-111 inject/event/script/story refs, temporal/evidence bindings, and API-423 delivery stages. |
+| Backend capability | `ParticipantFeatureSupport`, `PARTICIPANT_RUNTIME_POLICY_FEATURES`, `PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS`, `resolve_participant_feature_support()`, manifest round trips, and `BackendConformanceReport`. |
+| Runtime owner | `RuntimeControlPlane`, `ParticipantControlMixin`, `ParticipantRetrievalMixin`, backend call/result gates, `OperationReceipt`, `OperationStatus`, and `ControlPlaneOperationRecord`. |
+| State validation | `RuntimeSnapshot`, participant full-snapshot and append-only transition diagnostics, API-423 contextual validation, and `_finalize_backend_apply()` rollback-to-baseline behavior. |
+| Persistence | `ControlPlaneStore`, both shipped stores, expected-head atomic control commit, atomic replacement, and existing operation/audit serializers. |
+| Authentication | `create_control_plane_app()`, `ControlPlaneSecurityConfig.strict_defaults()`, `_ControlPlaneApiAuth`, `ControlPlaneIdentity`, roles, bearer/verified-proxy identity, and target binding. Add a separate closed trusted participant/audience binding where egress needs it; do not overload control-subject binding or role membership. |
+| Request protection | `request_size_guard_response()`, closed Pydantic request DTOs, `_request_fingerprint()`, and idempotency headers. No unbounded policy/payload/details maps. |
+| Errors/observability | `Diagnostic`, `Severity`, operation envelopes, bounded HTTP details, the redacted 500 handler, `AuditEvent`, evidence/provenance refs, and operational apparatus summaries. Add no exception family or logger. |
+| Contract/lineage governance | `schema_bundle()`, hand-governed schemas/fixtures/publication entries, `x-raes-invariants`, controlled vocabularies, `docs/explain/sdl/lineage.md`, its model/checker, and source audit. |
+| Workflow | `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`, and the existing repo-policy, requirement-governance, concept, schema, JSON, lineage, semantic-coverage, conformance, and full verification gates. |
+
+## Cross-Cutting Layers And Security Posture
+
+1. **Transport shape and size.** Existing HTTP bodies pass the content-length
+   and actual-byte guard, then closed Pydantic DTOs. The guard does not bound
+   path, query, or header values; any touched participant route must either add
+   no new such input or use a shared bounded-value validator for participant,
+   episode, audience, refs, and idempotency values. A body-size limit alone is
+   not a complete ingress bound.
+2. **Authentication and target binding.** Bearer or verified trusted-proxy
+   identity passes `_ControlPlaneApiAuth`, role authorization, and exact target
+   binding under empty fail-closed defaults. Bearer tokens and identity headers
+   never enter fingerprints, occurrence payloads, diagnostics, audit details,
+   or logs.
+3. **Participant/controller/audience binding.** Trusted identity configuration
+   separately binds the principal to participant/controller control authority
+   and, for participant-facing reads, participant/audience access. A backend,
+   operator, or auditor role alone grants neither. Cross-participant existence
+   must not be discoverable through differing status/detail text.
+4. **Compiled and exact-cut policy resolution.** Trusted compiled behavior,
+   control, inject, observation, exposure, policy-history, marking, and
+   authority resolvers supply semantic state. Requests, query values, current
+   wall-clock time, snapshot metadata, or backend dictionaries do not.
+   Missing, ambiguous, stale, future, or incomparable resolution denies.
+5. **Contract and semantic validation.** Closed API-423 models own local shape;
+   one resolver-backed API-423 contextual validator owns cross-record joins.
+   Existing SEM-211, SEM-226, RUN-310, lifecycle, and backend-result validators
+   retain their own invariants. Do not repeat the same join in models, routes,
+   mediation, stores, backends, and tests.
+6. **Capability and downgrade gate.** The target's admitted manifest passes the
+   canonical strength/evidence helper at the crossing state cut. Missing
+   entries, insufficient strength, missing required contracts/evidence, or
+   unauthorized weakening reject. Unsupported capability is an explicit
+   recorded posture, not a best-effort path.
+7. **Transformation and output gate.** Only governed source refs reach trusted
+   operation-specific transforms. Results receive fresh identity, inherited
+   markings/provenance, API-423 validation, and fresh admission where
+   actionable. Only the validated projected result is serialized.
+8. **Persistence, restart, and concurrency.** Full snapshot and transition
+   validators, expected-head atomic write-set commit, scoped idempotency,
+   restart parsing, and deterministic contextual replay must agree before
+   dispatch or output. Corrupt/truncated/unresolved state fails closed.
+9. **Diagnostic and error envelope.** Expected denials use stable codes and
+   value-independent bounded messages. Do not expose `str(exc)`, Pydantic
+   rejected input, hidden refs, policy/controller inventories, backend objects,
+   or cross-participant existence. Unexpected failures retain exactly
+   `{"detail":"internal server error"}`.
+10. **Secret, audit, and logging surface.** Occurrences, snapshots, operation
+    records, audit, diagnostics, fixtures, conformance, lineage, stdout/stderr,
+    and host logs carry safe ids, refs, digests, classifications, postures,
+    reason codes, and bounded limitations only. They exclude credentials,
+    tokens, headers, private prompts/memory, hidden answers/world state, raw
+    policy/evidence/payload bodies, environment dumps, and tracebacks.
+11. **Configuration and OS/process exposure.** RUN-319 needs no new environment
+    variable, secret loader, CLI policy argument, subprocess, shell, socket,
+    daemon, or host file. Security/policy resolvers remain injected typed
+    configuration. No token, policy body, participant payload, hidden value, or
+    arbitrary ref belongs in environment variables, process argv, filenames,
+    shell strings, stdout, or stderr.
+12. **Package and workflow boundary.** Normative semantics stay in `specs/`;
+    portable contracts in `raes_contracts`; pure compiled selectors in
+    `raes_processor`; live mediation/security/state/store work in
+    `raes_runtime`; declarations in `raes_backend_protocols`; and bounded
+    claims in conformance. Implementation checks set
+    `RAES_REQUIREMENT_UID=RUN-319` because the current branch name has no UID.
+
+## Extensibility Seam
+
+The stable seam is one runtime crossing transition parameterized by:
+
+- participant, episode, audience, direction, interaction kind, and typed
+  subject revision/digest;
+- exact policy decision/state cut, order model/head, controller, authority,
+  markings, and operation;
+- trusted subject/policy/exposure/evidence resolvers;
+- required backend feature/minimum strength and an already-authorized
+  downgrade;
+- an optional governed operation-specific transformation resolver; and
+- an expected-head atomic write set for API-423 stages, operation receipt, and
+  audit correlation.
+
+The runtime supplies state and produces decisions; adapters supply only intent.
+This seam permits a new governed carrier kind, audience, policy revision,
+streaming/multipart realization, partial-order backend, or durable multi-writer
+store by adding a closed contract variant or resolver/store capability. It does
+not require re-editing existing action, observation, control, inject,
+lifecycle, evidence, or audit carriers, and it is not an open metadata or
+generic plugin seam.
+
+## Assurance Guardrails
+
+Use the existing API-423 contract tests, RUN-310 mediation/store/API-security
+tests, SEM-226 projection/bypass tests, SEM-211 action admission/result tests,
+DSL-142 inject tests, API-407 manifest/admission/conformance tests,
+participant-runtime persistence tests, and Hypothesis patterns.
+
+Evidence must cover positive and deny-first behavior; negative
+cross-participant leakage and hidden-existence probing; stale policy/cut,
+controller, subject, marking, and capability changes; unauthorized and
+claim-retaining downgrades; transformed-proposal fresh admission; redacted
+errors; exact retry and conflicting key reuse; crash/restart/replay,
+append-only prefix integrity, and concurrent expected-head conflicts; and
+serialization only after durable authorization.
+
+Finite tests establish bounded reference-runtime behavior only. They do not
+prove native backend realization, distributed ordering, noninterference, trace
+equivalence/inclusion, simulation, refinement, epistemic equivalence, or
+bisimulation.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- a new policy engine, gateway, transport, workflow engine, DTO family,
+  participant lifecycle, store, audit stream, logger, exception hierarchy,
+  schema registry, concept catalog, or verification runner;
+- accepting caller-completed API-423 facts or policy bodies, evaluating policy
+  expressions from input, or using open `payload`, `metadata`, `details`,
+  `constraints`, or `extensions` bags;
+- treating effective order as exact state-cut identity, a current/final
+  snapshot as historical authority, or a later policy as authorization for an
+  earlier crossing;
+- treating caller authentication, role, target authorization, participant
+  authority, controller state, admission, visibility, marking,
+  declassification, backend support, and transformation validity as one gate;
+- treating approval as admission, admission as dispatch, schedule as delivery,
+  delivery as observation, observation as action, or audit as disclosure;
+- treating masking, projection, redaction, hashing, summarization, loss, or
+  weakening as authorization or declassification;
+- filtering after serialization, using `_project_scope()` or synthesized
+  visibility refs as policy, or returning raw crossing/control/history facts
+  through participant views;
+- mutating a transformation source, retaining source admission/idempotency,
+  removing inherited markings without declassification, or admitting a result
+  without the normal fresh path;
+- treating planner success, method presence, schema validity, supported
+  contract ids, a manifest claim, or finite conformance as runtime realization;
+- independent snapshot/receipt/audit writes, a second crossing persistence
+  file, last-writer-wins, arrival/timestamp order, or claims of multi-process
+  safety from an in-process lock and file rename;
+- exception text, rejected values, policy bodies, hidden refs, raw payloads,
+  credentials, headers, backend objects, or environment/process data in
+  responses, audit, logs, evidence, fixtures, or documentation; and
+- changing the lineage ledger/source audit solely because RUN-319 delivery
+  status changes.
+
+## Publication Workflow Compatibility
+
+The repository's configured Ground Control commands bridge the service's
+legacy requirement gate variable to the repository-owned
+`RAES_REQUIREMENT_UID` name without retaining the retired identity token in
+repository content. This preserves server-side issue/requirement authorization
+while allowing completion, policy, and pre-commit commands to evaluate RUN-319
+on issue-number branches that do not contain the UID.
+
+## Non-Goals And Implementation Boundaries
+
+- No participant gateway, transport, endpoint family, UI, external-agent API,
+  policy-expression language, credential broker, provider integration,
+  arbitrary transformation runtime, or OS sandbox.
+- No replacement or duplication of SEM-211 admission, SEM-226 exposure,
+  RUN-310/API-409 control, DSL-142 inject bindings, API-423 crossings, API-407
+  capability declarations, participant lifecycle/history, evidence/provenance,
+  or audit.
+- No participant prompt, chain-of-thought, private memory, hidden state, policy
+  body, credential, raw rejected input, raw evidence, or backend-private object
+  in portable or observable records.
+- No migration or silent promotion of legacy records. Missing policy/crossing
+  history remains legacy/unknown/unsupported until issue #802 supplies the
+  governed compatibility path.
+- No positive backend capability claim without the owning implementation and
+  conformance evidence.
+- No universal noninterference, timed/probabilistic security, erasure,
+  trace-equivalence, simulation, refinement, epistemic, or bisimulation claim.
+- No lineage-ledger/source-audit change unless implementation changes a
+  normative external derivation or compatibility claim. The participant
+  section of `docs/explain/sdl/lineage.md` is updated only with actual delivered
+  RUN-319 mappings, evidence, status, and nonclaims.

--- a/docs/explain/sdl/lineage.md
+++ b/docs/explain/sdl/lineage.md
@@ -1134,6 +1134,32 @@ which dynamic queue/log/config details remain evidence or bounded settings.
   participant-internal-reasoning claim. The lineage ledger and source audit
   remain unchanged because RUN-310 adds no normative derivation or
   compatibility claim.
+- RUN-319 composes the existing SEM-230/ADR-085 and ADR-095 information-flow
+  semantics with API-423 crossing facts, API-407 feature-strength resolution,
+  RUN-310 authenticated participant/controller binding and atomic control
+  storage, SEM-211 admission, and SEM-226 exposure decisions. The exact runtime
+  mapping is the closed `ParticipantCrossingIntent`, a trusted exact-cut
+  `ParticipantCrossingPolicyResolver`, separate controller and audience
+  bindings on `ControlPlaneIdentity`, deny-first independent API-423 gates,
+  `RuntimeSnapshot.participant_crossing_history`, and
+  `ControlPlaneStore.commit_participant_transition()`. Configured action and
+  supervisory-control ingress cannot dispatch around the shared crossing
+  mediator; transformed ingress receives a new typed subject and a fresh full
+  admission decision.
+- RUN-319 delivery evidence is the evolved
+  `participant-crossing-occurrence-v1` exact-cut policy reference, the
+  `runtime-snapshot-v1` crossing-history carrier and publication entries, the
+  in-memory and local-store atomic restart/replay implementation, and
+  `implementations/python/tests/test_run_319_participant_flow_policy.py`.
+  The reference backend keeps its six participant-policy features
+  `unsupported`; stronger behavior is exercised only with explicit test
+  manifests and evidence. This does not claim a new policy engine, participant
+  gateway or endpoint family, backend-native enforcement, delivery or
+  observation from a decision alone, multi-process CAS, distributed
+  linearizability, universal noninterference, refinement, simulation,
+  bisimulation, epistemic equivalence, or proof. No normative external
+  derivation or compatibility claim changes, so the lineage ledger and source
+  audit remain unchanged.
 - CALDERA adversary-emulation research informs the action semantics: cyber
   actions can change foothold, knowledge, observations, detection surface, and
   downstream outcomes under uncertainty.

--- a/implementations/python/packages/raes_conformance/conformance/target_probes.py
+++ b/implementations/python/packages/raes_conformance/conformance/target_probes.py
@@ -93,16 +93,16 @@ _DEFAULT_CONFORMANCE_SCENARIO = dedent(
 class _UnavailableConformanceCrossingPolicyResolver:
     """Explicitly fail closed if an unrelated adapter probe reaches crossing policy."""
 
+    @staticmethod
     def resolve(
-        self,
         intent: object,
         snapshot: RuntimeSnapshot,
     ) -> object:
         del intent, snapshot
         raise ValueError("target adapter conformance does not supply a crossing policy")
 
+    @staticmethod
     def validation_context(
-        self,
         snapshot: RuntimeSnapshot,
         participant_address: str,
     ) -> object:

--- a/implementations/python/packages/raes_conformance/conformance/target_probes.py
+++ b/implementations/python/packages/raes_conformance/conformance/target_probes.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 from textwrap import dedent
+from types import SimpleNamespace
 from typing import Any
 
 from raes_backend_protocols.manifest import backend_manifest_payload
 from raes_contracts.diagnostics import Diagnostic
+from raes_contracts.manifest_authority import PARTICIPANT_RUNTIME_POLICY_FEATURES
 from raes_contracts.participant_episode import (
     ParticipantEpisodeTerminalReason,
     iter_participant_episode_snapshot_violations,
 )
 from raes_contracts.planning import ProvisioningPlan, RuntimeDomain
-from raes_contracts.runtime_state import RuntimeSnapshotEnvelope
+from raes_contracts.runtime_state import RuntimeSnapshot, RuntimeSnapshotEnvelope
+from raes_contracts.vocabulary import ParticipantFeatureSupportLevel
 from raes_processor.reference import ScenarioInput, run_reference_processor
 from raes_runtime.control_plane import RuntimeControlPlane
 from raes_runtime.registry import RuntimeTarget
@@ -85,6 +88,46 @@ _DEFAULT_CONFORMANCE_SCENARIO = dedent(
           finish: {type: end}
     """
 )
+
+
+class _UnavailableConformanceCrossingPolicyResolver:
+    """Explicitly fail closed if an unrelated adapter probe reaches crossing policy."""
+
+    def resolve(
+        self,
+        intent: object,
+        snapshot: RuntimeSnapshot,
+    ) -> object:
+        del intent, snapshot
+        raise ValueError("target adapter conformance does not supply a crossing policy")
+
+    def validation_context(
+        self,
+        snapshot: RuntimeSnapshot,
+        participant_address: str,
+    ) -> object:
+        del snapshot, participant_address
+        return SimpleNamespace(
+            known_subjects=(),
+            policies=(),
+            known_evidence_refs=frozenset(),
+            known_authority_basis_refs=frozenset(),
+        )
+
+
+def _conformance_crossing_policy_resolver(
+    target: RuntimeTarget,
+) -> _UnavailableConformanceCrossingPolicyResolver | None:
+    capabilities = target.manifest.participant_runtime
+    if capabilities is None:
+        return None
+    if any(
+        declaration.feature in PARTICIPANT_RUNTIME_POLICY_FEATURES
+        and declaration.support_level != ParticipantFeatureSupportLevel.UNSUPPORTED
+        for declaration in capabilities.feature_support
+    ):
+        return _UnavailableConformanceCrossingPolicyResolver()
+    return None
 
 
 def _participant_snapshot_consistency_case(
@@ -420,6 +463,7 @@ def _target_adapter_cases(
     control_plane = RuntimeControlPlane(
         target,
         initial_snapshot=_participant_execution_probe_snapshot(target),
+        crossing_policy_resolver=_conformance_crossing_policy_resolver(target),
     )
     cases.append(_provisioning_probe_case(control_plane, execution_plan.provisioning))
     if known != BackendCapabilityProfile.PROVISIONING_ONLY:

--- a/implementations/python/packages/raes_contracts/contracts/participant_crossing.py
+++ b/implementations/python/packages/raes_contracts/contracts/participant_crossing.py
@@ -126,6 +126,8 @@ class ParticipantCrossingPolicyReferenceModel(ContractModel):
     policy_id: NonEmptyString
     policy_revision: NonEmptyString
     policy_digest: PrefixedDigestString
+    policy_decision_ref: NonEmptyString
+    decision_cut_ref: NonEmptyString
     effective_order: NonNegativeInteger
     valid_from_order: NonNegativeInteger
     valid_until_order: NonNegativeInteger

--- a/implementations/python/packages/raes_contracts/contracts/realization_plans.py
+++ b/implementations/python/packages/raes_contracts/contracts/realization_plans.py
@@ -21,6 +21,7 @@ from .execution_state import (
     WorkflowHistoryEventModel,
 )
 from .participant_control import ParticipantControlOccurrenceModel
+from .participant_crossing import ParticipantCrossingOccurrenceModel
 from .participant_envelopes import (
     ParticipantJointActionRecordModel,
     ParticipantSharedStateRecordModel,
@@ -221,6 +222,7 @@ class RuntimeSnapshotEnvelopeModel(ContractModel):
     participant_episode_history: dict[str, list[ParticipantEpisodeHistoryEventModel]] = Field(default_factory=dict)
     participant_behavior_history: dict[str, list[ParticipantBehaviorHistoryEventModel]] = Field(default_factory=dict)
     participant_control_history: dict[str, list[ParticipantControlOccurrenceModel]] = Field(default_factory=dict)
+    participant_crossing_history: dict[str, list[ParticipantCrossingOccurrenceModel]] = Field(default_factory=dict)
     participant_autonomous_execution_states: dict[str, ParticipantAutonomousExecutionStateModel] = Field(
         default_factory=dict
     )

--- a/implementations/python/packages/raes_contracts/participant_crossing_history.py
+++ b/implementations/python/packages/raes_contracts/participant_crossing_history.py
@@ -16,28 +16,42 @@ def iter_participant_crossing_history_snapshot_violations(
         yield ("runtime.participant-crossing-history", "participant crossing history must be a mapping")
         return
     for participant_address, events in history.items():
-        address = f"runtime.participant-crossing-history.{participant_address}"
-        if not isinstance(participant_address, str) or not participant_address:
-            yield (address, "participant crossing history map keys must be non-empty strings")
+        yield from _snapshot_entry_violations(participant_address, events)
+
+
+def _snapshot_entry_violations(
+    participant_address: object,
+    events: object,
+) -> Iterator[tuple[str, str]]:
+    address = f"runtime.participant-crossing-history.{participant_address}"
+    if not isinstance(participant_address, str) or not participant_address:
+        yield (address, "participant crossing history map keys must be non-empty strings")
+    elif not isinstance(events, list):
+        yield (address, "participant crossing history values must be event lists")
+    else:
+        yield from _event_violations(participant_address, address, events)
+
+
+def _event_violations(
+    participant_address: str,
+    address: str,
+    events: list[object],
+) -> Iterator[tuple[str, str]]:
+    event_ids: set[str] = set()
+    for event in events:
+        try:
+            parsed = ParticipantCrossingOccurrenceModel.model_validate(event)
+        except (TypeError, ValueError):
+            yield (address, "participant crossing history must contain closed API-423 occurrences")
             continue
-        if not isinstance(events, list):
-            yield (address, "participant crossing history values must be event lists")
-            continue
-        event_ids: set[str] = set()
-        for event in events:
-            try:
-                parsed = ParticipantCrossingOccurrenceModel.model_validate(event)
-            except (TypeError, ValueError):
-                yield (address, "participant crossing history must contain closed API-423 occurrences")
-                continue
-            if parsed.participant_address != participant_address:
-                yield (
-                    address,
-                    "participant crossing history map key must equal the embedded participant address",
-                )
-            if parsed.event_id in event_ids:
-                yield (address, "participant crossing history event identities must be unique")
-            event_ids.add(parsed.event_id)
+        if parsed.participant_address != participant_address:
+            yield (
+                address,
+                "participant crossing history map key must equal the embedded participant address",
+            )
+        if parsed.event_id in event_ids:
+            yield (address, "participant crossing history event identities must be unique")
+        event_ids.add(parsed.event_id)
 
 
 def iter_participant_crossing_history_transition_violations(

--- a/implementations/python/packages/raes_contracts/participant_crossing_history.py
+++ b/implementations/python/packages/raes_contracts/participant_crossing_history.py
@@ -1,0 +1,69 @@
+"""Runtime-snapshot invariants for append-only API-423 crossing history."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from raes_contracts.contracts import ParticipantCrossingOccurrenceModel
+
+
+def iter_participant_crossing_history_snapshot_violations(
+    history: object,
+) -> Iterator[tuple[str, str]]:
+    """Yield closed-shape and participant-key violations."""
+
+    if not isinstance(history, dict):
+        yield ("runtime.participant-crossing-history", "participant crossing history must be a mapping")
+        return
+    for participant_address, events in history.items():
+        address = f"runtime.participant-crossing-history.{participant_address}"
+        if not isinstance(participant_address, str) or not participant_address:
+            yield (address, "participant crossing history map keys must be non-empty strings")
+            continue
+        if not isinstance(events, list):
+            yield (address, "participant crossing history values must be event lists")
+            continue
+        event_ids: set[str] = set()
+        for event in events:
+            try:
+                parsed = ParticipantCrossingOccurrenceModel.model_validate(event)
+            except (TypeError, ValueError):
+                yield (address, "participant crossing history must contain closed API-423 occurrences")
+                continue
+            if parsed.participant_address != participant_address:
+                yield (
+                    address,
+                    "participant crossing history map key must equal the embedded participant address",
+                )
+            if parsed.event_id in event_ids:
+                yield (address, "participant crossing history event identities must be unique")
+            event_ids.add(parsed.event_id)
+
+
+def iter_participant_crossing_history_transition_violations(
+    previous: object,
+    current: object,
+) -> Iterator[tuple[str, str]]:
+    """Yield violations when a crossing stream does not retain its exact prefix."""
+
+    if not isinstance(previous, dict) or not isinstance(current, dict):
+        yield ("runtime.participant-crossing-history", "participant crossing history must remain append-only")
+        return
+    for participant_address, previous_events in previous.items():
+        current_events = current.get(participant_address)
+        if (
+            not isinstance(previous_events, list)
+            or not isinstance(current_events, list)
+            or len(current_events) < len(previous_events)
+            or current_events[: len(previous_events)] != previous_events
+        ):
+            yield (
+                f"runtime.participant-crossing-history.{participant_address}",
+                "participant crossing history must remain append-only and preserve its exact prefix",
+            )
+
+
+__all__ = (
+    "iter_participant_crossing_history_snapshot_violations",
+    "iter_participant_crossing_history_transition_violations",
+)

--- a/implementations/python/packages/raes_contracts/runtime_state.py
+++ b/implementations/python/packages/raes_contracts/runtime_state.py
@@ -87,6 +87,7 @@ class RuntimeSnapshot:
     participant_episode_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     participant_behavior_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     participant_control_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    participant_crossing_history: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
     participant_autonomous_execution_states: dict[str, dict[str, Any]] = field(default_factory=dict)
     participant_execution_services: dict[str, dict[str, Any]] = field(default_factory=dict)
     participant_resource_budget_states: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -171,6 +172,11 @@ def _snapshot_result_updates(
             updates,
             "participant_control_history",
             snapshot.participant_control_history,
+        ),
+        "participant_crossing_history": _history_update(
+            updates,
+            "participant_crossing_history",
+            snapshot.participant_crossing_history,
         ),
     }
 
@@ -264,6 +270,7 @@ _SNAPSHOT_UPDATE_KEYS = {
     "participant_episode_history",
     "participant_behavior_history",
     "participant_control_history",
+    "participant_crossing_history",
     "participant_autonomous_execution_states",
     "participant_execution_services",
     "participant_resource_budget_states",

--- a/implementations/python/packages/raes_runtime/control_plane.py
+++ b/implementations/python/packages/raes_runtime/control_plane.py
@@ -21,6 +21,7 @@ from raes_contracts.apparatus import (
     RUNTIME_REALIZATION_DOMAIN,
 )
 from raes_contracts.diagnostics import Diagnostic
+from raes_contracts.manifest_authority import PARTICIPANT_RUNTIME_POLICY_FEATURES
 from raes_contracts.planning import (
     EvaluationPlan,
     OrchestrationPlan,
@@ -36,6 +37,7 @@ from raes_contracts.runtime_state import (
     RuntimeSnapshot,
     RuntimeSnapshotEnvelope,
 )
+from raes_contracts.vocabulary import ParticipantFeatureSupportLevel
 from raes_contracts.workflow import (
     WorkflowCompensationStatus,
     WorkflowExecutionState,
@@ -62,6 +64,10 @@ from .control_plane_timeouts import workflow_timeout_update
 from .control_plane_workflows import maybe_apply_compensation
 from .operational_apparatus import operational_apparatus_summary
 from .participant_control import ParticipantControlMixin
+from .participant_crossing_mediation import (
+    ParticipantCrossingPolicyResolver,
+    validate_persisted_crossing_history,
+)
 from .participant_retrieval import ParticipantRetrievalMixin
 from .registry import RuntimeTarget
 
@@ -203,6 +209,24 @@ def _submitted_operation_diagnostic(
     return diagnostic
 
 
+def _require_crossing_policy_configuration(
+    target: RuntimeTarget,
+    resolver: ParticipantCrossingPolicyResolver | None,
+) -> None:
+    capabilities = target.manifest.participant_runtime
+    if capabilities is None:
+        return
+    enabled_policy_features = {
+        declaration.feature
+        for declaration in capabilities.feature_support
+        if declaration.feature in PARTICIPANT_RUNTIME_POLICY_FEATURES
+        and declaration.support_level != ParticipantFeatureSupportLevel.UNSUPPORTED
+    }
+    if enabled_policy_features and resolver is None:
+        features = ", ".join(sorted(enabled_policy_features))
+        raise ValueError(f"participant policy capabilities require a crossing policy resolver: {features}")
+
+
 class RuntimeControlPlane(ParticipantControlMixin, ParticipantRetrievalMixin):
     """Reference control plane for async runtime submission and observation."""
 
@@ -213,13 +237,20 @@ class RuntimeControlPlane(ParticipantControlMixin, ParticipantRetrievalMixin):
         initial_snapshot: RuntimeSnapshot | None = None,
         store: ControlPlaneStore | None = None,
         behavior_specifications: Mapping[str, ParticipantBehaviorSpecificationRuntime] | None = None,
+        crossing_policy_resolver: ParticipantCrossingPolicyResolver | None = None,
     ) -> None:
+        _require_crossing_policy_configuration(target, crossing_policy_resolver)
         self._target = target
         self._store = store or InMemoryControlPlaneStore(initial_snapshot)
         self._snapshot = initial_snapshot if initial_snapshot is not None else self._store.load_snapshot()
         self._operations: dict[str, ControlPlaneOperationRecord] = self._store.load_records()
         self._behavior_specifications = dict(behavior_specifications or {})
+        self._crossing_policy_resolver = crossing_policy_resolver
         self._participant_control_lock = RLock()
+        if self._snapshot.participant_crossing_history:
+            if crossing_policy_resolver is None:
+                raise ValueError("persisted participant crossing history requires a policy resolver")
+            validate_persisted_crossing_history(self._snapshot, crossing_policy_resolver)
 
     @property
     def snapshot(self) -> RuntimeSnapshot:

--- a/implementations/python/packages/raes_runtime/control_plane_api_models.py
+++ b/implementations/python/packages/raes_runtime/control_plane_api_models.py
@@ -164,6 +164,7 @@ def _snapshot_model(envelope: RuntimeSnapshotEnvelope) -> RuntimeSnapshotEnvelop
             "participant_episode_history": dict(snapshot.participant_episode_history),
             "participant_behavior_history": dict(snapshot.participant_behavior_history),
             "participant_control_history": dict(snapshot.participant_control_history),
+            "participant_crossing_history": dict(snapshot.participant_crossing_history),
             "participant_autonomous_execution_states": dict(snapshot.participant_autonomous_execution_states),
             "participant_execution_services": dict(snapshot.participant_execution_services),
             "participant_resource_budget_states": dict(snapshot.participant_resource_budget_states),

--- a/implementations/python/packages/raes_runtime/control_plane_execution.py
+++ b/implementations/python/packages/raes_runtime/control_plane_execution.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from raes_contracts.diagnostics import Diagnostic
 from raes_contracts.planning import RuntimeDomain
-from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus, RuntimeSnapshot
+from raes_contracts.runtime_state import ApplyResult, OperationReceipt, OperationState, OperationStatus, RuntimeSnapshot
 
 from .backend_calls import _call_backend_apply
 from .control_plane_store import ControlPlaneOperationRecord
@@ -17,6 +17,24 @@ from .control_plane_store import ControlPlaneOperationRecord
 
 def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def apply_authorized_participant_action(
+    *,
+    method: Callable[..., object],
+    request: object,
+    snapshot: RuntimeSnapshot,
+    address: str,
+) -> ApplyResult:
+    """Invoke and validate a participant backend after durable authorization."""
+
+    return _call_backend_apply(
+        method,
+        request,
+        snapshot,
+        address=address,
+        snapshot=snapshot,
+    )
 
 
 def execute_participant_action(

--- a/implementations/python/packages/raes_runtime/control_plane_security.py
+++ b/implementations/python/packages/raes_runtime/control_plane_security.py
@@ -27,6 +27,18 @@ class ParticipantControlSubjectBinding:
 
 
 @dataclass(frozen=True)
+class ParticipantAudienceSubjectBinding:
+    """One authenticated principal-to-participant/audience binding."""
+
+    participant_address: str
+    audience_scope_ref: str
+
+    def __post_init__(self) -> None:
+        if not self.participant_address or not self.audience_scope_ref:
+            raise ValueError("participant audience subject binding fields must be non-empty")
+
+
+@dataclass(frozen=True)
 class ControlPlaneIdentity:
     """Authenticated control-plane principal."""
 
@@ -34,6 +46,7 @@ class ControlPlaneIdentity:
     roles: frozenset[ControlPlaneRole] = field(default_factory=frozenset)
     target_name: str | None = None
     participant_control_subjects: tuple[ParticipantControlSubjectBinding, ...] = ()
+    participant_audience_subjects: tuple[ParticipantAudienceSubjectBinding, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/implementations/python/packages/raes_runtime/control_plane_store.py
+++ b/implementations/python/packages/raes_runtime/control_plane_store.py
@@ -9,14 +9,12 @@ from typing import TYPE_CHECKING, Any, Protocol
 from raes_contracts.artifact_requirements import ArtifactSatisfactionDisclosureModel
 from raes_contracts.contracts import RealizationEnvelopeIdentityModel
 from raes_contracts.contracts.time_model import TimeRuntimeStateModel
-from raes_contracts.diagnostics import Diagnostic, Severity
 from raes_contracts.participant_autonomous_state import require_participant_autonomous_runtime_snapshot
 from raes_contracts.planning import RuntimeDomain
 from raes_contracts.runtime_state import (
     ExplicitnessClass,
     ExplicitnessProvenance,
     OperationReceipt,
-    OperationState,
     OperationStatus,
     RealizationProvenanceEntry,
     RuntimeSnapshot,
@@ -50,6 +48,9 @@ class ControlPlaneOperationRecord:
     status: OperationStatus
     request_fingerprint: str = ""
     idempotency_key: str = ""
+    result_payload: dict[str, Any] | None = None
+    decision_history_heads: dict[str, str | None] = field(default_factory=dict)
+    result_history_heads: dict[str, str | None] = field(default_factory=dict)
 
 
 class ControlPlaneStore(Protocol):
@@ -82,6 +83,15 @@ class ControlPlaneStore(Protocol):
         audit_event: AuditEvent,
     ) -> None: ...
 
+    def commit_participant_transition(
+        self,
+        *,
+        expected_history_heads: dict[str, str | None],
+        snapshot: RuntimeSnapshot,
+        record: ControlPlaneOperationRecord,
+        audit_event: AuditEvent,
+    ) -> None: ...
+
 
 def _control_history_head(snapshot: RuntimeSnapshot, participant_address: str) -> str | None:
     events = snapshot.participant_control_history.get(participant_address, ())
@@ -98,6 +108,32 @@ def _require_expected_control_head(
 ) -> None:
     if _control_history_head(snapshot, participant_address) != expected_head:
         raise ValueError("expected control history head does not match durable state")
+
+
+def _participant_history_head(snapshot: RuntimeSnapshot, history_key: str) -> str | None:
+    history_name, separator, participant_address = history_key.partition(":")
+    histories = {
+        "participant_behavior_history": snapshot.participant_behavior_history,
+        "participant_control_history": snapshot.participant_control_history,
+        "participant_crossing_history": snapshot.participant_crossing_history,
+    }
+    history = histories.get(history_name)
+    if not separator or not participant_address or history is None:
+        raise ValueError("participant transition history key is not supported")
+    events = history.get(participant_address, ())
+    if not events:
+        return None
+    event_id = events[-1].get("event_id")
+    return event_id if isinstance(event_id, str) and event_id else None
+
+
+def _require_expected_history_heads(
+    snapshot: RuntimeSnapshot,
+    expected_history_heads: dict[str, str | None],
+) -> None:
+    for history_key, expected_head in expected_history_heads.items():
+        if _participant_history_head(snapshot, history_key) != expected_head:
+            raise ValueError("expected participant history head does not match durable state")
 
 
 def _snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
@@ -133,6 +169,10 @@ def _snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
         "participant_control_history": {
             participant_address: list(events)
             for participant_address, events in snapshot.participant_control_history.items()
+        },
+        "participant_crossing_history": {
+            participant_address: list(events)
+            for participant_address, events in snapshot.participant_crossing_history.items()
         },
         "participant_autonomous_execution_states": dict(snapshot.participant_autonomous_execution_states),
         "participant_execution_services": dict(snapshot.participant_execution_services),
@@ -209,6 +249,10 @@ def _snapshot_from_payload(payload: dict[str, Any]) -> RuntimeSnapshot:
             participant_address: list(events)
             for participant_address, events in payload.get("participant_control_history", {}).items()
         },
+        participant_crossing_history={
+            participant_address: list(events)
+            for participant_address, events in payload.get("participant_crossing_history", {}).items()
+        },
         participant_autonomous_execution_states=dict(payload.get("participant_autonomous_execution_states", {})),
         participant_execution_services=dict(payload.get("participant_execution_services", {})),
         participant_resource_budget_states=dict(payload.get("participant_resource_budget_states", {})),
@@ -254,99 +298,6 @@ def _snapshot_from_payload(payload: dict[str, Any]) -> RuntimeSnapshot:
     )
     require_participant_autonomous_runtime_snapshot(snapshot)
     return snapshot
-
-
-def _diagnostics_payload(diagnostics: list[Diagnostic]) -> list[dict[str, Any]]:
-    return [
-        {
-            "code": diagnostic.code,
-            "domain": diagnostic.domain,
-            "address": diagnostic.address,
-            "message": diagnostic.message,
-            "severity": diagnostic.severity.value,
-        }
-        for diagnostic in diagnostics
-    ]
-
-
-def _diagnostics_from_payload(payload: list[dict[str, Any]]) -> list[Diagnostic]:
-    return [
-        Diagnostic(
-            code=str(item.get("code", "runtime.control-plane")),
-            domain=str(item.get("domain", "runtime")),
-            address=str(item.get("address", "runtime.control-plane")),
-            message=str(item.get("message", "")),
-            severity=Severity(str(item.get("severity", "error"))),
-        )
-        for item in payload
-    ]
-
-
-def _record_payload(record: ControlPlaneOperationRecord) -> dict[str, Any]:
-    return {
-        "receipt": {
-            "schema_version": record.receipt.schema_version,
-            "operation_id": record.receipt.operation_id,
-            "domain": record.receipt.domain.value,
-            "submitted_at": record.receipt.submitted_at,
-            "accepted": record.receipt.accepted,
-            "diagnostics": _diagnostics_payload(record.receipt.diagnostics),
-        },
-        "status": {
-            "schema_version": record.status.schema_version,
-            "operation_id": record.status.operation_id,
-            "domain": record.status.domain.value,
-            "state": record.status.state.value,
-            "submitted_at": record.status.submitted_at,
-            "updated_at": record.status.updated_at,
-            "diagnostics": _diagnostics_payload(record.status.diagnostics),
-            "changed_addresses": list(record.status.changed_addresses),
-        },
-        "request_fingerprint": record.request_fingerprint,
-        "idempotency_key": record.idempotency_key,
-    }
-
-
-def _record_from_payload(payload: dict[str, Any]) -> ControlPlaneOperationRecord:
-    receipt_payload = dict(payload.get("receipt", {}))
-    status_payload = dict(payload.get("status", {}))
-    receipt = OperationReceipt(
-        schema_version=str(receipt_payload.get("schema_version", "runtime-operation/v1")),
-        operation_id=str(receipt_payload.get("operation_id", "")),
-        domain=RuntimeDomain(str(receipt_payload.get("domain", "provisioning"))),
-        submitted_at=str(receipt_payload.get("submitted_at", "")),
-        accepted=bool(receipt_payload.get("accepted", False)),
-        diagnostics=_diagnostics_from_payload(list(receipt_payload.get("diagnostics", []))),
-    )
-    status = OperationStatus(
-        schema_version=str(status_payload.get("schema_version", "runtime-operation/v1")),
-        operation_id=str(status_payload.get("operation_id", "")),
-        domain=RuntimeDomain(str(status_payload.get("domain", "provisioning"))),
-        state=OperationState(str(status_payload.get("state", "accepted"))),
-        submitted_at=str(status_payload.get("submitted_at", "")),
-        updated_at=str(status_payload.get("updated_at", "")),
-        diagnostics=_diagnostics_from_payload(list(status_payload.get("diagnostics", []))),
-        changed_addresses=list(status_payload.get("changed_addresses", [])),
-    )
-    return ControlPlaneOperationRecord(
-        receipt=receipt,
-        status=status,
-        request_fingerprint=str(payload.get("request_fingerprint", "")),
-        idempotency_key=str(payload.get("idempotency_key", "")),
-    )
-
-
-def _audit_event_from_payload(payload: dict[str, Any]) -> AuditEvent:
-    return AuditEvent(
-        timestamp=str(payload.get("timestamp", "")),
-        action=str(payload.get("action", "")),
-        identity=str(payload.get("identity", "")),
-        allowed=bool(payload.get("allowed", False)),
-        target=str(payload.get("target", "")),
-        operation_id=str(payload.get("operation_id", "")),
-        reason=str(payload.get("reason", "")),
-        details=dict(payload.get("details", {})),
-    )
 
 
 class InMemoryControlPlaneStore:
@@ -398,6 +349,24 @@ class InMemoryControlPlaneStore:
         audit_event: AuditEvent,
     ) -> None:
         _require_expected_control_head(self._snapshot, participant_address, expected_head)
+        self.commit_participant_transition(
+            expected_history_heads={
+                f"participant_control_history:{participant_address}": expected_head,
+            },
+            snapshot=snapshot,
+            record=record,
+            audit_event=audit_event,
+        )
+
+    def commit_participant_transition(
+        self,
+        *,
+        expected_history_heads: dict[str, str | None],
+        snapshot: RuntimeSnapshot,
+        record: ControlPlaneOperationRecord,
+        audit_event: AuditEvent,
+    ) -> None:
+        _require_expected_history_heads(self._snapshot, expected_history_heads)
         require_participant_autonomous_runtime_snapshot(snapshot)
         records = {**self._records, record.receipt.operation_id: record}
         idempotency = dict(self._idempotency)

--- a/implementations/python/packages/raes_runtime/control_plane_store_local.py
+++ b/implementations/python/packages/raes_runtime/control_plane_store_local.py
@@ -15,13 +15,16 @@ from raes_contracts.runtime_state import RuntimeSnapshot
 from .control_plane_store import (
     AuditEvent,
     ControlPlaneOperationRecord,
-    _audit_event_from_payload,
-    _record_from_payload,
-    _record_payload,
     _require_expected_control_head,
+    _require_expected_history_heads,
     _snapshot_from_payload,
     _snapshot_payload,
     os,
+)
+from .control_plane_store_records import (
+    _audit_event_from_payload,
+    _record_from_payload,
+    _record_payload,
 )
 
 
@@ -59,8 +62,8 @@ class LocalControlPlaneStore:
         if control_state is None:
             return legacy_snapshot
         committed_snapshot = _snapshot_from_payload(dict(control_state.get("snapshot", {})))
-        legacy_count = sum(len(events) for events in legacy_snapshot.participant_control_history.values())
-        committed_count = sum(len(events) for events in committed_snapshot.participant_control_history.values())
+        legacy_count = _participant_transition_count(legacy_snapshot)
+        committed_count = _participant_transition_count(committed_snapshot)
         return committed_snapshot if committed_count > legacy_count else legacy_snapshot
 
     def save_snapshot(self, snapshot: RuntimeSnapshot) -> None:
@@ -149,6 +152,25 @@ class LocalControlPlaneStore:
     ) -> None:
         current_snapshot = self.load_snapshot()
         _require_expected_control_head(current_snapshot, participant_address, expected_head)
+        self.commit_participant_transition(
+            expected_history_heads={
+                f"participant_control_history:{participant_address}": expected_head,
+            },
+            snapshot=snapshot,
+            record=record,
+            audit_event=audit_event,
+        )
+
+    def commit_participant_transition(
+        self,
+        *,
+        expected_history_heads: dict[str, str | None],
+        snapshot: RuntimeSnapshot,
+        record: ControlPlaneOperationRecord,
+        audit_event: AuditEvent,
+    ) -> None:
+        current_snapshot = self.load_snapshot()
+        _require_expected_history_heads(current_snapshot, expected_history_heads)
         require_participant_autonomous_runtime_snapshot(snapshot)
         records = self.load_records()
         records[record.receipt.operation_id] = record
@@ -162,6 +184,17 @@ class LocalControlPlaneStore:
         }
         content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
         self._atomic_write(self._control_state_path, content)
+
+
+def _participant_transition_count(snapshot: RuntimeSnapshot) -> int:
+    return sum(
+        len(events)
+        for history in (
+            snapshot.participant_control_history,
+            snapshot.participant_crossing_history,
+        )
+        for events in history.values()
+    )
 
 
 __all__ = ("LocalControlPlaneStore",)

--- a/implementations/python/packages/raes_runtime/control_plane_store_records.py
+++ b/implementations/python/packages/raes_runtime/control_plane_store_records.py
@@ -1,0 +1,119 @@
+"""Operation-record and audit serialization for control-plane stores."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from raes_contracts.diagnostics import Diagnostic, Severity
+from raes_contracts.planning import RuntimeDomain
+from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus
+
+from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
+
+
+def _diagnostics_payload(diagnostics: list[Diagnostic]) -> list[dict[str, Any]]:
+    return [
+        {
+            "code": diagnostic.code,
+            "domain": diagnostic.domain,
+            "address": diagnostic.address,
+            "message": diagnostic.message,
+            "severity": diagnostic.severity.value,
+        }
+        for diagnostic in diagnostics
+    ]
+
+
+def _diagnostics_from_payload(payload: list[dict[str, Any]]) -> list[Diagnostic]:
+    return [
+        Diagnostic(
+            code=str(item.get("code", "runtime.control-plane")),
+            domain=str(item.get("domain", "runtime")),
+            address=str(item.get("address", "runtime.control-plane")),
+            message=str(item.get("message", "")),
+            severity=Severity(str(item.get("severity", "error"))),
+        )
+        for item in payload
+    ]
+
+
+def _record_payload(record: ControlPlaneOperationRecord) -> dict[str, Any]:
+    return {
+        "receipt": {
+            "schema_version": record.receipt.schema_version,
+            "operation_id": record.receipt.operation_id,
+            "domain": record.receipt.domain.value,
+            "submitted_at": record.receipt.submitted_at,
+            "accepted": record.receipt.accepted,
+            "diagnostics": _diagnostics_payload(record.receipt.diagnostics),
+        },
+        "status": {
+            "schema_version": record.status.schema_version,
+            "operation_id": record.status.operation_id,
+            "domain": record.status.domain.value,
+            "state": record.status.state.value,
+            "submitted_at": record.status.submitted_at,
+            "updated_at": record.status.updated_at,
+            "diagnostics": _diagnostics_payload(record.status.diagnostics),
+            "changed_addresses": list(record.status.changed_addresses),
+        },
+        "request_fingerprint": record.request_fingerprint,
+        "idempotency_key": record.idempotency_key,
+        "result_payload": record.result_payload,
+        "decision_history_heads": dict(record.decision_history_heads),
+        "result_history_heads": dict(record.result_history_heads),
+    }
+
+
+def _record_from_payload(payload: dict[str, Any]) -> ControlPlaneOperationRecord:
+    receipt_payload = dict(payload.get("receipt", {}))
+    status_payload = dict(payload.get("status", {}))
+    receipt = OperationReceipt(
+        schema_version=str(receipt_payload.get("schema_version", "runtime-operation/v1")),
+        operation_id=str(receipt_payload.get("operation_id", "")),
+        domain=RuntimeDomain(str(receipt_payload.get("domain", "provisioning"))),
+        submitted_at=str(receipt_payload.get("submitted_at", "")),
+        accepted=bool(receipt_payload.get("accepted", False)),
+        diagnostics=_diagnostics_from_payload(list(receipt_payload.get("diagnostics", []))),
+    )
+    status = OperationStatus(
+        schema_version=str(status_payload.get("schema_version", "runtime-operation/v1")),
+        operation_id=str(status_payload.get("operation_id", "")),
+        domain=RuntimeDomain(str(status_payload.get("domain", "provisioning"))),
+        state=OperationState(str(status_payload.get("state", "accepted"))),
+        submitted_at=str(status_payload.get("submitted_at", "")),
+        updated_at=str(status_payload.get("updated_at", "")),
+        diagnostics=_diagnostics_from_payload(list(status_payload.get("diagnostics", []))),
+        changed_addresses=list(status_payload.get("changed_addresses", [])),
+    )
+    return ControlPlaneOperationRecord(
+        receipt=receipt,
+        status=status,
+        request_fingerprint=str(payload.get("request_fingerprint", "")),
+        idempotency_key=str(payload.get("idempotency_key", "")),
+        result_payload=(dict(payload["result_payload"]) if isinstance(payload.get("result_payload"), dict) else None),
+        decision_history_heads={
+            str(key): (str(value) if value is not None else None)
+            for key, value in dict(payload.get("decision_history_heads", {})).items()
+        },
+        result_history_heads={
+            str(key): (str(value) if value is not None else None)
+            for key, value in dict(payload.get("result_history_heads", {})).items()
+        },
+    )
+
+
+def _audit_event_from_payload(payload: dict[str, Any]) -> AuditEvent:
+    return AuditEvent(
+        timestamp=str(payload.get("timestamp", "")),
+        action=str(payload.get("action", "")),
+        identity=str(payload.get("identity", "")),
+        allowed=bool(payload.get("allowed", False)),
+        target=str(payload.get("target", "")),
+        operation_id=str(payload.get("operation_id", "")),
+        reason=str(payload.get("reason", "")),
+        details=dict(payload.get("details", {})),
+    )
+
+
+__all__ = ("_audit_event_from_payload", "_record_from_payload", "_record_payload")

--- a/implementations/python/packages/raes_runtime/operational_apparatus.py
+++ b/implementations/python/packages/raes_runtime/operational_apparatus.py
@@ -68,6 +68,7 @@ def _runtime_surface_summary(snapshot: RuntimeSnapshot) -> dict[str, int]:
         "participant_episode_results": len(snapshot.participant_episode_results),
         "participant_episode_history": _history_count(snapshot.participant_episode_history),
         "participant_behavior_history": _history_count(snapshot.participant_behavior_history),
+        "participant_crossing_history": _history_count(snapshot.participant_crossing_history),
         "shared_state_records": len(snapshot.shared_state_records),
         "shared_state_history": _history_count(snapshot.shared_state_history),
         "joint_action_records": len(snapshot.joint_action_records),

--- a/implementations/python/packages/raes_runtime/participant_control.py
+++ b/implementations/python/packages/raes_runtime/participant_control.py
@@ -47,10 +47,10 @@ from .participant_control_intents import (
 from .participant_crossing_boundary import (
     ParticipantCrossingControlIngressMixin,
     ParticipantCrossingEvidence,
-    execute_action_ingress_crossing,
 )
 from .participant_decision_surface_control_v2 import ParticipantDecisionSurfaceV2ControlMixin
 from .participant_execution_control_boundary import backend_execution_control_method
+from .participant_submission_options import ParticipantSubmissionOptions, submit_bound_participant_action
 
 
 def _participant_binding_diagnostics(
@@ -409,27 +409,13 @@ class ParticipantControlMixin(
                 request_fingerprint=request_fingerprint,
             )
         assert request is not None
-        if getattr(self, "_crossing_policy_resolver", None) is not None:
-            return execute_action_ingress_crossing(
-                self,
-                participant_behavior=participant_behavior,
-                request=request,
-                crossing_evidence=crossing_evidence,
-                identity=identity,
-                idempotency_key=idempotency_key,
-                method=self._target.participant_runtime.admit_action,
-                address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
-            )
-        if crossing_evidence is not None:
-            raise ValueError("participant crossing policy resolver is required")
-        return execute_participant_action(
-            self,
-            method=self._target.participant_runtime.admit_action,
-            request=request,
-            address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
+        options = ParticipantSubmissionOptions(
             idempotency_key=idempotency_key,
             request_fingerprint=request_fingerprint,
+            identity=identity,
+            crossing_evidence=crossing_evidence,
         )
+        return submit_bound_participant_action(self, participant_behavior, request, options)
 
     def admit_participant_decision_surface_selection(
         self,
@@ -439,19 +425,17 @@ class ParticipantControlMixin(
         selection: ParticipantDecisionSurfaceSelectionModel,
         admission_request: ParticipantActionAdmissionRequest,
         resolvers: ParticipantDecisionSurfaceBindingResolvers,
-        idempotency_key: str = "",
-        request_fingerprint: str = "",
-        identity: object | None = None,
-        crossing_evidence: ParticipantCrossingEvidence | None = None,
+        **submission_options: object,
     ) -> OperationReceipt:
         """Validate a SEM-220 selection before reusing normal action admission."""
 
+        options = ParticipantSubmissionOptions.from_fields(submission_options)
         if self._target.participant_runtime is None:
             return self._reject_submission(
                 domain=RuntimeDomain.PARTICIPANT,
                 message=_NO_PARTICIPANT_RUNTIME_MESSAGE,
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
+                idempotency_key=options.idempotency_key,
+                request_fingerprint=options.request_fingerprint,
             )
         try:
             request = bind_participant_decision_surface_selection(
@@ -467,16 +451,16 @@ class ParticipantControlMixin(
                 diagnostics=[
                     _participant_binding_diagnostic(_participant_binding_address(participant_behavior), str(exc))
                 ],
-                idempotency_key=idempotency_key,
-                request_fingerprint=request_fingerprint,
+                idempotency_key=options.idempotency_key,
+                request_fingerprint=options.request_fingerprint,
             )
         return self.admit_participant_action(
             participant_behavior,
             request,
-            idempotency_key=idempotency_key,
-            request_fingerprint=request_fingerprint,
-            identity=identity,
-            crossing_evidence=crossing_evidence,
+            idempotency_key=options.idempotency_key,
+            request_fingerprint=options.request_fingerprint,
+            identity=options.identity,
+            crossing_evidence=options.crossing_evidence,
         )
 
 

--- a/implementations/python/packages/raes_runtime/participant_control.py
+++ b/implementations/python/packages/raes_runtime/participant_control.py
@@ -44,7 +44,11 @@ from .participant_control_intents import (
     ParticipantOverrideControlIntent,
     ParticipantProposalControlIntent,
 )
-from .participant_control_mediation import record_participant_control
+from .participant_crossing_boundary import (
+    ParticipantCrossingControlIngressMixin,
+    ParticipantCrossingEvidence,
+    execute_action_ingress_crossing,
+)
 from .participant_decision_surface_control_v2 import ParticipantDecisionSurfaceV2ControlMixin
 from .participant_execution_control_boundary import backend_execution_control_method
 
@@ -211,26 +215,11 @@ def _participant_binding_request_diagnostics(
     return diagnostics
 
 
-class ParticipantControlMixin(ParticipantDecisionSurfaceV2ControlMixin):
+class ParticipantControlMixin(
+    ParticipantCrossingControlIngressMixin,
+    ParticipantDecisionSurfaceV2ControlMixin,
+):
     """Participant runtime methods for the shared runtime control plane."""
-
-    def record_participant_control(
-        self,
-        participant_address: str,
-        intent: ParticipantControlIntent,
-        *,
-        identity: object,
-        idempotency_key: str = "",
-    ) -> OperationReceipt:
-        """Mediate and durably append one supervisory control occurrence."""
-
-        return record_participant_control(
-            self,
-            participant_address=participant_address,
-            intent=intent,
-            identity=identity,
-            idempotency_key=idempotency_key,
-        )
 
     def control_participant_execution(
         self,
@@ -396,6 +385,8 @@ class ParticipantControlMixin(ParticipantDecisionSurfaceV2ControlMixin):
         *,
         idempotency_key: str = "",
         request_fingerprint: str = "",
+        identity: object | None = None,
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
         **admission_fields: object,
     ) -> OperationReceipt:
         if self._target.participant_runtime is None:
@@ -418,6 +409,19 @@ class ParticipantControlMixin(ParticipantDecisionSurfaceV2ControlMixin):
                 request_fingerprint=request_fingerprint,
             )
         assert request is not None
+        if getattr(self, "_crossing_policy_resolver", None) is not None:
+            return execute_action_ingress_crossing(
+                self,
+                participant_behavior=participant_behavior,
+                request=request,
+                crossing_evidence=crossing_evidence,
+                identity=identity,
+                idempotency_key=idempotency_key,
+                method=self._target.participant_runtime.admit_action,
+                address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
+            )
+        if crossing_evidence is not None:
+            raise ValueError("participant crossing policy resolver is required")
         return execute_participant_action(
             self,
             method=self._target.participant_runtime.admit_action,
@@ -437,6 +441,8 @@ class ParticipantControlMixin(ParticipantDecisionSurfaceV2ControlMixin):
         resolvers: ParticipantDecisionSurfaceBindingResolvers,
         idempotency_key: str = "",
         request_fingerprint: str = "",
+        identity: object | None = None,
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
     ) -> OperationReceipt:
         """Validate a SEM-220 selection before reusing normal action admission."""
 
@@ -469,6 +475,8 @@ class ParticipantControlMixin(ParticipantDecisionSurfaceV2ControlMixin):
             request,
             idempotency_key=idempotency_key,
             request_fingerprint=request_fingerprint,
+            identity=identity,
+            crossing_evidence=crossing_evidence,
         )
 
 

--- a/implementations/python/packages/raes_runtime/participant_control_mediation.py
+++ b/implementations/python/packages/raes_runtime/participant_control_mediation.py
@@ -18,7 +18,7 @@ from raes_contracts.contracts.participant_control import (
 )
 from raes_contracts.diagnostics import Diagnostic
 from raes_contracts.planning import RuntimeDomain
-from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus
+from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus, RuntimeSnapshot
 from raes_processor.models import (
     MixedControlControllerStateRuntime,
     MixedControlTransitionRuntime,
@@ -48,6 +48,17 @@ class _BoundControlRequest:
     scoped_key: str
 
 
+@dataclass(frozen=True)
+class PreparedParticipantControlTransition:
+    """Uncommitted RUN-310 transition for composition with RUN-319."""
+
+    next_snapshot: RuntimeSnapshot
+    record: ControlPlaneOperationRecord
+    audit_event: AuditEvent
+    expected_control_head: str | None
+    bound: _BoundControlRequest
+
+
 def record_participant_control(
     control_plane: object,
     *,
@@ -63,31 +74,40 @@ def record_participant_control(
     if identity.target_name is not None and identity.target_name != control_plane.target_name:
         raise PermissionError("participant control identity is not authorized for this target")
     _require_participant_binding(identity, participant_address)
-    bound = _bind_control_request(
-        control_plane,
-        participant_address,
-        intent,
-        identity,
-        idempotency_key,
-    )
-
     with control_plane._participant_control_lock:
+        bound = bind_participant_control_request(
+            control_plane,
+            participant_address,
+            intent,
+            identity,
+            idempotency_key,
+        )
         existing = control_plane._store.find_by_idempotency(bound.scoped_key) if bound.scoped_key else None
         if existing is not None:
             if existing.request_fingerprint != bound.semantic_fingerprint:
                 raise ValueError("Idempotency-Key was reused with different semantics.")
             control_plane._operations[existing.receipt.operation_id] = existing
             return existing.receipt
-        return _record_new_participant_control(
+        prepared = prepare_participant_control_transition(
             control_plane,
             participant_address,
             intent,
             identity,
             bound,
         )
+        control_plane._store.commit_control_transition(
+            participant_address=participant_address,
+            expected_head=prepared.expected_control_head,
+            snapshot=prepared.next_snapshot,
+            record=prepared.record,
+            audit_event=prepared.audit_event,
+        )
+        control_plane._snapshot = prepared.next_snapshot
+        control_plane._operations[prepared.record.receipt.operation_id] = prepared.record
+        return prepared.record.receipt
 
 
-def _bind_control_request(
+def bind_participant_control_request(
     control_plane: object,
     participant_address: str,
     intent: ParticipantControlIntent,
@@ -119,13 +139,13 @@ def _bind_control_request(
     )
 
 
-def _record_new_participant_control(
+def prepare_participant_control_transition(
     control_plane: object,
     participant_address: str,
     intent: ParticipantControlIntent,
     identity: ControlPlaneIdentity,
     bound: _BoundControlRequest,
-) -> OperationReceipt:
+) -> PreparedParticipantControlTransition:
     history = list(control_plane._snapshot.participant_control_history.get(participant_address, ()))
     current_state, current_revision = _fold_controller_state(
         bound.specification,
@@ -183,16 +203,13 @@ def _record_new_participant_control(
         accepted,
         rejection_reason,
     )
-    control_plane._store.commit_control_transition(
-        participant_address=participant_address,
-        expected_head=_history_head(history),
-        snapshot=next_snapshot,
+    return PreparedParticipantControlTransition(
+        next_snapshot=next_snapshot,
         record=record,
         audit_event=audit_event,
+        expected_control_head=_history_head(history),
+        bound=bound,
     )
-    control_plane._snapshot = next_snapshot
-    control_plane._operations[record.receipt.operation_id] = record
-    return record.receipt
 
 
 def _operation_artifacts(
@@ -446,4 +463,9 @@ def _rejection_diagnostic(participant_address: str, reason: str | None) -> Diagn
     )
 
 
-__all__ = ("record_participant_control",)
+__all__ = (
+    "PreparedParticipantControlTransition",
+    "bind_participant_control_request",
+    "prepare_participant_control_transition",
+    "record_participant_control",
+)

--- a/implementations/python/packages/raes_runtime/participant_crossing_action.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_action.py
@@ -1,0 +1,81 @@
+"""Action execution context and durable RUN-319 operation artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import cast
+
+from raes_contracts.runtime_state import OperationState, OperationStatus
+
+from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
+from .participant_crossing_mediation import ParticipantCrossingEvidence, PreparedParticipantCrossing
+
+
+@dataclass(frozen=True)
+class ActionIngressExecution:
+    """Operation target and authenticated crossing context for one action."""
+
+    crossing_evidence: ParticipantCrossingEvidence | None
+    identity: object
+    idempotency_key: str
+    method: Callable[..., object]
+    address: str
+
+
+def action_operation_record(
+    crossing: PreparedParticipantCrossing,
+    result: object,
+) -> ControlPlaneOperationRecord:
+    diagnostics = list(result.diagnostics)
+    receipt = replace(
+        crossing.record.receipt,
+        accepted=bool(result.success),
+        diagnostics=diagnostics,
+    )
+    status = OperationStatus(
+        operation_id=receipt.operation_id,
+        domain=receipt.domain,
+        state=OperationState.SUCCEEDED if result.success else OperationState.FAILED,
+        submitted_at=receipt.submitted_at,
+        updated_at=crossing.audit_event.timestamp,
+        diagnostics=diagnostics,
+        changed_addresses=list(result.changed_addresses),
+    )
+    return cast(
+        ControlPlaneOperationRecord,
+        replace(crossing.record, receipt=receipt, status=status),
+    )
+
+
+def combined_crossing_audit(
+    base: AuditEvent,
+    crossing: PreparedParticipantCrossing,
+    *,
+    action: str,
+    allowed: bool,
+    reason: str | None = None,
+) -> AuditEvent:
+    decision = crossing.decision
+    details = dict(base.details)
+    if decision is not None:
+        details.update(
+            {
+                "crossing_decision_id": decision.occurrence.decision_id,
+                "crossing_decision_cut_ref": decision.occurrence.policy.decision_cut_ref,
+                "crossing_disposition": decision.occurrence.disposition.value,
+            }
+        )
+    return cast(
+        AuditEvent,
+        replace(
+            base,
+            action=action,
+            allowed=allowed,
+            reason=reason or base.reason,
+            details=details,
+        ),
+    )
+
+
+__all__ = ("ActionIngressExecution", "action_operation_record", "combined_crossing_audit")

--- a/implementations/python/packages/raes_runtime/participant_crossing_boundary.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_boundary.py
@@ -1,0 +1,481 @@
+"""Operation-bound RUN-319 participant ingress mediation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import asdict, replace
+
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingDirection,
+    ParticipantCrossingInteractionKind,
+    ParticipantCrossingOperation,
+    ParticipantCrossingSubjectKind,
+    ParticipantCrossingSubjectReferenceModel,
+)
+from raes_contracts.participant_binding import ParticipantActionAdmissionRequest
+from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus
+from raes_processor.models import ParticipantBehaviorRuntime
+
+from .control_plane_execution import apply_authorized_participant_action
+from .control_plane_security import ControlPlaneIdentity
+from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
+from .participant_control_intents import ParticipantControlIntent, ParticipantControlIntentBase
+from .participant_control_mediation import (
+    bind_participant_control_request,
+    prepare_participant_control_transition,
+    record_participant_control,
+)
+from .participant_crossing_mediation import (
+    ParticipantCrossingEvidence,
+    ParticipantCrossingIntent,
+    PreparedParticipantCrossing,
+    commit_prepared_crossing,
+    prepare_participant_crossing,
+)
+from .participant_crossing_records import _expected_history_heads
+
+_CONTROL_INTERACTIONS = {
+    "proposal": ParticipantCrossingInteractionKind.ACTION_PROPOSAL,
+    "approval": ParticipantCrossingInteractionKind.APPROVAL,
+    "denial": ParticipantCrossingInteractionKind.DENIAL,
+    "external-direction": ParticipantCrossingInteractionKind.EXTERNAL_DIRECTION,
+    "intervention": ParticipantCrossingInteractionKind.INTERVENTION,
+    "handoff": ParticipantCrossingInteractionKind.HANDOFF,
+    "override": ParticipantCrossingInteractionKind.OVERRIDE,
+    "cancellation": ParticipantCrossingInteractionKind.CANCELLATION,
+}
+
+
+class ParticipantCrossingControlIngressMixin:
+    """Own one RUN-319 decision and RUN-310 transition under one state cut."""
+
+    def record_participant_control(
+        self,
+        participant_address: str,
+        intent: ParticipantControlIntent,
+        *,
+        identity: object,
+        idempotency_key: str = "",
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
+    ) -> OperationReceipt:
+        if getattr(self, "_crossing_policy_resolver", None) is None:
+            if crossing_evidence is not None:
+                raise ValueError("participant crossing policy resolver is required")
+            return record_participant_control(
+                self,
+                participant_address=participant_address,
+                intent=intent,
+                identity=identity,
+                idempotency_key=idempotency_key,
+            )
+        if crossing_evidence is None:
+            raise ValueError("configured participant ingress requires crossing evidence")
+        if not isinstance(identity, ControlPlaneIdentity):
+            raise PermissionError("participant control requires an authenticated identity")
+        with self._participant_control_lock:
+            bound = bind_participant_control_request(
+                self,
+                participant_address,
+                intent,
+                identity,
+                idempotency_key,
+            )
+            canonical = _control_crossing_intent(
+                participant_address,
+                intent,
+                crossing_evidence,
+                controller_ref=bound.state.controller_address,
+                authority_basis_refs=tuple(bound.state.authority_basis_addresses or bound.state.authority_basis_refs),
+                effective_order=bound.transition.effective_order,
+            )
+            crossing = prepare_participant_crossing(
+                self,
+                canonical,
+                identity=identity,
+                idempotency_key=idempotency_key,
+                incumbent_carrier=intent,
+            )
+            if crossing.existing_receipt is not None:
+                return crossing.existing_receipt
+            if not crossing.record.receipt.accepted:
+                return commit_prepared_crossing(self, crossing)
+
+            governed_intent = _governed_control_intent(self, crossing, intent)
+            governed_bound = bind_participant_control_request(
+                self,
+                participant_address,
+                governed_intent,
+                identity,
+                idempotency_key,
+            )
+            _require_governed_subject(
+                crossing,
+                _control_subject(participant_address, governed_intent),
+            )
+            transition = prepare_participant_control_transition(
+                self,
+                participant_address,
+                governed_intent,
+                identity,
+                governed_bound,
+            )
+            next_snapshot = transition.next_snapshot.with_entries(
+                dict(transition.next_snapshot.entries),
+                participant_crossing_history=crossing.next_snapshot.participant_crossing_history,
+            )
+            record = replace(
+                transition.record,
+                request_fingerprint=crossing.record.request_fingerprint,
+                idempotency_key=crossing.record.idempotency_key,
+                decision_history_heads=crossing.record.decision_history_heads,
+                result_history_heads=_expected_history_heads(next_snapshot, participant_address),
+            )
+            audit = _combined_audit(
+                transition.audit_event,
+                crossing,
+                action="record_participant_control",
+                allowed=record.receipt.accepted,
+            )
+            self._store.commit_participant_transition(
+                expected_history_heads=crossing.expected_history_heads,
+                snapshot=next_snapshot,
+                record=record,
+                audit_event=audit,
+            )
+            self._snapshot = next_snapshot
+            self._operations[record.receipt.operation_id] = record
+            return record.receipt
+
+
+def execute_action_ingress_crossing(
+    control_plane: object,
+    *,
+    participant_behavior: ParticipantBehaviorRuntime,
+    request: ParticipantActionAdmissionRequest,
+    crossing_evidence: ParticipantCrossingEvidence | None,
+    identity: object,
+    idempotency_key: str,
+    method: Callable[..., object],
+    address: str,
+) -> OperationReceipt:
+    """Durably authorize, execute, and finalize one action admission."""
+
+    if crossing_evidence is None:
+        raise ValueError("configured participant ingress requires crossing evidence")
+    if not isinstance(identity, ControlPlaneIdentity):
+        raise PermissionError("participant crossing requires an authenticated identity")
+    with control_plane._participant_control_lock:
+        canonical = _action_crossing_intent(
+            control_plane,
+            participant_behavior,
+            request,
+            crossing_evidence,
+            identity,
+        )
+        crossing = prepare_participant_crossing(
+            control_plane,
+            canonical,
+            identity=identity,
+            idempotency_key=idempotency_key,
+            incumbent_carrier=request,
+        )
+        if crossing.existing_receipt is not None:
+            return crossing.existing_receipt
+        if not crossing.record.receipt.accepted:
+            return commit_prepared_crossing(control_plane, crossing)
+
+        governed_request = _governed_action_request(control_plane, crossing, request)
+        _require_action_binding(participant_behavior, governed_request)
+        _require_governed_subject(crossing, _action_subject(control_plane, governed_request))
+        authorization_record = replace(
+            crossing.record,
+            status=replace(crossing.record.status, state=OperationState.RUNNING),
+        )
+        authorization_audit = _combined_audit(
+            crossing.audit_event,
+            crossing,
+            action="authorize_participant_action",
+            allowed=True,
+            reason="authorized",
+        )
+        control_plane._store.commit_participant_transition(
+            expected_history_heads=crossing.expected_history_heads,
+            snapshot=crossing.next_snapshot,
+            record=authorization_record,
+            audit_event=authorization_audit,
+        )
+        control_plane._snapshot = crossing.next_snapshot
+        control_plane._operations[authorization_record.receipt.operation_id] = authorization_record
+
+        result = apply_authorized_participant_action(
+            method=method,
+            request=governed_request,
+            snapshot=control_plane._snapshot,
+            address=address,
+        )
+        next_snapshot = result.snapshot.with_entries(
+            dict(result.snapshot.entries),
+            participant_crossing_history=crossing.next_snapshot.participant_crossing_history,
+        )
+        record = replace(
+            _action_operation_record(crossing, result),
+            result_history_heads=_expected_history_heads(next_snapshot, request.participant_address),
+        )
+        audit = _combined_audit(
+            crossing.audit_event,
+            crossing,
+            action="admit_participant_action",
+            allowed=result.success,
+            reason="accepted" if result.success else "backend-admission-failed",
+        )
+        control_plane._store.commit_participant_transition(
+            expected_history_heads=crossing.record.result_history_heads,
+            snapshot=next_snapshot,
+            record=record,
+            audit_event=audit,
+        )
+        control_plane._snapshot = next_snapshot
+        control_plane._operations[record.receipt.operation_id] = record
+        return record.receipt
+
+
+def _control_crossing_intent(
+    participant_address: str,
+    control_intent: ParticipantControlIntent,
+    evidence: ParticipantCrossingEvidence,
+    *,
+    controller_ref: str,
+    authority_basis_refs: tuple[str, ...],
+    effective_order: int,
+) -> ParticipantCrossingIntent:
+    return ParticipantCrossingIntent.model_validate(
+        {
+            **evidence.model_dump(mode="json"),
+            "participant_address": participant_address,
+            "episode_id": control_intent.episode_id,
+            "direction": ParticipantCrossingDirection.INGRESS,
+            "interaction_kind": _CONTROL_INTERACTIONS[control_intent.kind],
+            "subject": _control_subject(participant_address, control_intent),
+            "controller_ref": controller_ref,
+            "authority_basis_refs": list(authority_basis_refs),
+            "requested_operation": ParticipantCrossingOperation.ADMISSION,
+            "action_or_projection_ref": _control_operation_ref(participant_address, control_intent),
+            "effective_order": effective_order,
+            "order_model": "logical_clock",
+        },
+    )
+
+
+def _action_crossing_intent(
+    control_plane: object,
+    behavior: ParticipantBehaviorRuntime,
+    request: ParticipantActionAdmissionRequest,
+    evidence: ParticipantCrossingEvidence,
+    identity: ControlPlaneIdentity,
+) -> ParticipantCrossingIntent:
+    episode_id = _action_episode_id(control_plane, request)
+    controller_refs = {
+        binding.controller_ref
+        for binding in identity.participant_control_subjects
+        if binding.participant_address == request.participant_address
+    }
+    if len(controller_refs) > 1:
+        raise PermissionError("participant action requires one exact controller binding")
+    controller_ref = next(iter(controller_refs), "runtime.unbound-participant-controller")
+    interaction = (
+        ParticipantCrossingInteractionKind.CANDIDATE_SELECTION
+        if request.validated_selection is not None
+        else ParticipantCrossingInteractionKind.ACTION_PROPOSAL
+    )
+    authority_basis_refs = tuple(behavior.authority_anchor_addresses or behavior.authority_anchor_refs)
+    if not authority_basis_refs:
+        raise ValueError("participant action crossing requires compiled authority anchors")
+    return ParticipantCrossingIntent.model_validate(
+        {
+            **evidence.model_dump(mode="json"),
+            "participant_address": request.participant_address,
+            "episode_id": episode_id,
+            "direction": ParticipantCrossingDirection.INGRESS,
+            "interaction_kind": interaction,
+            "subject": _action_subject(control_plane, request),
+            "controller_ref": controller_ref,
+            "authority_basis_refs": list(authority_basis_refs),
+            "requested_operation": ParticipantCrossingOperation.ADMISSION,
+            "action_or_projection_ref": request.action_contract_address,
+            "effective_order": _next_effective_order(control_plane, request.participant_address),
+            "order_model": "logical_clock",
+        },
+    )
+
+
+def _control_subject(
+    participant_address: str,
+    intent: ParticipantControlIntent,
+) -> ParticipantCrossingSubjectReferenceModel:
+    payload = intent.model_dump(mode="json")
+    return ParticipantCrossingSubjectReferenceModel(
+        subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_CONTROL_OCCURRENCE,
+        contract_id="participant-control-intent-v1",
+        subject_ref=f"participant-control-intent:{participant_address}:{intent.client_correlation_id}",
+        subject_digest=_digest(payload),
+        participant_address=participant_address,
+        episode_id=intent.episode_id,
+    )
+
+
+def _action_subject(
+    control_plane: object,
+    request: ParticipantActionAdmissionRequest,
+) -> ParticipantCrossingSubjectReferenceModel:
+    episode_id = _action_episode_id(control_plane, request)
+    return ParticipantCrossingSubjectReferenceModel(
+        subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_ACTION_ADMISSION,
+        contract_id="participant-action-admission-v1",
+        subject_ref=(
+            f"participant-action-admission:{request.participant_address}:{episode_id}:{request.action_instance_id}"
+        ),
+        subject_digest=_digest(asdict(request)),
+        participant_address=request.participant_address,
+        episode_id=episode_id,
+    )
+
+
+def _action_episode_id(control_plane: object, request: ParticipantActionAdmissionRequest) -> str:
+    if request.action_result is not None:
+        return request.action_result.episode_id
+    state = control_plane._snapshot.participant_episode_results.get(request.participant_address, {})
+    value = state.get("episode_id")
+    if not isinstance(value, str) or not value:
+        raise ValueError("participant action crossing requires an active episode identity")
+    return value
+
+
+def _control_operation_ref(participant_address: str, intent: ParticipantControlIntent) -> str:
+    if intent.kind == "proposal":
+        return intent.action_contract_ref
+    return _control_subject(participant_address, intent).subject_ref
+
+
+def _next_effective_order(control_plane: object, participant_address: str) -> int:
+    histories = (
+        control_plane._snapshot.participant_behavior_history,
+        control_plane._snapshot.participant_control_history,
+        control_plane._snapshot.participant_crossing_history,
+    )
+    return sum(len(history.get(participant_address, ())) for history in histories) + 1
+
+
+def _digest(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _governed_control_intent(
+    control_plane: object,
+    crossing: PreparedParticipantCrossing,
+    incumbent: ParticipantControlIntent,
+) -> ParticipantControlIntent:
+    if crossing.governed_subject == crossing.intent.subject:
+        return incumbent
+    transformer = getattr(control_plane._crossing_policy_resolver, "transform_ingress", None)
+    if not callable(transformer):
+        raise ValueError("transformed participant ingress requires a trusted carrier transformer")
+    governed = transformer(crossing.intent, crossing.governed_subject, incumbent)
+    if not isinstance(governed, ParticipantControlIntentBase):
+        raise ValueError("participant control transformation returned an invalid governed carrier")
+    return governed
+
+
+def _governed_action_request(
+    control_plane: object,
+    crossing: PreparedParticipantCrossing,
+    incumbent: ParticipantActionAdmissionRequest,
+) -> ParticipantActionAdmissionRequest:
+    if crossing.governed_subject == crossing.intent.subject:
+        return incumbent
+    transformer = getattr(control_plane._crossing_policy_resolver, "transform_ingress", None)
+    if not callable(transformer):
+        raise ValueError("transformed participant ingress requires a trusted carrier transformer")
+    governed = transformer(crossing.intent, crossing.governed_subject, incumbent)
+    if not isinstance(governed, ParticipantActionAdmissionRequest):
+        raise ValueError("participant action transformation returned an invalid governed carrier")
+    return governed
+
+
+def _require_governed_subject(
+    crossing: PreparedParticipantCrossing,
+    actual: ParticipantCrossingSubjectReferenceModel,
+) -> None:
+    if actual != crossing.governed_subject:
+        raise ValueError("trusted transformation result does not match the governed carrier identity")
+
+
+def _require_action_binding(
+    behavior: ParticipantBehaviorRuntime,
+    request: ParticipantActionAdmissionRequest,
+) -> None:
+    if request.participant_address != behavior.address:
+        raise ValueError("governed action participant does not match the compiled behavior")
+    if request.action_contract_address not in behavior.action_contract_addresses:
+        raise ValueError("governed action is not declared by the compiled participant behavior")
+    if request.observation_boundary_address not in behavior.observation_boundary_addresses:
+        raise ValueError("governed observation boundary is not declared by the compiled participant behavior")
+
+
+def _action_operation_record(
+    crossing: PreparedParticipantCrossing,
+    result: object,
+) -> ControlPlaneOperationRecord:
+    diagnostics = list(result.diagnostics)
+    receipt = replace(
+        crossing.record.receipt,
+        accepted=bool(result.success),
+        diagnostics=diagnostics,
+    )
+    status = OperationStatus(
+        operation_id=receipt.operation_id,
+        domain=receipt.domain,
+        state=OperationState.SUCCEEDED if result.success else OperationState.FAILED,
+        submitted_at=receipt.submitted_at,
+        updated_at=crossing.audit_event.timestamp,
+        diagnostics=diagnostics,
+        changed_addresses=list(result.changed_addresses),
+    )
+    return replace(crossing.record, receipt=receipt, status=status)
+
+
+def _combined_audit(
+    base: AuditEvent,
+    crossing: PreparedParticipantCrossing,
+    *,
+    action: str,
+    allowed: bool,
+    reason: str | None = None,
+) -> AuditEvent:
+    decision = crossing.decision
+    details = dict(base.details)
+    if decision is not None:
+        details.update(
+            {
+                "crossing_decision_id": decision.occurrence.decision_id,
+                "crossing_decision_cut_ref": decision.occurrence.policy.decision_cut_ref,
+                "crossing_disposition": decision.occurrence.disposition.value,
+            }
+        )
+    return replace(
+        base,
+        action=action,
+        allowed=allowed,
+        reason=reason or base.reason,
+        details=details,
+    )
+
+
+__all__ = (
+    "ParticipantCrossingControlIngressMixin",
+    "ParticipantCrossingEvidence",
+    "ParticipantCrossingIntent",
+    "execute_action_ingress_crossing",
+)

--- a/implementations/python/packages/raes_runtime/participant_crossing_boundary.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_boundary.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable
 from dataclasses import asdict, replace
 
 from raes_contracts.contracts.participant_crossing import (
@@ -15,17 +14,21 @@ from raes_contracts.contracts.participant_crossing import (
     ParticipantCrossingSubjectReferenceModel,
 )
 from raes_contracts.participant_binding import ParticipantActionAdmissionRequest
-from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus
+from raes_contracts.runtime_state import OperationReceipt, OperationState
 from raes_processor.models import ParticipantBehaviorRuntime
 
 from .control_plane_execution import apply_authorized_participant_action
 from .control_plane_security import ControlPlaneIdentity
-from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
 from .participant_control_intents import ParticipantControlIntent, ParticipantControlIntentBase
 from .participant_control_mediation import (
     bind_participant_control_request,
     prepare_participant_control_transition,
     record_participant_control,
+)
+from .participant_crossing_action import (
+    ActionIngressExecution,
+    action_operation_record,
+    combined_crossing_audit,
 )
 from .participant_crossing_mediation import (
     ParticipantCrossingEvidence,
@@ -63,13 +66,32 @@ class ParticipantCrossingControlIngressMixin:
         if getattr(self, "_crossing_policy_resolver", None) is None:
             if crossing_evidence is not None:
                 raise ValueError("participant crossing policy resolver is required")
-            return record_participant_control(
+            receipt = record_participant_control(
                 self,
                 participant_address=participant_address,
                 intent=intent,
                 identity=identity,
                 idempotency_key=idempotency_key,
             )
+        else:
+            receipt = self._record_governed_participant_control(
+                participant_address,
+                intent,
+                identity=identity,
+                idempotency_key=idempotency_key,
+                crossing_evidence=crossing_evidence,
+            )
+        return receipt
+
+    def _record_governed_participant_control(
+        self,
+        participant_address: str,
+        intent: ParticipantControlIntent,
+        *,
+        identity: object,
+        idempotency_key: str,
+        crossing_evidence: ParticipantCrossingEvidence | None,
+    ) -> OperationReceipt:
         if crossing_evidence is None:
             raise ValueError("configured participant ingress requires crossing evidence")
         if not isinstance(identity, ControlPlaneIdentity):
@@ -132,7 +154,7 @@ class ParticipantCrossingControlIngressMixin:
                 decision_history_heads=crossing.record.decision_history_heads,
                 result_history_heads=_expected_history_heads(next_snapshot, participant_address),
             )
-            audit = _combined_audit(
+            audit = combined_crossing_audit(
                 transition.audit_event,
                 crossing,
                 action="record_participant_control",
@@ -151,34 +173,29 @@ class ParticipantCrossingControlIngressMixin:
 
 def execute_action_ingress_crossing(
     control_plane: object,
-    *,
     participant_behavior: ParticipantBehaviorRuntime,
     request: ParticipantActionAdmissionRequest,
-    crossing_evidence: ParticipantCrossingEvidence | None,
-    identity: object,
-    idempotency_key: str,
-    method: Callable[..., object],
-    address: str,
+    execution: ActionIngressExecution,
 ) -> OperationReceipt:
     """Durably authorize, execute, and finalize one action admission."""
 
-    if crossing_evidence is None:
+    if execution.crossing_evidence is None:
         raise ValueError("configured participant ingress requires crossing evidence")
-    if not isinstance(identity, ControlPlaneIdentity):
+    if not isinstance(execution.identity, ControlPlaneIdentity):
         raise PermissionError("participant crossing requires an authenticated identity")
     with control_plane._participant_control_lock:
         canonical = _action_crossing_intent(
             control_plane,
             participant_behavior,
             request,
-            crossing_evidence,
-            identity,
+            execution.crossing_evidence,
+            execution.identity,
         )
         crossing = prepare_participant_crossing(
             control_plane,
             canonical,
-            identity=identity,
-            idempotency_key=idempotency_key,
+            identity=execution.identity,
+            idempotency_key=execution.idempotency_key,
             incumbent_carrier=request,
         )
         if crossing.existing_receipt is not None:
@@ -193,7 +210,7 @@ def execute_action_ingress_crossing(
             crossing.record,
             status=replace(crossing.record.status, state=OperationState.RUNNING),
         )
-        authorization_audit = _combined_audit(
+        authorization_audit = combined_crossing_audit(
             crossing.audit_event,
             crossing,
             action="authorize_participant_action",
@@ -210,20 +227,20 @@ def execute_action_ingress_crossing(
         control_plane._operations[authorization_record.receipt.operation_id] = authorization_record
 
         result = apply_authorized_participant_action(
-            method=method,
+            method=execution.method,
             request=governed_request,
             snapshot=control_plane._snapshot,
-            address=address,
+            address=execution.address,
         )
         next_snapshot = result.snapshot.with_entries(
             dict(result.snapshot.entries),
             participant_crossing_history=crossing.next_snapshot.participant_crossing_history,
         )
         record = replace(
-            _action_operation_record(crossing, result),
+            action_operation_record(crossing, result),
             result_history_heads=_expected_history_heads(next_snapshot, request.participant_address),
         )
-        audit = _combined_audit(
+        audit = combined_crossing_audit(
             crossing.audit_event,
             crossing,
             action="admit_participant_action",
@@ -422,55 +439,6 @@ def _require_action_binding(
         raise ValueError("governed action is not declared by the compiled participant behavior")
     if request.observation_boundary_address not in behavior.observation_boundary_addresses:
         raise ValueError("governed observation boundary is not declared by the compiled participant behavior")
-
-
-def _action_operation_record(
-    crossing: PreparedParticipantCrossing,
-    result: object,
-) -> ControlPlaneOperationRecord:
-    diagnostics = list(result.diagnostics)
-    receipt = replace(
-        crossing.record.receipt,
-        accepted=bool(result.success),
-        diagnostics=diagnostics,
-    )
-    status = OperationStatus(
-        operation_id=receipt.operation_id,
-        domain=receipt.domain,
-        state=OperationState.SUCCEEDED if result.success else OperationState.FAILED,
-        submitted_at=receipt.submitted_at,
-        updated_at=crossing.audit_event.timestamp,
-        diagnostics=diagnostics,
-        changed_addresses=list(result.changed_addresses),
-    )
-    return replace(crossing.record, receipt=receipt, status=status)
-
-
-def _combined_audit(
-    base: AuditEvent,
-    crossing: PreparedParticipantCrossing,
-    *,
-    action: str,
-    allowed: bool,
-    reason: str | None = None,
-) -> AuditEvent:
-    decision = crossing.decision
-    details = dict(base.details)
-    if decision is not None:
-        details.update(
-            {
-                "crossing_decision_id": decision.occurrence.decision_id,
-                "crossing_decision_cut_ref": decision.occurrence.policy.decision_cut_ref,
-                "crossing_disposition": decision.occurrence.disposition.value,
-            }
-        )
-    return replace(
-        base,
-        action=action,
-        allowed=allowed,
-        reason=reason or base.reason,
-        details=details,
-    )
 
 
 __all__ = (

--- a/implementations/python/packages/raes_runtime/participant_crossing_egress.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_egress.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import replace
-from typing import TypeVar
+from dataclasses import dataclass, replace
+from typing import TypeVar, cast
 
 from raes_contracts.contracts.base import ContractModel
 from raes_contracts.contracts.participant_crossing import (
@@ -19,6 +19,7 @@ from raes_contracts.contracts.participant_crossing import (
 from .participant_crossing_mediation import (
     ParticipantCrossingEvidence,
     ParticipantCrossingIntent,
+    PreparedParticipantCrossing,
     commit_prepared_crossing,
     prepare_participant_crossing,
 )
@@ -26,51 +27,57 @@ from .participant_crossing_mediation import (
 _ViewT = TypeVar("_ViewT", bound=ContractModel)
 
 
+@dataclass(frozen=True)
+class ParticipantViewSerialization:
+    """Exact projection and authorization context for one egress operation."""
+
+    participant_address: str
+    episode_id: str
+    subject_kind: ParticipantCrossingSubjectKind
+    interaction_kind: ParticipantCrossingInteractionKind
+    projection_ref: str
+    identity: object
+    crossing_evidence: ParticipantCrossingEvidence | None
+    idempotency_key: str
+
+
 def serialize_participant_view(
     control_plane: object,
     view: _ViewT,
-    *,
-    participant_address: str,
-    episode_id: str,
-    subject_kind: ParticipantCrossingSubjectKind,
-    interaction_kind: ParticipantCrossingInteractionKind,
-    projection_ref: str,
-    identity: object,
-    crossing_evidence: ParticipantCrossingEvidence | None,
-    idempotency_key: str,
+    serialization: ParticipantViewSerialization,
 ) -> _ViewT:
     """Return a view only after its exact governed projection is committed."""
 
-    if crossing_evidence is None:
+    if serialization.crossing_evidence is None:
         raise ValueError("configured participant egress requires crossing evidence")
     with control_plane._participant_control_lock:
         subject = _view_subject(
             view,
-            participant_address=participant_address,
-            episode_id=episode_id,
-            subject_kind=subject_kind,
+            participant_address=serialization.participant_address,
+            episode_id=serialization.episode_id,
+            subject_kind=serialization.subject_kind,
         )
         canonical = ParticipantCrossingIntent.model_validate(
             {
-                **crossing_evidence.model_dump(mode="json"),
-                "participant_address": participant_address,
-                "episode_id": episode_id,
+                **serialization.crossing_evidence.model_dump(mode="json"),
+                "participant_address": serialization.participant_address,
+                "episode_id": serialization.episode_id,
                 "direction": ParticipantCrossingDirection.EGRESS,
-                "interaction_kind": interaction_kind,
+                "interaction_kind": serialization.interaction_kind,
                 "subject": subject,
                 "controller_ref": "runtime.control-plane.participant-retrieval",
                 "authority_basis_refs": ["runtime.authority:participant-projection"],
                 "requested_operation": ParticipantCrossingOperation.PROJECTION,
-                "action_or_projection_ref": projection_ref,
-                "effective_order": _next_effective_order(control_plane, participant_address),
+                "action_or_projection_ref": serialization.projection_ref,
+                "effective_order": _next_effective_order(control_plane, serialization.participant_address),
                 "order_model": "logical_clock",
             },
         )
         prepared = prepare_participant_crossing(
             control_plane,
             canonical,
-            identity=identity,
-            idempotency_key=idempotency_key,
+            identity=serialization.identity,
+            idempotency_key=serialization.idempotency_key,
             incumbent_carrier=view,
         )
         if prepared.existing_receipt is not None:
@@ -94,17 +101,20 @@ def serialize_participant_view(
             governed = candidate
             actual = _view_subject(
                 governed,
-                participant_address=participant_address,
-                episode_id=episode_id,
+                participant_address=serialization.participant_address,
+                episode_id=serialization.episode_id,
                 subject_kind=prepared.governed_subject.subject_kind,
             )
             if actual != prepared.governed_subject:
                 raise ValueError("trusted egress transformation does not match its governed identity")
-        prepared = replace(
-            prepared,
-            record=replace(
-                prepared.record,
-                result_payload=governed.model_dump(mode="json"),
+        prepared = cast(
+            PreparedParticipantCrossing,
+            replace(
+                prepared,
+                record=replace(
+                    prepared.record,
+                    result_payload=governed.model_dump(mode="json"),
+                ),
             ),
         )
         commit_prepared_crossing(control_plane, prepared)
@@ -143,4 +153,4 @@ def _next_effective_order(control_plane: object, participant_address: str) -> in
     return sum(len(history.get(participant_address, ())) for history in histories) + 1
 
 
-__all__ = ("serialize_participant_view",)
+__all__ = ("ParticipantViewSerialization", "serialize_participant_view")

--- a/implementations/python/packages/raes_runtime/participant_crossing_egress.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_egress.py
@@ -1,0 +1,146 @@
+"""Atomic RUN-319 mediation for participant retrieval serialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from typing import TypeVar
+
+from raes_contracts.contracts.base import ContractModel
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingDirection,
+    ParticipantCrossingInteractionKind,
+    ParticipantCrossingOperation,
+    ParticipantCrossingSubjectKind,
+    ParticipantCrossingSubjectReferenceModel,
+)
+
+from .participant_crossing_mediation import (
+    ParticipantCrossingEvidence,
+    ParticipantCrossingIntent,
+    commit_prepared_crossing,
+    prepare_participant_crossing,
+)
+
+_ViewT = TypeVar("_ViewT", bound=ContractModel)
+
+
+def serialize_participant_view(
+    control_plane: object,
+    view: _ViewT,
+    *,
+    participant_address: str,
+    episode_id: str,
+    subject_kind: ParticipantCrossingSubjectKind,
+    interaction_kind: ParticipantCrossingInteractionKind,
+    projection_ref: str,
+    identity: object,
+    crossing_evidence: ParticipantCrossingEvidence | None,
+    idempotency_key: str,
+) -> _ViewT:
+    """Return a view only after its exact governed projection is committed."""
+
+    if crossing_evidence is None:
+        raise ValueError("configured participant egress requires crossing evidence")
+    with control_plane._participant_control_lock:
+        subject = _view_subject(
+            view,
+            participant_address=participant_address,
+            episode_id=episode_id,
+            subject_kind=subject_kind,
+        )
+        canonical = ParticipantCrossingIntent.model_validate(
+            {
+                **crossing_evidence.model_dump(mode="json"),
+                "participant_address": participant_address,
+                "episode_id": episode_id,
+                "direction": ParticipantCrossingDirection.EGRESS,
+                "interaction_kind": interaction_kind,
+                "subject": subject,
+                "controller_ref": "runtime.control-plane.participant-retrieval",
+                "authority_basis_refs": ["runtime.authority:participant-projection"],
+                "requested_operation": ParticipantCrossingOperation.PROJECTION,
+                "action_or_projection_ref": projection_ref,
+                "effective_order": _next_effective_order(control_plane, participant_address),
+                "order_model": "logical_clock",
+            },
+        )
+        prepared = prepare_participant_crossing(
+            control_plane,
+            canonical,
+            identity=identity,
+            idempotency_key=idempotency_key,
+            incumbent_carrier=view,
+        )
+        if prepared.existing_receipt is not None:
+            if not prepared.existing_receipt.accepted:
+                raise PermissionError("participant projection was not permitted")
+            if prepared.record.result_payload is None:
+                raise ValueError("idempotent participant projection is missing its governed result")
+            return type(view).model_validate(prepared.record.result_payload)
+        if not prepared.record.receipt.accepted:
+            commit_prepared_crossing(control_plane, prepared)
+            raise PermissionError("participant projection was not permitted")
+
+        governed = view
+        if prepared.governed_subject != subject:
+            transformer = getattr(control_plane._crossing_policy_resolver, "transform_egress", None)
+            if not callable(transformer):
+                raise ValueError("transformed participant egress requires a trusted view transformer")
+            candidate = transformer(prepared.intent, prepared.governed_subject, view)
+            if not isinstance(candidate, type(view)):
+                raise ValueError("participant egress transformation returned an invalid governed view")
+            governed = candidate
+            actual = _view_subject(
+                governed,
+                participant_address=participant_address,
+                episode_id=episode_id,
+                subject_kind=prepared.governed_subject.subject_kind,
+            )
+            if actual != prepared.governed_subject:
+                raise ValueError("trusted egress transformation does not match its governed identity")
+        prepared = replace(
+            prepared,
+            record=replace(
+                prepared.record,
+                result_payload=governed.model_dump(mode="json"),
+            ),
+        )
+        commit_prepared_crossing(control_plane, prepared)
+        return governed
+
+
+def _view_subject(
+    view: ContractModel,
+    *,
+    participant_address: str,
+    episode_id: str,
+    subject_kind: ParticipantCrossingSubjectKind,
+) -> ParticipantCrossingSubjectReferenceModel:
+    payload = view.model_dump(mode="json")
+    payload.pop("generated_at", None)
+    view_ref = payload.get("view_id")
+    if not isinstance(view_ref, str) or not view_ref:
+        raise ValueError("participant projection requires an exact view identity")
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return ParticipantCrossingSubjectReferenceModel(
+        subject_kind=subject_kind,
+        contract_id=f"{subject_kind.value}-v1",
+        subject_ref=view_ref,
+        subject_digest=f"sha256:{hashlib.sha256(encoded).hexdigest()}",
+        participant_address=participant_address,
+        episode_id=episode_id,
+    )
+
+
+def _next_effective_order(control_plane: object, participant_address: str) -> int:
+    histories = (
+        control_plane._snapshot.participant_behavior_history,
+        control_plane._snapshot.participant_control_history,
+        control_plane._snapshot.participant_crossing_history,
+    )
+    return sum(len(history.get(participant_address, ())) for history in histories) + 1
+
+
+__all__ = ("serialize_participant_view",)

--- a/implementations/python/packages/raes_runtime/participant_crossing_mediation.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_mediation.py
@@ -1,0 +1,430 @@
+"""RUN-319 operation-bound mediation types and transaction preparation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import uuid4
+
+from pydantic import Field
+from raes_contracts.contracts.base import ContractModel, NonEmptyString
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingDecisionDisposition,
+    ParticipantCrossingDirection,
+    ParticipantCrossingGateDisposition,
+    ParticipantCrossingInteractionKind,
+    ParticipantCrossingOccurrenceModel,
+    ParticipantCrossingOperation,
+    ParticipantCrossingPolicyReferenceModel,
+    ParticipantCrossingSubjectReferenceModel,
+)
+from raes_contracts.contracts.participant_crossing_validation import (
+    validate_participant_crossing_occurrence_context,
+)
+from raes_contracts.contracts.participant_runtime import ParticipantRuntimeOrderingBasis
+from raes_contracts.diagnostics import Diagnostic
+from raes_contracts.planning import RuntimeDomain
+from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus, RuntimeSnapshot
+from raes_contracts.vocabulary import ParticipantFeatureSupportLevel
+
+from .control_plane_security import ControlPlaneIdentity
+from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+class ParticipantCrossingIntent(ContractModel):
+    """Trusted operation-bound intent; policy gates and outcomes are runtime-owned."""
+
+    participant_address: NonEmptyString
+    episode_id: NonEmptyString
+    direction: ParticipantCrossingDirection
+    interaction_kind: ParticipantCrossingInteractionKind
+    audience_scope_ref: NonEmptyString
+    subject: ParticipantCrossingSubjectReferenceModel
+    controller_ref: NonEmptyString
+    authority_basis_refs: list[NonEmptyString] = Field(min_length=1)
+    requested_operation: ParticipantCrossingOperation
+    action_or_projection_ref: NonEmptyString
+    required_evidence_refs: list[NonEmptyString] = Field(min_length=1)
+    effective_order: int = Field(ge=0)
+    order_model: ParticipantRuntimeOrderingBasis
+    provenance_refs: list[NonEmptyString] = Field(min_length=1)
+    evidence_refs: list[NonEmptyString] = Field(min_length=1)
+    object_marking_refs: list[NonEmptyString] = Field(min_length=1)
+    authorization_scope: NonEmptyString
+    loss_and_limitations: list[NonEmptyString] = Field(min_length=1)
+
+
+class ParticipantCrossingEvidence(ContractModel):
+    """Caller-owned evidence metadata with no incumbent-operation coordinates."""
+
+    audience_scope_ref: NonEmptyString
+    required_evidence_refs: list[NonEmptyString] = Field(min_length=1)
+    provenance_refs: list[NonEmptyString] = Field(min_length=1)
+    evidence_refs: list[NonEmptyString] = Field(min_length=1)
+    object_marking_refs: list[NonEmptyString] = Field(min_length=1)
+    authorization_scope: NonEmptyString
+    loss_and_limitations: list[NonEmptyString] = Field(min_length=1)
+
+
+@dataclass(frozen=True)
+class ParticipantCrossingSemanticGates:
+    """Trusted semantic gate results excluding runtime-owned identity/capability gates."""
+
+    participant_authority: ParticipantCrossingGateDisposition
+    action_admission: ParticipantCrossingGateDisposition
+    visibility: ParticipantCrossingGateDisposition
+    marking_authorization: ParticipantCrossingGateDisposition
+    declassification: ParticipantCrossingGateDisposition
+    transformation_validity: ParticipantCrossingGateDisposition
+
+
+@dataclass(frozen=True)
+class ParticipantCrossingPolicyResolution:
+    """One trusted exact-cut policy resolution."""
+
+    policy: ParticipantCrossingPolicyReferenceModel
+    gates: ParticipantCrossingSemanticGates
+    reason_code: str
+    required_operation: ParticipantCrossingOperation | None = None
+    required_support_level: ParticipantFeatureSupportLevel = ParticipantFeatureSupportLevel.EXACT
+    allowed_downgrades: dict[str, ParticipantFeatureSupportLevel] = field(default_factory=dict)
+    downgrade_policy_ref: str | None = None
+    downgrade_provenance_ref: str | None = None
+    transformation: ParticipantCrossingTransformationResolution | None = None
+
+
+@dataclass(frozen=True)
+class ParticipantCrossingTransformationResolution:
+    """Trusted non-mutating result of one governed crossing transformation."""
+
+    result_subject: ParticipantCrossingSubjectReferenceModel
+    rule_ref: str
+    rule_revision: str
+    result_marking_refs: tuple[str, ...]
+    declassification_basis_ref: str | None = None
+    losses: tuple[dict[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class ParticipantCrossingValidationContext:
+    """Trusted indexes needed by API-423 cross-record validation."""
+
+    known_subjects: tuple[ParticipantCrossingSubjectReferenceModel, ...]
+    policies: tuple[ParticipantCrossingPolicyReferenceModel, ...]
+    known_evidence_refs: frozenset[str]
+    known_authority_basis_refs: frozenset[str]
+
+
+class ParticipantCrossingPolicyResolver(Protocol):
+    """Resolve current policy and historical validation context from trusted state."""
+
+    def resolve(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantCrossingPolicyResolution: ...
+
+    def validation_context(
+        self,
+        snapshot: RuntimeSnapshot,
+        participant_address: str,
+    ) -> ParticipantCrossingValidationContext: ...
+
+
+@dataclass(frozen=True)
+class PreparedParticipantCrossing:
+    """Uncommitted crossing decision bound to one exact runtime state cut."""
+
+    intent: ParticipantCrossingIntent
+    identity: ControlPlaneIdentity
+    next_snapshot: RuntimeSnapshot
+    expected_history_heads: dict[str, str | None]
+    record: ControlPlaneOperationRecord
+    audit_event: AuditEvent
+    decision: ParticipantCrossingOccurrenceModel | None
+    disposition: ParticipantCrossingDecisionDisposition | None
+    governed_subject: ParticipantCrossingSubjectReferenceModel
+    existing_receipt: OperationReceipt | None = None
+
+
+def prepare_participant_crossing(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    *,
+    identity: object,
+    idempotency_key: str,
+    incumbent_carrier: object | None = None,
+) -> PreparedParticipantCrossing:
+    """Resolve one crossing without releasing the owning operation boundary."""
+
+    from .participant_crossing_policy import (
+        _applicable_semantic_gates,
+        _decision_disposition,
+        _decision_gates,
+        _require_crossing_identity,
+        _resolve_backend_support,
+    )
+    from .participant_crossing_records import (
+        _expected_history_heads,
+        _prepare_crossing_decision,
+        _scoped_idempotency_key,
+        _semantic_fingerprint,
+    )
+
+    authenticated = _require_crossing_identity(control_plane, intent, identity)
+    resolver = getattr(control_plane, "_crossing_policy_resolver", None)
+    if resolver is None:
+        raise ValueError("participant crossing policy resolver is required")
+    expected_heads = _expected_history_heads(control_plane._snapshot, intent.participant_address)
+    scoped_key = _scoped_idempotency_key(
+        control_plane,
+        intent,
+        authenticated,
+        idempotency_key,
+    )
+    existing = control_plane._store.find_by_idempotency(scoped_key) if scoped_key else None
+    fingerprint_heads = expected_heads
+    if existing is not None:
+        _require_replay_state_cut(existing, expected_heads)
+        fingerprint_heads = existing.decision_history_heads
+    try:
+        operation_resolver = getattr(resolver, "resolve_operation", None)
+        resolution = (
+            operation_resolver(intent, control_plane._snapshot, incumbent_carrier)
+            if callable(operation_resolver)
+            else resolver.resolve(intent, control_plane._snapshot)
+        )
+    except (TypeError, ValueError):
+        return _prepare_policy_unresolved(
+            control_plane,
+            intent,
+            authenticated,
+            idempotency_key,
+            expected_heads=expected_heads,
+            scoped_key=scoped_key,
+            existing=existing,
+        )
+    support = _resolve_backend_support(control_plane, intent, resolution)
+    gates = _decision_gates(_applicable_semantic_gates(intent, resolution), support.gate)
+    disposition = _decision_disposition(gates, resolution)
+    semantic_fingerprint = _semantic_fingerprint(
+        control_plane,
+        intent,
+        authenticated,
+        resolution,
+        support,
+        fingerprint_heads,
+    )
+    if existing is not None:
+        if existing.request_fingerprint != semantic_fingerprint:
+            raise ValueError("Idempotency-Key was reused with different semantics.")
+        control_plane._operations[existing.receipt.operation_id] = existing
+        return _existing_preparation(
+            control_plane,
+            intent,
+            authenticated,
+            expected_heads,
+            existing,
+        )
+    return _prepare_crossing_decision(
+        control_plane,
+        intent,
+        authenticated,
+        resolution,
+        support,
+        gates,
+        disposition,
+        expected_heads,
+        semantic_fingerprint,
+        scoped_key,
+    )
+
+
+def _existing_preparation(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    expected_heads: dict[str, str | None],
+    existing: ControlPlaneOperationRecord,
+) -> PreparedParticipantCrossing:
+    return PreparedParticipantCrossing(
+        intent=intent,
+        identity=identity,
+        next_snapshot=control_plane._snapshot,
+        expected_history_heads=expected_heads,
+        record=existing,
+        audit_event=AuditEvent(
+            timestamp=existing.status.updated_at,
+            action="participant_crossing_replay",
+            identity=identity.identity,
+            allowed=existing.receipt.accepted,
+            target=intent.participant_address,
+            operation_id=existing.receipt.operation_id,
+            reason="idempotent-replay",
+        ),
+        decision=None,
+        disposition=None,
+        governed_subject=intent.subject,
+        existing_receipt=existing.receipt,
+    )
+
+
+def commit_prepared_crossing(
+    control_plane: object,
+    prepared: PreparedParticipantCrossing,
+) -> OperationReceipt:
+    """Commit a denied or unresolved crossing when no incumbent operation may run."""
+
+    if prepared.existing_receipt is not None:
+        return prepared.existing_receipt
+    control_plane._store.commit_participant_transition(
+        expected_history_heads=prepared.expected_history_heads,
+        snapshot=prepared.next_snapshot,
+        record=prepared.record,
+        audit_event=prepared.audit_event,
+    )
+    control_plane._snapshot = prepared.next_snapshot
+    control_plane._operations[prepared.record.receipt.operation_id] = prepared.record
+    return prepared.record.receipt
+
+
+def _prepare_policy_unresolved(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    idempotency_key: str,
+    *,
+    expected_heads: dict[str, str | None],
+    scoped_key: str,
+    existing: ControlPlaneOperationRecord | None,
+) -> PreparedParticipantCrossing:
+    del idempotency_key
+    fingerprint_heads = existing.decision_history_heads if existing is not None else expected_heads
+    stable_intent = intent.model_dump(mode="json")
+    stable_intent.pop("effective_order", None)
+    fingerprint_payload = {
+        "target": control_plane.target_name,
+        "identity": identity.identity,
+        "decision_history_heads": fingerprint_heads,
+        "intent": stable_intent,
+        "outcome": "policy-unresolved",
+    }
+    semantic_fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    if existing is not None:
+        if existing.request_fingerprint != semantic_fingerprint:
+            raise ValueError("Idempotency-Key was reused with different semantics.")
+        control_plane._operations[existing.receipt.operation_id] = existing
+        return _existing_preparation(
+            control_plane,
+            intent,
+            identity,
+            expected_heads,
+            existing,
+        )
+    operation_id = str(uuid4())
+    submitted_at = _utc_now()
+    diagnostic = Diagnostic(
+        code="runtime.participant-crossing-policy-unresolved",
+        domain="participant",
+        address=intent.participant_address,
+        message="Participant crossing policy could not be resolved.",
+    )
+    receipt = OperationReceipt(
+        operation_id=operation_id,
+        domain=RuntimeDomain.PARTICIPANT,
+        submitted_at=submitted_at,
+        accepted=False,
+        diagnostics=[diagnostic],
+    )
+    record = ControlPlaneOperationRecord(
+        receipt=receipt,
+        status=OperationStatus(
+            operation_id=operation_id,
+            domain=RuntimeDomain.PARTICIPANT,
+            state=OperationState.FAILED,
+            submitted_at=submitted_at,
+            updated_at=submitted_at,
+            diagnostics=[diagnostic],
+            changed_addresses=[intent.participant_address],
+        ),
+        request_fingerprint=semantic_fingerprint,
+        idempotency_key=scoped_key,
+        decision_history_heads=expected_heads,
+        result_history_heads=expected_heads,
+    )
+    audit_event = AuditEvent(
+        timestamp=submitted_at,
+        action="record_participant_crossing",
+        identity=identity.identity,
+        allowed=False,
+        target=intent.participant_address,
+        operation_id=operation_id,
+        reason="policy-unresolved",
+        details={
+            "episode_id": intent.episode_id,
+            "audience_scope_ref": intent.audience_scope_ref,
+        },
+    )
+    return PreparedParticipantCrossing(
+        intent=intent,
+        identity=identity,
+        next_snapshot=control_plane._snapshot,
+        expected_history_heads=expected_heads,
+        record=record,
+        audit_event=audit_event,
+        decision=None,
+        disposition=None,
+        governed_subject=intent.subject,
+    )
+
+
+def _require_replay_state_cut(
+    existing: ControlPlaneOperationRecord,
+    current_heads: dict[str, str | None],
+) -> None:
+    if not existing.decision_history_heads or not existing.result_history_heads:
+        raise ValueError("idempotent participant crossing is missing its state-cut binding")
+    if current_heads != existing.result_history_heads:
+        raise ValueError("Idempotency-Key cannot replay after the participant state cut advanced.")
+
+
+def validate_persisted_crossing_history(
+    snapshot: RuntimeSnapshot,
+    resolver: ParticipantCrossingPolicyResolver,
+) -> None:
+    """Fail closed when persisted API-423 history cannot resolve on restart."""
+
+    for participant_address, values in snapshot.participant_crossing_history.items():
+        records = [ParticipantCrossingOccurrenceModel.model_validate(value) for value in values]
+        context = resolver.validation_context(snapshot, participant_address)
+        validate_participant_crossing_occurrence_context(
+            records,
+            known_subjects=context.known_subjects,
+            policies=context.policies,
+            known_evidence_refs=context.known_evidence_refs,
+            known_authority_basis_refs=context.known_authority_basis_refs,
+        )
+
+
+__all__ = (
+    "ParticipantCrossingEvidence",
+    "ParticipantCrossingIntent",
+    "ParticipantCrossingPolicyResolution",
+    "ParticipantCrossingPolicyResolver",
+    "ParticipantCrossingSemanticGates",
+    "ParticipantCrossingTransformationResolution",
+    "ParticipantCrossingValidationContext",
+    "PreparedParticipantCrossing",
+    "commit_prepared_crossing",
+    "prepare_participant_crossing",
+    "validate_persisted_crossing_history",
+)

--- a/implementations/python/packages/raes_runtime/participant_crossing_mediation.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_mediation.py
@@ -172,6 +172,7 @@ def prepare_participant_crossing(
         _resolve_backend_support,
     )
     from .participant_crossing_records import (
+        _CrossingDecisionPreparation,
         _expected_history_heads,
         _prepare_crossing_decision,
         _scoped_idempotency_key,
@@ -236,14 +237,16 @@ def prepare_participant_crossing(
     return _prepare_crossing_decision(
         control_plane,
         intent,
-        authenticated,
-        resolution,
-        support,
-        gates,
-        disposition,
-        expected_heads,
-        semantic_fingerprint,
-        scoped_key,
+        _CrossingDecisionPreparation(
+            identity=authenticated,
+            resolution=resolution,
+            support=support,
+            gates=gates,
+            disposition=disposition,
+            expected_heads=expected_heads,
+            semantic_fingerprint=semantic_fingerprint,
+            scoped_key=scoped_key,
+        ),
     )
 
 

--- a/implementations/python/packages/raes_runtime/participant_crossing_policy.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_policy.py
@@ -1,0 +1,279 @@
+"""RUN-319 caller, capability, and deny-first policy gates."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from raes_backend_protocols.capability_admission import resolve_participant_feature_support
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingBackendPosture,
+    ParticipantCrossingDecisionDisposition,
+    ParticipantCrossingDecisionGatesModel,
+    ParticipantCrossingDirection,
+    ParticipantCrossingGateDisposition,
+    ParticipantCrossingInteractionKind,
+    ParticipantCrossingOperation,
+)
+from raes_contracts.vocabulary import ParticipantFeatureSupportLevel
+
+from .control_plane_security import ControlPlaneIdentity, ControlPlaneRole
+from .participant_crossing_mediation import (
+    ParticipantCrossingIntent,
+    ParticipantCrossingPolicyResolution,
+    ParticipantCrossingSemanticGates,
+)
+
+
+@dataclass(frozen=True)
+class _BackendSupport:
+    gate: ParticipantCrossingGateDisposition
+    posture: ParticipantCrossingBackendPosture
+    evidence_refs: tuple[str, ...] = ()
+    limitations: tuple[str, ...] = ()
+    effective_levels: tuple[tuple[str, str], ...] = ()
+
+
+def _resolve_backend_support(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    resolution: ParticipantCrossingPolicyResolution,
+) -> _BackendSupport:
+    declarations = []
+    for feature in _required_features(intent):
+        try:
+            declaration = resolve_participant_feature_support(
+                control_plane._target.manifest,
+                feature,
+                required_level=resolution.required_support_level,
+                allowed_downgrade_level=resolution.allowed_downgrades.get(feature),
+                downgrade_policy_ref=resolution.downgrade_policy_ref,
+                downgrade_provenance_ref=resolution.downgrade_provenance_ref,
+            )
+        except ValueError:
+            return _BackendSupport(
+                gate=ParticipantCrossingGateDisposition.UNSUPPORTED,
+                posture=ParticipantCrossingBackendPosture.UNSUPPORTED,
+                limitations=(f"limitation:{feature}:unsupported",),
+                effective_levels=((feature, ParticipantFeatureSupportLevel.UNSUPPORTED.value),),
+            )
+        if declaration is not None:
+            declarations.append(declaration)
+    if not declarations:
+        return _BackendSupport(
+            gate=ParticipantCrossingGateDisposition.UNSUPPORTED,
+            posture=ParticipantCrossingBackendPosture.UNSUPPORTED,
+            limitations=("limitation:participant-policy-support-unresolved",),
+        )
+    weakest = min(
+        (declaration.support_level for declaration in declarations),
+        key=_support_rank,
+    )
+    posture = {
+        ParticipantFeatureSupportLevel.EXACT: ParticipantCrossingBackendPosture.EXACT,
+        ParticipantFeatureSupportLevel.BOUNDED: ParticipantCrossingBackendPosture.BOUNDED,
+        ParticipantFeatureSupportLevel.DISCLOSED_WEAK: ParticipantCrossingBackendPosture.DISCLOSED_WEAK,
+        ParticipantFeatureSupportLevel.UNSUPPORTED: ParticipantCrossingBackendPosture.UNSUPPORTED,
+    }[weakest]
+    return _BackendSupport(
+        gate=(
+            ParticipantCrossingGateDisposition.PERMIT
+            if weakest is not ParticipantFeatureSupportLevel.UNSUPPORTED
+            else ParticipantCrossingGateDisposition.UNSUPPORTED
+        ),
+        posture=posture,
+        evidence_refs=tuple(dict.fromkeys(ref for item in declarations for ref in item.evidence_refs)),
+        limitations=tuple(
+            dict.fromkeys(
+                ref
+                for item in declarations
+                for ref in (*item.constraint_refs, *item.limitation_refs, *item.disclosure_refs)
+            )
+        ),
+        effective_levels=tuple((item.feature, item.support_level.value) for item in declarations),
+    )
+
+
+def _support_rank(level: ParticipantFeatureSupportLevel) -> int:
+    return {
+        ParticipantFeatureSupportLevel.UNSUPPORTED: 0,
+        ParticipantFeatureSupportLevel.DISCLOSED_WEAK: 1,
+        ParticipantFeatureSupportLevel.BOUNDED: 2,
+        ParticipantFeatureSupportLevel.EXACT: 3,
+    }[level]
+
+
+def _required_features(intent: ParticipantCrossingIntent) -> tuple[str, ...]:
+    features: list[str] = []
+    if intent.direction is ParticipantCrossingDirection.INGRESS:
+        features.append("participant_ingress_admission")
+    else:
+        features.append("participant_egress_projection")
+    if intent.interaction_kind in {
+        ParticipantCrossingInteractionKind.INTERVENTION,
+        ParticipantCrossingInteractionKind.HANDOFF,
+    }:
+        features.append("participant_intervention")
+    if intent.interaction_kind is ParticipantCrossingInteractionKind.PARTICIPANT_INJECT_DELIVERY:
+        features.append("participant_directed_inject_delivery")
+    if intent.requested_operation is ParticipantCrossingOperation.DECLASSIFICATION:
+        features.append("participant_declassification")
+    if intent.requested_operation in {
+        ParticipantCrossingOperation.PROJECTION,
+        ParticipantCrossingOperation.MASKING,
+        ParticipantCrossingOperation.REDACTION,
+        ParticipantCrossingOperation.TRANSFORMATION,
+    }:
+        features.append("participant_transformation")
+    return tuple(dict.fromkeys(features))
+
+
+def _require_crossing_identity(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: object,
+) -> ControlPlaneIdentity:
+    if not isinstance(identity, ControlPlaneIdentity):
+        _record_identity_denial(control_plane, intent, "authentication-required")
+        raise PermissionError("participant crossing requires an authenticated identity")
+    if identity.target_name is not None and identity.target_name != control_plane.target_name:
+        _record_identity_denial(
+            control_plane,
+            intent,
+            "target-forbidden",
+            identity=identity.identity,
+        )
+        raise PermissionError("participant crossing identity is not authorized for this target")
+    allowed_roles = {
+        ControlPlaneRole.BACKEND,
+        ControlPlaneRole.OPERATOR,
+    }
+    if intent.direction is ParticipantCrossingDirection.EGRESS:
+        allowed_roles.add(ControlPlaneRole.AUDITOR)
+    if identity.roles.isdisjoint(allowed_roles):
+        _record_identity_denial(
+            control_plane,
+            intent,
+            "caller-forbidden",
+            identity=identity.identity,
+        )
+        raise PermissionError("participant crossing identity is not authorized for this operation")
+    if intent.direction is ParticipantCrossingDirection.INGRESS:
+        bound = any(
+            binding.participant_address == intent.participant_address
+            and binding.controller_ref == intent.controller_ref
+            for binding in identity.participant_control_subjects
+        )
+        if not bound:
+            _record_identity_denial(
+                control_plane,
+                intent,
+                "subject-forbidden",
+                identity=identity.identity,
+            )
+            raise PermissionError("participant crossing identity is not authorized for this subject")
+    else:
+        bound = any(
+            binding.participant_address == intent.participant_address
+            and binding.audience_scope_ref == intent.audience_scope_ref
+            for binding in identity.participant_audience_subjects
+        )
+        if not bound:
+            _record_identity_denial(
+                control_plane,
+                intent,
+                "audience-forbidden",
+                identity=identity.identity,
+            )
+            raise PermissionError("participant crossing identity is not authorized for this audience")
+    return identity
+
+
+def _record_identity_denial(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    reason: str,
+    *,
+    identity: str = "anonymous",
+) -> None:
+    control_plane.record_audit(
+        action="record_participant_crossing",
+        identity=identity,
+        allowed=False,
+        target=intent.participant_address,
+        reason=reason,
+    )
+
+
+def _decision_gates(
+    semantic: ParticipantCrossingSemanticGates,
+    backend_support: ParticipantCrossingGateDisposition,
+) -> ParticipantCrossingDecisionGatesModel:
+    return ParticipantCrossingDecisionGatesModel(
+        caller_authorization=ParticipantCrossingGateDisposition.PERMIT,
+        target_authorization=ParticipantCrossingGateDisposition.PERMIT,
+        participant_authority=semantic.participant_authority,
+        action_admission=semantic.action_admission,
+        visibility=semantic.visibility,
+        marking_authorization=semantic.marking_authorization,
+        declassification=semantic.declassification,
+        backend_support=backend_support,
+        transformation_validity=semantic.transformation_validity,
+    )
+
+
+def _applicable_semantic_gates(
+    intent: ParticipantCrossingIntent,
+    resolution: ParticipantCrossingPolicyResolution,
+) -> ParticipantCrossingSemanticGates:
+    values = asdict(resolution.gates)
+
+    def require(name: str) -> None:
+        if values[name] is ParticipantCrossingGateDisposition.NOT_APPLICABLE:
+            values[name] = ParticipantCrossingGateDisposition.UNKNOWN
+
+    require("participant_authority")
+    require("marking_authorization")
+    if intent.direction is ParticipantCrossingDirection.INGRESS:
+        require("action_admission")
+    else:
+        require("visibility")
+    if intent.requested_operation is ParticipantCrossingOperation.DECLASSIFICATION:
+        require("declassification")
+    if intent.requested_operation in {
+        ParticipantCrossingOperation.PROJECTION,
+        ParticipantCrossingOperation.MASKING,
+        ParticipantCrossingOperation.REDACTION,
+        ParticipantCrossingOperation.TRANSFORMATION,
+        ParticipantCrossingOperation.DECLASSIFICATION,
+    }:
+        require("transformation_validity")
+    if resolution.required_operation is not None and resolution.transformation is None:
+        values["transformation_validity"] = ParticipantCrossingGateDisposition.UNKNOWN
+    return ParticipantCrossingSemanticGates(**values)
+
+
+def _decision_disposition(
+    gates: ParticipantCrossingDecisionGatesModel,
+    resolution: ParticipantCrossingPolicyResolution,
+) -> ParticipantCrossingDecisionDisposition:
+    values = set(gates.dispositions())
+    if ParticipantCrossingGateDisposition.DENY in values:
+        return ParticipantCrossingDecisionDisposition.DENY
+    if values & {
+        ParticipantCrossingGateDisposition.UNKNOWN,
+        ParticipantCrossingGateDisposition.UNSUPPORTED,
+    }:
+        return ParticipantCrossingDecisionDisposition.UNSUPPORTED
+    if resolution.required_operation is not None:
+        return ParticipantCrossingDecisionDisposition.TRANSFORM
+    return ParticipantCrossingDecisionDisposition.PERMIT
+
+
+__all__ = (
+    "_BackendSupport",
+    "_applicable_semantic_gates",
+    "_decision_disposition",
+    "_decision_gates",
+    "_require_crossing_identity",
+    "_resolve_backend_support",
+)

--- a/implementations/python/packages/raes_runtime/participant_crossing_policy.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_policy.py
@@ -143,6 +143,16 @@ def _require_crossing_identity(
             identity=identity.identity,
         )
         raise PermissionError("participant crossing identity is not authorized for this target")
+    _require_crossing_role(control_plane, intent, identity)
+    _require_crossing_subject_binding(control_plane, intent, identity)
+    return identity
+
+
+def _require_crossing_role(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+) -> None:
     allowed_roles = {
         ControlPlaneRole.BACKEND,
         ControlPlaneRole.OPERATOR,
@@ -157,6 +167,13 @@ def _require_crossing_identity(
             identity=identity.identity,
         )
         raise PermissionError("participant crossing identity is not authorized for this operation")
+
+
+def _require_crossing_subject_binding(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+) -> None:
     if intent.direction is ParticipantCrossingDirection.INGRESS:
         bound = any(
             binding.participant_address == intent.participant_address
@@ -185,7 +202,6 @@ def _require_crossing_identity(
                 identity=identity.identity,
             )
             raise PermissionError("participant crossing identity is not authorized for this audience")
-    return identity
 
 
 def _record_identity_denial(
@@ -258,15 +274,17 @@ def _decision_disposition(
 ) -> ParticipantCrossingDecisionDisposition:
     values = set(gates.dispositions())
     if ParticipantCrossingGateDisposition.DENY in values:
-        return ParticipantCrossingDecisionDisposition.DENY
-    if values & {
+        disposition = ParticipantCrossingDecisionDisposition.DENY
+    elif values & {
         ParticipantCrossingGateDisposition.UNKNOWN,
         ParticipantCrossingGateDisposition.UNSUPPORTED,
     }:
-        return ParticipantCrossingDecisionDisposition.UNSUPPORTED
-    if resolution.required_operation is not None:
-        return ParticipantCrossingDecisionDisposition.TRANSFORM
-    return ParticipantCrossingDecisionDisposition.PERMIT
+        disposition = ParticipantCrossingDecisionDisposition.UNSUPPORTED
+    elif resolution.required_operation is not None:
+        disposition = ParticipantCrossingDecisionDisposition.TRANSFORM
+    else:
+        disposition = ParticipantCrossingDecisionDisposition.PERMIT
+    return disposition
 
 
 __all__ = (

--- a/implementations/python/packages/raes_runtime/participant_crossing_records.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_records.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -44,18 +44,28 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+@dataclass(frozen=True)
+class _CrossingDecisionPreparation:
+    identity: ControlPlaneIdentity
+    resolution: ParticipantCrossingPolicyResolution
+    support: _BackendSupport
+    gates: ParticipantCrossingDecisionGatesModel
+    disposition: ParticipantCrossingDecisionDisposition
+    expected_heads: dict[str, str | None]
+    semantic_fingerprint: str
+    scoped_key: str
+
+
 def _prepare_crossing_decision(
     control_plane: object,
     intent: ParticipantCrossingIntent,
-    identity: ControlPlaneIdentity,
-    resolution: ParticipantCrossingPolicyResolution,
-    support: _BackendSupport,
-    gates: ParticipantCrossingDecisionGatesModel,
-    disposition: ParticipantCrossingDecisionDisposition,
-    expected_heads: dict[str, str | None],
-    semantic_fingerprint: str,
-    scoped_key: str,
+    preparation: _CrossingDecisionPreparation,
 ) -> PreparedParticipantCrossing:
+    identity = preparation.identity
+    resolution = preparation.resolution
+    support = preparation.support
+    gates = preparation.gates
+    disposition = preparation.disposition
     history = list(control_plane._snapshot.participant_crossing_history.get(intent.participant_address, ()))
     request, decision = _crossing_records(intent, identity, resolution, support, gates, disposition)
     records = [request, decision]
@@ -117,13 +127,12 @@ def _prepare_crossing_decision(
         known_authority_basis_refs=context.known_authority_basis_refs,
     )
     record, audit_event = _operation_artifacts(
-        control_plane,
         intent,
         identity,
         final_decision,
         final_disposition,
-        semantic_fingerprint,
-        scoped_key,
+        preparation.semantic_fingerprint,
+        preparation.scoped_key,
     )
     record = ControlPlaneOperationRecord(
         receipt=record.receipt,
@@ -131,7 +140,7 @@ def _prepare_crossing_decision(
         request_fingerprint=record.request_fingerprint,
         idempotency_key=record.idempotency_key,
         result_payload=record.result_payload,
-        decision_history_heads=expected_heads,
+        decision_history_heads=preparation.expected_heads,
         result_history_heads=_expected_history_heads(next_snapshot, intent.participant_address),
     )
     governed_subject = (
@@ -143,7 +152,7 @@ def _prepare_crossing_decision(
         intent=intent,
         identity=identity,
         next_snapshot=next_snapshot,
-        expected_history_heads=expected_heads,
+        expected_history_heads=preparation.expected_heads,
         record=record,
         audit_event=audit_event,
         decision=final_decision,
@@ -334,7 +343,6 @@ def _base_envelope(
 
 
 def _operation_artifacts(
-    control_plane: object,
     intent: ParticipantCrossingIntent,
     identity: ControlPlaneIdentity,
     decision: ParticipantCrossingOccurrenceModel,

--- a/implementations/python/packages/raes_runtime/participant_crossing_records.py
+++ b/implementations/python/packages/raes_runtime/participant_crossing_records.py
@@ -1,0 +1,477 @@
+"""RUN-319 crossing occurrence construction and operation artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingDecisionDisposition,
+    ParticipantCrossingDecisionGatesModel,
+    ParticipantCrossingDirection,
+    ParticipantCrossingGateDisposition,
+    ParticipantCrossingOccurrenceModel,
+    ParticipantCrossingOperation,
+)
+from raes_contracts.contracts.participant_crossing_validation import (
+    validate_participant_crossing_occurrence_context,
+)
+from raes_contracts.diagnostics import Diagnostic
+from raes_contracts.planning import RuntimeDomain
+from raes_contracts.runtime_state import OperationReceipt, OperationState, OperationStatus, RuntimeSnapshot
+
+from .control_plane_security import ControlPlaneIdentity
+from .control_plane_store import AuditEvent, ControlPlaneOperationRecord
+from .participant_crossing_mediation import (
+    ParticipantCrossingIntent,
+    ParticipantCrossingPolicyResolution,
+    ParticipantCrossingTransformationResolution,
+    PreparedParticipantCrossing,
+)
+from .participant_crossing_policy import (
+    _applicable_semantic_gates,
+    _BackendSupport,
+    _decision_disposition,
+    _decision_gates,
+    _resolve_backend_support,
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _prepare_crossing_decision(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    resolution: ParticipantCrossingPolicyResolution,
+    support: _BackendSupport,
+    gates: ParticipantCrossingDecisionGatesModel,
+    disposition: ParticipantCrossingDecisionDisposition,
+    expected_heads: dict[str, str | None],
+    semantic_fingerprint: str,
+    scoped_key: str,
+) -> PreparedParticipantCrossing:
+    history = list(control_plane._snapshot.participant_crossing_history.get(intent.participant_address, ()))
+    request, decision = _crossing_records(intent, identity, resolution, support, gates, disposition)
+    records = [request, decision]
+    final_decision = decision
+    final_disposition = disposition
+    if disposition is ParticipantCrossingDecisionDisposition.TRANSFORM:
+        transformation = resolution.transformation
+        assert transformation is not None
+        transformed = _transformation_record(
+            intent,
+            identity,
+            resolution,
+            support,
+            decision,
+            transformation,
+        )
+        records.append(transformed)
+        if intent.direction is ParticipantCrossingDirection.INGRESS:
+            fresh_intent = _fresh_transformed_intent(intent, transformation, transformed)
+            fresh_resolution = control_plane._crossing_policy_resolver.resolve(
+                fresh_intent,
+                control_plane._snapshot,
+            )
+            fresh_support = _resolve_backend_support(control_plane, fresh_intent, fresh_resolution)
+            fresh_gates = _decision_gates(
+                _applicable_semantic_gates(fresh_intent, fresh_resolution),
+                fresh_support.gate,
+            )
+            fresh_disposition = _decision_disposition(fresh_gates, fresh_resolution)
+            fresh_request, fresh_decision = _crossing_records(
+                fresh_intent,
+                identity,
+                fresh_resolution,
+                fresh_support,
+                fresh_gates,
+                fresh_disposition,
+                request_predecessor_refs=(transformed.event_id,),
+            )
+            records.extend((fresh_request, fresh_decision))
+            final_decision = fresh_decision
+            final_disposition = fresh_disposition
+    candidate_history = [*history, *(record.model_dump(mode="json") for record in records)]
+    next_snapshot = control_plane._snapshot.with_entries(
+        dict(control_plane._snapshot.entries),
+        participant_crossing_history={
+            **control_plane._snapshot.participant_crossing_history,
+            intent.participant_address: candidate_history,
+        },
+    )
+    context = control_plane._crossing_policy_resolver.validation_context(
+        control_plane._snapshot,
+        intent.participant_address,
+    )
+    validate_participant_crossing_occurrence_context(
+        [ParticipantCrossingOccurrenceModel.model_validate(item) for item in candidate_history],
+        known_subjects=context.known_subjects,
+        policies=context.policies,
+        known_evidence_refs=context.known_evidence_refs,
+        known_authority_basis_refs=context.known_authority_basis_refs,
+    )
+    record, audit_event = _operation_artifacts(
+        control_plane,
+        intent,
+        identity,
+        final_decision,
+        final_disposition,
+        semantic_fingerprint,
+        scoped_key,
+    )
+    record = ControlPlaneOperationRecord(
+        receipt=record.receipt,
+        status=record.status,
+        request_fingerprint=record.request_fingerprint,
+        idempotency_key=record.idempotency_key,
+        result_payload=record.result_payload,
+        decision_history_heads=expected_heads,
+        result_history_heads=_expected_history_heads(next_snapshot, intent.participant_address),
+    )
+    governed_subject = (
+        records[-1].occurrence.subject
+        if records[-1].occurrence.stage == "decided"
+        else records[-1].occurrence.result_subject
+    )
+    return PreparedParticipantCrossing(
+        intent=intent,
+        identity=identity,
+        next_snapshot=next_snapshot,
+        expected_history_heads=expected_heads,
+        record=record,
+        audit_event=audit_event,
+        decision=final_decision,
+        disposition=final_disposition,
+        governed_subject=governed_subject,
+    )
+
+
+def _crossing_records(
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    resolution: ParticipantCrossingPolicyResolution,
+    support: _BackendSupport,
+    gates: ParticipantCrossingDecisionGatesModel,
+    disposition: ParticipantCrossingDecisionDisposition,
+    *,
+    request_predecessor_refs: tuple[str, ...] = (),
+) -> tuple[ParticipantCrossingOccurrenceModel, ParticipantCrossingOccurrenceModel]:
+    now = _utc_now()
+    request_id = f"crossing-request.{uuid4()}"
+    request_event_id = f"crossing-occurrence.requested.{uuid4()}"
+    decision_id = f"crossing-decision.{uuid4()}"
+    common = _common_occurrence(intent, resolution, support)
+    envelope = _base_envelope(intent, identity, support, now)
+    request = ParticipantCrossingOccurrenceModel.model_validate(
+        {
+            **envelope,
+            "event_id": request_event_id,
+            "predecessor_event_refs": list(request_predecessor_refs),
+            "occurrence": {
+                **common,
+                "stage": "requested",
+                "request_id": request_id,
+                "requested_operation": intent.requested_operation.value,
+                "action_or_projection_ref": intent.action_or_projection_ref,
+                "required_evidence_refs": list(intent.required_evidence_refs),
+            },
+        }
+    )
+    decision_order = intent.effective_order + 1
+    reason_code = (
+        resolution.reason_code
+        if support.gate is ParticipantCrossingGateDisposition.PERMIT
+        else "backend-feature-unsupported"
+    )
+    decision = ParticipantCrossingOccurrenceModel.model_validate(
+        {
+            **envelope,
+            "event_id": f"crossing-occurrence.decided.{uuid4()}",
+            "logical_order_ref": f"{resolution.policy.decision_cut_ref}:order:{decision_order}",
+            "predecessor_event_refs": [request_event_id],
+            "occurrence": {
+                **common,
+                "stage": "decided",
+                "effective_order": decision_order,
+                "request_ref": request_id,
+                "decision_id": decision_id,
+                "decision_revision": 1,
+                "gates": gates.model_dump(mode="json"),
+                "disposition": disposition.value,
+                "reason_code": reason_code,
+                "required_evidence_refs": list(intent.required_evidence_refs),
+                **(
+                    {"required_operation": resolution.required_operation.value}
+                    if disposition is ParticipantCrossingDecisionDisposition.TRANSFORM
+                    and resolution.required_operation is not None
+                    else {}
+                ),
+            },
+        }
+    )
+    return request, decision
+
+
+def _transformation_record(
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    resolution: ParticipantCrossingPolicyResolution,
+    support: _BackendSupport,
+    decision: ParticipantCrossingOccurrenceModel,
+    transformation: ParticipantCrossingTransformationResolution,
+) -> ParticipantCrossingOccurrenceModel:
+    operation = resolution.required_operation
+    assert operation is not None
+    effective_order = intent.effective_order + 2
+    common = {
+        **_common_occurrence(intent, resolution, support),
+        "subject": transformation.result_subject.model_dump(mode="json"),
+        "effective_order": effective_order,
+    }
+    envelope = {
+        **_base_envelope(intent, identity, support, decision.recorded_at),
+        "object_marking_refs": list(transformation.result_marking_refs),
+        "logical_order_ref": f"{resolution.policy.decision_cut_ref}:order:{effective_order}",
+    }
+    return ParticipantCrossingOccurrenceModel.model_validate(
+        {
+            **envelope,
+            "event_id": f"crossing-occurrence.transformed.{uuid4()}",
+            "predecessor_event_refs": [decision.event_id],
+            "occurrence": {
+                **common,
+                "stage": "transformed",
+                "decision_ref": decision.occurrence.decision_id,
+                "transformation_id": f"crossing-transformation.{uuid4()}",
+                "operation": operation.value,
+                "source_subject": intent.subject.model_dump(mode="json"),
+                "result_subject": transformation.result_subject.model_dump(mode="json"),
+                "rule_ref": transformation.rule_ref,
+                "rule_revision": transformation.rule_revision,
+                "source_marking_refs": list(intent.object_marking_refs),
+                "result_marking_refs": list(transformation.result_marking_refs),
+                **(
+                    {"declassification_basis_ref": transformation.declassification_basis_ref}
+                    if transformation.declassification_basis_ref is not None
+                    else {}
+                ),
+                "losses": list(transformation.losses),
+            },
+        }
+    )
+
+
+def _fresh_transformed_intent(
+    intent: ParticipantCrossingIntent,
+    transformation: ParticipantCrossingTransformationResolution,
+    transformed: ParticipantCrossingOccurrenceModel,
+) -> ParticipantCrossingIntent:
+    payload = intent.model_dump(mode="json")
+    payload.update(
+        {
+            "subject": transformation.result_subject.model_dump(mode="json"),
+            "requested_operation": ParticipantCrossingOperation.ADMISSION.value,
+            "action_or_projection_ref": transformation.result_subject.subject_ref,
+            "effective_order": transformed.occurrence.effective_order + 1,
+            "object_marking_refs": list(transformation.result_marking_refs),
+        }
+    )
+    return ParticipantCrossingIntent.model_validate(payload)
+
+
+def _common_occurrence(
+    intent: ParticipantCrossingIntent,
+    resolution: ParticipantCrossingPolicyResolution,
+    support: _BackendSupport,
+) -> dict[str, object]:
+    return {
+        "direction": intent.direction.value,
+        "interaction_kind": intent.interaction_kind.value,
+        "audience_scope_ref": intent.audience_scope_ref,
+        "subject": intent.subject.model_dump(mode="json"),
+        "controller_ref": intent.controller_ref,
+        "authority_basis_refs": list(intent.authority_basis_refs),
+        "policy": resolution.policy.model_dump(mode="json"),
+        "effective_order": intent.effective_order,
+        "order_model": intent.order_model,
+        "backend_posture": support.posture.value,
+        "loss_and_limitations": list(dict.fromkeys([*intent.loss_and_limitations, *support.limitations])),
+    }
+
+
+def _base_envelope(
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    support: _BackendSupport,
+    now: str,
+) -> dict[str, object]:
+    return {
+        "schema_name": "participant-crossing-occurrence",
+        "schema_version": "1.0.0",
+        "event_type": "participant-crossing-occurrence",
+        "extension_policy": "closed",
+        "participant_address": intent.participant_address,
+        "episode_id": intent.episode_id,
+        "occurred_at": now,
+        "recorded_at": now,
+        "ingested_at": now,
+        "clock_authority": "runtime.control-plane.clock",
+        "ordering_basis": intent.order_model,
+        "logical_order_ref": f"runtime.crossing-order:{intent.effective_order}",
+        "actor_ref": identity.identity,
+        "producer_ref": "runtime.control-plane.participant-crossing",
+        "provenance_refs": list(intent.provenance_refs),
+        "evidence_refs": list(dict.fromkeys([*intent.evidence_refs, *support.evidence_refs])),
+        "object_marking_refs": list(intent.object_marking_refs),
+        "authorization_scope": intent.authorization_scope,
+    }
+
+
+def _operation_artifacts(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    decision: ParticipantCrossingOccurrenceModel,
+    disposition: ParticipantCrossingDecisionDisposition,
+    semantic_fingerprint: str,
+    scoped_key: str,
+) -> tuple[ControlPlaneOperationRecord, AuditEvent]:
+    operation_id = str(uuid4())
+    submitted_at = decision.recorded_at
+    allowed = disposition is ParticipantCrossingDecisionDisposition.PERMIT or (
+        intent.direction is ParticipantCrossingDirection.EGRESS
+        and disposition is ParticipantCrossingDecisionDisposition.TRANSFORM
+    )
+    diagnostics = (
+        []
+        if allowed
+        else [
+            Diagnostic(
+                code="runtime.participant-crossing-denied",
+                domain="participant",
+                address=intent.participant_address,
+                message="Participant crossing was not permitted by the governed decision.",
+            )
+        ]
+    )
+    receipt = OperationReceipt(
+        operation_id=operation_id,
+        domain=RuntimeDomain.PARTICIPANT,
+        submitted_at=submitted_at,
+        accepted=allowed,
+        diagnostics=diagnostics,
+    )
+    status = OperationStatus(
+        operation_id=operation_id,
+        domain=RuntimeDomain.PARTICIPANT,
+        state=OperationState.SUCCEEDED if allowed else OperationState.FAILED,
+        submitted_at=submitted_at,
+        updated_at=submitted_at,
+        diagnostics=diagnostics,
+        changed_addresses=[intent.participant_address],
+    )
+    record = ControlPlaneOperationRecord(
+        receipt=receipt,
+        status=status,
+        request_fingerprint=semantic_fingerprint,
+        idempotency_key=scoped_key,
+    )
+    occurrence = decision.occurrence
+    audit_event = AuditEvent(
+        timestamp=submitted_at,
+        action="record_participant_crossing",
+        identity=identity.identity,
+        allowed=allowed,
+        target=intent.participant_address,
+        operation_id=operation_id,
+        reason=occurrence.reason_code,
+        details={
+            "episode_id": intent.episode_id,
+            "decision_id": occurrence.decision_id,
+            "decision_cut_ref": occurrence.policy.decision_cut_ref,
+            "disposition": occurrence.disposition.value,
+        },
+    )
+    return record, audit_event
+
+
+def _semantic_fingerprint(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    resolution: ParticipantCrossingPolicyResolution,
+    support: _BackendSupport,
+    expected_heads: dict[str, str | None],
+) -> str:
+    stable_intent = intent.model_dump(mode="json")
+    stable_intent.pop("effective_order", None)
+    payload = {
+        "target": control_plane.target_name,
+        "identity": identity.identity,
+        "decision_history_heads": expected_heads,
+        "intent": stable_intent,
+        "policy": resolution.policy.model_dump(mode="json"),
+        "gates": asdict(resolution.gates),
+        "required_operation": (
+            resolution.required_operation.value if resolution.required_operation is not None else None
+        ),
+        "required_support_level": resolution.required_support_level.value,
+        "allowed_downgrades": {key: value.value for key, value in sorted(resolution.allowed_downgrades.items())},
+        "backend": asdict(support),
+        "transformation": (asdict(resolution.transformation) if resolution.transformation is not None else None),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _scoped_idempotency_key(
+    control_plane: object,
+    intent: ParticipantCrossingIntent,
+    identity: ControlPlaneIdentity,
+    idempotency_key: str,
+) -> str:
+    if not idempotency_key:
+        return ""
+    encoded = "\x1f".join(
+        (
+            control_plane.target_name,
+            identity.identity,
+            intent.participant_address,
+            intent.episode_id,
+            intent.audience_scope_ref,
+            idempotency_key,
+        )
+    ).encode()
+    return f"participant-crossing:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _expected_history_heads(
+    snapshot: RuntimeSnapshot,
+    participant_address: str,
+) -> dict[str, str | None]:
+    def head(history: dict[str, list[dict[str, object]]]) -> str | None:
+        events = history.get(participant_address, ())
+        if not events:
+            return None
+        value = events[-1].get("event_id")
+        return value if isinstance(value, str) and value else None
+
+    return {
+        f"participant_behavior_history:{participant_address}": head(snapshot.participant_behavior_history),
+        f"participant_control_history:{participant_address}": head(snapshot.participant_control_history),
+        f"participant_crossing_history:{participant_address}": head(snapshot.participant_crossing_history),
+    }
+
+
+__all__ = (
+    "_expected_history_heads",
+    "_prepare_crossing_decision",
+    "_scoped_idempotency_key",
+    "_semantic_fingerprint",
+)

--- a/implementations/python/packages/raes_runtime/participant_result_contracts.py
+++ b/implementations/python/packages/raes_runtime/participant_result_contracts.py
@@ -15,6 +15,10 @@ from raes_contracts.participant_control_history import (
     iter_participant_control_history_snapshot_violations,
     iter_participant_control_history_transition_violations,
 )
+from raes_contracts.participant_crossing_history import (
+    iter_participant_crossing_history_snapshot_violations,
+    iter_participant_crossing_history_transition_violations,
+)
 from raes_contracts.participant_episode import iter_participant_episode_snapshot_violations
 from raes_contracts.participant_shared_state import (
     iter_participant_shared_state_history_transition_violations,
@@ -83,6 +87,9 @@ def participant_runtime_state_contract_diagnostics(
         *iter_participant_control_history_snapshot_violations(
             snapshot.participant_control_history,
         ),
+        *iter_participant_crossing_history_snapshot_violations(
+            snapshot.participant_crossing_history,
+        ),
     ]
     return [
         _failure_diagnostic("runtime.backend-contract-invalid", address, message) for address, message in violations
@@ -126,6 +133,13 @@ def participant_runtime_history_transition_diagnostics(
             for address, message in iter_participant_control_history_transition_violations(
                 previous_snapshot.participant_control_history,
                 next_snapshot.participant_control_history,
+            )
+        ]
+        + [
+            _failure_diagnostic("runtime.backend-contract-invalid", address, message)
+            for address, message in iter_participant_crossing_history_transition_violations(
+                previous_snapshot.participant_crossing_history,
+                next_snapshot.participant_crossing_history,
             )
         ]
     )

--- a/implementations/python/packages/raes_runtime/participant_retrieval.py
+++ b/implementations/python/packages/raes_runtime/participant_retrieval.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from raes_contracts.contracts import (
@@ -18,10 +19,58 @@ from raes_contracts.planning import RuntimeDomain
 from raes_contracts.runtime_state import OperationState, RuntimeSnapshot
 
 from .control_plane_store import ControlPlaneOperationRecord
-from .participant_crossing_egress import serialize_participant_view
+from .participant_crossing_egress import ParticipantViewSerialization, serialize_participant_view
 from .participant_crossing_mediation import ParticipantCrossingEvidence
 
 _CURRENT_SNAPSHOT_REF = "runtime.snapshot.current"
+_CROSSING_RESOLVER_REQUIRED = "participant crossing policy resolver is required"
+
+
+@dataclass(frozen=True)
+class _ContextViewOptions:
+    episode_id: str | None = None
+    derivation_basis_ref: str | None = None
+    payload_ref: str | None = None
+    derived_from_refs: tuple[str, ...] = ()
+    identity: object | None = None
+    crossing_evidence: ParticipantCrossingEvidence | None = None
+    idempotency_key: str = ""
+
+    @classmethod
+    def from_fields(cls, fields: dict[str, object]) -> _ContextViewOptions:
+        unknown = set(fields) - {
+            "episode_id",
+            "derivation_basis_ref",
+            "payload_ref",
+            "derived_from_refs",
+            "identity",
+            "crossing_evidence",
+            "idempotency_key",
+        }
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise TypeError(f"unexpected participant context options: {names}")
+        episode_id = _optional_string(fields.get("episode_id"), "episode_id")
+        derivation_basis_ref = _optional_string(fields.get("derivation_basis_ref"), "derivation_basis_ref")
+        payload_ref = _optional_string(fields.get("payload_ref"), "payload_ref")
+        derived_from_refs = fields.get("derived_from_refs", ())
+        idempotency_key = fields.get("idempotency_key", "")
+        crossing_evidence = fields.get("crossing_evidence")
+        if not isinstance(derived_from_refs, tuple) or not all(isinstance(item, str) for item in derived_from_refs):
+            raise TypeError("derived_from_refs must be a tuple of strings")
+        if not isinstance(idempotency_key, str):
+            raise TypeError("idempotency_key must be a string")
+        if crossing_evidence is not None and not isinstance(crossing_evidence, ParticipantCrossingEvidence):
+            raise TypeError("crossing_evidence must be ParticipantCrossingEvidence")
+        return cls(
+            episode_id=episode_id,
+            derivation_basis_ref=derivation_basis_ref,
+            payload_ref=payload_ref,
+            derived_from_refs=derived_from_refs,
+            identity=fields.get("identity"),
+            crossing_evidence=crossing_evidence,
+            idempotency_key=idempotency_key,
+        )
 
 
 class ParticipantRetrievalMixin:
@@ -58,19 +107,21 @@ class ParticipantRetrievalMixin:
         )
         if getattr(self, "_crossing_policy_resolver", None) is None:
             if crossing_evidence is not None:
-                raise ValueError("participant crossing policy resolver is required")
+                raise ValueError(_CROSSING_RESOLVER_REQUIRED)
             return view
         return serialize_participant_view(
             self,
             view,
-            participant_address=participant_address,
-            episode_id=_required_episode_id(episode_id),
-            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_STATUS_VIEW,
-            interaction_kind=ParticipantCrossingInteractionKind.STATUS_PROJECTION,
-            projection_ref=view.visibility_projection_ref,
-            identity=identity,
-            crossing_evidence=crossing_evidence,
-            idempotency_key=idempotency_key,
+            ParticipantViewSerialization(
+                participant_address=participant_address,
+                episode_id=_required_episode_id(episode_id),
+                subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_STATUS_VIEW,
+                interaction_kind=ParticipantCrossingInteractionKind.STATUS_PROJECTION,
+                projection_ref=view.visibility_projection_ref,
+                identity=identity,
+                crossing_evidence=crossing_evidence,
+                idempotency_key=idempotency_key,
+            ),
         )
 
     def get_participant_history_view(
@@ -112,19 +163,21 @@ class ParticipantRetrievalMixin:
         )
         if getattr(self, "_crossing_policy_resolver", None) is None:
             if crossing_evidence is not None:
-                raise ValueError("participant crossing policy resolver is required")
+                raise ValueError(_CROSSING_RESOLVER_REQUIRED)
             return view
         return serialize_participant_view(
             self,
             view,
-            participant_address=participant_address,
-            episode_id=episode_id,
-            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_HISTORY_VIEW,
-            interaction_kind=ParticipantCrossingInteractionKind.HISTORY_PROJECTION,
-            projection_ref=view.visibility_projection_ref,
-            identity=identity,
-            crossing_evidence=crossing_evidence,
-            idempotency_key=idempotency_key,
+            ParticipantViewSerialization(
+                participant_address=participant_address,
+                episode_id=episode_id,
+                subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_HISTORY_VIEW,
+                interaction_kind=ParticipantCrossingInteractionKind.HISTORY_PROJECTION,
+                projection_ref=view.visibility_projection_ref,
+                identity=identity,
+                crossing_evidence=crossing_evidence,
+                idempotency_key=idempotency_key,
+            ),
         )
 
     def get_participant_context_view(
@@ -132,29 +185,21 @@ class ParticipantRetrievalMixin:
         participant_address: str,
         *,
         view_ref: str,
-        episode_id: str | None = None,
-        derivation_basis_ref: str | None = None,
-        payload_ref: str | None = None,
-        derived_from_refs: tuple[str, ...] = (),
-        identity: object | None = None,
-        crossing_evidence: ParticipantCrossingEvidence | None = None,
-        idempotency_key: str = "",
+        **context_fields: object,
     ) -> ParticipantContextViewModel | None:
-        if episode_id is not None:
-            if not _participant_episode_exists(self._snapshot, participant_address, episode_id):
-                return None
-        elif not _participant_exists(self._snapshot, participant_address):
+        options = _ContextViewOptions.from_fields(context_fields)
+        if not _context_participant_exists(self._snapshot, participant_address, options.episode_id):
             return None
-        source_refs = tuple(derived_from_refs or (_CURRENT_SNAPSHOT_REF,))
+        source_refs = tuple(options.derived_from_refs or (_CURRENT_SNAPSHOT_REF,))
         source_ref = source_refs[0]
         source_id = "source-snapshot"
-        resolved_observation_point = episode_id or _CURRENT_SNAPSHOT_REF
-        resolved_derivation_basis_ref = derivation_basis_ref or view_ref
+        resolved_observation_point = options.episode_id or _CURRENT_SNAPSHOT_REF
+        resolved_derivation_basis_ref = options.derivation_basis_ref or view_ref
         view = ParticipantContextViewModel.model_validate(
             {
-                "view_id": _view_id("context", participant_address, episode_id or view_ref),
+                "view_id": _view_id("context", participant_address, options.episode_id or view_ref),
                 "participant_address": participant_address,
-                "episode_id": episode_id,
+                "episode_id": options.episode_id,
                 "generated_at": _utc_now(),
                 "source_snapshot_ref": _CURRENT_SNAPSHOT_REF,
                 "view_ref": view_ref,
@@ -193,33 +238,37 @@ class ParticipantRetrievalMixin:
                 "semantic_limitations": [
                     "Context-view payload remains a referenced derived view, not backend-private state"
                 ],
-                "derivation_basis_ref": derivation_basis_ref,
-                "payload_ref": payload_ref,
+                "derivation_basis_ref": options.derivation_basis_ref,
+                "payload_ref": options.payload_ref,
                 "visibility_projection_ref": _visibility_projection_ref(participant_address, "context"),
                 "marking_definition_refs": [],
                 "redaction_policy_ref": None,
             }
         )
         if getattr(self, "_crossing_policy_resolver", None) is None:
-            if crossing_evidence is not None:
-                raise ValueError("participant crossing policy resolver is required")
-            return view
-        resolved_episode_id = episode_id or _string_value(
-            self._snapshot.participant_episode_results.get(participant_address),
-            "episode_id",
-        )
-        return serialize_participant_view(
-            self,
-            view,
-            participant_address=participant_address,
-            episode_id=_required_episode_id(resolved_episode_id),
-            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_CONTEXT_VIEW,
-            interaction_kind=ParticipantCrossingInteractionKind.DECISION_SURFACE_PROJECTION,
-            projection_ref=view.visibility_projection_ref,
-            identity=identity,
-            crossing_evidence=crossing_evidence,
-            idempotency_key=idempotency_key,
-        )
+            if options.crossing_evidence is not None:
+                raise ValueError(_CROSSING_RESOLVER_REQUIRED)
+            result = view
+        else:
+            resolved_episode_id = options.episode_id or _string_value(
+                self._snapshot.participant_episode_results.get(participant_address),
+                "episode_id",
+            )
+            result = serialize_participant_view(
+                self,
+                view,
+                ParticipantViewSerialization(
+                    participant_address=participant_address,
+                    episode_id=_required_episode_id(resolved_episode_id),
+                    subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_CONTEXT_VIEW,
+                    interaction_kind=ParticipantCrossingInteractionKind.DECISION_SURFACE_PROJECTION,
+                    projection_ref=view.visibility_projection_ref,
+                    identity=options.identity,
+                    crossing_evidence=options.crossing_evidence,
+                    idempotency_key=options.idempotency_key,
+                ),
+            )
+        return result
 
 
 def _string_value(payload: dict[str, object] | None, key: str) -> str | None:
@@ -227,6 +276,22 @@ def _string_value(payload: dict[str, object] | None, key: str) -> str | None:
         return None
     value = payload.get(key)
     return value if isinstance(value, str) and value else None
+
+
+def _optional_string(value: object, name: str) -> str | None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{name} must be a string or None")
+    return value
+
+
+def _context_participant_exists(
+    snapshot: RuntimeSnapshot,
+    participant_address: str,
+    episode_id: str | None,
+) -> bool:
+    if episode_id is not None:
+        return _participant_episode_exists(snapshot, participant_address, episode_id)
+    return _participant_exists(snapshot, participant_address)
 
 
 def _required_episode_id(value: str | None) -> str:

--- a/implementations/python/packages/raes_runtime/participant_retrieval.py
+++ b/implementations/python/packages/raes_runtime/participant_retrieval.py
@@ -10,10 +10,16 @@ from raes_contracts.contracts import (
     ParticipantHistoryViewModel,
     ParticipantStatusViewModel,
 )
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingInteractionKind,
+    ParticipantCrossingSubjectKind,
+)
 from raes_contracts.planning import RuntimeDomain
 from raes_contracts.runtime_state import OperationState, RuntimeSnapshot
 
 from .control_plane_store import ControlPlaneOperationRecord
+from .participant_crossing_egress import serialize_participant_view
+from .participant_crossing_mediation import ParticipantCrossingEvidence
 
 _CURRENT_SNAPSHOT_REF = "runtime.snapshot.current"
 
@@ -24,12 +30,19 @@ class ParticipantRetrievalMixin:
     _snapshot: RuntimeSnapshot
     _operations: dict[str, ControlPlaneOperationRecord]
 
-    def get_participant_status_view(self, participant_address: str) -> ParticipantStatusViewModel | None:
+    def get_participant_status_view(
+        self,
+        participant_address: str,
+        *,
+        identity: object | None = None,
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
+        idempotency_key: str = "",
+    ) -> ParticipantStatusViewModel | None:
         if not _participant_exists(self._snapshot, participant_address):
             return None
         episode_state = self._snapshot.participant_episode_results.get(participant_address)
         episode_id = _string_value(episode_state, "episode_id") if episode_state is not None else None
-        return ParticipantStatusViewModel.model_validate(
+        view = ParticipantStatusViewModel.model_validate(
             {
                 "view_id": _view_id("status", participant_address, episode_id),
                 "participant_address": participant_address,
@@ -43,11 +56,31 @@ class ParticipantRetrievalMixin:
                 "redaction_policy_ref": None,
             }
         )
+        if getattr(self, "_crossing_policy_resolver", None) is None:
+            if crossing_evidence is not None:
+                raise ValueError("participant crossing policy resolver is required")
+            return view
+        return serialize_participant_view(
+            self,
+            view,
+            participant_address=participant_address,
+            episode_id=_required_episode_id(episode_id),
+            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_STATUS_VIEW,
+            interaction_kind=ParticipantCrossingInteractionKind.STATUS_PROJECTION,
+            projection_ref=view.visibility_projection_ref,
+            identity=identity,
+            crossing_evidence=crossing_evidence,
+            idempotency_key=idempotency_key,
+        )
 
     def get_participant_history_view(
         self,
         participant_address: str,
         episode_id: str,
+        *,
+        identity: object | None = None,
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
+        idempotency_key: str = "",
     ) -> ParticipantHistoryViewModel | None:
         if not _participant_episode_exists(self._snapshot, participant_address, episode_id):
             return None
@@ -61,7 +94,7 @@ class ParticipantRetrievalMixin:
             for event in self._snapshot.participant_behavior_history.get(participant_address, [])
             if event.get("episode_id") == episode_id
         ]
-        return ParticipantHistoryViewModel.model_validate(
+        view = ParticipantHistoryViewModel.model_validate(
             {
                 "view_id": _view_id("history", participant_address, episode_id),
                 "participant_address": participant_address,
@@ -77,6 +110,22 @@ class ParticipantRetrievalMixin:
                 "marking_definition_refs": [],
             }
         )
+        if getattr(self, "_crossing_policy_resolver", None) is None:
+            if crossing_evidence is not None:
+                raise ValueError("participant crossing policy resolver is required")
+            return view
+        return serialize_participant_view(
+            self,
+            view,
+            participant_address=participant_address,
+            episode_id=episode_id,
+            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_HISTORY_VIEW,
+            interaction_kind=ParticipantCrossingInteractionKind.HISTORY_PROJECTION,
+            projection_ref=view.visibility_projection_ref,
+            identity=identity,
+            crossing_evidence=crossing_evidence,
+            idempotency_key=idempotency_key,
+        )
 
     def get_participant_context_view(
         self,
@@ -87,6 +136,9 @@ class ParticipantRetrievalMixin:
         derivation_basis_ref: str | None = None,
         payload_ref: str | None = None,
         derived_from_refs: tuple[str, ...] = (),
+        identity: object | None = None,
+        crossing_evidence: ParticipantCrossingEvidence | None = None,
+        idempotency_key: str = "",
     ) -> ParticipantContextViewModel | None:
         if episode_id is not None:
             if not _participant_episode_exists(self._snapshot, participant_address, episode_id):
@@ -98,7 +150,7 @@ class ParticipantRetrievalMixin:
         source_id = "source-snapshot"
         resolved_observation_point = episode_id or _CURRENT_SNAPSHOT_REF
         resolved_derivation_basis_ref = derivation_basis_ref or view_ref
-        return ParticipantContextViewModel.model_validate(
+        view = ParticipantContextViewModel.model_validate(
             {
                 "view_id": _view_id("context", participant_address, episode_id or view_ref),
                 "participant_address": participant_address,
@@ -148,6 +200,26 @@ class ParticipantRetrievalMixin:
                 "redaction_policy_ref": None,
             }
         )
+        if getattr(self, "_crossing_policy_resolver", None) is None:
+            if crossing_evidence is not None:
+                raise ValueError("participant crossing policy resolver is required")
+            return view
+        resolved_episode_id = episode_id or _string_value(
+            self._snapshot.participant_episode_results.get(participant_address),
+            "episode_id",
+        )
+        return serialize_participant_view(
+            self,
+            view,
+            participant_address=participant_address,
+            episode_id=_required_episode_id(resolved_episode_id),
+            subject_kind=ParticipantCrossingSubjectKind.PARTICIPANT_CONTEXT_VIEW,
+            interaction_kind=ParticipantCrossingInteractionKind.DECISION_SURFACE_PROJECTION,
+            projection_ref=view.visibility_projection_ref,
+            identity=identity,
+            crossing_evidence=crossing_evidence,
+            idempotency_key=idempotency_key,
+        )
 
 
 def _string_value(payload: dict[str, object] | None, key: str) -> str | None:
@@ -155,6 +227,12 @@ def _string_value(payload: dict[str, object] | None, key: str) -> str | None:
         return None
     value = payload.get(key)
     return value if isinstance(value, str) and value else None
+
+
+def _required_episode_id(value: str | None) -> str:
+    if value is None:
+        raise ValueError("participant projection requires an exact episode identity")
+    return value
 
 
 def _utc_now() -> str:

--- a/implementations/python/packages/raes_runtime/participant_submission_options.py
+++ b/implementations/python/packages/raes_runtime/participant_submission_options.py
@@ -1,0 +1,81 @@
+"""Validated optional context for participant action submissions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from raes_contracts.participant_binding import ParticipantActionAdmissionRequest
+from raes_contracts.runtime_state import OperationReceipt
+from raes_processor.models import ParticipantBehaviorRuntime
+
+from .control_plane_execution import execute_participant_action
+from .participant_crossing_action import ActionIngressExecution
+from .participant_crossing_boundary import execute_action_ingress_crossing
+from .participant_crossing_mediation import ParticipantCrossingEvidence
+
+
+@dataclass(frozen=True)
+class ParticipantSubmissionOptions:
+    idempotency_key: str = ""
+    request_fingerprint: str = ""
+    identity: object | None = None
+    crossing_evidence: ParticipantCrossingEvidence | None = None
+
+    @classmethod
+    def from_fields(cls, fields: dict[str, object]) -> ParticipantSubmissionOptions:
+        unknown = set(fields) - {
+            "idempotency_key",
+            "request_fingerprint",
+            "identity",
+            "crossing_evidence",
+        }
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise TypeError(f"unexpected participant submission options: {names}")
+        idempotency_key = fields.get("idempotency_key", "")
+        request_fingerprint = fields.get("request_fingerprint", "")
+        crossing_evidence = fields.get("crossing_evidence")
+        if not isinstance(idempotency_key, str) or not isinstance(request_fingerprint, str):
+            raise TypeError("participant submission keys must be strings")
+        if crossing_evidence is not None and not isinstance(crossing_evidence, ParticipantCrossingEvidence):
+            raise TypeError("crossing_evidence must be ParticipantCrossingEvidence")
+        return cls(
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            identity=fields.get("identity"),
+            crossing_evidence=crossing_evidence,
+        )
+
+
+def submit_bound_participant_action(
+    control_plane: object,
+    participant_behavior: ParticipantBehaviorRuntime,
+    request: ParticipantActionAdmissionRequest,
+    options: ParticipantSubmissionOptions,
+) -> OperationReceipt:
+    if getattr(control_plane, "_crossing_policy_resolver", None) is not None:
+        return execute_action_ingress_crossing(
+            control_plane,
+            participant_behavior,
+            request,
+            ActionIngressExecution(
+                crossing_evidence=options.crossing_evidence,
+                identity=options.identity,
+                idempotency_key=options.idempotency_key,
+                method=control_plane._target.participant_runtime.admit_action,
+                address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
+            ),
+        )
+    if options.crossing_evidence is not None:
+        raise ValueError("participant crossing policy resolver is required")
+    return execute_participant_action(
+        control_plane,
+        method=control_plane._target.participant_runtime.admit_action,
+        request=request,
+        address=f"runtime.control-plane.participant.{request.participant_address}.admit-action",
+        idempotency_key=options.idempotency_key,
+        request_fingerprint=options.request_fingerprint,
+    )
+
+
+__all__ = ("ParticipantSubmissionOptions", "submit_bound_participant_action")

--- a/implementations/python/tests/test_api_423_participant_crossing_contracts.py
+++ b/implementations/python/tests/test_api_423_participant_crossing_contracts.py
@@ -62,6 +62,8 @@ def _policy() -> dict[str, object]:
         "policy_id": "participant-crossing-policy:red",
         "policy_revision": "revision-3",
         "policy_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "policy_decision_ref": "participant-crossing-policy-decision:red:episode-1:8",
+        "decision_cut_ref": "participant-policy-cut:red:episode-1:8",
         "effective_order": 8,
         "valid_from_order": 8,
         "valid_until_order": 20,
@@ -229,6 +231,24 @@ def test_crossing_request_is_a_closed_participant_runtime_fact() -> None:
     assert record.occurrence.stage == "requested"
     assert record.participant_address == "participants.red.operator"
     assert record.occurrence.subject.subject_ref == "control-occurrence.proposal.1"
+    assert record.occurrence.policy.policy_decision_ref == "participant-crossing-policy-decision:red:episode-1:8"
+    assert record.occurrence.policy.decision_cut_ref == "participant-policy-cut:red:episode-1:8"
+
+
+def test_crossing_policy_requires_an_exact_policy_decision_identity() -> None:
+    policy = _policy()
+    del policy["policy_decision_ref"]
+
+    with pytest.raises(ValidationError, match="policy_decision_ref"):
+        ParticipantCrossingPolicyReferenceModel.model_validate(policy)
+
+
+def test_crossing_policy_requires_an_exact_decision_cut() -> None:
+    policy = _policy()
+    del policy["decision_cut_ref"]
+
+    with pytest.raises(ValidationError, match="decision_cut_ref"):
+        ParticipantCrossingPolicyReferenceModel.model_validate(policy)
 
 
 def test_crossing_request_rejects_payload_policy_and_secret_bags() -> None:

--- a/implementations/python/tests/test_run_319_participant_flow_policy.py
+++ b/implementations/python/tests/test_run_319_participant_flow_policy.py
@@ -379,14 +379,13 @@ def test_crossing_history_is_preserved_and_append_only() -> None:
 
 
 def test_caller_evidence_cannot_describe_the_protected_operation() -> None:
+    payload = {
+        **_evidence().model_dump(mode="json"),
+        "interaction_kind": "denial",
+        "participant_address": "participant.attacker",
+    }
     with pytest.raises(ValidationError, match="interaction_kind"):
-        ParticipantCrossingEvidence.model_validate(
-            {
-                **_evidence().model_dump(mode="json"),
-                "interaction_kind": "denial",
-                "participant_address": "participant.attacker",
-            }
-        )
+        ParticipantCrossingEvidence.model_validate(payload)
 
 
 def test_action_boundary_authorizes_and_finalizes_one_operation() -> None:
@@ -423,12 +422,15 @@ def test_action_boundary_derives_exact_subject_and_semantics_from_request() -> N
 
 def test_configured_action_ingress_cannot_bypass_crossing_mediation() -> None:
     plane = _action_plane(_StaticCrossingResolver())
+    behavior = _behavior()
+    request = _admission_request()
+    identity = _identity()
 
     with pytest.raises(ValueError, match="requires crossing evidence"):
         plane.admit_participant_action(
-            _behavior(),
-            _admission_request(),
-            identity=_identity(),
+            behavior,
+            request,
+            identity=identity,
         )
 
     assert plane.snapshot.participant_behavior_history == {}
@@ -436,8 +438,9 @@ def test_configured_action_ingress_cannot_bypass_crossing_mediation() -> None:
 
 
 def test_policy_capable_target_requires_crossing_resolver_at_startup() -> None:
+    target = _policy_capable_target()
     with pytest.raises(ValueError, match="policy capabilities require a crossing policy resolver"):
-        RuntimeControlPlane(_policy_capable_target())
+        RuntimeControlPlane(target)
 
 
 def test_unsupported_backend_never_executes_the_incumbent_action() -> None:
@@ -471,9 +474,10 @@ def test_independent_ingress_gate_denials_do_not_execute_action(gate: str) -> No
 
 def test_identity_denials_are_security_audited_without_participant_facts() -> None:
     plane = _action_plane(_StaticCrossingResolver())
+    identity = _identity(bound=False)
 
     with pytest.raises(PermissionError, match="subject"):
-        _admit(plane, identity=_identity(bound=False))
+        _admit(plane, identity=identity)
 
     assert plane.snapshot.participant_crossing_history == {}
     assert plane.snapshot.participant_behavior_history == {}
@@ -491,10 +495,11 @@ def test_operation_bound_idempotency_replays_neither_decision_nor_action() -> No
     assert len(plane.snapshot.participant_crossing_history[_PARTICIPANT]) == 2
     behavior_count = len(plane.snapshot.participant_behavior_history[_PARTICIPANT])
     assert behavior_count >= 2
+    different_request = _admission_request(action_instance_id="different")
     with pytest.raises(ValueError, match="different semantics"):
         _admit(
             plane,
-            request=_admission_request(action_instance_id="different"),
+            request=different_request,
             idempotency_key="same-operation",
         )
     assert len(plane.snapshot.participant_behavior_history[_PARTICIPANT]) == behavior_count
@@ -651,9 +656,10 @@ def test_egress_requires_separate_audience_authority_and_commits_before_return()
             "participant_transformation",
         ),
     )
+    unbound_identity = _identity()
 
     with pytest.raises(PermissionError, match="audience"):
-        _status_evidence_call(plane, identity=_identity(), idempotency_key="egress-unbound")
+        _status_evidence_call(plane, identity=unbound_identity, idempotency_key="egress-unbound")
     assert plane.snapshot.participant_crossing_history == {}
 
     view = _status_evidence_call(
@@ -763,11 +769,12 @@ def test_missing_visibility_gate_fails_closed_without_serializing_output() -> No
             "participant_transformation",
         ),
     )
+    audience_identity = _identity(audience_bound=True)
 
     with pytest.raises(PermissionError, match="not permitted"):
         _status_evidence_call(
             plane,
-            identity=_identity(audience_bound=True),
+            identity=audience_identity,
             idempotency_key="egress-no-visibility",
         )
 

--- a/implementations/python/tests/test_run_319_participant_flow_policy.py
+++ b/implementations/python/tests/test_run_319_participant_flow_policy.py
@@ -1,0 +1,1041 @@
+"""RUN-319 operation-bound participant information-flow enforcement tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from threading import Barrier, Thread
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+from raes.participant_behavior_specification import MixedControlTransitionKind
+from raes_backend_protocols.backend_manifest import BackendManifest
+from raes_backend_protocols.capabilities import ParticipantFeatureSupport
+from raes_backend_stubs.stubs import create_stub_target
+from raes_contracts.contracts.participant_crossing import (
+    ParticipantCrossingGateDisposition,
+    ParticipantCrossingOperation,
+    ParticipantCrossingPolicyReferenceModel,
+    ParticipantCrossingSubjectReferenceModel,
+)
+from raes_contracts.participant_binding import ParticipantActionAdmissionRequest
+from raes_contracts.runtime_state import RuntimeSnapshot, RuntimeSnapshotEnvelope
+from raes_contracts.vocabulary import ParticipantFeatureSupportLevel
+from raes_operations.deterministic_participant_fixtures import (
+    build_implementation_manifest,
+    build_implementation_selection,
+)
+from raes_processor.models import (
+    MixedControlControllerStateRuntime,
+    MixedControlDispositionRulesRuntime,
+    MixedControlTransitionRuntime,
+    ParticipantBehaviorRuntime,
+    ParticipantBehaviorSpecificationRuntime,
+)
+from raes_runtime.control_plane import RuntimeControlPlane
+from raes_runtime.control_plane_api_models import _snapshot_model
+from raes_runtime.control_plane_security import (
+    ControlPlaneIdentity,
+    ControlPlaneRole,
+    ParticipantAudienceSubjectBinding,
+    ParticipantControlSubjectBinding,
+)
+from raes_runtime.control_plane_store import (
+    InMemoryControlPlaneStore,
+    LocalControlPlaneStore,
+    _snapshot_from_payload,
+    _snapshot_payload,
+)
+from raes_runtime.operational_apparatus import operational_apparatus_summary
+from raes_runtime.participant_control_intents import ParticipantHandoffControlIntent
+from raes_runtime.participant_crossing_boundary import _action_subject
+from raes_runtime.participant_crossing_egress import _view_subject
+from raes_runtime.participant_crossing_mediation import (
+    ParticipantCrossingEvidence,
+    ParticipantCrossingIntent,
+    ParticipantCrossingPolicyResolution,
+    ParticipantCrossingSemanticGates,
+    ParticipantCrossingTransformationResolution,
+    ParticipantCrossingValidationContext,
+)
+from raes_runtime.participant_result_contracts import (
+    participant_runtime_history_transition_diagnostics,
+    participant_runtime_state_contract_diagnostics,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PARTICIPANT = "participant.behavior.red-agent"
+_CONTROLLER = "participant.behavior.supervisor"
+_AUDIENCE = "audience:red-operator"
+_ACTION = "participant.action-contract.contain-host"
+_TRANSFORMED_ACTION = "participant.action-contract.redacted-contain-host"
+_OBSERVATION = "participant.observation-boundary.red-view"
+
+
+def _crossing_request() -> dict[str, object]:
+    fixture = (
+        REPO_ROOT
+        / "contracts"
+        / "fixtures"
+        / "participant-runtime"
+        / "participant-crossing-occurrence-v1"
+        / "valid"
+        / "request.json"
+    )
+    return json.loads(fixture.read_text(encoding="utf-8"))
+
+
+def _evidence() -> ParticipantCrossingEvidence:
+    return ParticipantCrossingEvidence(
+        audience_scope_ref=_AUDIENCE,
+        required_evidence_refs=["evidence-requirement:crossing-decision"],
+        provenance_refs=["provenance:crossing-1"],
+        evidence_refs=["evidence:crossing-1"],
+        object_marking_refs=["marking:participant-control"],
+        authorization_scope="scope:red-team",
+        loss_and_limitations=["limitation:bounded-reference-runtime"],
+    )
+
+
+def _identity(*, bound: bool = True, audience_bound: bool = False) -> ControlPlaneIdentity:
+    return ControlPlaneIdentity(
+        identity="operator.red",
+        roles=frozenset({ControlPlaneRole.OPERATOR}),
+        target_name="stub",
+        participant_control_subjects=(
+            (
+                ParticipantControlSubjectBinding(
+                    participant_address=_PARTICIPANT,
+                    controller_ref=_CONTROLLER,
+                ),
+            )
+            if bound
+            else ()
+        ),
+        participant_audience_subjects=(
+            (
+                ParticipantAudienceSubjectBinding(
+                    participant_address=_PARTICIPANT,
+                    audience_scope_ref=_AUDIENCE,
+                ),
+            )
+            if audience_bound
+            else ()
+        ),
+    )
+
+
+def _behavior() -> ParticipantBehaviorRuntime:
+    return ParticipantBehaviorRuntime(
+        address=_PARTICIPANT,
+        name="red-agent",
+        spec={},
+        authority_anchor_refs=("red-team",),
+        authority_anchor_addresses=("authority:red-team",),
+        action_contract_addresses=(_ACTION, _TRANSFORMED_ACTION),
+        observation_boundary_addresses=(_OBSERVATION,),
+    )
+
+
+def _admission_request(
+    *,
+    action_contract_address: str = _ACTION,
+    action_instance_id: str = "action-1",
+) -> ParticipantActionAdmissionRequest:
+    return ParticipantActionAdmissionRequest(
+        participant_address=_PARTICIPANT,
+        action_contract_address=action_contract_address,
+        observation_boundary_address=_OBSERVATION,
+        action_instance_id=action_instance_id,
+        implementation_manifest=build_implementation_manifest(),
+        implementation_selection=build_implementation_selection(_PARTICIPANT),
+        evidence_refs=("evidence:action",),
+        observation_boundary_evidence_refs=("evidence:action",),
+    )
+
+
+def _policy_capable_target(
+    *features: str,
+    support_level: ParticipantFeatureSupportLevel = ParticipantFeatureSupportLevel.EXACT,
+):
+    selected_features = set(features or ("participant_ingress_admission",))
+    target = create_stub_target()
+    manifest = target.manifest
+    capabilities = manifest.participant_runtime
+    assert capabilities is not None
+    feature_support = tuple(
+        (
+            ParticipantFeatureSupport(
+                feature=entry.feature,
+                support_level=support_level,
+                constraint_refs=(
+                    (f"constraint:{entry.feature}:bounded",)
+                    if support_level is ParticipantFeatureSupportLevel.BOUNDED
+                    else ()
+                ),
+                limitation_refs=(
+                    (f"limitation:{entry.feature}:bounded",)
+                    if support_level is not ParticipantFeatureSupportLevel.EXACT
+                    else ()
+                ),
+                disclosure_refs=(
+                    (f"disclosure:{entry.feature}:bounded",)
+                    if support_level is not ParticipantFeatureSupportLevel.EXACT
+                    else ()
+                ),
+                evidence_refs=(f"evidence:backend:{entry.feature}",),
+            )
+            if entry.feature in selected_features
+            else entry
+        )
+        for entry in capabilities.feature_support
+    )
+    participant_runtime = replace(
+        capabilities,
+        supported_behavior_features=(capabilities.supported_behavior_features | selected_features),
+        feature_support=feature_support,
+    )
+    updated_manifest = BackendManifest(
+        identity=manifest.identity,
+        supported_contract_versions=manifest.supported_contract_versions,
+        compatibility=manifest.compatibility,
+        realization_support=manifest.realization_support,
+        concept_bindings=manifest.concept_bindings,
+        constraints=manifest.constraints,
+        capabilities=replace(manifest.capabilities, participant_runtime=participant_runtime),
+        realization_envelope=manifest.realization_envelope,
+    )
+    return replace(target, manifest=updated_manifest)
+
+
+class _StaticCrossingResolver:
+    def __init__(
+        self,
+        *,
+        gate_overrides: dict[str, ParticipantCrossingGateDisposition] | None = None,
+        allowed_downgrades: dict[str, ParticipantFeatureSupportLevel] | None = None,
+    ) -> None:
+        self.gate_overrides = gate_overrides or {}
+        self.allowed_downgrades = allowed_downgrades or {}
+        self.seen_intents: list[ParticipantCrossingIntent] = []
+        self.subjects: list[ParticipantCrossingSubjectReferenceModel] = []
+        self.evidence_refs: set[str] = set()
+        self.authority_refs: set[str] = {
+            "authority:red-team",
+            "entities.red-team",
+            "runtime.authority:participant-projection",
+        }
+        fixture_policy = ParticipantCrossingPolicyReferenceModel.model_validate(
+            _crossing_request()["occurrence"]["policy"]
+        )
+        self.policy = fixture_policy.model_copy(
+            update={
+                "effective_order": 0,
+                "valid_from_order": 0,
+                "valid_until_order": 1000,
+            }
+        )
+
+    def resolve(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantCrossingPolicyResolution:
+        del snapshot
+        self._remember(intent)
+        defaults = {
+            "participant_authority": ParticipantCrossingGateDisposition.PERMIT,
+            "action_admission": (
+                ParticipantCrossingGateDisposition.PERMIT
+                if intent.direction.value == "ingress"
+                else ParticipantCrossingGateDisposition.NOT_APPLICABLE
+            ),
+            "visibility": (
+                ParticipantCrossingGateDisposition.PERMIT
+                if intent.direction.value == "egress"
+                else ParticipantCrossingGateDisposition.NOT_APPLICABLE
+            ),
+            "marking_authorization": ParticipantCrossingGateDisposition.PERMIT,
+            "declassification": ParticipantCrossingGateDisposition.NOT_APPLICABLE,
+            "transformation_validity": ParticipantCrossingGateDisposition.NOT_APPLICABLE,
+        }
+        if intent.requested_operation in {
+            ParticipantCrossingOperation.PROJECTION,
+            ParticipantCrossingOperation.MASKING,
+            ParticipantCrossingOperation.REDACTION,
+            ParticipantCrossingOperation.TRANSFORMATION,
+            ParticipantCrossingOperation.DECLASSIFICATION,
+        }:
+            defaults["transformation_validity"] = ParticipantCrossingGateDisposition.PERMIT
+        defaults.update(self.gate_overrides)
+        return ParticipantCrossingPolicyResolution(
+            policy=self.policy,
+            gates=ParticipantCrossingSemanticGates(**defaults),
+            reason_code="policy-satisfied",
+            allowed_downgrades=self.allowed_downgrades,
+            downgrade_policy_ref=("policy:downgrade:authorized" if self.allowed_downgrades else None),
+            downgrade_provenance_ref=("provenance:downgrade:authorized" if self.allowed_downgrades else None),
+        )
+
+    def _remember(self, intent: ParticipantCrossingIntent) -> None:
+        self.seen_intents.append(intent)
+        if intent.subject not in self.subjects:
+            self.subjects.append(intent.subject)
+        self.evidence_refs.update(intent.evidence_refs)
+        self.evidence_refs.update(intent.required_evidence_refs)
+        self.authority_refs.update(intent.authority_basis_refs)
+
+    def validation_context(
+        self,
+        snapshot: RuntimeSnapshot,
+        participant_address: str,
+    ) -> ParticipantCrossingValidationContext:
+        del snapshot, participant_address
+        return ParticipantCrossingValidationContext(
+            known_subjects=tuple(self.subjects),
+            policies=(self.policy,),
+            known_evidence_refs=frozenset(
+                {
+                    *self.evidence_refs,
+                    "evidence:backend:participant_ingress_admission",
+                    "evidence:backend:participant_egress_projection",
+                    "evidence:backend:participant_transformation",
+                    "evidence:backend:participant_intervention",
+                }
+            ),
+            known_authority_basis_refs=frozenset(self.authority_refs),
+        )
+
+
+def _action_plane(
+    resolver: _StaticCrossingResolver,
+    *,
+    target: object | None = None,
+    store: object | None = None,
+) -> RuntimeControlPlane:
+    plane = RuntimeControlPlane(
+        target or _policy_capable_target(),
+        crossing_policy_resolver=resolver,
+        store=store,
+    )
+    plane.initialize_participant_episode(_PARTICIPANT, episode_id="episode-1")
+    return plane
+
+
+def _admit(
+    plane: RuntimeControlPlane,
+    *,
+    request: ParticipantActionAdmissionRequest | None = None,
+    idempotency_key: str = "crossing-action",
+    identity: ControlPlaneIdentity | None = None,
+):
+    return plane.admit_participant_action(
+        _behavior(),
+        request or _admission_request(),
+        identity=identity or _identity(),
+        crossing_evidence=_evidence(),
+        idempotency_key=idempotency_key,
+    )
+
+
+def test_crossing_history_is_first_class_serialized_and_operational_state() -> None:
+    request = _crossing_request()
+    snapshot = RuntimeSnapshot(participant_crossing_history={_PARTICIPANT: [request]})
+
+    restored = _snapshot_from_payload(_snapshot_payload(snapshot))
+    published = _snapshot_model(RuntimeSnapshotEnvelope(snapshot=snapshot))
+    summary = operational_apparatus_summary(
+        target_name="reference",
+        snapshot=snapshot,
+        operation_records=[],
+        audit_events=[],
+    )
+
+    assert restored.participant_crossing_history == {_PARTICIPANT: [request]}
+    assert published.participant_crossing_history[_PARTICIPANT][0].event_id == request["event_id"]
+    assert summary["runtime_surfaces"]["participant_crossing_history"] == 1
+
+
+def test_crossing_history_is_preserved_and_append_only() -> None:
+    request = _crossing_request()
+    snapshot = RuntimeSnapshot(participant_crossing_history={_PARTICIPANT: [request]})
+    rewritten = RuntimeSnapshot(
+        participant_crossing_history={
+            _PARTICIPANT: [{**request, "event_id": "crossing-occurrence.requested.rewritten"}]
+        },
+    )
+
+    assert snapshot.with_entries({}).participant_crossing_history == snapshot.participant_crossing_history
+    assert any(
+        "append-only" in diagnostic.message
+        for diagnostic in participant_runtime_history_transition_diagnostics(snapshot, rewritten)
+    )
+    invalid = RuntimeSnapshot(participant_crossing_history={"participants.other": [request]})
+    assert any(
+        "map key" in diagnostic.message for diagnostic in participant_runtime_state_contract_diagnostics(invalid)
+    )
+
+
+def test_caller_evidence_cannot_describe_the_protected_operation() -> None:
+    with pytest.raises(ValidationError, match="interaction_kind"):
+        ParticipantCrossingEvidence.model_validate(
+            {
+                **_evidence().model_dump(mode="json"),
+                "interaction_kind": "denial",
+                "participant_address": "participant.attacker",
+            }
+        )
+
+
+def test_action_boundary_authorizes_and_finalizes_one_operation() -> None:
+    resolver = _StaticCrossingResolver()
+    plane = _action_plane(resolver)
+
+    receipt = _admit(plane)
+
+    assert receipt.accepted is True
+    assert len(plane.snapshot.participant_behavior_history[_PARTICIPANT]) >= 2
+    crossing = plane.snapshot.participant_crossing_history[_PARTICIPANT]
+    assert [item["occurrence"]["stage"] for item in crossing] == ["requested", "decided"]
+    assert len(plane._operations) == 2  # episode initialization plus the combined action
+    audit = plane.audit_log()[-1]
+    assert audit.action == "admit_participant_action"
+    assert audit.operation_id == receipt.operation_id
+    assert audit.details["crossing_decision_id"] == crossing[-1]["occurrence"]["decision_id"]
+
+
+def test_action_boundary_derives_exact_subject_and_semantics_from_request() -> None:
+    resolver = _StaticCrossingResolver()
+    plane = _action_plane(resolver)
+    request = _admission_request()
+
+    _admit(plane, request=request)
+
+    resolved = resolver.seen_intents[0]
+    assert resolved.interaction_kind.value == "action-proposal"
+    assert resolved.action_or_projection_ref == request.action_contract_address
+    assert resolved.subject == _action_subject(plane, request)
+    assert resolved.participant_address == request.participant_address
+    assert resolved.episode_id == "episode-1"
+
+
+def test_configured_action_ingress_cannot_bypass_crossing_mediation() -> None:
+    plane = _action_plane(_StaticCrossingResolver())
+
+    with pytest.raises(ValueError, match="requires crossing evidence"):
+        plane.admit_participant_action(
+            _behavior(),
+            _admission_request(),
+            identity=_identity(),
+        )
+
+    assert plane.snapshot.participant_behavior_history == {}
+    assert plane.snapshot.participant_crossing_history == {}
+
+
+def test_policy_capable_target_requires_crossing_resolver_at_startup() -> None:
+    with pytest.raises(ValueError, match="policy capabilities require a crossing policy resolver"):
+        RuntimeControlPlane(_policy_capable_target())
+
+
+def test_unsupported_backend_never_executes_the_incumbent_action() -> None:
+    resolver = _StaticCrossingResolver()
+    plane = _action_plane(resolver, target=create_stub_target())
+
+    receipt = _admit(plane)
+
+    assert receipt.accepted is False
+    assert plane.snapshot.participant_behavior_history == {}
+    decision = plane.snapshot.participant_crossing_history[_PARTICIPANT][-1]["occurrence"]
+    assert decision["disposition"] == "unsupported"
+    assert decision["gates"]["backend_support"] == "unsupported"
+
+
+@pytest.mark.parametrize(
+    "gate",
+    ["participant_authority", "action_admission", "marking_authorization"],
+)
+def test_independent_ingress_gate_denials_do_not_execute_action(gate: str) -> None:
+    resolver = _StaticCrossingResolver(gate_overrides={gate: ParticipantCrossingGateDisposition.DENY})
+    plane = _action_plane(resolver)
+
+    receipt = _admit(plane, idempotency_key=f"denied-{gate}")
+
+    assert receipt.accepted is False
+    assert plane.snapshot.participant_behavior_history == {}
+    decision = plane.snapshot.participant_crossing_history[_PARTICIPANT][-1]["occurrence"]
+    assert decision["gates"][gate] == "deny"
+
+
+def test_identity_denials_are_security_audited_without_participant_facts() -> None:
+    plane = _action_plane(_StaticCrossingResolver())
+
+    with pytest.raises(PermissionError, match="subject"):
+        _admit(plane, identity=_identity(bound=False))
+
+    assert plane.snapshot.participant_crossing_history == {}
+    assert plane.snapshot.participant_behavior_history == {}
+    assert plane.audit_log()[-1].reason == "subject-forbidden"
+    assert plane.audit_log()[-1].details == {}
+
+
+def test_operation_bound_idempotency_replays_neither_decision_nor_action() -> None:
+    plane = _action_plane(_StaticCrossingResolver())
+
+    first = _admit(plane, idempotency_key="same-operation")
+    retry = _admit(plane, idempotency_key="same-operation")
+
+    assert retry.operation_id == first.operation_id
+    assert len(plane.snapshot.participant_crossing_history[_PARTICIPANT]) == 2
+    behavior_count = len(plane.snapshot.participant_behavior_history[_PARTICIPANT])
+    assert behavior_count >= 2
+    with pytest.raises(ValueError, match="different semantics"):
+        _admit(
+            plane,
+            request=_admission_request(action_instance_id="different"),
+            idempotency_key="same-operation",
+        )
+    assert len(plane.snapshot.participant_behavior_history[_PARTICIPANT]) == behavior_count
+
+
+def test_operation_bound_idempotency_rejects_replay_after_state_cut_advances() -> None:
+    plane = _action_plane(_StaticCrossingResolver())
+
+    _admit(plane, idempotency_key="state-cut-bound")
+    _admit(
+        plane,
+        request=_admission_request(action_instance_id="later-action"),
+        idempotency_key="later-operation",
+    )
+
+    with pytest.raises(ValueError, match="state cut advanced"):
+        _admit(plane, idempotency_key="state-cut-bound")
+
+
+class _TransformedActionResolver(_StaticCrossingResolver):
+    def __init__(self, *, deny_fresh: bool = False) -> None:
+        super().__init__()
+        self.deny_fresh = deny_fresh
+        self.governed_request: ParticipantActionAdmissionRequest | None = None
+
+    def resolve_operation(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+        carrier: object,
+    ) -> ParticipantCrossingPolicyResolution:
+        assert isinstance(carrier, ParticipantActionAdmissionRequest)
+        self._remember(intent)
+        self.governed_request = replace(
+            carrier,
+            action_contract_address=_TRANSFORMED_ACTION,
+            action_instance_id=f"{carrier.action_instance_id}-redacted",
+        )
+        result_subject = _action_subject(SimpleNamespace(_snapshot=snapshot), self.governed_request)
+        if result_subject not in self.subjects:
+            self.subjects.append(result_subject)
+        base = super().resolve(intent, snapshot)
+        return replace(
+            base,
+            gates=replace(
+                base.gates,
+                transformation_validity=ParticipantCrossingGateDisposition.PERMIT,
+            ),
+            required_operation=ParticipantCrossingOperation.REDACTION,
+            transformation=ParticipantCrossingTransformationResolution(
+                result_subject=result_subject,
+                rule_ref="rule:redact-action",
+                rule_revision="1",
+                result_marking_refs=("marking:participant-control",),
+            ),
+        )
+
+    def resolve(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantCrossingPolicyResolution:
+        resolution = super().resolve(intent, snapshot)
+        if self.governed_request is not None and intent.subject.subject_ref.endswith(
+            self.governed_request.action_instance_id
+        ):
+            if self.deny_fresh:
+                return replace(
+                    resolution,
+                    gates=replace(
+                        resolution.gates,
+                        action_admission=ParticipantCrossingGateDisposition.DENY,
+                    ),
+                )
+        return resolution
+
+    def transform_ingress(
+        self,
+        intent: ParticipantCrossingIntent,
+        governed_subject: ParticipantCrossingSubjectReferenceModel,
+        carrier: object,
+    ) -> ParticipantActionAdmissionRequest:
+        del intent, governed_subject, carrier
+        assert self.governed_request is not None
+        return self.governed_request
+
+
+def test_transformed_action_is_revalidated_and_the_governed_carrier_executes() -> None:
+    resolver = _TransformedActionResolver()
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            "participant_ingress_admission",
+            "participant_transformation",
+        ),
+    )
+
+    receipt = _admit(plane)
+
+    assert receipt.accepted is True
+    history = plane.snapshot.participant_crossing_history[_PARTICIPANT]
+    assert [item["occurrence"]["stage"] for item in history] == [
+        "requested",
+        "decided",
+        "transformed",
+        "requested",
+        "decided",
+    ]
+    behavior = plane.snapshot.participant_behavior_history[_PARTICIPANT]
+    assert all(
+        item.get("action_contract_address") == _TRANSFORMED_ACTION
+        for item in behavior
+        if "action_contract_address" in item
+    )
+
+
+def test_fresh_denial_of_transformed_action_prevents_backend_execution() -> None:
+    resolver = _TransformedActionResolver(deny_fresh=True)
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            "participant_ingress_admission",
+            "participant_transformation",
+        ),
+    )
+
+    receipt = _admit(plane)
+
+    assert receipt.accepted is False
+    assert plane.snapshot.participant_behavior_history == {}
+    assert plane.snapshot.participant_crossing_history[_PARTICIPANT][-1]["occurrence"]["disposition"] == "deny"
+
+
+def _status_evidence_call(
+    plane: RuntimeControlPlane,
+    *,
+    identity: ControlPlaneIdentity,
+    idempotency_key: str,
+):
+    return plane.get_participant_status_view(
+        _PARTICIPANT,
+        identity=identity,
+        crossing_evidence=_evidence(),
+        idempotency_key=idempotency_key,
+    )
+
+
+def test_egress_requires_separate_audience_authority_and_commits_before_return() -> None:
+    resolver = _StaticCrossingResolver()
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            "participant_egress_projection",
+            "participant_transformation",
+        ),
+    )
+
+    with pytest.raises(PermissionError, match="audience"):
+        _status_evidence_call(plane, identity=_identity(), idempotency_key="egress-unbound")
+    assert plane.snapshot.participant_crossing_history == {}
+
+    view = _status_evidence_call(
+        plane,
+        identity=_identity(audience_bound=True),
+        idempotency_key="egress-bound",
+    )
+
+    assert view is not None
+    assert view.participant_address == _PARTICIPANT
+    assert plane.snapshot.participant_crossing_history[_PARTICIPANT][-1]["occurrence"]["disposition"] == "permit"
+    assert plane.audit_log()[-1].operation_id in plane._operations
+
+
+class _TransformedEgressResolver(_StaticCrossingResolver):
+    def __init__(self) -> None:
+        super().__init__()
+        self.governed_view: object | None = None
+
+    def resolve_operation(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+        carrier: object,
+    ) -> ParticipantCrossingPolicyResolution:
+        self._remember(intent)
+        self.governed_view = carrier.model_copy(
+            update={
+                "view_id": f"{carrier.view_id}.redacted",
+                "redaction_policy_ref": "policy:redacted-status",
+                "marking_definition_refs": ["marking:participant-control", "marking:redacted"],
+            }
+        )
+        result_subject = _view_subject(
+            self.governed_view,
+            participant_address=intent.participant_address,
+            episode_id=intent.episode_id,
+            subject_kind=intent.subject.subject_kind,
+        )
+        if result_subject not in self.subjects:
+            self.subjects.append(result_subject)
+        base = super().resolve(intent, snapshot)
+        return replace(
+            base,
+            gates=replace(
+                base.gates,
+                transformation_validity=ParticipantCrossingGateDisposition.PERMIT,
+            ),
+            required_operation=ParticipantCrossingOperation.REDACTION,
+            transformation=ParticipantCrossingTransformationResolution(
+                result_subject=result_subject,
+                rule_ref="rule:redact-status",
+                rule_revision="1",
+                result_marking_refs=("marking:participant-control", "marking:redacted"),
+            ),
+        )
+
+    def transform_egress(
+        self,
+        intent: ParticipantCrossingIntent,
+        governed_subject: ParticipantCrossingSubjectReferenceModel,
+        carrier: object,
+    ) -> object:
+        del intent, governed_subject, carrier
+        return self.governed_view
+
+
+def test_egress_transformation_returns_only_the_committed_governed_view() -> None:
+    resolver = _TransformedEgressResolver()
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            "participant_egress_projection",
+            "participant_transformation",
+        ),
+    )
+
+    view = _status_evidence_call(
+        plane,
+        identity=_identity(audience_bound=True),
+        idempotency_key="egress-redacted",
+    )
+    retry = _status_evidence_call(
+        plane,
+        identity=_identity(audience_bound=True),
+        idempotency_key="egress-redacted",
+    )
+
+    assert view is not None
+    assert view.redaction_policy_ref == "policy:redacted-status"
+    assert view.marking_definition_refs == ["marking:participant-control", "marking:redacted"]
+    assert retry == view
+    history = plane.snapshot.participant_crossing_history[_PARTICIPANT]
+    assert [item["occurrence"]["stage"] for item in history] == [
+        "requested",
+        "decided",
+        "transformed",
+    ]
+
+
+def test_missing_visibility_gate_fails_closed_without_serializing_output() -> None:
+    resolver = _StaticCrossingResolver(gate_overrides={"visibility": ParticipantCrossingGateDisposition.NOT_APPLICABLE})
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            "participant_egress_projection",
+            "participant_transformation",
+        ),
+    )
+
+    with pytest.raises(PermissionError, match="not permitted"):
+        _status_evidence_call(
+            plane,
+            identity=_identity(audience_bound=True),
+            idempotency_key="egress-no-visibility",
+        )
+
+    decision = plane.snapshot.participant_crossing_history[_PARTICIPANT][-1]["occurrence"]
+    assert decision["gates"]["visibility"] == "unknown"
+
+
+def test_authorized_downgrade_records_only_effective_backend_strength() -> None:
+    feature = "participant_ingress_admission"
+    resolver = _StaticCrossingResolver(allowed_downgrades={feature: ParticipantFeatureSupportLevel.BOUNDED})
+    plane = _action_plane(
+        resolver,
+        target=_policy_capable_target(
+            feature,
+            support_level=ParticipantFeatureSupportLevel.BOUNDED,
+        ),
+    )
+
+    receipt = _admit(plane)
+
+    assert receipt.accepted is True
+    history = plane.snapshot.participant_crossing_history[_PARTICIPANT]
+    assert all(item["occurrence"]["backend_posture"] == "bounded" for item in history)
+
+
+def _control_specification() -> ParticipantBehaviorSpecificationRuntime:
+    autonomous = MixedControlControllerStateRuntime(
+        address="participant.behavior-specification.controlled.controller-state.autonomous",
+        name="autonomous",
+        spec={},
+        state_id="autonomous",
+        controller_ref="supervisor",
+        controller_address=_CONTROLLER,
+        authority_basis_refs=("red-team",),
+        authority_basis_addresses=("entities.red-team",),
+        scope_refs=("web",),
+        scope_addresses=("nodes.web",),
+        policy_revision="1.0.0",
+        valid_from_order=0,
+        valid_until_order=20,
+        authority_status="active",
+        evidence_refs=("authority-evidence",),
+        evidence_addresses=("evidence.authority",),
+    )
+    supervised = replace(
+        autonomous,
+        address="participant.behavior-specification.controlled.controller-state.supervised",
+        name="supervised",
+        state_id="supervised",
+    )
+    transition = MixedControlTransitionRuntime(
+        address="participant.behavior-specification.controlled.control-transition.handoff",
+        name="handoff",
+        spec={},
+        transition_id="handoff",
+        transition_kind=MixedControlTransitionKind.HANDOFF.value,
+        from_state_address=autonomous.address,
+        to_state_address=supervised.address,
+        policy_revision="1.0.0",
+        expected_state_revision=0,
+        resulting_state_revision=1,
+        effective_order=1,
+        valid_from_order=0,
+        valid_until_order=20,
+        completion_evidence_refs=("handoff-evidence",),
+        completion_evidence_addresses=("evidence.handoff",),
+    )
+    return ParticipantBehaviorSpecificationRuntime(
+        address="participant.behavior-specification.controlled",
+        name="controlled",
+        spec={},
+        spec_name="controlled",
+        participant_addresses=(_PARTICIPANT,),
+        behavior_mode="mixed-control",
+        mixed_control_participant_address=_PARTICIPANT,
+        mixed_control_policy_revision="1.0.0",
+        mixed_control_order_strategy="total-effective-order",
+        mixed_control_initial_state_address=autonomous.address,
+        mixed_control_dispositions=MixedControlDispositionRulesRuntime(
+            duplicate="idempotent",
+            stale="reject",
+            revoked="reject",
+            late="reject",
+            concurrent="reject",
+            conflict="reject",
+        ),
+        controller_states=(autonomous, supervised),
+        control_transitions=(transition,),
+    )
+
+
+def test_supervisory_control_derives_handoff_semantics_and_commits_one_transition() -> None:
+    resolver = _StaticCrossingResolver()
+    specification = _control_specification()
+    plane = RuntimeControlPlane(
+        _policy_capable_target(
+            "participant_ingress_admission",
+            "participant_intervention",
+        ),
+        behavior_specifications={specification.address: specification},
+        crossing_policy_resolver=resolver,
+    )
+    intent = ParticipantHandoffControlIntent(
+        declaration_ref=specification.control_transitions[0].address,
+        episode_id="episode-1",
+        client_correlation_id="handoff-1",
+        policy_revision="1.0.0",
+        expected_state_revision=0,
+        provenance_refs=["provenance:handoff"],
+        evidence_refs=["evidence:handoff"],
+        object_marking_refs=["marking:participant-control"],
+        limitation_refs=["limitation:none"],
+        completion_evidence_ref="evidence:handoff",
+    )
+
+    receipt = plane.record_participant_control(
+        _PARTICIPANT,
+        intent,
+        identity=_identity(),
+        crossing_evidence=_evidence(),
+        idempotency_key="handoff",
+    )
+
+    assert receipt.accepted is True
+    assert resolver.seen_intents[0].interaction_kind.value == "handoff"
+    assert len(plane.snapshot.participant_control_history[_PARTICIPANT]) == 1
+    assert len(plane.snapshot.participant_crossing_history[_PARTICIPANT]) == 2
+    assert len(plane._operations) == 1
+
+
+def test_crossing_history_restarts_and_operation_replays_idempotently(tmp_path: Path) -> None:
+    resolver = _StaticCrossingResolver()
+    store_path = tmp_path / "control-plane"
+    first = _action_plane(resolver, store=LocalControlPlaneStore(store_path))
+    receipt = _admit(first, idempotency_key="restart-crossing")
+
+    restarted_resolver = _StaticCrossingResolver()
+    restarted_resolver.subjects = list(resolver.subjects)
+    restarted_resolver.evidence_refs = set(resolver.evidence_refs)
+    restarted = RuntimeControlPlane(
+        _policy_capable_target(),
+        store=LocalControlPlaneStore(store_path),
+        crossing_policy_resolver=restarted_resolver,
+    )
+    retry = _admit(restarted, idempotency_key="restart-crossing")
+
+    assert retry.operation_id == receipt.operation_id
+    assert len(restarted.snapshot.participant_crossing_history[_PARTICIPANT]) == 2
+
+
+class _FailingCommitStore(InMemoryControlPlaneStore):
+    def commit_participant_transition(self, **kwargs: object) -> None:
+        del kwargs
+        raise RuntimeError("injected atomic write failure")
+
+
+def test_atomic_write_failure_leaves_backend_and_histories_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = _StaticCrossingResolver()
+    store = _FailingCommitStore()
+    target = _policy_capable_target()
+    runtime = target.participant_runtime
+    assert runtime is not None
+    original = runtime.admit_action
+    calls = 0
+
+    def tracked_admit_action(*args: object, **kwargs: object):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "admit_action", tracked_admit_action)
+    plane = _action_plane(resolver, store=store, target=target)
+
+    with pytest.raises(RuntimeError, match="atomic write failure"):
+        _admit(plane)
+
+    assert calls == 0
+    assert plane.snapshot.participant_crossing_history == {}
+    assert plane.snapshot.participant_behavior_history == {}
+    assert store.load_snapshot().participant_crossing_history == {}
+    assert store.load_snapshot().participant_behavior_history == {}
+
+
+class _BarrierResolver(_StaticCrossingResolver):
+    def __init__(self, barrier: Barrier) -> None:
+        super().__init__()
+        self.barrier = barrier
+
+    def resolve(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantCrossingPolicyResolution:
+        resolution = super().resolve(intent, snapshot)
+        self.barrier.wait(timeout=5)
+        return resolution
+
+
+def test_concurrent_operation_cannot_commit_against_a_stale_history_cut() -> None:
+    base = RuntimeControlPlane(
+        _policy_capable_target(),
+        crossing_policy_resolver=_StaticCrossingResolver(),
+    )
+    base.initialize_participant_episode(_PARTICIPANT, episode_id="episode-1")
+    store = base._store
+    barrier = Barrier(2)
+    planes = [
+        RuntimeControlPlane(
+            _policy_capable_target(),
+            store=store,
+            crossing_policy_resolver=_BarrierResolver(barrier),
+        )
+        for _ in range(2)
+    ]
+    results: list[object] = []
+
+    def run(index: int) -> None:
+        try:
+            results.append(
+                _admit(
+                    planes[index],
+                    request=_admission_request(action_instance_id=f"concurrent-{index}"),
+                    idempotency_key=f"concurrent-{index}",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - concurrency outcome is the assertion surface
+            results.append(exc)
+
+    threads = [Thread(target=run, args=(index,)) for index in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert sum(not isinstance(result, Exception) for result in results) == 1
+    assert any(
+        "expected participant history head" in str(result) for result in results if isinstance(result, Exception)
+    )
+    durable = store.load_snapshot()
+    assert len(durable.participant_crossing_history[_PARTICIPANT]) == 2
+
+
+class _MissingPolicyResolver(_StaticCrossingResolver):
+    def resolve(
+        self,
+        intent: ParticipantCrossingIntent,
+        snapshot: RuntimeSnapshot,
+    ) -> ParticipantCrossingPolicyResolution:
+        del intent, snapshot
+        raise ValueError("secret policy lookup detail")
+
+
+def test_missing_policy_fails_closed_with_safe_diagnostic_and_audit() -> None:
+    plane = _action_plane(_MissingPolicyResolver())
+
+    receipt = _admit(plane, idempotency_key="missing-policy")
+
+    assert receipt.accepted is False
+    assert plane.snapshot.participant_behavior_history == {}
+    assert plane.snapshot.participant_crossing_history == {}
+    assert receipt.diagnostics[0].code == "runtime.participant-crossing-policy-unresolved"
+    assert "secret" not in receipt.diagnostics[0].message
+    assert plane.audit_log()[-1].reason == "policy-unresolved"
+
+
+def test_runtime_exposes_no_detached_crossing_recorder() -> None:
+    plane = _action_plane(_StaticCrossingResolver())
+
+    assert not hasattr(plane, "record_participant_crossing")

--- a/tools/policy/historical_identity_records.json
+++ b/tools/policy/historical_identity_records.json
@@ -17,7 +17,7 @@
       "binding_class": "external-service-project-key",
       "rationale": "Retains the existing service-owned Ground Control and SonarCloud project designations without treating them as current RAES product identity.",
       "occurrences": 2,
-      "content_sha256": "b14a2788739afd43e5301dda391979a0922b729af0a3cabacba822a2d97d98e8"
+      "content_sha256": "c56a0e9194d21c490e797363b5701d2839195329acf70d110a6eb6ae7069a5e2"
     },
     {
       "path": "sonar-project.properties",


### PR DESCRIPTION
## Summary

Enforce participant information-flow policy across runtime ingress, control, and egress boundaries with durable, replay-safe decision evidence.

## Requirement UIDs

- `RUN-319`

## Related Issues

Closes #799

## ADR Impact

- No ADR required

## Changes

- Bind participant crossings to authenticated audience, subject, operation, policy decision, and exact state-cut references.
- Persist append-only crossing history and governed egress results atomically for restart-safe replay.
- Fail closed when required policy resolution or authorization commits are unavailable, before backend execution.
- Add contract fixtures, generated schemas, conformance coverage, and persistent runtime tests for RUN-319.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Configured completion and policy gates passed on origin/dev 1e7ffd43: 5,160 unit tests, 55 integration tests, 92% coverage, schemas, lint, docs, links, and repository policy. The post-sync RUN-319/API-423 focused suite passed 54 tests.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: implementations/python/packages/raes_runtime/participant_crossing_mediation.py, implementations/python/packages/raes_runtime/participant_crossing_policy.py, implementations/python/packages/raes_runtime/participant_crossing_records.py, implementations/python/packages/raes_contracts/participant_crossing_history.py
- TESTS: implementations/python/tests/test_run_319_participant_flow_policy.py, implementations/python/tests/test_api_423_participant_crossing_contracts.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.