### PR TITLE
docs: document participant input and output control

### DIFF
--- a/docs/decisions/issue-803-participant-control-guidance-preflight.md
+++ b/docs/decisions/issue-803-participant-control-guidance-preflight.md
@@ -1,0 +1,374 @@
+# Issue #803 Participant I/O Control Guidance Preflight
+
+Date: 2026-07-29
+
+Issue: #803.
+
+Requirement: RUN-319, with SEM-230 and API-423 as the issue's named semantic
+and contract dependencies.
+
+This note records repository-wide boundaries for participant-control
+documentation. It is guidance only. It does not change participant semantics,
+contracts, runtime behavior, backend declarations, conformance results,
+scientific-completeness status, or lineage authority. It does not supply the
+author, operator, backend, or researcher guide itself.
+
+## Decisive Current-State Findings
+
+The architecture is already settled. Issue #803 explains the shipped boundary;
+it must not define another one:
+
+- ADR-085 as amended by ADR-095 and SEM-230 revision `sem-230/rev2` own
+  participant-relative world, view, local history, archival evidence,
+  exact-cut policy resolution, independent information-flow operations, and
+  nonclaims.
+- API-423 `participant-crossing-occurrence-v1` owns the closed requested,
+  decided, transformed, disclosed, delivery-attempted, delivered, observed,
+  and audited fact stages. `validate_participant_crossing_occurrence_context()`
+  owns their cross-record joins.
+- RUN-319 owns the shared reference-runtime crossing boundary, trusted policy
+  resolver, deny-first gates, participant crossing history, scoped
+  idempotency, and expected-head atomic participant transition.
+- API-407 owns the six participant-policy capability terms, support strength,
+  required contracts, limitations, disclosures, evidence, and authorized
+  downgrade behavior.
+- ADR-081 and the current
+  `raes-behavioral-relations@rev4` catalog own relation identity, quantifiers,
+  claim surfaces, assurance status, evidence boundaries, and explicit
+  nonclaims.
+- Issue #802 and
+  `docs/migration/participant-information-flow-control.md` own legacy,
+  opt-in, required, and rollback interpretation. Documentation must not create
+  another adoption-mode vocabulary.
+
+No new ADR, schema, policy engine, documentation contract, example envelope,
+claim registry, or runtime abstraction is warranted.
+
+The current explanatory surface has two visible drifts that issue #803 must
+correct without changing authority:
+
+- `docs/research/participant-io-control/index.md` still describes the portable
+  policy boundary as undelivered even though RUN-319, ASR-535, and issue #802
+  evidence is present.
+- `docs/explain/sdl/scientific-scenario-completeness.md` names behavioral
+  taxonomy revision `rev1`; the canonical completeness profile and the current
+  relation catalog bind `rev4`.
+
+The version spaces must remain distinct: `sem-230/rev2` is a semantic authority
+revision, `rev4` is the behavioral-taxonomy revision, and
+`behavioral-relations-v1` and `participant-crossing-occurrence-v1` are contract
+identities. A guide must not normalize those labels into one "version".
+
+### Current evidence limits that examples must preserve
+
+The documentation cannot use an example to claim a path stronger than the
+repository currently executes:
+
+1. The reference backend declares all six participant-policy features
+   `unsupported`. Positive runtime behavior in tests uses explicit
+   test-capable manifests and bounded evidence; it is not a shipped
+   native-backend claim.
+2. API-423 defines `ParticipantCrossingDecisionDisposition.WITHHOLD`, but
+   RUN-319 `_decision_disposition()` currently emits only `permit`, `deny`,
+   `transform`, or `unsupported`. The ASR-535 withholding expectation accepts a
+   recorded `deny`. That is valid refusal evidence under the current finite
+   probe, but it is not evidence that the runtime produced the semantically
+   distinct `withhold` fact. A withholding example must therefore be labelled
+   as semantic/contract guidance or state this reference-runtime limitation;
+   it must not relabel a denial.
+3. The shipped participant-view entry points construct a requested
+   `projection`. No public runtime entry point constructs a requested
+   `declassification`, and the ASR-535 governed-declassification case drives a
+   status projection. The example can explain exact-cut declassification and
+   its API-423 contract, but it cannot claim that the finite case exercised an
+   independently selected `participant_declassification` runtime capability
+   unless additional executable evidence exists.
+4. `deliver_participant_directed_view()` records delivery of an already
+   projected `ParticipantStatusViewModel` with the
+   `participant-inject-delivery` interaction kind. It does not accept or bind a
+   compiled DSL-142 `ParticipantInjectDelivery` or its original DSL-111
+   inject/event/script/story identity. The authoring and runtime evidence must
+   be described as separate delivered surfaces until an end-to-end stable-ref
+   binding is executable.
+5. The HTTP adapter exposes participant status, history, and context views and
+   participant control occurrences. There is no generic participant-crossing
+   endpoint, policy authoring endpoint, gateway, or public transformation API.
+6. API-408 retains legacy behavior when no crossing resolver is configured.
+   With a resolver, the HTTP adapter requires an audience candidate before
+   lookup, resolves trusted crossing evidence, and commits before
+   serialization. The guide must label these modes explicitly and must not
+   describe default/legacy retrieval as governed participant-safe egress.
+
+These are documentation and claim boundaries. Issue #803 is not authorization
+to repair them in runtime code.
+
+## Architecture Decisions And Guardrails
+
+### Explanatory prose consumes authority
+
+Reader guidance may explain the current semantics and link to the closest
+authority. It must not introduce new normative operations, policy fields,
+failure states, support levels, relation definitions, or migration rules.
+Normative language belongs to the owning ADR, `specs/`, or `contracts/`
+artifact. Examples are non-normative evidence illustrations.
+
+Do not copy exhaustive enums, contract fields, required-contract maps, or
+relation definitions into several audience pages. Use the existing identifiers
+and link to the owning artifact. Where a compact comparison is necessary, one
+table should map the existing operation or relation id to its owner, current
+evidence, and nonclaim.
+
+### Publish through the curated public-docs boundary
+
+`docs/public/` is the only hosted reader-documentation source. The research
+index, migration record, lineage explanation, scientific-completeness
+explanation, ADRs, and preflights remain repository-visible internal records.
+The issue's publish outcome cannot be satisfied solely by adding prose outside
+`docs/public/`.
+
+A hosted page must be under `docs/public/`, be reachable from that root's
+toctree or an existing public route, and pass the existing public source,
+output-inventory, Vale, Sphinx HTML, and linkcheck gates. Public
+`include`/`literalinclude`/`download` targets must stay within `docs/public/`;
+the source-boundary checker rejects cross-root includes and symlinks. Link to
+repository authorities through stable repository URLs rather than copying
+them into the public tree.
+
+Use the existing task-first documentation style and route readers by role:
+scenario author, participant-implementation author, runtime operator, backend
+implementor, and researcher. This is presentation over one semantic boundary,
+not five role-specific policy models.
+
+### Keep examples operation- and evidence-specific
+
+Each denial, withholding, redaction, declassification, intervention, inject
+delivery, and unsupported-capability example must identify:
+
+- whether it is authored semantics, a portable API-423 fact, reference-runtime
+  behavior, backend declaration, bounded conformance, or a claim example;
+- participant, episode, audience, direction, interaction kind, typed subject,
+  requested operation, exact policy decision/state cut, order model, markings,
+  capability posture, and safe evidence/provenance refs that actually apply;
+- which independent gate or operation owns the result;
+- which fact was recorded: request, decision, transformation, disclosure,
+  attempted delivery, delivery, observation, or audit;
+- whether backend dispatch or participant-visible serialization occurred; and
+- the exact limitation and nonclaim.
+
+An admitted decision is not a delivery. A delivery is not observation. Audit
+retention is not participant disclosure. Redaction is not authorization or
+declassification. Intervention and handoff remain API-409 control transitions
+surrounded by API-423 crossing facts; they are not generic crossings that
+replace the control state machine.
+
+Contract-bearing examples must validate with the same published model and
+contextual validator as production artifacts. Reuse current API-423 fixtures
+and RUN-319/ASR-535 test builders when they demonstrate the exact case. A
+hosted standalone example belongs under the existing
+`docs/public/_static/examples/` convention and needs a focused test in the
+current public-docs example suite. Do not add an example schema, a prose-only
+validator, or a second fixture runner.
+
+### Bind claims to the current relation authority
+
+The claim-selection guide must use exact catalog relation ids and state the
+evidence boundary beside each choice:
+
+| Reader question | Canonical relation or evidence surface | Guardrail |
+| --- | --- | --- |
+| Did finite named cases pass? | `bounded-probe-success` | Bound, target, profile, cases, assumptions, and failures remain visible. |
+| Are two recorded participant histories equal under one declared projection? | `participant-projected-history-equivalence` | Same participant and projection revision are required; this is not noninterference. |
+| Are implementation traces contained in an abstract trace set? | `trace-inclusion` | Direction, labels, hiding, projection, and universal proof obligation are required. |
+| Can steps be matched directionally? | `forward-simulation` or `backward-simulation` | State relation and direction are explicit. |
+| Does a concrete state preserve abstract operations and observations? | `data-refinement` | Abstraction relation and operation obligations are explicit. |
+| Are branching systems mutually matched? | `strong-bisimulation` or `weak-bisimulation` | Hidden closure, stuttering, divergence, and both directions are explicit. |
+| Are unauthorized high variations invisible to a participant policy? | `policy-noninterference` | Use the complete SEM-230 adaptive-strategy, memory, exact-cut, purge, scheduler/environment, order, and declassification quantifiers. Proof remains deliberately unproved. |
+
+Positive claim-bearing artifacts use `BehavioralClaimBindingModel` and
+`validate_behavioral_claim_binding()`. Public prose should usually report the
+bounded result and explicit nonclaim instead of manufacturing a structured
+claim. Passing schemas, examples, runtime tests, or backend probes establish no
+automatic trace relation, refinement, simulation, bisimulation,
+noninterference, native realization, model check, or proof.
+
+### Keep status and lineage views honest
+
+The participant-control index is a navigation/current-state view, not a second
+implementation program. Scientific completeness consumes the canonical
+profile and delivery assessment; it must not hand-promote a concern or profile.
+The lineage page records that issue #803 re-expresses the already adopted
+SEM-230/API-423/RUN-319/ASR-535 lineage and maps the exact documentation and
+evidence surfaces with explicit nonclaims.
+
+Issue #803 adds no external intellectual source, normative derivation, or
+compatibility claim. Therefore
+`contracts/provenance/sdl-lineage-ledger-v1.json` and the lineage source audit
+remain unchanged. If implementation discovers a real new derivation or
+compatibility claim, that is a separately governed authority change rather
+than a documentation convenience edit.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent and required use |
+| --- | --- |
+| Semantic authority | ADR-085, ADR-095, and `specs/formal/participant-semantics/information-flow-control.md`. Link and explain; do not redefine. |
+| Crossing contract | `ParticipantCrossingOccurrenceModel`, the closed API-423 vocabularies/stage models, `participant-crossing-occurrence-v1`, and `validate_participant_crossing_occurrence_context()`. |
+| Authoring/control/inject semantics | ACT-617 mixed-control declarations, API-409 `ParticipantControlOccurrenceModel`, DSL-142 `ParticipantInjectDelivery`, and their existing compiler/semantic validators. Preserve their identities and boundaries. |
+| Runtime mediation | `RuntimeControlPlane`, `ParticipantCrossingPolicyResolver`, `prepare_participant_crossing()`, `commit_prepared_crossing()`, `ParticipantControlMixin`, `ParticipantRetrievalMixin`, SEM-211 admission, and SEM-226 exposure. |
+| Authentication | `ControlPlaneSecurityConfig.strict_defaults()`, `_ControlPlaneApiAuth`, `ControlPlaneIdentity`, `ParticipantControlSubjectBinding`, `ParticipantAudienceSubjectBinding`, roles, and exact target binding. |
+| Backend support | `ParticipantFeatureSupport`, `PARTICIPANT_RUNTIME_POLICY_FEATURES`, `PARTICIPANT_RUNTIME_CAPABILITY_REQUIRED_CONTRACTS`, `resolve_participant_feature_support()`, backend profiles, and `BackendConformanceReport`. |
+| Validation | Closed `ContractModel`/Pydantic shapes, API-423 contextual validation, API-409 control validation, participant snapshot and append-only transition diagnostics, and backend result validation. |
+| Persistence | `RuntimeSnapshot.participant_crossing_history`, `ControlPlaneStore.commit_participant_transition()`, in-memory/local stores, expected history heads, atomic local replacement, operation records, idempotency fingerprints, and `AuditEvent`. |
+| Errors and observability | `Diagnostic`, `Severity`, operation receipt/status envelopes, bounded HTTP 401/403/409 details, the redacted 500 envelope, safe audit events, operational summaries, and the conformance diagnostic sanitizer. Add no logger or exception family. |
+| Claims | ADR-081, `raes-behavioral-relations@rev4`, `BehavioralClaimBindingModel`, `validate_behavioral_claim_binding()`, and `tools/check_behavioral_relation_claims.py`. |
+| Migration | Issue #802 fixtures and `docs/migration/participant-information-flow-control.md`. Reuse legacy/opt-in/required and asymmetric rollback semantics. |
+| Documentation | `docs/public/`, `docs/public/index.md`, `docs/explain/reference/documentation-style-guide.md`, `tools/check_public_docs.py`, and `implementations/python/tests/test_public_docs_policy.py`. |
+| Lineage/completeness | `docs/explain/sdl/lineage.md`, the lineage ledger/model/checker, canonical scientific-completeness profile/delivery assessment, and `tools/check_scientific_scenario_completeness.py`. |
+| Workflow | `.ground-control.yaml`, `.gc/plan-rules.md`, `noxfile.py`, repo-policy, requirement-governance, behavioral-claim, lineage, public-docs, Sphinx, and full verification gates. |
+
+## Cross-Cutting Layers And Security Posture
+
+The guidance and any executable examples must pass every applicable layer:
+
+1. **Authority and publication placement.** Explanatory prose stays in
+   `docs/`; normative meaning stays in `specs/` and `contracts/`. Hosted
+   content stays under the curated public root and cannot escape it through an
+   include, download, or symlink.
+2. **Example shape validation.** JSON examples pass the published schema and
+   closed Pydantic model; multi-record API-423 examples also pass
+   `validate_participant_crossing_occurrence_context()` with trusted subject,
+   policy, evidence, and authority indexes. SDL examples retain safe YAML
+   loading, parser limits, closed source models, semantic validation,
+   instantiation, and post-instantiation validation. Documentation parsing is
+   not a substitute.
+3. **HTTP request/authentication gate.** Any live example uses
+   `create_control_plane_app()` with explicit
+   `ControlPlaneSecurityConfig`; strict defaults contain no principal or token.
+   Bodies pass content-length and actual-byte guards, then closed DTOs.
+   Bearer or trusted verified-proxy identity passes `_ControlPlaneApiAuth`,
+   role authorization, and exact target binding.
+4. **Participant authority/audience gate.** Ingress separately requires the
+   principal-to-participant/controller binding. Governed HTTP egress requires
+   one participant/audience candidate before lookup and the same binding again
+   at crossing mediation. A backend/operator/auditor role alone is neither
+   participant authority nor audience authorization. Direct in-process
+   retrieval methods are not a standalone HTTP authentication boundary.
+5. **Semantic/capability gate.** Trusted compiled/runtime state supplies exact
+   policy, state cut, controller, authority, marking, exposure, and evidence
+   coordinates. API-407 support is resolved per feature and strength. Missing
+   resolver, required semantics, contracts, evidence, or support fails closed;
+   a downgrade requires the existing policy and provenance references.
+6. **Persistence and serialization gate.** API-423 facts remain append-only in
+   the first-class crossing history. Expected-head
+   `commit_participant_transition()` atomically binds the snapshot, operation,
+   idempotency result, and audit event before dispatch or participant-visible
+   serialization. The local store is a single-process/single-writer reference
+   bound, not distributed linearizability. Administrative snapshots can carry
+   raw crossing history; participant views must not.
+7. **Error-envelope and observability gate.** Expected failures use the current
+   bounded status/detail or diagnostic surfaces. Governed HTTP projection maps
+   authorization failure to generic `403 forbidden` and conflicts to bounded
+   `409` details; unexpected failures retain
+   `{"detail":"internal server error"}`. Examples must not teach `str(exc)`,
+   rejected input, hidden participant existence, policy bodies, or backend
+   objects as response or log content.
+8. **Secret and OS/process exposure gate.** This documentation change needs no
+   credential, environment binding, secret loader, subprocess, daemon, socket,
+   database, or host file. Do not invent token environment variables or CLI
+   flags. Real bearer tokens, identity headers, private participant content,
+   policy bodies, raw evidence, and hidden state never appear in Markdown,
+   fixtures, process argv, environment variables, filenames, shell history,
+   stdout/stderr, audit, or screenshots. Executable HTTP examples use an
+   obvious test-only sentinel in-process, never a real credential.
+9. **Claim and lineage gate.** The behavioral-claim checker scans live docs
+   outside preflight records. A positive relation phrase must carry the exact
+   governed relation and evidence boundary or be an explicit nonclaim. The
+   lineage checker continues to validate the existing revision-pinned ledger;
+   explanatory delivery evidence does not mutate provenance authority.
+10. **Workflow gate.** Public guidance passes public-source containment,
+    output inventory, Vale, executable example tests, Sphinx HTML, and
+    linkcheck. The full repository policy still runs behavioral-claim,
+    authority, lineage, completeness, requirement-governance, and verification
+    checks. The branch name contains issue `803`, not requirement UID
+    `RUN-319`, so governed checks use `RAES_REQUIREMENT_UID=RUN-319`.
+
+## Extensibility Seam
+
+The documentation seam is the tuple:
+
+```text
+(reader_role, interaction_kind, operation,
+ authority_or_capability_owner, evidence_level, explicit_nonclaim)
+```
+
+Each value is backed by an existing role description, API-423 vocabulary,
+API-407 feature, owning runtime/contract surface, or behavioral relation. A
+future carrier, participant audience, operation, support strength, or proof
+status adds a bounded row/example and evidence link. It does not require a new
+guide schema, role-specific policy model, generic message object, or rewrite of
+every audience section.
+
+Keep exact ids and revisions visible so examples can be checked. Do not make
+the seam an open metadata bag or build a documentation generator that becomes
+a second authority. The next reasonable backend or interaction variation
+should reuse the same example/evidence structure and replace only its typed
+carrier, capability feature, policy coordinates, and evidence boundary.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- defining participant policy, authority, audience, state cuts, or relation
+  meaning in explanatory prose;
+- presenting the research index, migration record, lineage page, or
+  scientific-completeness explanation as normative authority;
+- satisfying "publish" only under non-hosted `docs/` paths;
+- cross-root public includes, symlinks, copied schemas, or copied exhaustive
+  vocabularies;
+- inventing a participant gateway, crossing endpoint, policy authoring API,
+  configuration file, environment variable, token loader, or CLI command;
+- treating authentication, role, target authorization, participant authority,
+  audience binding, admission, visibility, marking, declassification,
+  transformation validity, and backend support as one gate;
+- treating approval as admission, denial as withholding, admission as
+  dispatch, schedule as delivery, delivery as observation, or audit as
+  disclosure;
+- treating redaction, masking, projection, hashing, summarization, loss, or
+  weakening as authorization or declassification;
+- presenting API-423 schema validity, a manifest declaration, method presence,
+  or finite conformance as runtime or native-backend realization;
+- presenting the reference backend as positively supporting participant
+  policy features;
+- claiming an end-to-end DSL-142 inject delivery identity from the current
+  status-view delivery boundary;
+- claiming a declassification capability was exercised when the runtime
+  requested only projection;
+- exposing administrative snapshot/crossing history as a participant view;
+- showing tokens, raw payloads, hidden refs, rejected values, policy bodies,
+  backend objects, exception strings, or tracebacks in examples or expected
+  output;
+- adding a documentation DTO, example schema, validator stack, exception
+  hierarchy, logger, store, audit stream, relation registry, capability
+  registry, migration mode, or verification workflow; and
+- changing the lineage ledger/source audit or completeness status merely to
+  make explanatory prose appear current.
+
+## Non-Goals And Implementation Boundaries
+
+- No implementation or repair of RUN-319, SEM-230, API-423, API-407, API-409,
+  DSL-142, ASR-535, or issue #802 behavior.
+- No schema, contract, controlled-vocabulary, backend manifest/profile,
+  conformance report, scientific-completeness profile/assessment, or lineage
+  authority change.
+- No new endpoint, gateway, UI, policy engine, expression language,
+  transformation runtime, provider integration, authentication mechanism,
+  secret handling, environment configuration, persistence service, or OS
+  sandbox.
+- No synthetic legacy crossing history and no inference of permit, denial,
+  withholding, delivery, observation, declassification, or enforcement from
+  absent/empty history.
+- No universal noninterference, trace inclusion/equivalence, simulation,
+  refinement, strong/weak/probabilistic bisimulation, epistemic equivalence,
+  timed/probabilistic security, native realization, model-check, or proof claim
+  from documentation or finite examples.
+- No promise that planned issue #810-#813 work is delivered.

