### PR TITLE
chore: prune build artifacts in the authority-boundary top-level scan

### DIFF
--- a/implementations/python/tests/test_authority_boundary.py
+++ b/implementations/python/tests/test_authority_boundary.py
@@ -730,6 +730,21 @@ def test_dotfiles_and_hidden_dirs_are_not_unclassified(tmp_path: Path) -> None:
     )
 
 
+def test_build_artifacts_are_not_unclassified(tmp_path: Path) -> None:
+    # Operational build/cache artifacts (build/, dist/, node_modules/, venv/)
+    # are git-ignored and never authority-bearing. They must not trip the gate
+    # when they linger in a developer's checkout; CI's clean checkout never
+    # sees them.
+    seeded = _seed_repo(tmp_path)
+    for artifact in ("build", "dist", "node_modules", "venv"):
+        (seeded / artifact).mkdir()
+        (seeded / artifact / "artifact.txt").write_text("x", encoding="utf-8")
+    failures = evaluate_authority_boundary(seeded)
+    assert not _flagged(failures, "authority-boundary-unclassified-top-level"), (
+        f"build artifacts must not be flagged; got: {[failure.render() for failure in failures]}"
+    )
+
+
 def test_schema_outside_normative_root_is_flagged(tmp_path: Path) -> None:
     seeded = _seed_repo(
         tmp_path,

--- a/tools/check_authority_boundary.py
+++ b/tools/check_authority_boundary.py
@@ -1085,9 +1085,13 @@ def _check_unclassified_top_level(
             # authority artifacts; don't fail the gate on them.
             continue
         name = child.name
-        if name.startswith(".") or name == "__pycache__":
-            # Hidden directories (.github, .codex, .gc, .pytest_cache, etc.)
-            # and Python bytecode caches are operational, not authority-bearing.
+        if name.startswith(".") or name in _PRUNE_DIR_NAMES:
+            # Hidden directories (.github, .codex, .gc, ...) and operational
+            # build/cache artifacts (build/, dist/, node_modules/, venv/,
+            # __pycache__/, ...) are git-ignored and never authority-bearing.
+            # The schema-misplaced scan prunes this same set, so a
+            # developer-local build artifact does not trip a gate that CI's
+            # clean checkout would never see.
             continue
         if name in classified:
             continue
@@ -1108,9 +1112,10 @@ import os
 
 # Directory names that are operational/build artifacts (developer-local
 # virtualenvs, caches, dependency caches, test caches, VCS metadata, etc.).
-# The schema-misplaced scan prunes these so the gate is deterministic over
-# tracked repository contents rather than over whichever third-party
-# packages happen to be installed under `implementations/python/.venv/`.
+# Both the schema-misplaced scan and the unclassified-top-level scan prune
+# these so the gate is deterministic over tracked repository contents rather
+# than over whichever third-party packages or local build artifacts happen to
+# be present in a developer's checkout.
 _PRUNE_DIR_NAMES: frozenset[str] = frozenset(
     {
         ".git",


### PR DESCRIPTION
## Summary

Prune operational build artifacts in the authority-boundary unclassified-top-level scan (`tools/check_authority_boundary.py`). The scan walked the live filesystem and flagged any unclassified top-level directory, skipping only hidden dirs and `__pycache__`, so a git-ignored developer-local `build/` directory tripped `policy / authority boundary ADR` during a local `nox verify` even though CI's clean checkout never sees it. The scan now skips the `_PRUNE_DIR_NAMES` set the sibling schema-misplaced scan already prunes. Behavior on a clean checkout is unchanged; genuinely unclassified top-level directories are still flagged.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #950

## ADR Impact

- ADR-009

## Changes

- Skip `_PRUNE_DIR_NAMES` (build, dist, node_modules, venv, site-packages, ...) in `_check_unclassified_top_level`; this also subsumes the former `__pycache__` special-case, since it is in that set.
- Add a regression test asserting build-artifact top-level directories are not flagged, while keeping the existing test that a genuinely unclassified directory is flagged.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Verified via `nox verify -- --skip-requirement` (requirement-free tooling fix; CI applies the same skip for a UID-less branch). New test `test_build_artifacts_are_not_unclassified` passes; the existing `test_unclassified_top_level_dir_is_flagged` and `test_dotfiles_and_hidden_dirs_are_not_unclassified` still pass. No `raes` package or consumer surface changes — typed `chore:` so release-please cuts no version bump.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed