### PR TITLE
feat: add executable behavioral validation probes

### DIFF
--- a/docs/decisions/issue-260-asr-512-executable-behavioral-validation-preflight.md
+++ b/docs/decisions/issue-260-asr-512-executable-behavioral-validation-preflight.md
@@ -1,0 +1,304 @@
+# Issue 260 ASR-512 executable behavioral validation preflight
+
+Date: 2026-07-28
+
+Issue: #260. Ground Control requirement: ASR-512. The issue statement and the
+requirement record are the delivery contract.
+
+This note sets the boundary for executable behavioral validation probes. It
+does not add SDL syntax, contracts, schemas, fixtures, or executors. It also
+does not add reports, APIs, storage, or runtime behavior. No new ADR is needed.
+ADR-072 owns validation strength and disclosure. ADR-079 owns proposition,
+probe-binding, and truth semantics. ADR-081 owns behavioral-relation claims.
+ADR-066 owns the observation and evidence-plane split.
+
+## Implementation status
+
+Issue #260 implements the subject-bound execution seam in
+`raes_conformance.behavioral_validation`. A `BehavioralProbeCase` joins one
+scenario, participant, workflow, or experiment subject to one validated
+behavioral claim, digest-pinned probe binding, finite input digest, and
+execution basis. `run_behavioral_validation_probe()` admits the claim and
+its left-carrier match to the exact subject ref, plus executor capabilities,
+before invoking trusted injected code. It then constructs a
+`BehavioralProbeResult` from the admitted case identities and returned
+evidence. The executor cannot replace the subject, claim, binding, input, or
+execution basis in the result.
+
+The runner fails closed for invalid claims, subject-claim carrier mismatches,
+unsupported capabilities, missing or blank evidence references, unverified
+cleanup, residual state, and sanitized executor failures. It is an internal
+implementation seam, not a portable schema, command dispatcher, plugin loader,
+truth algebra, report graph, or persistence surface. Subject-specific carriers
+remain authoritative and supply cases through their trusted adapters.
+
+## Decision boundary
+
+ASR-512 adds an independent technique for exercising a behavioral property
+claimed by a scenario, participant, workflow, or experiment. It does not add a
+new meaning for those properties.
+
+Keep four concerns separate:
+
+1. **Claim semantics** say what property is claimed. Use a proposition and
+   assertion for finite state truth. Use a revisioned
+   `BehavioralClaimBindingModel` for a behavioral or empirical relation. A
+   probe must not infer meaning from a command or test name. It must not infer
+   meaning from a workflow outcome, action name, metric, or description.
+2. **Probe binding** names a checked and versioned implementation. It may
+   exercise the claim, but it cannot change the claim. Use
+   `PropositionProbeBindingModel` for proposition truth. Use the injected
+   `RealizationConformanceHarness` pattern for conformance-owned execution. Do
+   not put Python callables or module names in profile data. The same ban
+   covers shell commands, executable URLs, and backend dispatch rules.
+3. **Probe execution** is one bounded invocation. It binds the exact subject,
+   target, configuration, input, clock or seed, observation policy, and
+   cleanup policy. It runs only after parser and semantic admission. Capability,
+   authorization, and contract gates also run first.
+4. **Probe evidence and disclosure** record what happened. Use the owning
+   truth, workflow, participant-history, experiment-evidence, and conformance
+   carriers. Use the existing validation-basis carrier too. A probe result may
+   support `behavioral_execution` and `governed_diagnostics` gate rows. It does
+   not replace `ValidationBasisDisclosureModel`. It cannot create strength by
+   itself.
+
+A probe pass is finite evidence about the exact recorded case. It is not a
+universal proof or backend equivalence. It is not participant conformance or
+experiment validity. It is not a falsification-backed claim. Those stronger
+claims have separate quantifier, evidence, and protocol rules.
+
+## Claim-surface mapping
+
+| Subject | Claim authority | Execution and observation authority | Durable result/evidence |
+| --- | --- | --- | --- |
+| Scenario or scenario snapshot | `Proposition`, `Assertion`, snapshot identity, and `SemanticValidator`. | Compiled claim resources, evaluator capabilities, a versioned probe binding, and runtime truth admission. | `PropositionTruthResultModel`, evidence refs, and a subject-bound `ValidationBasisDisclosureModel`. |
+| Workflow | Assertion refs and workflow state-machine semantics. Step completion is not property truth. | The existing workflow and control-plane path. Proposition truth is checked at the governed step or window boundary. | `WorkflowExecutionStateModel` and workflow history. Also use attempt truth/evidence refs and validation-basis disclosure. |
+| Participant or behavior specification | Action contracts, observation boundaries, outcome rules, authority, scope, and behavior specifications. Use any revisioned relation claim too. | Existing action admission, lifecycle, decision surface, history validators, and conformance probes. | Participant behavior and episode history. Also use observation, outcome, evidence, claim, and validation-basis records. |
+| Experiment task, run, or study | Task protocol, metric definitions, study `behavioral_claims`, allocation, analysis plan, and validity notes. | Existing apparatus, capture, evidence, derived-measure, and cross-validation paths. | `ExperimentEvidenceRecordModel`, run traceability, result summaries, and derived measures. Also use claim and validation-basis records. |
+| Backend or participant conformance claim | A revisioned relation binding and selected backend/profile contract. | `run_fixture_suite()`, `run_target_conformance()`, existing cases and probes, and the realization harness when needed. | Existing bounded report and claim. Also use evidence refs, diagnostics, and validation-basis disclosure. |
+
+Do not force every subject into proposition truth. Proposition truth is the
+oracle for a finite typed state claim. Participant trace properties use their
+own contracts. Cross-carrier and statistical claims use the relation catalog
+and existing evidence contracts. The reverse shortcut is also banned. Do not
+use a generic relation claim to avoid proposition truth rules.
+
+## Canonical incumbents
+
+| Concern | Canonical incumbent and required reuse |
+| --- | --- |
+| Validation taxonomy and result disclosure | Use ADR-072 and the validation profile catalog. Use `select_validation_profile()` and the existing disclosure, gate, and limit models. Catalog and disclosure data never dispatch execution. |
+| Scenario truth | Use ADR-079, `Proposition`, `Assertion`, compiled claim resources, and evaluator capabilities. Use `Condition` only for the legacy binding. Keep `PropositionProbeBindingModel`, `PropositionTruthResultModel`, and runtime truth diagnostics. |
+| Behavioral and empirical claims | Use ADR-081 and the behavioral-relations catalog. Use `BehavioralClaimBindingModel`, its validator, and `bounded-probe-success`. Do not add a local relation registry. Do not weaken universal-quantifier checks. |
+| Participant behavior | Use ADR-067 and the participant formal specs. Keep action contracts, behavior specifications, observation boundaries, outcome rules, action admission, and history. Keep participant history, snapshot, concurrency, and conformance validators. |
+| Workflow behavior | Use workflow state-machine and compensation semantics. Keep compiled assertion refs, workflow state/history, and attempt provenance. Use the proposition truth algebra. Lifecycle success is not truth. |
+| Experiment behavior | Use the task, run, and study models. Keep capture, evidence, derived-measure, traceability, and cross-artifact validators. |
+| Conformance execution | Use the fixture and target runners, existing cases and reports, execution bases, probe outcomes, and injected harness pattern. Keep deterministic cases, cleanup, diagnostics, evidence, and bounded claims. Do not make realization DTOs a universal schema. |
+| Diagnostics and errors | Use `Diagnostic`, `Severity`, and stable local codes. Keep existing SDL and Pydantic errors, operation envelopes, and the redacted HTTP 500 envelope. Do not add an ASR-512 exception tree or logger. |
+| Persistence and artifacts | Use snapshots and `ControlPlaneStore` for live state. Use experiment evidence, provenance, and validation disclosures for archive facts. Use the shared redaction, safe-path, and atomic-write helpers for a requested artifact. |
+| Schema and workflow governance | Use closed `ContractModel` shapes and `schema_bundle()`. Keep published schemas, the publication ledger, fixtures, and conformance checks in sync. Use the checked-in Ground Control, nox, and verification workflow. |
+
+`ConformanceCaseResult`, `RealizationProbeRequest`, and
+`RealizationProbeEvidence` are useful internal patterns. They do not authorize
+an unreviewed generic schema. `BackendConformanceReport` remains specific to
+backend conformance. Do not overload it for all ASR-512 subjects. Prefer the
+owning result and evidence carrier. Pair it with the generic validation-basis
+disclosure. Add a contract only when a portable fact has no typed home. Keep
+that contract small and subject-bound.
+
+## Cross-cutting and security gates
+
+1. **SDL source and parser.** Authoring changes pass the safe YAML loader and
+   its limits. Duplicate keys, bad names, and invalid variables still fail.
+   Closed `SDLModel` shapes still apply. Instantiation rejects unresolved
+   tokens. `SemanticValidator` runs again after instantiation. Parsing and
+   language tools remain inert. They never run a probe.
+2. **Claim and reference shape.** A probe resolves one exact subject. It also
+   resolves an admitted proposition and assertion, or a pinned relation claim.
+   Existing reference, role, polarity, projection, scope, digest, and version
+   checks fail closed. Carrier identity must match. A path or test name is not
+   claim identity. Neither is a free string or object id.
+3. **Contract and schema shape.** Portable data uses closed `ContractModel`
+   shapes and existing primitive types. It carries a schema version. Cross-file
+   rules use `x-raes-invariants`. Add valid and single-defect invalid fixtures
+   when a contract changes. Keep generated and published schemas equal. Update
+   the publication ledger and conformance registry. A dataclass or serializer
+   is not a published contract.
+4. **Profile and capability admission.** Resolve the exact profile with
+   `select_validation_profile()`. Resolve backend capabilities through existing
+   manifests, profiles, and admission helpers. This covers evaluation,
+   orchestration, participant runtime, observation, cleanup, and time.
+   Unknown or missing support yields an explicit failed or unsupported result.
+   Never select a nearby probe. Never lower the property in silence.
+5. **Configuration and environment shape.** ASR-512 needs no generic
+   environment binder. It also needs no executable path, profile root, plugin
+   root, or remote registry. Backend execution still passes its closed config
+   checks. Libvirt uses `_validate_config_keys` and the safe URI check. Test
+   environment inputs are opt-in apparatus settings. Validate them before
+   driver creation. Ambient environment state is not claim or evidence
+   authority.
+6. **Executable artifact and supply-chain gate.** Treat each script, package,
+   image, and external probe as untrusted apparatus. Use pinned digests,
+   trust policy, source limits, and allowlists. Use `ImageTrustPolicy` when it
+   fits. A source name, import, executable bit, image tag, or download does not
+   grant trust. Probe data must not select an arbitrary import or executable.
+7. **Authentication and authorization.** Prefer the in-process conformance
+   composition root. ASR-512 needs no new route. If a probe crosses HTTP, use
+   `create_control_plane_app()` and strict security defaults. Keep verified
+   identity, role, target, and participant-controller checks. Keep request
+   limits, idempotency, fingerprints, and audit records. Scenario authority is
+   not participant authority. Probe capability is not caller authorization. A
+   profile never grants execution or evidence-read access.
+8. **OS and host exposure.** Adapters use fixed argument lists and
+   `shell=False`. They set time, output, and resource bounds. They use a
+   controlled work directory and environment. They run with least privilege
+   and clean up owned resources. Secrets and hidden answers never enter argv.
+   The same ban covers raw payloads, connection URIs, and host paths. Keep the
+   OCI injected-runner and redacted-output pattern. Keep the libvirt read-only
+   fact channel. Do not add a general guest command runner.
+9. **Observation and evidence admission.** Process success, HTTP 2xx, workflow
+   completion, action success, and receipts are not property truth.
+   Observations must be fresh and addressed. Bind them to the subject, probe,
+   and configuration. Meet the required observation strength. Apply the owning
+   visibility and redaction rules. Capture intent is not evidence. Raw evidence
+   is not a derived measure. Logs are not portable evidence. Participant views
+   are not hidden truth.
+10. **Error envelopes and observability.** Public failures use a stable code,
+    safe address, coarse outcome, and short redacted message. Never expose
+    rejected bodies, commands, output, environment values, native objects, or
+    traces. Some current helpers join `str(exc)` into messages. Participant
+    probe and operation errors can also carry unsafe text. So can
+    `HTTPException(detail=str(exc))`. Sanitize these paths before reuse. Audit
+    and logs may summarize work. They are not probe evidence.
+11. **Persistence and cleanup.** Live state stays in typed snapshots and the
+    control-plane store. Archive facts stay in truth, workflow, participant,
+    experiment, conformance, and validation-basis carriers. Do not store probe
+    meaning only in metadata, details, audit blobs, DTOs, tags, or logs.
+    Validate and redact a report before an atomic write. A mutating probe needs
+    owned teardown and residual-state disclosure. Unverified cleanup makes the
+    result fail.
+12. **Repository and package boundary.** SDL meaning stays in `raes`.
+    Portable DTOs stay in `raes_contracts`. Compilation stays in
+    `raes_processor`. Live control, security, and storage stay in
+    `raes_runtime`. Capabilities stay in `raes_backend_protocols`. Adapters
+    execute concrete probes. `raes_conformance` owns conformance flow.
+    `raes_operations` owns native assembly and artifact writes. `raes_cli`
+    owns user wiring. Keep the package policy intact. Do not bypass it with
+    private imports, `Any` bags, or compatibility code.
+
+## Outcome and concept separation
+
+These vocabularies answer different questions and must not be merged:
+
+| Surface | Meaning |
+| --- | --- |
+| `ProbeOutcome` (`passed`, `failed`, `skipped`, `unsupported`) | Whether one bounded probe case executed and met its case oracle |
+| Proposition outcome (`true`, `false`, `unknown`, `unsupported`) | Truth/support result for one proposition |
+| Validation gate outcome (`passed`, `failed`, `partial`, `not_run`, `unknown`, `unsupported`, `withheld`, `not_applicable`) | One row in an ASR-515 validation-basis disclosure |
+| Operation/workflow/evaluator lifecycle status | Whether apparatus work progressed or completed |
+| Participant action/outcome interpretation | What one participant action meant at its participant-local boundary |
+| ADR-021 evidence status (`untested`, `partial`, `demonstrated`, `refuted`) | Status of a falsification protocol for a major claim |
+| Behavioral relation assurance/evidence scope | Quantified boundary and strength of a revisioned relation claim |
+
+A mapping between two rows must be explicit and cautious. A passed finite probe
+may support a passed `behavioral_execution` gate. It may also support a finite
+`bounded-probe-success` claim. Both uses need evidence and diagnostics. The
+probe cannot produce `true` by itself. Nor can it produce `demonstrated`,
+`proved`, or `falsification_backed`.
+
+## Extensibility seam
+
+The seam is a stable, subject-bound probe case. Trusted code gives it to an
+injected and capability-checked executor. The result uses existing evidence
+carriers. The seam has these parameters:
+
+- exact subject kind, stable ref, version, digest, target, and configuration;
+- an oracle ref to a proposition/assertion or revisioned relation claim;
+- probe implementation id, version, digest, and required capabilities;
+- finite case identity and canonical input digest;
+- execution basis and any governed clock, boundary, seed, or observation
+  policy;
+- expected observation and evidence rules, with a cautious outcome map;
+- time, resource, and cleanup policy chosen by trusted code; and
+- evidence and diagnostic refs, limits, audience, redaction, and profile
+  identity.
+
+A future predicate family should add one governed adapter at this seam. The
+same rule applies to a participant case or workflow oracle. It also applies to
+an experiment design, backend, execution basis, or observation source. Such an
+addition must not need a new claim language or profile registry. It must not
+need a new truth algebra, report graph, error tree, logger, store, auth path,
+or process framework.
+
+## Whole-repository surfaces in scope
+
+- **Normative:** validation profiles and proposition truth. Also include the
+  relation taxonomy, participant behavior, workflows, evidence, and experiment
+  specs. Include each changed schema, fixture, profile, catalog, and publication
+  record.
+- **Implementation:** SDL models and semantic checks. Include contract models,
+  schema output, compiler projections, manifests, and capability admission.
+  Include runtime truth, workflow, participant, security, audit, snapshot,
+  store, and cleanup paths. Include conformance runners, injected harnesses,
+  adapters, redaction, and artifact writes. Include CLI wiring only if a user
+  command is in scope.
+- **Verification:** positive and negative fixtures and truth tables. Include
+  bad subject, ref, digest, and capability cases. Include stable replay and
+  dishonest, no-op, stale, and wrong-target evidence. Test auth, redaction,
+  argv, time, resources, cleanup, and residue. Check report/disclosure links,
+  module rules, authority, schemas, and policy.
+- **Workflow:** use `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`,
+  and the three required policy and verification tools. Use
+  `RAES_REQUIREMENT_UID=ASR-512` because the branch name lacks a UID. Issue #260
+  remains the delivery contract.
+
+## Gotchas and anti-patterns
+
+Avoid:
+
+- executable code, commands, imports, URLs, or dispatch tables in contract
+  data;
+- one universal property, probe, report, or metadata dictionary;
+- making legacy `Condition.command` the portable probe contract;
+- deriving expected truth from process exit status;
+- making realization-envelope probes the universal ASR-512 model;
+- using `BackendConformanceReport` for every subject family;
+- creating four new report or runner stacks;
+- calling schema acceptance, operation success, action success, evaluator
+  readiness, workflow success, or a lone evidence ref behavioral validation;
+- equating finite probe coverage with all inputs, all traces, equivalence,
+  conformance, empirical validity, or proof;
+- merging timeout, missing evidence, unsupported support, false, skip,
+  withheld evidence, and cleanup failure into one Boolean;
+- copying raw evidence into truth results or disclosures;
+- using snapshots or logs as archive evidence;
+- using derived measures as raw observations;
+- selecting executors or paths from untrusted data;
+- falling back to a default target, profile, or probe;
+- using `shell=True` or an open child environment;
+- leaking sensitive values through argv or errors;
+- passing a mutating negative probe without independent non-mutation,
+  ownership, cleanup, and residual-state evidence; or
+- duplicating schemas, resolvers, vocabularies, validators, truth tables,
+  errors, diagnostics, audit, storage, or workflow policy.
+
+## Non-goals and implementation boundaries
+
+- This preflight does not implement ASR-512. It does not choose final field
+  names.
+- It does not implement ASR-513 counterfactual or necessity validation. It also
+  does not implement ASR-514 determinism or stability validation. Negative
+  cases and repeated executions do not establish either sibling claim.
+- It adds no rules engine, query language, temporal logic, theorem prover, or
+  model checker. It adds no statistics engine, remote probe service, plugin
+  system, credential broker, or command API.
+- It does not redesign profiles, disclosures, truth, relations, action
+  admission, workflows, experiment analysis, conformance, security, evidence
+  storage, or cleanup.
+- It does not make every claim executable. Unsupported properties stay
+  explicit when a safe governed path does not exist.
+- It adds no authoring-time side effects. Parsing, validation, compilation,
+  documentation, MCP inspection, and schema generation remain inert.
+- A finite suite does not prove universal behavior, backend equivalence,
+  participant strategy coverage, experiment validity, or
+  falsification-backed strength.