--- a/docs/explain/sdl/lineage.md
+++ b/docs/explain/sdl/lineage.md
@@ -1228,6 +1228,33 @@ which dynamic queue/log/config details remain evidence or bounded settings.
   refinement, bisimulation, epistemic, timed, or probabilistic security.
   Because the work adds compatibility evidence without changing normative
   external derivation, the lineage ledger and source audit remain unchanged.
+- Issue #803 re-expresses the already adopted SEM-230/API-423/RUN-319 and
+  ASR-535 lineage for scenario authors, participant-implementation authors,
+  runtime operators, backend implementors, and researchers. It adds no
+  external source, semantic rule, contract meaning, runtime behavior,
+  compatibility claim, or behavioral-relation definition.
+- The exact issue #803 artifact mapping is the hosted
+  `docs/public/participant-control.md` role routes and bounded examples,
+  `docs/public/index.md` navigation,
+  `docs/research/participant-io-control/index.md` adoption status,
+  `docs/explain/sdl/scientific-scenario-completeness.md` delivery explanation,
+  the issue #803 architecture preflight, and the executable public-guide
+  `BehavioralClaimBindingModel` example in
+  `implementations/python/tests/test_public_docs_policy.py`. The example
+  resolves `bounded-probe-success` against
+  `raes-behavioral-relations@rev4`; it does not define a documentation claim
+  schema or a second relation catalog.
+- Issue #803 delivery status is published explanatory guidance over shipped
+  bounded evidence. The reference backend still declares the six
+  participant-policy features unsupported. The current runtime does not emit
+  a distinct API-423 `withhold` decision, the finite declassification case
+  drives projection, and inject delivery does not bind the compiled
+  DSL-142/DSL-111 identity end to end. No native-backend realization,
+  universal noninterference, projected-history equality, trace inclusion or
+  equivalence, simulation, refinement, strong or weak bisimulation,
+  model-check, or proof is claimed. The lineage ledger and source audit remain
+  unchanged because the documentation adds neither a normative derivation nor
+  a compatibility claim.
 - CALDERA adversary-emulation research informs the action semantics: cyber
   actions can change foothold, knowledge, observations, detection surface, and
   downstream outcomes under uncertainty.