--- a/docs/research/behavioral-validation/traceability-matrix-asr-512.md
+++ b/docs/research/behavioral-validation/traceability-matrix-asr-512.md
@@ -1,0 +1,48 @@
+# ASR-512 Executable Behavioral Validation Matrix
+
+Date: 2026-07-28.
+
+Issue: #260.
+
+Requirement: ASR-512.
+
+ASR-512 requires executable validation probes for behavioral properties claimed
+by scenarios, participants, workflows, or experiments. The repository
+implements that capability through a subject-bound execution seam and
+subject-specific claim, adapter, and evidence surfaces. This matrix records the
+join, its incumbents, and their structural gates. It does not introduce a
+portable universal probe contract, report, or truth algebra.
+
+## Clause Matrix
+
+| Clause | Executable implementation | Structural gate or evidence |
+| --- | --- | --- |
+| Support executable validation probes. | `BehavioralProbeCase` joins one exact subject, validated claim, digest-pinned probe implementation, finite input digest, and execution basis. `run_behavioral_validation_probe()` admits and invokes a trusted injected executor and returns a `BehavioralProbeResult` whose identities come only from that case. Existing target and realization conformance runners remain concrete adapters. | `test_behavioral_validation_probes.py::test_probe_result_joins_subject_claim_binding_execution_and_evidence` executes the join for every admitted subject kind. Existing target and realization conformance tests continue to cover their concrete execution boundaries. |
+| Bind a probe to the behavioral property it evaluates. | The case carries the revisioned `BehavioralClaimBindingModel` beside `BehavioralProbeBinding`; its canonical digest covers the subject, complete claim, implementation identity and digest, capability refs, input, basis, and mutation posture. Before execution, the runner validates the claim against the canonical relation catalog and requires its left carrier to equal the admitted subject ref. It copies those admitted identities into the result. | `test_case_digest_changes_when_any_joined_identity_changes`, `test_unknown_claim_relation_fails_closed_before_execution`, `test_claim_for_another_subject_fails_closed_before_execution`, and the parameterized join test prove identity binding and pre-execution refusal. |
+| Validate scenario claims. | A trusted scenario adapter supplies `subject_kind=scenario`, the stable scenario or snapshot ref, its admitted behavioral claim, and a subject-specific executor. Existing target conformance remains the concrete scenario execution adapter. | The scenario parameters of the join and subject-claim mismatch tests prove the enforced join and refusal boundary. `test_runtime_conformance.py::test_target_conformance_accepts_supplied_reference_scenario` covers the concrete target path. |
+| Validate participant claims. | A trusted participant adapter supplies `subject_kind=participant`, its participant-local claim and observation boundary, and the existing lifecycle, execution, or conformance executor. The result cannot replace that participant ref or claim with executor-returned metadata. | The participant parameters of the join and subject-claim mismatch tests protect the property-to-result binding. `test_reference_backend_conformance.py::test_reference_target_drives_full_participant_probe_case_set` and the dishonest/no-op participant tests cover the concrete participant adapters. |
+| Validate workflow claims. | A trusted workflow adapter supplies `subject_kind=workflow`, a workflow-scoped behavioral claim, and an executor that observes the governed step or window boundary. The result preserves the case claim rather than inferring truth from lifecycle success. | The workflow parameters of the join and subject-claim mismatch tests protect the property-to-result binding. Existing target-conformance and truth-result tests protect orchestration execution and the separate lifecycle/truth boundary. |
+| Validate experiment claims. | A trusted experiment adapter supplies `subject_kind=experiment`, a study, run, or task ref, a catalog-valid claim, and an executor tied to its apparatus and evidence rules. The result binds actual evidence refs to that admitted finite case; owning experiment carriers retain the archive record. | The experiment parameters of the join and subject-claim mismatch tests protect the property-to-result binding. Behavioral-relation and validation-disclosure tests continue to protect the owning study claim and disclosure carriers. |
+| Preserve the finite evidence boundary of a passing probe. | The case claim must pass `validate_behavioral_claim_binding()` before execution, so finite evidence cannot carry a universal quantifier. A passed result additionally requires at least one non-empty evidence reference identifier from this invocation. Existing `_bounded_conformance_claim()` remains the backend-report projection for finite conformance cases. | `test_unknown_claim_relation_fails_closed_before_execution`, `test_passed_probe_requires_evidence`, `test_passed_probe_rejects_blank_evidence_reference`, `test_behavioral_relations.py::test_claim_binding_rejects_bounded_evidence_promoted_to_universal_claim`, and the behavioral-claim policy gate protect the boundary. |
+| Preserve capability, diagnostics, cleanup, and sensitive-data boundaries. | The runner refuses missing bound capabilities before execution, preserves executor-reported failures and structured diagnostics, requires verified cleanup and no residual state for mutating cases, and reduces executor exceptions to a stable code plus exception type without exception text. | `test_missing_executor_capability_fails_closed_before_execution`, `test_executor_reported_failure_is_preserved_without_synthetic_diagnostic`, `test_executor_diagnostic_is_preserved_and_downgrades_passed_outcome`, the cleanup/residual-state parameterized test, and `test_executor_failure_is_sanitized_and_fails_closed` cover the generic join. Existing realization and report tests retain deeper native mutation and report-redaction coverage. |
+
+## Existing Authority
+
+- ADR-066 separates observations from evidence.
+- ADR-072 defines validation strength and validation-basis disclosure.
+- ADR-079 defines proposition, assertion, probe-binding, and truth-result
+  semantics.
+- ADR-081 defines behavioral relations, finite evidence boundaries, assurance,
+  limitations, and nonclaims.
+- The issue #260 preflight records the implementation guardrails and package
+  boundaries for future probe adapters.
+
+## Nonclaims
+
+- A passing finite probe does not establish coverage of all inputs or traces.
+- A conformance case does not establish behavioral equivalence, bisimulation,
+  participant strategy coverage, experiment validity, or proof.
+- Process exit, HTTP success, operation completion, workflow completion, or an
+  evidence reference alone does not decide a behavioral property.
+- ASR-512 does not implement ASR-513 counterfactual or necessity validation, or
+  ASR-514 determinism or stability validation.

--- a/implementations/python/packages/raes_conformance/behavioral_validation.py
+++ b/implementations/python/packages/raes_conformance/behavioral_validation.py
@@ -204,69 +204,40 @@ def _result(
     )
 
 
-def run_behavioral_validation_probe(
+def _admission_diagnostic(
     case: BehavioralProbeCase,
     executor: BehavioralProbeExecutor,
-) -> BehavioralProbeResult:
-    """Validate and execute one exact subject/property/probe join."""
-
+) -> Diagnostic | None:
+    diagnostic = None
     try:
         validate_behavioral_claim_binding(case.claim)
     except ValueError:
-        return _result(
+        diagnostic = _diagnostic(
             case,
-            outcome=BehavioralProbeOutcome.UNSUPPORTED,
-            diagnostics=(
-                _diagnostic(
-                    case,
-                    "conformance.behavioral-probe-claim-invalid",
-                    "The behavioral probe claim does not resolve against the canonical relation catalog.",
-                ),
-            ),
+            "conformance.behavioral-probe-claim-invalid",
+            "The behavioral probe claim does not resolve against the canonical relation catalog.",
         )
-
-    if case.claim.left_carrier_ref != case.subject_ref:
-        return _result(
+    if diagnostic is None and case.claim.left_carrier_ref != case.subject_ref:
+        diagnostic = _diagnostic(
             case,
-            outcome=BehavioralProbeOutcome.UNSUPPORTED,
-            diagnostics=(
-                _diagnostic(
-                    case,
-                    "conformance.behavioral-probe-subject-claim-mismatch",
-                    "The behavioral claim left carrier does not identify the admitted probe subject.",
-                ),
-            ),
+            "conformance.behavioral-probe-subject-claim-mismatch",
+            "The behavioral claim left carrier does not identify the admitted probe subject.",
         )
+    if diagnostic is None:
+        missing_capabilities = set(case.probe_binding.capability_refs) - set(executor.capability_refs)
+        if missing_capabilities:
+            diagnostic = _diagnostic(
+                case,
+                "conformance.behavioral-probe-capability-unsupported",
+                "The injected executor does not support every capability required by the probe binding.",
+            )
+    return diagnostic
 
-    missing_capabilities = sorted(set(case.probe_binding.capability_refs) - set(executor.capability_refs))
-    if missing_capabilities:
-        return _result(
-            case,
-            outcome=BehavioralProbeOutcome.UNSUPPORTED,
-            diagnostics=(
-                _diagnostic(
-                    case,
-                    "conformance.behavioral-probe-capability-unsupported",
-                    "The injected executor does not support every capability required by the probe binding.",
-                ),
-            ),
-        )
 
-    try:
-        evidence = executor.execute(case)
-    except Exception as exc:
-        return _result(
-            case,
-            outcome=BehavioralProbeOutcome.FAILED,
-            diagnostics=(
-                _diagnostic(
-                    case,
-                    "conformance.behavioral-probe-execution-failed",
-                    f"Behavioral probe executor raised {type(exc).__name__}.",
-                ),
-            ),
-        )
-
+def _evidence_diagnostics(
+    case: BehavioralProbeCase,
+    evidence: BehavioralProbeEvidence,
+) -> tuple[Diagnostic, ...]:
     diagnostics = list(evidence.diagnostics)
     if evidence.outcome is BehavioralProbeOutcome.PASSED:
         if not evidence.evidence_refs:
@@ -301,7 +272,14 @@ def run_behavioral_validation_probe(
                 "A mutating behavioral probe left residual owned state.",
             )
         )
+    return tuple(diagnostics)
 
+
+def _result_from_evidence(
+    case: BehavioralProbeCase,
+    evidence: BehavioralProbeEvidence,
+) -> BehavioralProbeResult:
+    diagnostics = _evidence_diagnostics(case, evidence)
     outcome = evidence.outcome
     if diagnostics and outcome is BehavioralProbeOutcome.PASSED:
         outcome = BehavioralProbeOutcome.FAILED
@@ -309,10 +287,41 @@ def run_behavioral_validation_probe(
         case,
         outcome=outcome,
         evidence_refs=evidence.evidence_refs,
-        diagnostics=tuple(diagnostics),
+        diagnostics=diagnostics,
         cleanup_verified=evidence.cleanup_verified,
         residual_state=evidence.residual_state,
     )
+
+
+def run_behavioral_validation_probe(
+    case: BehavioralProbeCase,
+    executor: BehavioralProbeExecutor,
+) -> BehavioralProbeResult:
+    """Validate and execute one exact subject/property/probe join."""
+
+    admission_diagnostic = _admission_diagnostic(case, executor)
+    if admission_diagnostic is not None:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.UNSUPPORTED,
+            diagnostics=(admission_diagnostic,),
+        )
+
+    try:
+        evidence = executor.execute(case)
+    except Exception as exc:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.FAILED,
+            diagnostics=(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-execution-failed",
+                    f"Behavioral probe executor raised {type(exc).__name__}.",
+                ),
+            ),
+        )
+    return _result_from_evidence(case, evidence)
 
 
 __all__ = (

--- a/implementations/python/packages/raes_conformance/behavioral_validation.py
+++ b/implementations/python/packages/raes_conformance/behavioral_validation.py
@@ -1,0 +1,327 @@
+"""Subject-bound executable behavioral validation probes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from raes_contracts.behavioral_relations import validate_behavioral_claim_binding
+from raes_contracts.contracts import BehavioralClaimBindingModel
+from raes_contracts.diagnostics import Diagnostic, Severity
+
+from ._realization_models import ExecutionBasis
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class BehavioralSubjectKind(str, Enum):
+    """Claim-bearing subject families admitted by ASR-512."""
+
+    SCENARIO = "scenario"
+    PARTICIPANT = "participant"
+    WORKFLOW = "workflow"
+    EXPERIMENT = "experiment"
+
+
+class BehavioralProbeOutcome(str, Enum):
+    """Closed outcome vocabulary for one bounded behavioral probe."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_digest(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a sha256 digest")
+
+
+def _require_unique_text(values: tuple[str, ...], field_name: str) -> None:
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field_name} entries must be non-empty")
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} entries must be unique")
+
+
+@dataclass(frozen=True)
+class BehavioralProbeBinding:
+    """Digest-pinned identity of trusted code that implements one probe."""
+
+    implementation_id: str
+    implementation_version: str
+    artifact_digest: str
+    capability_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.implementation_id, "implementation_id")
+        _require_text(self.implementation_version, "implementation_version")
+        _require_digest(self.artifact_digest, "artifact_digest")
+        _require_unique_text(self.capability_refs, "capability_refs")
+        if not self.capability_refs:
+            raise ValueError("capability_refs must not be empty")
+
+
+@dataclass(frozen=True)
+class BehavioralProbeCase:
+    """One admitted subject, property claim, implementation, and finite input."""
+
+    case_id: str
+    subject_kind: BehavioralSubjectKind
+    subject_ref: str
+    claim: BehavioralClaimBindingModel
+    probe_binding: BehavioralProbeBinding
+    input_digest: str
+    execution_basis: ExecutionBasis | str
+    mutates_state: bool = False
+
+    def __post_init__(self) -> None:
+        _require_text(self.case_id, "case_id")
+        if not isinstance(self.subject_kind, BehavioralSubjectKind):
+            raise ValueError("subject_kind must be a BehavioralSubjectKind")
+        _require_text(self.subject_ref, "subject_ref")
+        if not isinstance(self.claim, BehavioralClaimBindingModel):
+            raise ValueError("claim must be a BehavioralClaimBindingModel")
+        if not isinstance(self.probe_binding, BehavioralProbeBinding):
+            raise ValueError("probe_binding must be a BehavioralProbeBinding")
+        _require_digest(self.input_digest, "input_digest")
+        try:
+            basis = ExecutionBasis(self.execution_basis)
+        except ValueError as exc:
+            raise ValueError("execution_basis must be a supported ExecutionBasis") from exc
+        object.__setattr__(self, "execution_basis", basis)
+
+    @property
+    def digest(self) -> str:
+        """Return the canonical identity of every property-to-result join input."""
+
+        payload = {
+            "case_id": self.case_id,
+            "subject_kind": self.subject_kind.value,
+            "subject_ref": self.subject_ref,
+            "claim": self.claim.model_dump(mode="json"),
+            "probe_binding": {
+                "implementation_id": self.probe_binding.implementation_id,
+                "implementation_version": self.probe_binding.implementation_version,
+                "artifact_digest": self.probe_binding.artifact_digest,
+                "capability_refs": list(self.probe_binding.capability_refs),
+            },
+            "input_digest": self.input_digest,
+            "execution_basis": self.execution_basis.value,
+            "mutates_state": self.mutates_state,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class BehavioralProbeEvidence:
+    """Evidence returned by a subject-specific injected executor."""
+
+    outcome: BehavioralProbeOutcome
+    evidence_refs: tuple[str, ...] = ()
+    diagnostics: tuple[Diagnostic, ...] = ()
+    cleanup_verified: bool = False
+    residual_state: tuple[str, ...] = ()
+
+
+class BehavioralProbeExecutor(Protocol):
+    """Trusted, capability-advertising execution adapter."""
+
+    capability_refs: frozenset[str]
+
+    def execute(self, case: BehavioralProbeCase) -> BehavioralProbeEvidence:
+        """Execute one already-admitted case."""
+        ...
+
+
+@dataclass(frozen=True)
+class BehavioralProbeResult:
+    """Bounded result whose identities come only from the admitted case."""
+
+    case_id: str
+    case_digest: str
+    subject_kind: BehavioralSubjectKind
+    subject_ref: str
+    claim: BehavioralClaimBindingModel
+    probe_binding: BehavioralProbeBinding
+    input_digest: str
+    execution_basis: ExecutionBasis
+    outcome: BehavioralProbeOutcome
+    evidence_refs: tuple[str, ...]
+    diagnostics: tuple[Diagnostic, ...]
+    cleanup_verified: bool
+    residual_state: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return whether this exact bounded case passed."""
+
+        return self.outcome is BehavioralProbeOutcome.PASSED
+
+
+def _diagnostic(case: BehavioralProbeCase, code: str, message: str) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        domain="conformance",
+        address=f"behavioral-probe.{case.case_id}",
+        message=message,
+        severity=Severity.ERROR,
+    )
+
+
+def _result(
+    case: BehavioralProbeCase,
+    *,
+    outcome: BehavioralProbeOutcome,
+    evidence_refs: tuple[str, ...] = (),
+    diagnostics: tuple[Diagnostic, ...] = (),
+    cleanup_verified: bool = False,
+    residual_state: tuple[str, ...] = (),
+) -> BehavioralProbeResult:
+    return BehavioralProbeResult(
+        case_id=case.case_id,
+        case_digest=case.digest,
+        subject_kind=case.subject_kind,
+        subject_ref=case.subject_ref,
+        claim=case.claim,
+        probe_binding=case.probe_binding,
+        input_digest=case.input_digest,
+        execution_basis=case.execution_basis,
+        outcome=outcome,
+        evidence_refs=evidence_refs,
+        diagnostics=diagnostics,
+        cleanup_verified=cleanup_verified,
+        residual_state=residual_state,
+    )
+
+
+def run_behavioral_validation_probe(
+    case: BehavioralProbeCase,
+    executor: BehavioralProbeExecutor,
+) -> BehavioralProbeResult:
+    """Validate and execute one exact subject/property/probe join."""
+
+    try:
+        validate_behavioral_claim_binding(case.claim)
+    except ValueError:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.UNSUPPORTED,
+            diagnostics=(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-claim-invalid",
+                    "The behavioral probe claim does not resolve against the canonical relation catalog.",
+                ),
+            ),
+        )
+
+    if case.claim.left_carrier_ref != case.subject_ref:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.UNSUPPORTED,
+            diagnostics=(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-subject-claim-mismatch",
+                    "The behavioral claim left carrier does not identify the admitted probe subject.",
+                ),
+            ),
+        )
+
+    missing_capabilities = sorted(set(case.probe_binding.capability_refs) - set(executor.capability_refs))
+    if missing_capabilities:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.UNSUPPORTED,
+            diagnostics=(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-capability-unsupported",
+                    "The injected executor does not support every capability required by the probe binding.",
+                ),
+            ),
+        )
+
+    try:
+        evidence = executor.execute(case)
+    except Exception as exc:
+        return _result(
+            case,
+            outcome=BehavioralProbeOutcome.FAILED,
+            diagnostics=(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-execution-failed",
+                    f"Behavioral probe executor raised {type(exc).__name__}.",
+                ),
+            ),
+        )
+
+    diagnostics = list(evidence.diagnostics)
+    if evidence.outcome is BehavioralProbeOutcome.PASSED:
+        if not evidence.evidence_refs:
+            diagnostics.append(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-evidence-missing",
+                    "A passed behavioral probe requires at least one evidence reference.",
+                )
+            )
+        elif any(not isinstance(reference, str) or not reference.strip() for reference in evidence.evidence_refs):
+            diagnostics.append(
+                _diagnostic(
+                    case,
+                    "conformance.behavioral-probe-evidence-invalid",
+                    "A passed behavioral probe requires non-empty evidence reference identifiers.",
+                )
+            )
+    if case.mutates_state and not evidence.cleanup_verified:
+        diagnostics.append(
+            _diagnostic(
+                case,
+                "conformance.behavioral-probe-cleanup-unverified",
+                "A mutating behavioral probe requires independently verified cleanup.",
+            )
+        )
+    if case.mutates_state and evidence.residual_state:
+        diagnostics.append(
+            _diagnostic(
+                case,
+                "conformance.behavioral-probe-residual-state",
+                "A mutating behavioral probe left residual owned state.",
+            )
+        )
+
+    outcome = evidence.outcome
+    if diagnostics and outcome is BehavioralProbeOutcome.PASSED:
+        outcome = BehavioralProbeOutcome.FAILED
+    return _result(
+        case,
+        outcome=outcome,
+        evidence_refs=evidence.evidence_refs,
+        diagnostics=tuple(diagnostics),
+        cleanup_verified=evidence.cleanup_verified,
+        residual_state=evidence.residual_state,
+    )
+
+
+__all__ = (
+    "BehavioralProbeBinding",
+    "BehavioralProbeCase",
+    "BehavioralProbeEvidence",
+    "BehavioralProbeExecutor",
+    "BehavioralProbeOutcome",
+    "BehavioralProbeResult",
+    "BehavioralSubjectKind",
+    "run_behavioral_validation_probe",
+)

--- a/implementations/python/tests/test_behavioral_validation_probes.py
+++ b/implementations/python/tests/test_behavioral_validation_probes.py
@@ -1,0 +1,304 @@
+"""ASR-512 subject-bound executable behavioral validation probes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from raes_conformance.behavioral_validation import (
+    BehavioralProbeBinding,
+    BehavioralProbeCase,
+    BehavioralProbeEvidence,
+    BehavioralProbeOutcome,
+    BehavioralSubjectKind,
+    run_behavioral_validation_probe,
+)
+from raes_contracts.contracts import BehavioralClaimBindingModel
+from raes_contracts.diagnostics import Diagnostic
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+
+
+def _claim(
+    relation_id: str = "bounded-probe-success",
+    *,
+    left_carrier_ref: str = "scenario:example",
+) -> BehavioralClaimBindingModel:
+    return BehavioralClaimBindingModel(
+        taxonomy_id="raes-behavioral-relations",
+        taxonomy_revision="rev3",
+        relation_id=relation_id,
+        subject="The named subject satisfies its bounded validation property.",
+        left_carrier_ref=left_carrier_ref,
+        right_carrier_ref="probe-case:health",
+        observation_projection_ref="behavioral-probe-result",
+        observation_projection_revision="rev1",
+        quantifier_scope="finite-cases",
+        evidence_scope="finite",
+        evidence_boundary="One admitted subject-bound executable probe case.",
+        assurance_status="implemented",
+        evidence_refs=[],
+        limitations=["The result covers only the recorded subject, input, target, and execution basis."],
+        explicit_non_claims=["Does not establish coverage of all inputs or traces."],
+    )
+
+
+def _case(
+    subject_kind: BehavioralSubjectKind = BehavioralSubjectKind.SCENARIO,
+    *,
+    claim: BehavioralClaimBindingModel | None = None,
+    mutates_state: bool = False,
+) -> BehavioralProbeCase:
+    subject_ref = f"{subject_kind.value}:example"
+    return BehavioralProbeCase(
+        case_id="health-check",
+        subject_kind=subject_kind,
+        subject_ref=subject_ref,
+        claim=claim or _claim(left_carrier_ref=subject_ref),
+        probe_binding=BehavioralProbeBinding(
+            implementation_id="example/health-probe",
+            implementation_version="1.0.0",
+            artifact_digest=_DIGEST_A,
+            capability_refs=("observation.health",),
+        ),
+        input_digest=_DIGEST_B,
+        execution_basis="hermetic-live",
+        mutates_state=mutates_state,
+    )
+
+
+class _Executor:
+    def __init__(
+        self,
+        evidence: BehavioralProbeEvidence | None = None,
+        *,
+        capability_refs: tuple[str, ...] = ("observation.health",),
+        error: Exception | None = None,
+    ) -> None:
+        self.capability_refs = frozenset(capability_refs)
+        self.evidence = evidence or BehavioralProbeEvidence(
+            outcome=BehavioralProbeOutcome.PASSED,
+            evidence_refs=("evidence:probe-run-1",),
+            cleanup_verified=True,
+        )
+        self.error = error
+        self.calls: list[BehavioralProbeCase] = []
+
+    def execute(self, case: BehavioralProbeCase) -> BehavioralProbeEvidence:
+        self.calls.append(case)
+        if self.error is not None:
+            raise self.error
+        return self.evidence
+
+
+@pytest.mark.parametrize("subject_kind", list(BehavioralSubjectKind))
+def test_probe_result_joins_subject_claim_binding_execution_and_evidence(
+    subject_kind: BehavioralSubjectKind,
+) -> None:
+    case = _case(subject_kind)
+    executor = _Executor()
+
+    result = run_behavioral_validation_probe(case, executor)
+
+    assert result.passed
+    assert result.outcome is BehavioralProbeOutcome.PASSED
+    assert result.case_digest.startswith("sha256:")
+    assert result.subject_kind is subject_kind
+    assert result.subject_ref == case.subject_ref
+    assert result.claim == case.claim
+    assert result.probe_binding == case.probe_binding
+    assert result.input_digest == case.input_digest
+    assert result.execution_basis == case.execution_basis
+    assert result.evidence_refs == ("evidence:probe-run-1",)
+    assert executor.calls == [case]
+
+
+def test_case_digest_changes_when_any_joined_identity_changes() -> None:
+    case = _case()
+    variants = (
+        replace(case, case_id="other"),
+        replace(case, subject_kind=BehavioralSubjectKind.PARTICIPANT),
+        replace(case, subject_ref="scenario:other"),
+        replace(
+            case,
+            claim=case.claim.model_copy(
+                update={"subject": "The named subject satisfies a different bounded property."}
+            ),
+        ),
+        replace(
+            case,
+            probe_binding=replace(case.probe_binding, implementation_id="example/other-probe"),
+        ),
+        replace(
+            case,
+            probe_binding=replace(case.probe_binding, implementation_version="1.0.1"),
+        ),
+        replace(
+            case,
+            probe_binding=replace(case.probe_binding, artifact_digest="sha256:" + "c" * 64),
+        ),
+        replace(
+            case,
+            probe_binding=replace(case.probe_binding, capability_refs=("observation.other",)),
+        ),
+        replace(case, input_digest="sha256:" + "c" * 64),
+        replace(case, execution_basis="native-live"),
+        replace(case, mutates_state=True),
+    )
+
+    assert all(case.digest != variant.digest for variant in variants)
+
+
+def test_unknown_claim_relation_fails_closed_before_execution() -> None:
+    executor = _Executor()
+
+    result = run_behavioral_validation_probe(
+        _case(claim=_claim("unknown-relation", left_carrier_ref="scenario:example")),
+        executor,
+    )
+
+    assert result.outcome is BehavioralProbeOutcome.UNSUPPORTED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {"conformance.behavioral-probe-claim-invalid"}
+    assert not executor.calls
+
+
+@pytest.mark.parametrize("subject_kind", list(BehavioralSubjectKind))
+def test_claim_for_another_subject_fails_closed_before_execution(
+    subject_kind: BehavioralSubjectKind,
+) -> None:
+    executor = _Executor()
+    claim = _claim(left_carrier_ref=f"{subject_kind.value}:other")
+
+    result = run_behavioral_validation_probe(_case(subject_kind, claim=claim), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.UNSUPPORTED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {
+        "conformance.behavioral-probe-subject-claim-mismatch"
+    }
+    assert not executor.calls
+
+
+def test_missing_executor_capability_fails_closed_before_execution() -> None:
+    executor = _Executor(capability_refs=())
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.UNSUPPORTED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {
+        "conformance.behavioral-probe-capability-unsupported"
+    }
+    assert not executor.calls
+
+
+def test_passed_probe_requires_evidence() -> None:
+    executor = _Executor(
+        BehavioralProbeEvidence(
+            outcome=BehavioralProbeOutcome.PASSED,
+            cleanup_verified=True,
+        )
+    )
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {"conformance.behavioral-probe-evidence-missing"}
+
+
+@pytest.mark.parametrize("evidence_ref", ["", "   "])
+def test_passed_probe_rejects_blank_evidence_reference(evidence_ref: str) -> None:
+    executor = _Executor(
+        BehavioralProbeEvidence(
+            outcome=BehavioralProbeOutcome.PASSED,
+            evidence_refs=(evidence_ref,),
+            cleanup_verified=True,
+        )
+    )
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert {diagnostic.code for diagnostic in result.diagnostics} == {"conformance.behavioral-probe-evidence-invalid"}
+
+
+def test_executor_reported_failure_is_preserved_without_synthetic_diagnostic() -> None:
+    executor = _Executor(
+        BehavioralProbeEvidence(
+            outcome=BehavioralProbeOutcome.FAILED,
+            evidence_refs=("evidence:probe-run-1",),
+            cleanup_verified=True,
+        )
+    )
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert not result.diagnostics
+
+
+def test_executor_diagnostic_is_preserved_and_downgrades_passed_outcome() -> None:
+    executor_diagnostic = Diagnostic(
+        code="conformance.behavioral-probe-property-failed",
+        domain="conformance",
+        address="behavioral-probe.health-check",
+        message="The observed behavior did not satisfy the admitted property.",
+    )
+    executor = _Executor(
+        BehavioralProbeEvidence(
+            outcome=BehavioralProbeOutcome.PASSED,
+            evidence_refs=("evidence:probe-run-1",),
+            diagnostics=(executor_diagnostic,),
+            cleanup_verified=True,
+        )
+    )
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert result.diagnostics == (executor_diagnostic,)
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected_code"),
+    [
+        (
+            BehavioralProbeEvidence(
+                outcome=BehavioralProbeOutcome.PASSED,
+                evidence_refs=("evidence:probe-run-1",),
+                cleanup_verified=False,
+            ),
+            "conformance.behavioral-probe-cleanup-unverified",
+        ),
+        (
+            BehavioralProbeEvidence(
+                outcome=BehavioralProbeOutcome.PASSED,
+                evidence_refs=("evidence:probe-run-1",),
+                cleanup_verified=True,
+                residual_state=("owned-resource:residual",),
+            ),
+            "conformance.behavioral-probe-residual-state",
+        ),
+    ],
+)
+def test_mutating_probe_requires_verified_cleanup_without_residual_state(
+    evidence: BehavioralProbeEvidence,
+    expected_code: str,
+) -> None:
+    result = run_behavioral_validation_probe(_case(mutates_state=True), _Executor(evidence))
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert expected_code in {diagnostic.code for diagnostic in result.diagnostics}
+
+
+def test_executor_failure_is_sanitized_and_fails_closed() -> None:
+    executor = _Executor(error=RuntimeError("credential=do-not-leak"))
+
+    result = run_behavioral_validation_probe(_case(), executor)
+
+    assert result.outcome is BehavioralProbeOutcome.FAILED
+    assert len(result.diagnostics) == 1
+    diagnostic = result.diagnostics[0]
+    assert diagnostic.code == "conformance.behavioral-probe-execution-failed"
+    assert "RuntimeError" in diagnostic.message
+    assert "credential" not in diagnostic.message
+    assert "do-not-leak" not in diagnostic.message


### PR DESCRIPTION
## Summary

Adds an internal, subject-bound execution seam for finite behavioral validation probes while preserving the repository's existing claim, evidence, capability, cleanup, and truth boundaries.

## Requirement UIDs

- `ASR-512`

## Related Issues

Closes #260

## ADR Impact

- ADR-066
- ADR-072
- ADR-079
- ADR-081

## Changes

- Add a subject-bound behavioral probe case, injected executor seam, and bounded result model for scenarios, participants, workflows, and experiments.
- Fail closed on invalid claims, subject-carrier mismatches, unsupported capabilities, invalid evidence, unsafe cleanup, residual state, and sanitized executor failures.
- Document the architectural boundary and ASR-512 clause-to-implementation/test traceability matrix.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

`RAES_REQUIREMENT_UID=ASR-512 uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s verify`; `RAES_REQUIREMENT_UID=ASR-512 make policy`; 5,165 unit tests and 55 integration tests passed with 92% coverage before synchronization, followed by the synchronization boundary's final-tree gates.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-512 ← implementations/python/packages/raes_conformance/behavioral_validation.py
- TESTS: ASR-512 ← implementations/python/tests/test_behavioral_validation_probes.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.