--- a/docs/explain/sdl/scientific-scenario-completeness.md
+++ b/docs/explain/sdl/scientific-scenario-completeness.md
@@ -15,12 +15,29 @@ The current assessment is deliberately conservative. Only
 blocking concerns directly, including authored/observed-state binding,
 specificity, teardown, credentials, time and clocks, participant budgets,
 verifiers, hidden assets, and trajectories. Behavioral-relation semantics are
-now implemented as `raes-behavioral-relations@rev1`, while the stronger formal
+now implemented as `raes-behavioral-relations@rev4`, while the stronger formal
 relations it defines retain their honest unproved or future assurance states.
 
 These profiles are scope contracts, not validators that silently strengthen
 ordinary SDL parsing. They also do not certify a backend, an experiment result,
 reproducibility, or behavioral equivalence.
+
+## Participant Control Delivery
+
+The canonical delivery assessment keeps `participant-action-observation`
+partial. The shipped surface now includes SEM-230 participant-relative
+information-flow semantics, API-423 crossing facts, RUN-319 deny-first
+reference-runtime mediation and persistence, API-407 capability selection,
+ASR-535 finite falsification evidence, issue #802 migration guidance, and the
+issue #803 [role-routed reader guide](../../public/participant-control.md).
+
+That evidence does not promote the concern to implemented. The reference
+backend declares all six participant-policy features unsupported, and native
+backend realization remains unestablished. The finite cases do not establish
+universal noninterference, projected-history equality, trace inclusion,
+simulation, refinement, strong or weak bisimulation, model checking, or proof.
+Documentation explains the assessed status; it does not change the canonical
+profile or assessment.
 
 ## Use Through MCP
 

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -13,6 +13,8 @@ about five minutes and uses the Python package.
   [first-scenario tutorial](tutorials/first-scenario.md).
 - **Writing a scenario?** Use the [SDL guide](sdl/index.md) and
   [examples](https://github.com/RAESystem/rae/tree/main/examples/scenarios).
+- **Controlling participant input or output?** Use the
+  [participant-control guide](participant-control.md).
 - **Integrating RAES?** Choose the [Python API](guides/python.md) or
   [command-line interface](guides/cli.md).
 - **Building a backend?** Read the [backend and conformance guide](backends.md).
@@ -30,6 +32,7 @@ quickstart
 concepts
 tutorials/first-scenario
 sdl/index
+participant-control
 guides/python
 guides/cli
 backends

--- a/docs/public/participant-control.md
+++ b/docs/public/participant-control.md
@@ -1,0 +1,316 @@
+# Control participant input and output
+
+Use participant control to set three things. Set what may cross a participant
+boundary. Set who may direct the participant. Set what proof a run retains.
+This guide explains the shipped RAES model. It serves five reader roles. It
+does not define participant-control semantics.
+
+Read
+[ADR-085](https://github.com/RAESystem/rae/blob/main/docs/decisions/adrs/adr-085-participant-information-flow-and-control.md),
+[ADR-095](https://github.com/RAESystem/rae/blob/main/docs/decisions/adrs/adr-095-participant-decision-epoch-state-cut-and-delivery-semantics.md),
+[SEM-230 information-flow specification](https://github.com/RAESystem/rae/blob/main/specs/formal/participant-semantics/information-flow-control.md),
+and the
+[API-423 crossing schema](https://github.com/RAESystem/rae/blob/main/contracts/schemas/participant-runtime/participant-crossing-occurrence-v1.json).
+They own the rules. Follow them if this guide seems to differ.
+
+## Keep four planes separate
+
+| Plane | What it contains | What it does not imply |
+| --- | --- | --- |
+| World truth | Backend or environment state under its owning semantics | Participant visibility |
+| Participant view | A projection authorized for one participant and audience at an exact policy state cut | Complete world truth or future delivery |
+| Participant-visible history | The append-only actions, controls, views, deliveries, and observations exposed to that participant | Administrative crossing history |
+| Archival evidence | Crossing decisions, operations, audit, provenance, and conformance records retained for authorized review | Participant disclosure |
+
+Projection, disclosure, delivery, and observation are different facts. A
+permitted projection can still fail before delivery. A delivered value may
+never be observed. Audit retention does not put a value in the participant
+view.
+
+The crossing history keeps each API-423 stage apart. The stages are request,
+decision, change, release, delivery attempt, delivery, observation, and audit.
+Each stage refers to an existing carrier. It does not copy the carrier payload
+into a generic participant message.
+
+## Choose the route for your role
+
+### Scenario author
+
+Start with the participant and behavior specification. Then select an
+observation boundary. Reuse the action, control, or inject carrier.
+
+- Use an explicit `mixed-control` behavior declaration when control can move
+  between the participant and another controller. Declare controller states.
+  Declare authority, scope, moves, and proof. Keep approval and intervention
+  apart. Keep handoff, override, and cancellation apart. Action admission,
+  execution, and observation also stay apart.
+- Use `participant_inject_deliveries` when an existing orchestration inject is
+  addressed to a participant. Retain its inject identity. Retain its
+  event/script/story identity. Bind an observation boundary. Name each needed
+  delivery, order, evidence, or control reference.
+- Do not infer a participant addressee from an environment inject. Do not put
+  policy text, hidden answers, credentials, or raw evidence in a participant
+  carrier.
+
+The
+[mixed-control fixture](https://github.com/RAESystem/rae/blob/main/contracts/fixtures/sdl/mixed-control-v1/valid/mixed-control-participant.yaml)
+and
+[participant-directed inject fixture](https://github.com/RAESystem/rae/blob/main/contracts/fixtures/sdl/participant-inject-delivery-v1/valid/participant-directed.yaml)
+show the governed authoring shapes. They show SDL checks. They do not show
+runtime delivery.
+
+### Participant-implementation author
+
+Consume only the carrier sent through the participant interface. It may be an
+admitted action or control input. It may be a projected status, context,
+history, observation, or inject view. Keep its source ID. Keep its exposed
+order data.
+
+Do not request or consume administrative `participant_crossing_history`,
+hidden policy inputs, or operator audit records. Do not consume another
+participant's view or raw world state. The participant-facing carrier is the
+data plane. API-423 crossing facts form the assurance plane.
+
+Treat these outcomes independently:
+
+1. accepted by a parser or contract model;
+2. authorized at the exact participant policy state cut;
+3. admitted by the owning action or control semantics;
+4. supported by the selected backend;
+5. dispatched, delivered, or observed; and
+6. retained as evidence.
+
+A missing delivery record is not success. A missing observation record is not
+success. Neither one proves a policy denial. Check the allowed operation and
+evidence surfaces.
+
+### Runtime operator
+
+Select participant control by backend profile and feature strength. Governed
+operation requires:
+
+- a trusted participant crossing policy resolver;
+- authenticated caller and exact runtime-target binding;
+- a participant/controller binding for ingress or one participant/audience
+  binding for egress;
+- exact policy-decision and state-cut evidence;
+- the applicable API-407 feature, strength, required contracts, limitations,
+  and evidence;
+- a compatible append-only store; and
+- the shared RUN-319 crossing mediator.
+
+Missing policy meaning fails closed. So does a missing identity or evidence.
+Missing contracts or backend support also fail closed. Each check fails at its
+own gate. Only the API-407 policy path can allow a downgrade. Record its real
+strength. Record its limits, release, and source. Missing support is not a
+downgrade.
+
+Legacy API-408 status, context, and history retrieval remains available when
+no crossing resolver is set. That legacy mode is not governed egress. With a
+resolver, the HTTP adapter binds the audience before lookup. It resolves
+trusted evidence. It commits crossing facts before it writes the view.
+
+Use the
+[participant-control migration guide](https://github.com/RAESystem/rae/blob/dev/docs/migration/participant-information-flow-control.md)
+for legacy, opt-in, required, rollout, and rollback steps. After the first
+governed write, keep a resolver-aware reader. Keep the crossing history,
+operation, idempotency, and audit write set. Never delete crossing facts. Do
+not rebuild them from policy, time stamps, logs, or empty defaults.
+
+### Build a backend
+
+Declare each participant-policy feature on its own. Use the API-407 backend
+manifest. A positive entry needs an exact support strength. It also needs the
+required contracts, limits, release, and proof. A method or valid schema does
+not show runtime support.
+
+Run the participant-policy conformance harness only against behavior the
+target may test. Keep the target and profile in the report. Keep the probe-set
+digest and case IDs. Keep the finite scope, errors, and real support. A feature
+without an allowed probe result is `unsupported`. It is not conformant.
+
+The shipped reference backend currently declares all six participant-policy
+features `unsupported`. Some tests use stronger manifests. Those tests do not
+turn the reference backend into a native implementation. Start with the
+[backend guide](backends.md). Then read the
+[feature-admission implementation](https://github.com/RAESystem/rae/blob/main/implementations/python/packages/raes_backend_protocols/participant_feature_admission.py),
+and
+[finite participant-policy probes](https://github.com/RAESystem/rae/blob/dev/implementations/python/packages/raes_conformance/conformance/participant_policy_probes.py).
+
+### Researcher
+
+Name the question first. Then select a relation. Record the subject and
+carriers. Record the direction and projection revision. Name all quantifiers.
+State the scheduler, setting, and order assumptions. State the evidence bound,
+status, limits, and nonclaims.
+
+Finite examples can find faults in their stated bounds. So can conformance
+probes. They do not prove a broad property. Keep each failed case as a
+counterexample. Do not average it away. Do not give a finite report a stronger
+relation.
+
+## Read the crossing examples
+
+The examples below use synthetic identifiers and summarize existing evidence.
+They are explanatory illustrations, not new API payloads.
+
+### Denial
+
+An egress request names participant `red-1`. It also names audience
+`red-primary`. A policy or audience gate returns deny at the exact state cut.
+The runtime records the request. It also records the deny result. It releases
+no value and makes no backend call. Safe audit proof may retain the refusal.
+It does not reveal the rejected value or a hidden participant.
+
+The ASR-535 `denial` case checks the refusal and those side-effect boundaries
+through the shipped runtime. It is one named finite case. It is not a broad
+information-flow result.
+
+### Withholding
+
+Withholding is a choice not to release an available item. It is not packet
+loss. It is not a backend fault or missing record. API-423 can record a
+`withhold` result. It can keep safe proof of why the crossing stopped.
+
+The current RUN-319 decision mapper does not emit `withhold`. Its finite
+ASR-535 probe accepts a deny as refusal proof. The probe tests nonrelease. It
+does not show that the runtime made a distinct withholding fact.
+
+### Redaction
+
+For an allowed status projection, policy can select redaction. It can also
+select a governed change before release. The result keeps a typed subject. It
+records the source and result link. It records loss, markings, the policy
+result, and proof. Only the new carrier may be written to the view.
+
+Redaction does not allow a crossing. It does not declassify the source. An
+ingress change creates a new typed subject. That subject needs fresh checks
+and full action admission. The ASR-535 `redaction` case gives bounded runtime
+proof of this split.
+
+### Governed declassification
+
+Declassification needs an exact authority basis. It needs the policy result,
+state cut, source mark, allowed release, order, and proof. Authority at one cut
+does not change the past. It does not survive an unrelated policy revision.
+The result is still not delivery or observation.
+
+The finite ASR-535 governed-declassification case drives a status projection.
+It does not request a separate declassification operation. It does not prove
+support for the `participant_declassification` backend feature.
+
+### Intervention and transformation
+
+Each external control event remains an API-409 control occurrence. This
+includes a proposal, approval, intervention, handoff, override, or
+cancellation. The event stays bound to the authored mixed-control state
+machine. Participant ingress adds the needed API-423 crossing facts. Approval
+does not admit or run an action. An intervention does not replace the control
+move.
+
+If mediation transforms the proposed ingress, the transformed subject gets a
+new identity. It gets a fresh semantic check and action-admission result. The
+ASR-535 `transformation` case is bounded refusal proof. It is not a general
+refinement or simulation result.
+
+### Participant-directed inject delivery
+
+The authoring model binds one participant to one inject occurrence. It binds
+the observation boundary, order, and proof needs. It may also bind a matching
+mixed-control move. Environment-only injects stay as orchestration events.
+Normal participant projection must allow them.
+
+The shipped runtime probe records delivery of an already projected status view
+under the `participant-inject-delivery` interaction kind. It keeps delivery
+apart from observation. It does not bind the compiled DSL-142 delivery to the
+original DSL-111 inject identity. It also does not bind the full
+event/script/story identity end to end.
+
+### Unsupported capability
+
+The selected target may omit a needed feature. It may omit a contract, proof,
+resolver, or minimum strength. In each case, selection or crossing fails
+closed. This happens before backend dispatch or view output. The report keeps
+the stated level and a safe reason. It makes no positive support claim.
+
+The ASR-535 `unsupported-capability` case and the no-harness path demonstrate
+this bounded behavior. A manifest entry alone is not runtime support. It is
+not conformance.
+
+All seven finite cases are exercised and bounded in
+[the ASR-535 assurance tests](https://github.com/RAESystem/rae/blob/dev/implementations/python/tests/test_asr_535_participant_flow_assurance.py).
+
+## Select a behavioral claim
+
+Read the current
+[behavioral-relation catalog](https://github.com/RAESystem/rae/blob/main/contracts/concept-authority/behavioral-relations-v1.json)
+instead of defining relation meaning in a report.
+
+| Question | Catalog relation | Required boundary |
+| --- | --- | --- |
+| Did named finite fixtures or probes produce their expected results? | `bounded-probe-success` | Exact target, profile, cases, assumptions, failures, and finite bound |
+| Are two histories equal for one participant under one projection revision? | `participant-projected-history-equivalence` | Both carriers, participant, projection, order, and compared bound |
+| Are unauthorized high variations invisible under the full participant policy? | `policy-noninterference` | Adaptive strategies, memory, exact policy cuts, purge and declassification schedule, scheduler, environment, order, and support-set quantifiers |
+| Does every projected implementation trace belong to an abstract trace set? | `trace-inclusion` | Left-to-right direction, labels, hiding, projection, assumptions, and the universal obligation |
+| Can implementation and abstract steps be matched in one direction? | `forward-simulation` or `backward-simulation` | State relation, initiality, direction, and step obligations |
+| Do concrete states and operations preserve an abstract data model? | `data-refinement` | Retrieve relation plus initialization and operation obligations |
+| Do two branching systems match in both directions? | `strong-bisimulation` or `weak-bisimulation` | Symmetry; weak matching also names the governed hidden-action set, closure, stuttering, and divergence treatment |
+
+Two equal sampled histories support a bounded comparison. They do not show
+participant-policy noninterference. A successful trace sample does not show
+trace inclusion. A matching finite example does not show simulation or
+refinement. It also does not show strong or weak bisimulation.
+
+The following existing claim-binding contract reports only the seven named
+examples in this guide:
+
+<!-- participant-control-claim:start -->
+```json
+{
+  "taxonomy_id": "raes-behavioral-relations",
+  "taxonomy_revision": "rev4",
+  "relation_id": "bounded-probe-success",
+  "subject": "Seven named participant-policy examples for one declared target and profile",
+  "left_carrier_ref": "backend-conformance-report:participant-policy-example",
+  "right_carrier_ref": null,
+  "observation_projection_ref": "participant-policy-probe-projection",
+  "observation_projection_revision": "rev1",
+  "quantifier_scope": "finite-cases",
+  "evidence_scope": "finite",
+  "evidence_boundary": "Only denial, withholding, redaction, governed declassification, transformation, participant-directed inject delivery, and unsupported-capability cases named by this guide for the disclosed target and profile",
+  "assurance_status": "tested",
+  "evidence_refs": [
+    "implementations/python/tests/test_asr_535_participant_flow_assurance.py"
+  ],
+  "limitations": [
+    "The reference backend declares all participant-policy features unsupported; positive paths use explicit test manifests."
+  ],
+  "explicit_non_claims": [
+    "Does not establish universal participant-policy noninterference or participant-projected history equivalence.",
+    "Does not establish trace inclusion, simulation, refinement, strong or weak bisimulation, native-backend realization, model checking, or proof."
+  ]
+}
+```
+<!-- participant-control-claim:end -->
+
+The public documentation test loads this JSON through
+`BehavioralClaimBindingModel` and resolves its relation against the canonical
+catalog. A stronger claim needs the full governed binding. It also needs the
+right proof. A prose change is not enough.
+
+## Diagnose failures without leaking data
+
+Keep expected failures on the existing safe surfaces. These include
+diagnostic, operation, and HTTP results. An HTTP authorization failure is a
+generic `403 forbidden`. An ambiguity or state conflict uses a bounded `409`
+detail. An unexpected fault stays `{"detail":"internal server error"}`.
+
+Do not expose rejected payloads or policy bodies. Do not expose hidden state
+or participant existence. Keep credentials and bearer tokens out. Keep
+backend objects, exception strings, and tracebacks out. The same rule covers
+environment values, host paths, and raw proof. Do not place these values in
+responses, logs, fixtures, screenshots, or docs.
+
+For current delivery status, evidence, and known limits, use the
+[participant-control adoption index](https://github.com/RAESystem/rae/tree/main/docs/research/participant-io-control)
+and [current project limitations](limitations.md).

--- a/docs/research/participant-io-control/index.md
+++ b/docs/research/participant-io-control/index.md
@@ -1,16 +1,55 @@
 # Participant Information-Flow And Control Adoption
 
 Issue [#794](https://github.com/RAESystem/rae/issues/794) assesses and
-designs the participant-control model. It is a design/program artifact, not an
-implementation or proof claim.
+designs the participant-control model. The ordered child work now delivers the
+SEM-230 semantics, API-423 crossing contract, RUN-319 reference-runtime
+boundary, API-407 capability declarations, ASR-535 bounded assurance, and
+issue #802 migration evidence.
+
+Start with the
+[published participant-control guide](../../public/participant-control.md) for
+role-specific authoring, participant-implementation, operations, backend, and
+research guidance. The guide explains these artifacts; it is not semantic
+authority.
+
+## Adopted authority and delivery
+
+- [ADR-085](../../decisions/adrs/adr-085-participant-information-flow-and-control.md)
+  and the
+  [SEM-230 formal specification](../../../specs/formal/participant-semantics/information-flow-control.md)
+  own participant-relative world, view, history, crossing-operation, policy,
+  and claim boundaries.
+- The
+  [API-423 schema](../../../contracts/schemas/participant-runtime/participant-crossing-occurrence-v1.json)
+  and contextual validator own portable crossing facts.
+- RUN-319 owns reference-runtime enforcement and append-only persistence.
+- API-407 owns feature support, required contracts, and policy-authorized
+  downgrade.
+- ASR-535 owns finite participant-policy conformance evidence.
+- The [migration guide](../../migration/participant-information-flow-control.md)
+  owns legacy, opt-in, required, and rollback procedures.
+- The
+  [behavioral-relation catalog](../../../contracts/concept-authority/behavioral-relations-v1.json)
+  owns relation identity, evidence boundaries, assurance state, and
+  nonclaims.
+
+The shipped reference backend declares all six participant-policy features
+unsupported. Positive runtime paths use explicit test manifests and finite
+evidence. RUN-319 does not currently emit API-423's distinct `withhold`
+disposition, the declassification probe drives projection, and runtime inject
+delivery does not yet bind the compiled DSL-142/DSL-111 identity end to end.
+These limits prevent native-backend, universal noninterference, equivalence,
+simulation, refinement, or bisimulation claims.
+
+## Design and implementation record
 
 - [Architecture preflight](../../decisions/issue-794-participant-io-control-preflight.md)
 - [Current-state assessment](current-state-assessment.md)
-- [ADR-085](../../decisions/adrs/adr-085-participant-information-flow-and-control.md)
 - [Detailed adoption design](adoption-design.md)
 - [Requirement disposition](requirement-disposition.md)
 - [Ordered implementation program](adoption-program.md)
 - [Machine-readable acceptance manifest](adoption-program.json)
+- [Issue #803 guidance preflight](../../decisions/issue-803-participant-control-guidance-preflight.md)
 
 ```{toctree}
 :hidden:
@@ -21,8 +60,8 @@ requirement-disposition
 adoption-program
 ```
 
-The decisive finding is that ACES has adjacent participant action,
-observation, visibility, runtime, intervention, orchestration, backend, and
-assurance mechanisms, but not yet one portable participant ingress/egress
-policy and evidence boundary. The program composes those mechanisms without a
-universal message DTO, gateway, second history, or inflated relation claim.
+The design record captures the pre-adoption gap and the choices used to close
+it. Current delivery status comes from the shipped artifacts above, not from
+the original program's draft requirement dispositions. The implementation
+composes incumbent carriers without a universal message DTO, gateway, second
+history, or inflated relation claim.

--- a/implementations/python/tests/test_public_docs_policy.py
+++ b/implementations/python/tests/test_public_docs_policy.py
@@ -15,6 +15,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from raes import parse_sdl_file  # noqa: E402
+from raes_contracts.behavioral_relations import validate_behavioral_claim_binding  # noqa: E402
+from raes_contracts.contracts import BehavioralClaimBindingModel  # noqa: E402
 from tools.check_public_docs import (  # noqa: E402
     REQUIRED_PUBLIC_PAGES,
     REQUIRED_PUBLIC_REDIRECTS,
@@ -169,3 +171,38 @@ def test_readme_quickstart_matches_checked_in_scenario() -> None:
     )
 
     assert readme_scenario == checked_in_scenario
+
+
+def test_participant_control_claim_example_is_bounded() -> None:
+    guide = (REPO_ROOT / "docs" / "public" / "participant-control.md").read_text(encoding="utf-8")
+    match = re.search(
+        r"<!-- participant-control-claim:start -->\s*```json\s*(.*?)\s*```"
+        r"\s*<!-- participant-control-claim:end -->",
+        guide,
+        re.DOTALL,
+    )
+    assert match is not None
+
+    binding = BehavioralClaimBindingModel.model_validate_json(match.group(1))
+    validated = validate_behavioral_claim_binding(binding)
+
+    assert validated.relation_id == "bounded-probe-success"
+    assert validated.quantifier_scope == "finite-cases"
+    assert validated.evidence_scope == "finite"
+    assert validated.assurance_status == "tested"
+    assert validated.observation_projection_ref == "participant-policy-probe-projection"
+    assert validated.observation_projection_revision == "rev1"
+    required_cases = {
+        "denial",
+        "withholding",
+        "redaction",
+        "governed declassification",
+        "transformation",
+        "participant-directed inject delivery",
+        "unsupported-capability",
+    }
+    assert all(case in validated.evidence_boundary for case in required_cases)
+    assert validated.evidence_refs
+    assert validated.limitations
+    assert any("noninterference" in nonclaim for nonclaim in validated.explicit_non_claims)
+    assert any("bisimulation" in nonclaim for nonclaim in validated.explicit_non_claims)

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,7 @@ PUBLIC_DOCS_ENTRYPOINTS = (
 PUBLIC_DOCS_EXAMPLE_TESTS = (
     "implementations/python/tests/test_public_docs_policy.py::test_checked_in_quickstart_scenario_parses",
     "implementations/python/tests/test_public_docs_policy.py::test_readme_quickstart_matches_checked_in_scenario",
+    "implementations/python/tests/test_public_docs_policy.py::test_participant_control_claim_example_is_bounded",
 )
 RUFF_CONFIG = PROJECT_ROOT / "pyproject.toml"
 OSV_LOCKFILE_PATH = PROJECT_ROOT / "uv.lock"

--- a/tools/policy/historical_identity_records.json
+++ b/tools/policy/historical_identity_records.json
@@ -1625,13 +1625,6 @@
       "content_sha256": "53c30870282bd09b493abddf2f96d966137be04f8af880d1965ad90d655a048e"
     },
     {
-      "path": "docs/research/participant-io-control/index.md",
-      "record_class": "research-record",
-      "rationale": "Preserves preregistered, frozen, dated, or lineage-bearing research evidence from before the RAES identity cutover.",
-      "occurrences": 1,
-      "content_sha256": "d12d66ff4b97231ac253700baa3e4b8754906e07cc0621e1c96d2e1987069b08"
-    },
-    {
       "path": "docs/research/participant-io-control/requirement-disposition.md",
       "record_class": "research-record",
       "rationale": "Preserves preregistered, frozen, dated, or lineage-bearing research evidence from before the RAES identity cutover.",


### PR DESCRIPTION
## Summary

Publish role-routed participant input/output control guidance over the shipped SEM-230, API-423, and RUN-319 boundary without changing normative semantics or delivery status.

## Requirement UIDs

- `SEM-230`
- `API-423`
- `RUN-319`

## Related Issues

Closes #803

## ADR Impact

- ADR-085
- ADR-095

## Changes

- Add a hosted participant-control guide for scenario authors, participant implementations, operators, backend implementors, and researchers.
- Document bounded denial, withholding, redaction, declassification, intervention, inject-delivery, and unsupported-capability examples plus claim-selection boundaries.
- Update public navigation, the adoption index, scientific-completeness explanation, and participant lineage.
- Validate the embedded rev4 behavioral-claim binding and remove the obsolete retired-identity exemption from the updated research index.

## Test Plan

- [x] Configured completion command passes
- [x] Configured repository policy command passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Canonical /implement mechanical verification passed, including repository policy, requirement governance, full tests, Vale, warning-strict Sphinx HTML, output inventory, and linkcheck. The focused public-doc policy and identity-cutover suites also pass.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: docs/public/participant-control.md, docs/research/participant-io-control/index.md, docs/explain/sdl/scientific-scenario-completeness.md, docs/explain/sdl/lineage.md
- TESTS: implementations/python/tests/test_public_docs_policy.py::test_participant_control_claim_example_is_bounded, implementations/python/tests/test_identity_cutover_policy.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.