### PR TITLE
feat: add bounded determinism and replay-consistency verification (ASR-514)

### DIFF
--- a/docs/decisions/issue-262-asr-514-determinism-stability-verification-preflight.md
+++ b/docs/decisions/issue-262-asr-514-determinism-stability-verification-preflight.md
@@ -1,0 +1,369 @@
+# Issue 262 ASR-514 determinism and stability verification preflight
+
+Date: 2026-07-29
+
+Issue: #262. Ground Control requirement: ASR-514. The issue statement and the
+supplied requirement record are the delivery contract. `ASR-514` is the
+requirement-governance context for CI because the branch name does not contain
+the UID.
+
+This note fixes the repository-wide boundary for determinism, stability, and
+replay-consistency verification. It does not add a claim, comparator, schema,
+fixture, runner, API, storage, or runtime behavior. No new ADR is needed.
+ADR-066 owns observation/evidence separation, ADR-068 owns repeated runs and
+replay claims, ADR-072 owns validation strength/disclosure, ADR-081 owns
+behavioral-relation meaning, and ADR-084 owns deterministic trial realization
+and controlled randomness.
+
+## Decision boundary
+
+ASR-514 applies when a producer makes an explicit repeatability claim. The
+verification must bind that claim to exact subjects, inputs, execution or
+artifact identities, an observation projection, a controlled-variation policy,
+and a versioned comparison criterion. It must not infer repeatability from a
+successful run, a seed, a retry, equal exit status, or two equal values.
+
+Keep four concerns separate:
+
+1. **Claim semantics** state what is expected to remain equal, equivalent, or
+   within tolerance and under which variation. Use
+   `BehavioralClaimBindingModel` and the canonical behavioral-relations
+   catalog. Do not add a generic `repeatable`, `deterministic`, or `stable`
+   Boolean, a local relation registry, or a free-form claim DTO.
+   Relation carriers and observation projection are separate coordinates:
+   for `canonical-artifact-identity`, left and right carriers are the two
+   canonical artifacts, while the named canonicalization/projection profile
+   belongs in the projection/criterion fields. Do not put a projection id in a
+   carrier field. For a cohort larger than two, retain the individual
+   baseline-to-repetition comparisons or use the study/statistical claim
+   surface; do not silently reinterpret a binary relation as an n-ary one.
+2. **Repetition identity and admission** identify distinct immutable artifacts
+   or runs. Under ADR-068, a genuine re-execution has a distinct `run_id`;
+   an idempotent pre-execution retry reuses the preallocated run identity and
+   is not a replicate. Every compared scenario, task, run, study, apparatus,
+   stochastic, time, evidence, and lineage artifact passes its existing
+   structural and semantic validators before comparison.
+3. **Comparison semantics** name the projection, canonicalization or metric,
+   matching/variation policy, sample boundary, and decision rule before results
+   are observed. Exact equality, projected equivalence, and statistical
+   stability are different criteria, not modes of one untyped comparator.
+4. **Evidence and disclosure** preserve the compared identities, provenance,
+   projected observations or derived measures, mismatch evidence, limitations,
+   and criterion outcome. Reuse experiment evidence/derived-measure/
+   traceability carriers and `ValidationBasisDisclosureModel`. A comparator
+   result does not replace those carriers or create validation strength by
+   itself.
+
+The relation and evidence authority depends on the claim:
+
+| Claim family | Canonical authority and boundary |
+| --- | --- |
+| Exact artifact or pipeline-output determinism | `canonical-artifact-identity` plus one named canonicalization profile and exact input identity. `canonical_sdl_digest()`, `canonical_instantiated_sdl_digest()`, and `canonical_contract_digest()` are the incumbent canonicalizers for their owning types. Equality across a finite set is a bounded witness, not proof of universal determinism. |
+| Replay consistency | Original and replay are distinct admitted run/artifact identities joined by preserved lineage. Compare only the declared observation projection. Use `participant-projected-history-equivalence` for two histories projected for the same named participant and projection revision, `canonical-artifact-identity` for exact canonical artifacts, or another already-defined relation whose full obligations match the projection. A completed replay is not consistency evidence by itself. |
+| Stability under controlled variation | Use `ExperimentStudyModel`, factors, allocation, analysis plan, evidence, derived measures, and `statistical-similarity` or `statistical-equivalence`. Population, metric, tolerance/equivalence margin, uncertainty method, sample/stopping rule, and missing-data policy are predeclared. Pairwise equality is not a stability analysis. |
+| Strict trace or behavioral equivalence | Use `trace-equivalence` or the narrower governed relation only when its projection, state, trace, scheduler, concurrency, probability, time, and quantifier obligations are actually met. Digest equality and shared seeds are not substitutes. |
+
+`bounded-probe-success` may describe that the finite verifier cases executed.
+It does not itself mean determinism, replay consistency, statistical stability,
+trace equivalence, or backend equivalence. The default design needs no new
+generic repeatability relation: the existing relations intentionally preserve
+the distinctions above.
+
+The existing
+`implementations/python/tests/test_pipeline_determinism.py` is a valid narrow
+exact-output witness for parse -> instantiate -> compile, including
+cross-process `PYTHONHASHSEED` variation. It is not the portable ASR-514
+comparison contract, and its local serializer must not become a public
+canonicalization API or an oracle for runtime, replay, or statistical claims.
+
+The comparison core belongs in `raes_conformance` only when the required join
+has no existing subject-specific validator. It should consume already-admitted
+typed artifacts and evidence; it must not parse authoring input, schedule
+repetitions, replay a run, select a backend, resolve secrets, dispatch commands,
+or persist results. A trusted assembler must derive projection, matching,
+lineage, reset, cleanup, and evidence facts from their typed authorities.
+Caller-supplied booleans or bare digest/evidence-reference strings are not
+verification.
+
+The ASR-513 `necessity_evidence` path is the incumbent pattern for a
+digest-pinned validator authority, typed run/evidence joins, assembler-owned
+facts, stable diagnostics, and an internal comparison result. Reuse that
+discipline, not its causal concepts. Do not route ASR-514 through
+`BoundedButForCase`, `NecessityMatchingPolicy`, intervention records, or
+necessity outcomes. If producer/validator binding and verification-record
+identity are byte-for-byte common, promote those neutral primitives once
+rather than copying them; necessity-specific and repeatability-specific facts
+remain separate.
+
+## Canonical incumbents
+
+| Concern | Canonical incumbent and required reuse |
+| --- | --- |
+| Validation taxonomy and disclosure | ADR-072, `validation-profile-catalog-v1.json`, `select_validation_profile()`, `ValidationBasisDisclosureModel`, gate-result rows, evidence/diagnostic refs, and explicit limitations. A supported ASR-514 result may support existing behavioral/evidence gate rows; it does not require a second profile loader or strength taxonomy. |
+| Claim meaning | ADR-081, `behavioral-relations-v1.json`, `BehavioralClaimBindingModel`, and `validate_behavioral_claim_binding()`. Use the relation matching the comparison criterion; do not weaken catalog-revision or carrier checks. |
+| SDL identity and lifecycle | `parse_sdl()`, `parse_sdl_file()`, safe source normalization, module trust/composition, `SemanticValidator`, `instantiate_scenario()`, post-instantiation admission, `canonical_sdl_digest()`, and `canonical_instantiated_sdl_digest()`. |
+| Contract canonicalization | `ContractModel(extra="forbid")`, `model_dump(mode="json")`, the shared RFC 8785/JCS canonicalization path, and `canonical_contract_digest()`. Do not use `repr`, object identity, host paths, insertion-order text, broad field scrubbing, or `default=str` as portable identity. If a non-`ContractModel` internal case needs canonical JSON identity, expose/reuse the existing neutral JCS helper through a policy-compliant public boundary instead of copying another `json.dumps`/`hashlib` serializer. |
+| Repeated runs and studies | ADR-068; `ExperimentTaskModel`, `ExperimentRunModel`, `ExperimentStudyModel`, membership, factors, condition assignments, `ExperimentRunAllocationPlanModel`, `ExperimentAnalysisPlanModel`, `validate_experiment_run_against_task()`, and `validate_experiment_study_against_tasks_and_runs()`. |
+| Randomness and time | ADR-084; executable stochastic controls, random-stream profiles/addresses/draw records, `ExperimentRunModel` stochastic draw/control validation, study common-random-number consistency checks, `TimeModelDeclarationModel`, `RealizedTimeModelProvenanceModel`, and `validate_realized_time_model()`. A seed alone is insufficient. |
+| Reset, cleanup, and isolation | `TrialCleanupPlanModel`, `TrialCleanupReceiptModel`, `validate_trial_cleanup_receipt()`, `SchedulerIsolationProofModel`, backend `CleanupCapabilities`, `require_cleanup_plan_capability()`, and time/participant coordinated-reset capability admission. These authorities decide whether state-bearing repetitions are comparable; a comparator must not replace them with a `cleanup_verified` or `isolated` caller Boolean. |
+| Per-run execution | ASR-512 `BehavioralProbeCase` and trusted injected executor where a subject needs a bounded behavioral probe; existing conformance fixture/target runners and realization harnesses otherwise. Per-run probe success is input evidence, not the cross-run conclusion. |
+| Evidence and analysis | `ExperimentEvidenceRecordModel`, `ExperimentDerivedMeasureModel`, `ExperimentRunTraceabilityModel`, result summaries, realized-form/augmentation disclosures, capture specs, source evidence refs, redaction/loss disclosure, and claim refs grounded by derived measures. |
+| Diagnostics and errors | `Diagnostic`, `DiagnosticModel`, `Severity`, namespaced stable codes, `sanitized_failure_message()`, existing SDL/Pydantic errors at their owning boundaries, operation envelopes, and the redacted HTTP 500 handler. Add no ASR-514 exception hierarchy or logger. |
+| Artifact persistence | Existing operations-owned artifacts use their artifact-specific validation/redaction gate plus `run_artifact_path()`, `portable_artifact_ref()`, and `atomic_write_json_artifact()`. `redaction_violations()` is the incumbent for the existing evidence-run artifact family, not a general secret classifier for a new carrier. Live state remains in typed runtime snapshots and `ControlPlaneStore`; archival claims remain in experiment/evidence/disclosure artifacts. |
+| Existing deterministic witnesses | `test_pipeline_determinism.py` covers the SDL parse/instantiate/compile path; `test_random_stream_determinism.py` covers schedule, partition, thread, process, and hash-seed invariance; random-stream vector tests cover the published cross-language profile. Reuse their fixture and fixed-argv techniques where applicable, but do not promote their local serializers into portable identity. |
+| Workflow governance | `.ground-control.yaml`, `.gc/plan-rules.md`, ADR-014, `noxfile.py`, `tools/check_repo_policy.py`, `tools/check_requirement_governance.py`, and `tools/verify_all.py`. Tests under the existing marker taxonomy are already discovered by the canonical `verify` graph; do not add a second workflow or nox path unless a genuinely new external-runtime class cannot use an incumbent session. |
+
+There is no controller, repository, mutable registry, replay scheduler, or
+generic environment binder in the default design. There is also no need for a
+portable `repeatability-report`, `determinism-result`, `replay-result`, or
+`stability-result` root schema. Existing run/study/evidence/derived-measure/
+claim/disclosure carriers already own durable facts. A small frozen internal
+case/result seam is justified only for the executable join that has no portable
+home.
+
+## Cross-cutting validation, security, and operational layers
+
+1. **SDL source, parser, and phase admission.** Compared scenario artifacts
+   pass the bounded safe YAML loader, duplicate-key/source-profile checks,
+   closed SDL shapes, module trust/composition rules, instantiation,
+   unresolved-token rejection, and post-instantiation `SemanticValidator`.
+   Parsing, schema generation, documentation, and MCP inspection stay inert.
+2. **Claim and reference shape.** Resolve one exact catalog revision, relation,
+   subject/carrier pair, projection revision, quantifier/evidence scope, and
+   explicit nonclaims. Resolve every artifact/run/study reference by stable id,
+   version, and digest where the owning type supports one. Paths, test names,
+   tags, object ids, or prose are not claim identity.
+3. **Repetition and matching admission.** Compared executions use distinct run
+   identities, compatible task/scenario lineage, and one declared policy for
+   held-fixed and deliberately varied dimensions. Validate apparatus,
+   participant implementation, parameters, scheduler/order, time, randomness,
+   observation, augmentation, reset, cleanup, and residual-state facts through
+   their owners. Ambient similarity is not verification.
+4. **Contract and schema shape.** Portable changes use closed
+   `ContractModel` shapes, existing primitive/reference types, schema versions,
+   and `x-raes-invariants` for cross-artifact rules. Keep generated and
+   published schemas identical and update the publication ledger, fixtures,
+   registry, and conformance checks together. Internal dataclasses and test
+   serializers are not published contracts.
+5. **Profile, capability, and apparatus admission.** Resolve the exact
+   validation profile with `select_validation_profile()`. Resolve processor,
+   backend, observation, evaluation, time, isolation, reset, cleanup, and
+   participant capability through existing manifests/profiles and admission
+   helpers. Comparator adapters use the existing injected-adapter pattern and
+   exact required-capability refs; there is no generic comparison capability in
+   the backend manifest to assume or add by default. Unsupported support remains
+   explicit. Neither a profile nor a capability grants execution or evidence
+   access.
+6. **Configuration and environment shape.** The comparison core reads no
+   ambient environment and adds no executable path, plugin root, profile root,
+   remote registry, credential, or generic config mapping. Repeated runs retain
+   typed experiment parameters and apparatus context. Concrete backends retain
+   their closed config checks; libvirt keeps `_validate_config_keys`, driver
+   mode/manifest/envelope agreement, and safe connection handling. Environment
+   dumps are neither held-fixed evidence nor replay context.
+7. **Executable artifact and supply-chain gate.** Any script, package, image,
+   probe, or external analyzer used to produce repetitions is untrusted
+   apparatus. Reuse pinned digests, declared trust policy, allowlists, source
+   limits, and `ImageTrustPolicy` where applicable. Claim/profile/comparison
+   data must not choose imports, Python callables, shell commands, executable
+   URLs, images, guest commands, or backend dispatch.
+8. **Authentication and authorization.** Prefer an in-process conformance
+   composition root; ASR-514 needs no new route. If execution or evidence access
+   crosses HTTP, use `create_control_plane_app()` and
+   `ControlPlaneSecurityConfig.strict_defaults()`: verified identity,
+   target-bound roles, participant controller/audience bindings, request-size
+   guards, idempotency keys, request fingerprints, and append-only
+   `AuditEvent`s remain mandatory. Claim authorship, replay permission,
+   execution capability, and evidence-read authority are distinct.
+9. **Secrets and information boundaries.** Secrets, hidden answers, prompts,
+   raw environment values, credentials, and sensitive entropy never enter a
+   comparison key, variation label, projection digest, claim text, fixture,
+   diagnostic, argv item, log, or public evidence payload. Use governed
+   references at authorized late-bound sinks. Preserve evidence sensitivity,
+   redaction, withholding, loss, participant visibility, and audience rules.
+   A public result cannot borrow strength from a stronger hidden comparison.
+10. **OS and host exposure.** The comparison core performs no subprocess,
+    network, daemon, or privileged operation. A concrete adapter uses the
+    existing injected-runner pattern: fixed argv, `shell=False`, controlled
+    cwd/environment, bounded time/output/resources, least privilege, and owned
+    cleanup. Tokens, raw scenario/evidence bodies, connection URIs, host paths,
+    seeds/entropy, native object dumps, and hidden assets never enter argv or
+    child output. Reuse the OCI fixed-argv/redacted-output boundary and
+    credential-free libvirt fact channels; do not add a general guest runner.
+11. **Observation and evidence admission.** Compare fresh, addressed,
+    subject-bound observations under the same named projection revision.
+    Resolve each observation/derived value through the exact run traceability
+    and evidence record. Capture intent is not capture; raw evidence is not a
+    derived measure; a log is not portable evidence; participant-visible state
+    is not hidden truth. Redaction or loss can make the result inconclusive.
+12. **Error envelopes and observability.** Failures expose stable codes, safe
+    addresses, coarse outcomes, counts, and short fixed messages. Use
+    `sanitized_failure_message()` rather than `str(exc)` for untrusted inputs.
+    Any diagnostic that may become a `DiagnosticModel` must satisfy its closed
+    shape: lower-case namespaced code/domain, a JSON Pointer `address` (not a
+    dotted internal label or raw caller id), and the 512-character message
+    bound.
+    Never expose rejected bodies, compared values, mismatch payloads, commands,
+    stdout/stderr, environment, evidence content, native objects, or traces.
+    Logs and audit events may summarize lifecycle activity; they are not
+    repeatability evidence.
+13. **Persistence, reset, and cleanup.** Never mutate one run into a replay or
+    replicate. Every executed repetition has immutable run/evidence identity.
+    State-bearing comparisons require the declared reset boundary, independent
+    cleanup verification, and no residual owned state. Validate and redact
+    before `atomic_write_json_artifact()`. Runtime snapshots, operation
+    details, audit blobs, tags, and logs are not the archival claim record.
+14. **Repository and package boundary.** SDL meaning stays in `raes`; portable
+    DTOs in `raes_contracts`; compilation/admission in `raes_processor`; live
+    control/security/storage in `raes_runtime`; capabilities in
+    `raes_backend_protocols`; concrete execution in adapters; comparison and
+    conformance flow in `raes_conformance`; artifact assembly/writes in
+    `raes_operations`; and user wiring in `raes_cli`. Keep module policy and
+    source-size limits intact; do not use private imports, compatibility
+    wrappers, or `Any` bags to evade ownership.
+
+## Outcome and concept separation
+
+| Surface | Question answered |
+| --- | --- |
+| Exact canonical comparison | Are the named projected artifacts byte/digest-identical under one canonicalization revision? |
+| Replay-consistency comparison | Does the replay match the original under the declared observation relation and projection? |
+| Statistical stability result | Does the preregistered metric satisfy the stated tolerance/equivalence criterion for the sampled population? |
+| Per-run probe outcome | Did one bounded apparatus invocation execute and meet its case oracle? |
+| Proposition truth outcome | What is the governed truth/support result for one proposition in one run? |
+| Validation gate outcome | Did one ASR-515 gate pass, fail, remain partial/not-run/unknown/unsupported/withheld, or not apply? |
+| Operation/workflow status | Did apparatus work progress or complete? |
+| ADR-021 evidence status | What is the falsification-protocol status: `untested`, `partial`, `demonstrated`, or `refuted`? |
+
+Mappings are explicit. A mismatch may refute one exact bounded determinism or
+replay-consistency claim after identity, projection, matching, and evidence
+gates pass. Missing, stale, withheld, lossy, unsupported, incomparable, or
+cleanup-invalid evidence is inconclusive or unsupported, not a match or
+mismatch. A stable sample does not prove deterministic execution; exact equality
+does not establish statistical stability, trace equivalence, backend
+equivalence, or falsification-backed strength.
+
+## Extensibility seam
+
+The stable seam is a subject-bound, immutable comparison case supplied by
+trusted code to a criterion-specific, capability-checked comparator. It binds:
+
+- exact revisioned claim and subject/carrier identities;
+- comparison family and criterion id/version;
+- observation projection and canonicalization/metric revision;
+- immutable original/baseline and repetition artifact/run identities, digests,
+  and lineage;
+- controlled-variation/matching policy with held-fixed and deliberately varied
+  dimensions;
+- replicate/sample identity, minimum count or stopping rule, and canonical
+  input digest;
+- scheduler/concurrency, time, random-stream, participant, apparatus,
+  augmentation, reset, cleanup, and missing-data policies where relevant;
+- digest-pinned producer/validator authority and required capabilities; and
+- evidence, derived-measure, diagnostic, limitation, audience, redaction,
+  profile, and disclosure refs.
+
+Future variations add one governed criterion/projection adapter at this seam.
+Examples include a new canonical projection, an allowed jitter tolerance, a
+participant-history replay, a different scheduler perturbation, or a
+preregistered statistical criterion. They must not require a new claim
+registry, scenario lifecycle, trial identity, evidence graph, report root,
+exception tree, logger, store, auth route, subprocess framework, or CI
+workflow.
+
+## Whole-repository scope
+
+- **Normative authority:** ADR-066/068/072/081/084; behavioral relations;
+  validation profiles; experiment, evidence, time, random-stream, participant,
+  workflow, and replay-claim specifications; and every changed catalog, schema,
+  fixture, profile, publication record, and assurance mapping.
+- **Implementation authority:** SDL parse/validate/instantiate/canonicalize;
+  contract canonicalization; task/run/study/allocation/analysis/evidence/
+  traceability/disclosure contracts; random streams and time models;
+  cleanup plans/receipts and scheduler-isolation proofs; behavioral probes;
+  conformance harnesses; manifests/capabilities; runtime auth/audit/store/reset;
+  adapters; artifact-family redaction; artifact writes; and CLI wiring only if
+  a user command is explicitly in scope.
+- **Verification authority:** positive and single-defect negative cases for
+  claim/ref/digest/criterion/projection admission; distinct run identity;
+  stale or cross-run evidence; held-fixed and deliberately varied dimensions;
+  hash seed, ordering, scheduling, concurrency, time, random stream, reset,
+  retry, redaction, missing-data, mismatch, cleanup, residue, capability, auth,
+  argv, and exception leakage; plus schema, authority, module, claim, and
+  repository-policy gates.
+- **Workflow authority:** `.ground-control.yaml`, `.gc/plan-rules.md`,
+  `noxfile.py`, `tools/check_repo_policy.py`,
+  `tools/check_requirement_governance.py`, and `tools/verify_all.py`.
+  `RAES_REQUIREMENT_UID=ASR-514` is required for governance commands on this
+  branch.
+
+## Gotchas and anti-patterns
+
+Avoid:
+
+- a generic `repeatable`, `stable`, `deterministic`, `replay_passed`, or
+  `consistent` Boolean without a claim, projection, variation policy,
+  criterion, sample boundary, and evidence;
+- treating same seed, task id, scenario name, backend name, wall-clock
+  proximity, exit code, response status, run status, retry, or operation id as
+  equivalent inputs or outputs;
+- calling two equal outputs universal determinism, or calling one unequal pair
+  instability without first proving comparable inputs and projections;
+- treating exact digest equality as trace, participant-history, behavioral,
+  statistical, or backend equivalence;
+- putting the canonicalization/projection id in a relation carrier field,
+  treating a binary catalog relation as an n-ary cohort relation, or giving an
+  exact-equality-only comparator a generic stability/statistics name;
+- sorting away semantically ordered lists, dropping all time-like keys, or
+  excluding volatile fields without naming their producer and exclusion
+  rationale;
+- promoting the local `test_pipeline_determinism.py` serializer into a public
+  contract or copying it into production comparators;
+- reusing one run id for multiple executions, reconstructing a replay from
+  mutable live state, or changing the comparison policy after seeing results;
+- accepting projection/matching/reset/cleanup success, output digests, metrics,
+  or evidence refs as caller assertions rather than resolving typed
+  producer/validator output through exact run/evidence joins;
+- using a necessity world/intervention type, proposition truth, validation gate
+  outcome, probe outcome, operation status, or ADR-021 evidence status as the
+  repeatability result;
+- adding a generic replay record, repeatability report, determinism schema,
+  comparison graph, evidence store, runtime snapshot metadata bag, exception
+  hierarchy, logger, registry, or workflow;
+- executable code, commands, imports, URLs, paths, dynamic plugins, or dispatch
+  tables in claim/profile/criterion data;
+- arbitrary dictionaries such as `repeatability_metadata`,
+  `comparison_config`, `replay_context`, `stability_metrics`, or
+  `ignored_fields`;
+- selecting a comparator, executor, path, profile, projection, target, or
+  fallback criterion from untrusted data;
+- emitting dotted or caller-derived diagnostic addresses that later fail or
+  leak through the closed `DiagnosticModel` JSON Pointer boundary;
+- raw evidence in disclosures or derived measures, logs/snapshots as archival
+  evidence, public strength borrowed from hidden evidence, or missing/withheld
+  data silently discarded; and
+- `shell=True`, open child environments, unbounded output/time/resources,
+  secrets or raw payloads in argv, unsanitized `str(exc)`, unverified cleanup,
+  or ignored residual state.
+
+## Non-goals and implementation boundaries
+
+- This preflight does not implement issue #262 or choose final field/class
+  names.
+- It does not add a runtime replay engine, scheduler, worker, artifact
+  retrieval/retention service, environment snapshotter, generic comparison
+  service, statistics engine, model checker, theorem prover, or query language.
+- It does not redesign SDL parsing/canonicalization, experiment runs/studies,
+  random streams, time, behavioral relations, profiles/disclosures, evidence,
+  conformance, authentication, redaction, persistence, reset, or cleanup.
+- It does not guarantee exact environmental recreation, external artifact
+  availability, deterministic participant or backend behavior, universal trace
+  equivalence, backend equivalence, statistical generalization, experiment
+  validity, proof, or falsification-backed strength.
+- It adds no API, MCP tool, UI, database, mutable registry, remote plugin
+  system, credential broker, command endpoint, general guest execution channel,
+  or authoring-time side effect.
+- Unsupported comparison families or insufficiently evidenced claims remain
+  explicit. The implementation must not weaken the claim, substitute a nearby
+  relation/criterion, silently canonicalize a mismatch away, or invent a
+  default projection/variation policy to make verification pass.

--- a/docs/research/behavioral-validation/traceability-matrix-asr-514.md
+++ b/docs/research/behavioral-validation/traceability-matrix-asr-514.md
@@ -1,0 +1,84 @@
+# ASR-514 Determinism And Stability Verification Matrix
+
+Date: 2026-07-29.
+
+Issue: #262.
+
+Policy UID: ASR-514.
+
+Issue #262 requires the ecosystem to support verification of determinism,
+stability, or replay-consistency where repeatability claims are made. Following
+the binding architecture preflight, determinism and replay-consistency claims
+bind existing behavioral relations rather than a new one, so no catalog
+revision changes. The implementation adds only the executable join that has no
+portable home: one bounded comparator over a single binary baseline-to-repetition
+pair of one held-fixed subject, under the exact `canonical-artifact-identity`
+relation. The claim's two carriers name the two compared projected artifacts,
+and a larger set of repeated runs composes as several pairwise cases rather than
+one n-ary comparison. The comparator does not schedule, replay, canonicalize
+runs, execute, or persist; it consumes already-admitted typed runs and evidence,
+and every projection, variation, reset, and cleanup fact is derived by a
+digest-pinned validator and resolved through the exact run traceability. Case
+and verification-record identities use the repository JCS canonical digest, and
+diagnostics use a fixed JSON-Pointer address.
+
+## Clause Matrix
+
+| Clause | Executable implementation | Structural gate or evidence |
+| --- | --- | --- |
+| Verify a repeatability claim over admitted repeated executions. | `RepeatabilityConsistencyCase` binds one revisioned repeatability claim to an exact subject, a baseline and a repetition `RepetitionRef`, an observation projection, a versioned criterion, a variation policy, required capabilities, and a validator authority; its JCS `digest` seals every join input. `assemble_repeatability_consistency_evidence()` invokes the digest-pinned validator and `compare_repeatability_consistency()` returns a distinct `consistent`, `divergent`, `inconclusive`, or `unsupported` result. | `test_verified_equal_pair_is_consistent`, `test_divergent_projected_outcomes_refute_without_execution_failure`, and `test_case_digest_changes_for_every_join_identity`. |
+| Bind the claim to an existing relation whose carriers name the compared artifacts. | The comparator admits only `SUPPORTED_REPEATABILITY_RELATION_IDS` (`canonical-artifact-identity`) and requires the claim's left and right carriers to equal the baseline and repetition `projected_artifact_ref` and the projection to match, then calls `validate_behavioral_claim_binding()` against the catalog revision without weakening it. No catalog relation, revision, or schema is added. | `test_claim_binds_the_existing_canonical_artifact_identity_relation`, `test_claim_carriers_must_identify_the_baseline_and_repetition_artifacts`, `test_wrong_relation_or_stale_catalog_coordinate_fails_before_comparison`, and `test_non_finite_claim_boundary_is_not_interpreted_by_the_comparator`. |
+| Require a distinct, lineage-preserving repetition of the same subject. | `RepeatabilityConsistencyCase._validate_pair()` requires distinct `run_ref` and `projected_artifact_ref` values and a subject held fixed by ref and digest (ADR-068 distinct-run identity, not a retry). The assembler revalidates each run against its task and matches run, snapshot, and digest identities. | `test_case_requires_a_distinct_lineage_preserving_pair`, `test_assembler_rejects_a_side_that_does_not_match_the_typed_run`, and `test_assembler_runs_the_canonical_task_run_validator`. |
+| Require a declared variation policy. | `VariationPolicy` names held-fixed dimensions and permitted variation. The assembler derives the variation disposition through the admitted validator and independently computes every observed variation not permitted by the policy; any unpermitted observed variation leaves the comparison inconclusive. | `test_variation_reset_and_cleanup_gates_fail_closed`, `test_unpermitted_observed_variation_makes_the_pair_incomparable`, and `test_variation_verification_must_match_the_declared_policy`. |
+| Require reset, isolation, and absence of residue. | `ResetVerificationRecord` and `CleanupVerificationRecord` carry only run-bound refs; the admitted validator derives their dispositions. A comparison is not consistent without verified reset, verified cleanup, run-resolved evidence, and an empty residual-state set. | `test_variation_reset_and_cleanup_gates_fail_closed`, `test_unsupported_verification_disposition_remains_unsupported`, and `test_diagnostics_use_a_stable_json_pointer_address_and_hide_untrusted_values`. |
+| Decide identity and divergence correctly. | Once every gate passes, an equal baseline and repetition projected digest yields `consistent`; an unequal pair yields `divergent` and refutes the finite claim without reporting an execution failure. Unsupported or indeterminate projected outcomes remain `unsupported` or `inconclusive`. | `test_verified_equal_pair_is_consistent`, `test_divergent_projected_outcomes_refute_without_execution_failure`, `test_indeterminate_projected_outcome_is_inconclusive`, and `test_unsupported_projected_outcome_remains_unsupported`. |
+| Bind claim, subject, projection, criterion, capabilities, and evidence exactly. | Admission resolves the supported relation and criterion, matches the claim carriers to the artifacts and projection, checks required capabilities, and matches the sealed evidence to the case digest and admitted pair. The assembler pins the validator to the case authority, resolves each projected observation through the exact run traceability, and joins each variation, reset, and cleanup record to an admitted pair run. | `test_unsupported_criterion_is_rejected_before_comparison`, `test_missing_comparator_capability_fails_before_evidence_interpretation`, `test_case_digest_mismatch_is_rejected_before_comparison`, `test_comparator_rejects_pair_evidence_mismatch_in_sealed_evidence`, `test_assembler_rejects_validator_outside_the_case_authority_pin`, `test_assembler_rejects_projection_evidence_from_the_other_run`, and `test_assembler_rejects_verification_evidence_outside_the_pair`. |
+| Preserve security and disclosure boundaries. | Direct `RepeatabilityConsistencyEvidence` construction is blocked and assembled values carry a module-owned authenticity token rechecked by the comparator. Caller-constructible verification inputs contain no disposition, binding, or digest. The host-owned admitted adapter derives projections and dispositions, the assembler computes record digests with the JCS canonical helper and preserves authority identity, and the comparator rechecks the preserved identities. Neither layer performs import selection, command dispatch, environment lookup, filesystem access, secret binding, logging, or persistence. Diagnostics use a fixed JSON-Pointer address and coarse messages; unmatched values and raw evidence are never rendered. | `test_comparison_evidence_cannot_be_constructed_directly`, `test_comparator_rejects_an_unsealed_copy_of_assembled_evidence`, `test_comparator_rejects_authority_mismatch_in_sealed_evidence`, `test_verification_inputs_cannot_assert_disposition_binding_or_digest`, and `test_diagnostics_use_a_stable_json_pointer_address_and_hide_untrusted_values`. |
+
+## Existing Authority Reused
+
+- ADR-066 separates observations, evidence, and derived results.
+- ADR-068 owns repeated runs, replication, and replay claims; a genuine
+  re-execution has a distinct run identity, and an idempotent retry is not a
+  replicate.
+- ADR-072 owns validation strength and disclosure.
+- ADR-081 owns behavioral-relation meaning and claim discipline.
+- ADR-084 owns deterministic trial realization and controlled randomness.
+- `canonical-artifact-identity` remains the exact-identity relation; the
+  comparator adds only the baseline-to-repetition admission around it and never
+  reinterprets the binary relation as n-ary.
+- The ASR-513 `necessity_evidence` discipline is reused for the digest-pinned
+  validator authority, typed run and evidence joins, assembler-owned facts, and
+  stable diagnostics; the shared neutral primitives are promoted into
+  `verification_authority`, and no necessity concept is imported.
+- The repository JCS canonical digest (`canonical_json_digest`) computes case and
+  verification-record identities; no local serializer is introduced.
+
+## Trust Boundary
+
+The comparator is a trusted-composition-only surface, invoked by code that owns
+the validator authority and the case. The module assembly token is integrity
+defense-in-depth against accidental or unsealed construction, not access control
+against a caller already trusted to drive the comparator. Each evidence
+reference is bound to the digest-verified run's declared evidence set; because
+the experiment-run traceability model does not admit per-evidence content
+digests and this comparator adds no evidence store, content authenticity of an
+individual evidence record remains owned by the platform evidence provenance and
+resolution layer that supplies the records.
+
+## Nonclaims
+
+- A consistent result applies only to the exact finite pair, subject,
+  observation projection, variation policy, and equality criterion.
+- A shared seed, a reused task identifier, wall-clock proximity, an exit or run
+  status, a retry, or a completed replay does not establish repeatability.
+- The result does not establish universal determinism, statistical equivalence,
+  trace equivalence, bisimulation, backend equivalence, necessity, experiment
+  validity, proof, or falsification-backed strength.
+- Statistical stability under controlled variation and participant-history
+  replay are separate criteria bound to `statistical-equivalence` or
+  `participant-projected-history-equivalence`; the shipped criterion decides
+  exact canonical projected-outcome identity only.
+- The comparator does not construct, schedule, or execute repetitions. Ordinary
+  parsing, semantic admission, authorization, capability, execution, evidence,
+  reset, and cleanup boundaries remain with their owning layers.

--- a/implementations/python/packages/raes_conformance/necessity_types.py
+++ b/implementations/python/packages/raes_conformance/necessity_types.py
@@ -2,83 +2,17 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
-from enum import Enum
 
 from raes_contracts.contracts import PropositionTruthResultModel
 
-_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+from .verification_authority import (
+    VerificationBinding,
+    VerificationDisposition,
+    VerificationRecordIdentity,
+)
+
 _ASSEMBLY_TOKEN = object()
-
-
-class VerificationDisposition(str, Enum):
-    """Typed outcome derived by an admitted verification adapter."""
-
-    VERIFIED = "verified"
-    FAILED = "failed"
-    UNSUPPORTED = "unsupported"
-
-
-def _require_text(value: str, field_name: str) -> None:
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{field_name} must be non-empty")
-
-
-def _require_digest(value: str, field_name: str) -> None:
-    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
-        raise ValueError(f"{field_name} must be a sha256 digest")
-
-
-@dataclass(frozen=True)
-class VerificationBinding:
-    """Digest-pinned producer and validator identity admitted by a case."""
-
-    producer_id: str
-    producer_version: str
-    producer_digest: str
-    validator_id: str
-    validator_version: str
-    validator_digest: str
-
-    def __post_init__(self) -> None:
-        for field_name in (
-            "producer_id",
-            "producer_version",
-            "validator_id",
-            "validator_version",
-        ):
-            _require_text(getattr(self, field_name), field_name)
-        _require_digest(self.producer_digest, "producer_digest")
-        _require_digest(self.validator_digest, "validator_digest")
-
-
-@dataclass(frozen=True)
-class VerificationRecordIdentity:
-    """Producer and validator provenance retained from one verified fact."""
-
-    record_id: str
-    record_version: str
-    record_digest: str
-    producer_id: str
-    producer_version: str
-    producer_digest: str
-    validator_id: str
-    validator_version: str
-    validator_digest: str
-
-    @property
-    def binding(self) -> VerificationBinding:
-        """Return the exact producer/validator binding retained by the record."""
-
-        return VerificationBinding(
-            producer_id=self.producer_id,
-            producer_version=self.producer_version,
-            producer_digest=self.producer_digest,
-            validator_id=self.validator_id,
-            validator_version=self.validator_version,
-            validator_digest=self.validator_digest,
-        )
 
 
 @dataclass(frozen=True, init=False)

--- a/implementations/python/packages/raes_conformance/repeatability_evidence.py
+++ b/implementations/python/packages/raes_conformance/repeatability_evidence.py
@@ -1,0 +1,396 @@
+"""Trusted evidence assembly for bounded repeatability-consistency (ASR-514).
+
+The assembler admits a baseline run and one repetition run of the same
+held-fixed subject, invokes the digest-pinned, capability-checked validator to
+derive each side's projected outcome and the variation, reset, and cleanup
+dispositions, resolves every projected observation and verification fact through
+the exact run traceability, and seals the comparison evidence. It performs no
+execution, scheduling, replay, canonicalization of runs, secret access, or
+persistence.
+
+Trust boundary: this is a trusted-composition-only surface. The runs are
+digest-verified (``run_digest`` equals the run's canonical digest), so the set
+of evidence-record identities that belong to each run is fixed by that verified
+digest; an evidence reference is admitted only when it is a member of the
+admitted run's declared evidence set. The experiment-run traceability model does
+not admit per-evidence content digests, and this comparator adds no evidence
+store, so content authenticity of an individual evidence record remains owned by
+the platform evidence provenance and resolution layer that supplies the records
+to this trusted composition.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Protocol
+
+from raes_contracts.contracts import (
+    ExperimentEvidenceRecordModel,
+    ExperimentRunModel,
+    ExperimentTaskModel,
+    validate_experiment_run_against_task,
+)
+from raes_contracts.satisfiability import canonical_contract_digest, canonical_json_digest
+
+from .repeatability_types import (
+    RepeatabilityConsistencyEvidence,
+    RepetitionProjection,
+    _new_repeatability_consistency_evidence,
+    _RepeatabilityConsistencyEvidenceParts,
+)
+from .repeatability_validation import RepeatabilityConsistencyCase, RepetitionRef
+from .verification_authority import (
+    VerificationBinding,
+    VerificationDisposition,
+    VerificationRecordIdentity,
+)
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_unique_text(values: tuple[str, ...], field_name: str) -> None:
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field_name} entries must be non-empty")
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} entries must be unique")
+
+
+def _validate_record_header(
+    record: VariationVerificationRecord | ResetVerificationRecord | CleanupVerificationRecord,
+) -> None:
+    _require_text(record.record_id, "record_id")
+    _require_text(record.record_version, "record_version")
+    _require_unique_text(record.evidence_record_refs, "evidence_record_refs")
+    if not record.evidence_record_refs:
+        raise ValueError("evidence_record_refs must not be empty")
+
+
+@dataclass(frozen=True)
+class VariationVerificationRecord:
+    """Run-bound inputs from which an admitted adapter verifies variation."""
+
+    record_id: str
+    record_version: str
+    pair_run_refs: tuple[str, ...]
+    policy_id: str
+    policy_version: str
+    observed_variation_refs: tuple[str, ...]
+    evidence_record_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _validate_record_header(self)
+        for field_name in ("policy_id", "policy_version"):
+            _require_text(getattr(self, field_name), field_name)
+        _require_unique_text(self.pair_run_refs, "pair_run_refs")
+        _require_unique_text(self.observed_variation_refs, "observed_variation_refs")
+
+
+@dataclass(frozen=True)
+class ResetVerificationRecord:
+    """Run-bound inputs from which an admitted adapter verifies reset/isolation."""
+
+    record_id: str
+    record_version: str
+    pair_run_refs: tuple[str, ...]
+    evidence_record_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _validate_record_header(self)
+        _require_unique_text(self.pair_run_refs, "pair_run_refs")
+
+
+@dataclass(frozen=True)
+class CleanupVerificationRecord:
+    """Run-bound inputs from which an admitted adapter verifies cleanup."""
+
+    record_id: str
+    record_version: str
+    subject_ref: str
+    residual_state: tuple[str, ...]
+    evidence_record_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _validate_record_header(self)
+        _require_text(self.subject_ref, "subject_ref")
+        _require_unique_text(self.residual_state, "residual_state")
+
+
+@dataclass(frozen=True)
+class RepeatabilityRunInput:
+    """One admitted run and its typed task, labelled by its repetition id."""
+
+    repetition_id: str
+    task: ExperimentTaskModel
+    run: ExperimentRunModel
+
+
+@dataclass(frozen=True)
+class RepeatabilityRunPair:
+    """The typed baseline and repetition task/run inputs for one comparison."""
+
+    baseline: RepeatabilityRunInput
+    repetition: RepeatabilityRunInput
+
+
+@dataclass(frozen=True)
+class RepeatabilityVerificationRecords:
+    """The three pair-bound verification inputs for one comparison."""
+
+    variation: VariationVerificationRecord
+    reset: ResetVerificationRecord
+    cleanup: CleanupVerificationRecord
+
+    def as_tuple(
+        self,
+    ) -> tuple[VariationVerificationRecord, ResetVerificationRecord, CleanupVerificationRecord]:
+        """Return the records in canonical comparison order."""
+
+        return (self.variation, self.reset, self.cleanup)
+
+
+class RepeatabilityEvidenceValidator(Protocol):
+    """Host-owned adapter admitted by the case's exact executable binding."""
+
+    binding: VerificationBinding
+
+    def project_outcome(
+        self,
+        *,
+        role: str,
+        case: RepeatabilityConsistencyCase,
+        run: ExperimentRunModel,
+        evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    ) -> RepetitionProjection: ...
+
+    def verify_variation(
+        self,
+        *,
+        case: RepeatabilityConsistencyCase,
+        record: VariationVerificationRecord,
+        evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    ) -> VerificationDisposition: ...
+
+    def verify_reset(
+        self,
+        *,
+        case: RepeatabilityConsistencyCase,
+        record: ResetVerificationRecord,
+        evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    ) -> VerificationDisposition: ...
+
+    def verify_cleanup(
+        self,
+        *,
+        case: RepeatabilityConsistencyCase,
+        record: CleanupVerificationRecord,
+        evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    ) -> VerificationDisposition: ...
+
+
+def _run_ref(run: ExperimentRunModel) -> str:
+    return f"experiment-run:{run.run_id}@{run.run_version}"
+
+
+def _snapshot_ref(run: ExperimentRunModel) -> str:
+    snapshot = run.scenario_snapshot_ref
+    return f"scenario-snapshot:{snapshot.ref_id}@{snapshot.ref_version}"
+
+
+def _validate_side(role: str, rep: RepetitionRef, task: ExperimentTaskModel, run: ExperimentRunModel) -> None:
+    try:
+        validate_experiment_run_against_task(task, run)
+    except ValueError as exc:
+        raise ValueError(f"{role} task/run validation failed") from exc
+    snapshot = run.scenario_snapshot_ref
+    if (
+        rep.run_ref != _run_ref(run)
+        or rep.run_digest != canonical_contract_digest(run)
+        or rep.subject_ref != _snapshot_ref(run)
+        or rep.subject_digest != snapshot.ref_digest
+    ):
+        raise ValueError(f"{role} does not match the validated task, run, and scenario snapshot")
+
+
+def _run_evidence_index(run: ExperimentRunModel) -> set[tuple[str, str | None]]:
+    return {(reference.ref_id, reference.ref_version) for reference in run.traceability.evidence_record_refs}
+
+
+def _record_matches_run(record: ExperimentEvidenceRecordModel, run: ExperimentRunModel) -> bool:
+    return (
+        record.run_ref.ref_kind == "run"
+        and record.run_ref.ref_id == run.run_id
+        and record.run_ref.ref_version == run.run_version
+        and (record.evidence_record_id, record.record_version) in _run_evidence_index(run)
+    )
+
+
+def _validate_evidence_refs(
+    label: str,
+    refs: tuple[str, ...],
+    runs: tuple[ExperimentRunModel, ...],
+    evidence_by_id: dict[str, ExperimentEvidenceRecordModel],
+) -> None:
+    for evidence_ref in refs:
+        record = evidence_by_id.get(evidence_ref)
+        if record is None or not any(_record_matches_run(record, run) for run in runs):
+            raise ValueError(f"{label} evidence must resolve through an admitted run traceability")
+
+
+def _validate_verification_joins(
+    case: RepeatabilityConsistencyCase,
+    records: RepeatabilityVerificationRecords,
+    pair_run_refs: frozenset[str],
+) -> None:
+    variation, reset, cleanup = records.as_tuple()
+    if (variation.policy_id, variation.policy_version) != (
+        case.variation_policy.policy_id,
+        case.variation_policy.policy_version,
+    ):
+        raise ValueError("variation verification does not match the admitted variation policy")
+    if frozenset(variation.pair_run_refs) != pair_run_refs:
+        raise ValueError("variation verification does not cover the admitted pair")
+    if frozenset(reset.pair_run_refs) != pair_run_refs:
+        raise ValueError("reset verification does not cover the admitted pair")
+    if cleanup.subject_ref != case.subject_ref:
+        raise ValueError("cleanup verification does not match the admitted subject")
+
+
+def _record_digest(
+    record: VariationVerificationRecord | ResetVerificationRecord | CleanupVerificationRecord,
+) -> str:
+    return canonical_json_digest({"record_kind": type(record).__name__, **asdict(record)})
+
+
+def _identity(
+    record: VariationVerificationRecord | ResetVerificationRecord | CleanupVerificationRecord,
+    binding: VerificationBinding,
+) -> VerificationRecordIdentity:
+    return VerificationRecordIdentity(
+        record_id=record.record_id,
+        record_version=record.record_version,
+        record_digest=_record_digest(record),
+        producer_id=binding.producer_id,
+        producer_version=binding.producer_version,
+        producer_digest=binding.producer_digest,
+        validator_id=binding.validator_id,
+        validator_version=binding.validator_version,
+        validator_digest=binding.validator_digest,
+    )
+
+
+def _project(
+    role: str,
+    rep: RepetitionRef,
+    run: ExperimentRunModel,
+    validator: RepeatabilityEvidenceValidator,
+    evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    case: RepeatabilityConsistencyCase,
+    evidence_by_id: dict[str, ExperimentEvidenceRecordModel],
+) -> RepetitionProjection:
+    projection = validator.project_outcome(role=role, case=case, run=run, evidence_records=evidence_records)
+    if not isinstance(projection, RepetitionProjection):
+        raise ValueError("validator must derive typed RepetitionProjection values")
+    if projection.run_ref != rep.run_ref:
+        raise ValueError(f"{role} projection does not identify its admitted run")
+    _validate_evidence_refs(f"{role} projection", projection.evidence_refs, (run,), evidence_by_id)
+    return projection
+
+
+def assemble_repeatability_consistency_evidence(
+    case: RepeatabilityConsistencyCase,
+    *,
+    runs: RepeatabilityRunPair,
+    evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    verification_records: RepeatabilityVerificationRecords,
+    validator: RepeatabilityEvidenceValidator,
+) -> RepeatabilityConsistencyEvidence:
+    """Invoke the admitted adapter and assemble evidence after every join passes."""
+
+    if (
+        runs.baseline.repetition_id != case.baseline.repetition_id
+        or runs.repetition.repetition_id != case.repetition.repetition_id
+    ):
+        raise ValueError("run pair repetition ids must match the admitted case baseline and repetition")
+    _validate_side("baseline", case.baseline, runs.baseline.task, runs.baseline.run)
+    _validate_side("repetition", case.repetition, runs.repetition.task, runs.repetition.run)
+
+    binding = getattr(validator, "binding", None)
+    if not isinstance(binding, VerificationBinding) or binding != case.verification_authority:
+        raise ValueError("validator binding does not match the authority admitted by the case")
+
+    evidence_by_id = {record.evidence_record_id: record for record in evidence_records}
+    if len(evidence_by_id) != len(evidence_records):
+        raise ValueError("evidence_records must use unique evidence_record_id values")
+
+    baseline_projection = _project(
+        "baseline", case.baseline, runs.baseline.run, validator, evidence_records, case, evidence_by_id
+    )
+    repetition_projection = _project(
+        "repetition", case.repetition, runs.repetition.run, validator, evidence_records, case, evidence_by_id
+    )
+
+    pair_runs = (runs.baseline.run, runs.repetition.run)
+    pair_run_refs = frozenset((case.baseline.run_ref, case.repetition.run_ref))
+    _validate_verification_joins(case, verification_records, pair_run_refs)
+    for label, record in zip(
+        ("variation verification", "reset verification", "cleanup verification"),
+        verification_records.as_tuple(),
+        strict=True,
+    ):
+        _validate_evidence_refs(label, record.evidence_record_refs, pair_runs, evidence_by_id)
+
+    variation_disposition = validator.verify_variation(
+        case=case, record=verification_records.variation, evidence_records=evidence_records
+    )
+    reset_disposition = validator.verify_reset(
+        case=case, record=verification_records.reset, evidence_records=evidence_records
+    )
+    cleanup_disposition = validator.verify_cleanup(
+        case=case, record=verification_records.cleanup, evidence_records=evidence_records
+    )
+    dispositions = (variation_disposition, reset_disposition, cleanup_disposition)
+    if any(not isinstance(disposition, VerificationDisposition) for disposition in dispositions):
+        raise ValueError("validator methods must return VerificationDisposition values")
+
+    permitted = set(case.variation_policy.permitted_variation_refs)
+    observed = set(verification_records.variation.observed_variation_refs)
+    unmatched = tuple(sorted(observed - permitted))
+    records = verification_records.as_tuple()
+    record_ids = [record.record_id for record in records]
+    if len(record_ids) != len(set(record_ids)):
+        raise ValueError("verification records must use unique record_id values")
+    return _new_repeatability_consistency_evidence(
+        _RepeatabilityConsistencyEvidenceParts(
+            case_digest=case.digest,
+            baseline_artifact_ref=case.baseline.projected_artifact_ref,
+            baseline_projection=baseline_projection,
+            repetition_artifact_ref=case.repetition.projected_artifact_ref,
+            repetition_projection=repetition_projection,
+            variation_disposition=variation_disposition,
+            unmatched_dimension_refs=unmatched,
+            reset_disposition=reset_disposition,
+            reset_evidence_refs=verification_records.reset.evidence_record_refs,
+            cleanup_disposition=cleanup_disposition,
+            cleanup_evidence_refs=verification_records.cleanup.evidence_record_refs,
+            residual_state=verification_records.cleanup.residual_state,
+            verification_binding=binding,
+            verification_identities=tuple(_identity(record, binding) for record in records),
+        )
+    )
+
+
+__all__ = (
+    "CleanupVerificationRecord",
+    "RepeatabilityEvidenceValidator",
+    "RepeatabilityRunInput",
+    "RepeatabilityRunPair",
+    "RepeatabilityVerificationRecords",
+    "ResetVerificationRecord",
+    "VariationVerificationRecord",
+    "VerificationBinding",
+    "VerificationDisposition",
+    "assemble_repeatability_consistency_evidence",
+)

--- a/implementations/python/packages/raes_conformance/repeatability_types.py
+++ b/implementations/python/packages/raes_conformance/repeatability_types.py
@@ -1,0 +1,144 @@
+"""Internal assembled evidence types for bounded repeatability-consistency.
+
+These types support ASR-514 determinism, stability, and replay-consistency
+verification. One comparison is a single binary baseline-to-repetition pair
+under the exact ``canonical-artifact-identity`` relation; a larger set of
+repeated runs composes as several pairwise cases.
+
+Trust boundary: ``compare_repeatability_consistency`` and
+``assemble_repeatability_consistency_evidence`` are a trusted-composition-only
+surface, invoked by code that already owns the validator authority and the case.
+The module-owned assembly token is integrity defense-in-depth - it detects
+accidental or unsealed construction - not an access-control boundary against a
+caller that is already trusted to drive the comparator. Each evidence reference
+is bound to the digest-verified run's declared evidence set (see
+``repeatability_evidence``); content authenticity of an individual evidence
+record remains owned by the platform evidence provenance layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from raes_contracts.satisfiability import canonical_json_digest
+
+from .verification_authority import (
+    VerificationBinding,
+    VerificationDisposition,
+    VerificationRecordIdentity,
+)
+
+_ASSEMBLY_TOKEN = object()
+
+
+def _is_sha256(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    prefix, _, hexpart = value.partition(":")
+    return prefix == "sha256" and len(hexpart) == 64 and all(character in "0123456789abcdef" for character in hexpart)
+
+
+class ProjectionOutcome(str, Enum):
+    """Support status of one side's admitted projected outcome."""
+
+    DECIDED = "decided"
+    INDETERMINATE = "indeterminate"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class RepetitionProjection:
+    """One side's projected outcome derived by the admitted validator.
+
+    A decided projection carries the canonical digest of the projected artifact
+    under the declared observation projection and the run-bound evidence it
+    resolved through. An indeterminate or unsupported projection carries no
+    digest, so it can never be read as an equal or unequal outcome.
+    """
+
+    run_ref: str
+    outcome: ProjectionOutcome
+    projected_digest: str | None
+    evidence_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_ref, str) or not self.run_ref.strip():
+            raise ValueError("run_ref must be non-empty")
+        if not isinstance(self.outcome, ProjectionOutcome):
+            raise ValueError("outcome must be a ProjectionOutcome")
+        if self.outcome is ProjectionOutcome.DECIDED:
+            if not _is_sha256(self.projected_digest):
+                raise ValueError("a decided projection must carry a sha256 projected_digest")
+            if not self.evidence_refs:
+                raise ValueError("a decided projection must carry run-bound evidence_refs")
+        elif self.projected_digest is not None:
+            raise ValueError("an undecided projection must not carry a projected_digest")
+
+
+@dataclass(frozen=True, init=False)
+class RepeatabilityConsistencyEvidence:
+    """Evidence assembled only from validator-derived, run-bound artifacts."""
+
+    case_digest: str
+    baseline_artifact_ref: str
+    baseline_projection: RepetitionProjection
+    repetition_artifact_ref: str
+    repetition_projection: RepetitionProjection
+    variation_disposition: VerificationDisposition
+    unmatched_dimension_refs: tuple[str, ...]
+    reset_disposition: VerificationDisposition
+    reset_evidence_refs: tuple[str, ...]
+    cleanup_disposition: VerificationDisposition
+    cleanup_evidence_refs: tuple[str, ...]
+    residual_state: tuple[str, ...]
+    verification_binding: VerificationBinding
+    verification_identities: tuple[VerificationRecordIdentity, ...]
+    _assembly_token: object = field(repr=False, compare=False)
+
+    def __init__(self) -> None:
+        raise TypeError("use assemble_repeatability_consistency_evidence() to construct comparison evidence")
+
+    def _has_authentic_assembly(self) -> bool:
+        return self._assembly_token is _ASSEMBLY_TOKEN
+
+
+def _new_repeatability_consistency_evidence(
+    parts: _RepeatabilityConsistencyEvidenceParts,
+) -> RepeatabilityConsistencyEvidence:
+    """Construct one module-sealed evidence value for the trusted assembler."""
+
+    instance = object.__new__(RepeatabilityConsistencyEvidence)
+    for field_name in RepeatabilityConsistencyEvidence.__dataclass_fields__:
+        value = _ASSEMBLY_TOKEN if field_name == "_assembly_token" else getattr(parts, field_name)
+        object.__setattr__(instance, field_name, value)
+    return instance
+
+
+@dataclass(frozen=True)
+class _RepeatabilityConsistencyEvidenceParts:
+    """Typed content passed across the private assembly boundary."""
+
+    case_digest: str
+    baseline_artifact_ref: str
+    baseline_projection: RepetitionProjection
+    repetition_artifact_ref: str
+    repetition_projection: RepetitionProjection
+    variation_disposition: VerificationDisposition
+    unmatched_dimension_refs: tuple[str, ...]
+    reset_disposition: VerificationDisposition
+    reset_evidence_refs: tuple[str, ...]
+    cleanup_disposition: VerificationDisposition
+    cleanup_evidence_refs: tuple[str, ...]
+    residual_state: tuple[str, ...]
+    verification_binding: VerificationBinding
+    verification_identities: tuple[VerificationRecordIdentity, ...]
+
+
+# canonical_json_digest re-exported for the trusted assembler's identity digests.
+__all__ = (
+    "ProjectionOutcome",
+    "RepeatabilityConsistencyEvidence",
+    "RepetitionProjection",
+    "canonical_json_digest",
+)

--- a/implementations/python/packages/raes_conformance/repeatability_validation.py
+++ b/implementations/python/packages/raes_conformance/repeatability_validation.py
@@ -1,0 +1,438 @@
+"""Bounded repeatability-consistency comparison (ASR-514).
+
+Decides one finite determinism / replay-consistency claim as a single binary
+baseline-to-repetition comparison of the same held-fixed subject. The claim
+binds the existing ``canonical-artifact-identity`` relation, and its two
+carriers name the two compared projected artifacts (baseline and repetition).
+A larger set of repeated runs composes as several such pairwise cases; this
+module never reinterprets the binary relation as an n-ary one.
+
+It performs no execution, scheduling, replay, canonicalization of runs, I/O, or
+persistence: every fact comes from the trusted assembler in
+``repeatability_evidence``. Identity digests use the repository JCS canonical
+digest, not a local serializer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+from raes_contracts.behavioral_relations import validate_behavioral_claim_binding
+from raes_contracts.contracts import BehavioralClaimBindingModel
+from raes_contracts.diagnostics import Diagnostic, Severity
+from raes_contracts.satisfiability import canonical_json_digest
+
+from .repeatability_types import (
+    ProjectionOutcome,
+    RepeatabilityConsistencyEvidence,
+)
+from .verification_authority import (
+    VerificationBinding,
+    VerificationDisposition,
+    VerificationRecordIdentity,
+)
+
+CANONICAL_ARTIFACT_IDENTITY_RELATION_ID = "canonical-artifact-identity"
+SUPPORTED_REPEATABILITY_RELATION_IDS = frozenset({CANONICAL_ARTIFACT_IDENTITY_RELATION_ID})
+_CRITERION_ID = "canonical-projection-equality"
+_CRITERION_VERSION = "1.0.0"
+_DIAGNOSTIC_ADDRESS = "/conformance/repeatability-comparison"
+RepeatabilityVerificationAuthority = VerificationBinding
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_digest(value: str, field_name: str) -> None:
+    prefix, _, hexpart = value.partition(":") if isinstance(value, str) else ("", "", "")
+    if prefix != "sha256" or len(hexpart) != 64 or any(character not in "0123456789abcdef" for character in hexpart):
+        raise ValueError(f"{field_name} must be a sha256 digest")
+
+
+def _require_unique_text(values: tuple[str, ...], field_name: str) -> None:
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError(f"{field_name} entries must be non-empty")
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} entries must be unique")
+
+
+@dataclass(frozen=True)
+class RepetitionRef:
+    """Immutable identity of one already-admitted run and its projected artifact."""
+
+    repetition_id: str
+    run_ref: str
+    run_digest: str
+    subject_ref: str
+    subject_digest: str
+    projected_artifact_ref: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("repetition_id", "run_ref", "subject_ref", "projected_artifact_ref"):
+            _require_text(getattr(self, field_name), field_name)
+        _require_digest(self.run_digest, "run_digest")
+        _require_digest(self.subject_digest, "subject_digest")
+
+
+@dataclass(frozen=True)
+class VariationPolicy:
+    """Named policy for the held-fixed and deliberately-varied dimensions."""
+
+    policy_id: str
+    policy_version: str
+    held_fixed_dimensions: tuple[str, ...]
+    permitted_variation_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _require_text(self.policy_id, "policy_id")
+        _require_text(self.policy_version, "policy_version")
+        _require_unique_text(self.held_fixed_dimensions, "held_fixed_dimensions")
+        _require_unique_text(self.permitted_variation_refs, "permitted_variation_refs")
+        if not self.held_fixed_dimensions:
+            raise ValueError("held_fixed_dimensions must not be empty")
+
+
+@dataclass(frozen=True)
+class RepeatabilityConsistencyCase:
+    """Trusted, subject-bound input to one binary repeatability comparison."""
+
+    case_id: str
+    claim: BehavioralClaimBindingModel
+    subject_ref: str
+    baseline: RepetitionRef
+    repetition: RepetitionRef
+    observation_projection_ref: str
+    observation_projection_revision: str
+    criterion_id: str
+    criterion_version: str
+    variation_policy: VariationPolicy
+    required_capability_refs: tuple[str, ...]
+    verification_authority: RepeatabilityVerificationAuthority
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "case_id",
+            "subject_ref",
+            "observation_projection_ref",
+            "observation_projection_revision",
+            "criterion_id",
+            "criterion_version",
+        ):
+            _require_text(getattr(self, field_name), field_name)
+        if not isinstance(self.claim, BehavioralClaimBindingModel):
+            raise ValueError("claim must be a BehavioralClaimBindingModel")
+        if not isinstance(self.baseline, RepetitionRef) or not isinstance(self.repetition, RepetitionRef):
+            raise ValueError("baseline and repetition must be RepetitionRef values")
+        if not isinstance(self.variation_policy, VariationPolicy):
+            raise ValueError("variation_policy must be a VariationPolicy")
+        if not isinstance(self.verification_authority, VerificationBinding):
+            raise ValueError("verification_authority must be a RepeatabilityVerificationAuthority")
+        _require_unique_text(self.required_capability_refs, "required_capability_refs")
+        if not self.required_capability_refs:
+            raise ValueError("required_capability_refs must not be empty")
+        self._validate_pair()
+
+    def _validate_pair(self) -> None:
+        if self.baseline.run_ref == self.repetition.run_ref:
+            raise ValueError("baseline and repetition must use distinct run_ref values")
+        if self.baseline.projected_artifact_ref == self.repetition.projected_artifact_ref:
+            raise ValueError("baseline and repetition must name distinct projected_artifact_ref values")
+        for side in (self.baseline, self.repetition):
+            if side.subject_ref != self.subject_ref:
+                raise ValueError("baseline and repetition must repeat the case subject_ref")
+        if self.baseline.subject_digest != self.repetition.subject_digest:
+            raise ValueError("baseline and repetition must hold the subject fixed by digest")
+
+    @property
+    def digest(self) -> str:
+        """Return the JCS canonical identity of every comparison join input."""
+
+        payload = {
+            "case_id": self.case_id,
+            "claim": self.claim.model_dump(mode="json"),
+            "subject_ref": self.subject_ref,
+            "baseline": asdict(self.baseline),
+            "repetition": asdict(self.repetition),
+            "observation_projection_ref": self.observation_projection_ref,
+            "observation_projection_revision": self.observation_projection_revision,
+            "criterion_id": self.criterion_id,
+            "criterion_version": self.criterion_version,
+            "variation_policy": {
+                "policy_id": self.variation_policy.policy_id,
+                "policy_version": self.variation_policy.policy_version,
+                "held_fixed_dimensions": list(self.variation_policy.held_fixed_dimensions),
+                "permitted_variation_refs": list(self.variation_policy.permitted_variation_refs),
+            },
+            "required_capability_refs": list(self.required_capability_refs),
+            "verification_authority": asdict(self.verification_authority),
+        }
+        return canonical_json_digest(payload)
+
+
+class RepeatabilityConsistencyOutcome(str, Enum):
+    """Finite decision for one admitted repeatability comparison."""
+
+    CONSISTENT = "consistent"
+    DIVERGENT = "divergent"
+    INCONCLUSIVE = "inconclusive"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class RepeatabilityConsistencyResult:
+    """Finite comparison result whose identities come only from the case."""
+
+    case_id: str
+    case_digest: str
+    claim: BehavioralClaimBindingModel
+    subject_ref: str
+    baseline_artifact_ref: str
+    repetition_artifact_ref: str
+    baseline_run_ref: str
+    repetition_run_ref: str
+    outcome: RepeatabilityConsistencyOutcome
+    evidence_refs: tuple[str, ...]
+    verification_identities: tuple[VerificationRecordIdentity, ...]
+    diagnostics: tuple[Diagnostic, ...]
+
+    @property
+    def consistent(self) -> bool:
+        return self.outcome is RepeatabilityConsistencyOutcome.CONSISTENT
+
+
+def _diagnostic(code: str, message: str) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        domain="conformance",
+        address=_DIAGNOSTIC_ADDRESS,
+        message=message,
+        severity=Severity.ERROR,
+    )
+
+
+def _result(
+    case: RepeatabilityConsistencyCase,
+    evidence: RepeatabilityConsistencyEvidence,
+    outcome: RepeatabilityConsistencyOutcome,
+    diagnostics: tuple[Diagnostic, ...] = (),
+) -> RepeatabilityConsistencyResult:
+    evidence_refs = tuple(
+        dict.fromkeys(
+            ref
+            for source in (
+                evidence.baseline_projection.evidence_refs,
+                evidence.repetition_projection.evidence_refs,
+                evidence.reset_evidence_refs,
+                evidence.cleanup_evidence_refs,
+            )
+            for ref in source
+        )
+    )
+    return RepeatabilityConsistencyResult(
+        case_id=case.case_id,
+        case_digest=case.digest,
+        claim=case.claim,
+        subject_ref=case.subject_ref,
+        baseline_artifact_ref=case.baseline.projected_artifact_ref,
+        repetition_artifact_ref=case.repetition.projected_artifact_ref,
+        baseline_run_ref=case.baseline.run_ref,
+        repetition_run_ref=case.repetition.run_ref,
+        outcome=outcome,
+        evidence_refs=evidence_refs,
+        verification_identities=evidence.verification_identities,
+        diagnostics=diagnostics,
+    )
+
+
+def _claim_catalog_diagnostic(case: RepeatabilityConsistencyCase) -> Diagnostic | None:
+    diagnostic = None
+    try:
+        validate_behavioral_claim_binding(case.claim)
+    except ValueError:
+        diagnostic = _diagnostic(
+            "conformance.repeatability-claim-invalid",
+            "The claim does not resolve against the canonical behavioral-relation catalog.",
+        )
+    return diagnostic
+
+
+def _claim_admission_diagnostic(case: RepeatabilityConsistencyCase) -> Diagnostic | None:
+    diagnostic = None
+    if case.claim.relation_id not in SUPPORTED_REPEATABILITY_RELATION_IDS:
+        diagnostic = _diagnostic(
+            "conformance.repeatability-claim-relation-invalid",
+            "The claim does not use a supported repeatability relation.",
+        )
+    elif (catalog_diagnostic := _claim_catalog_diagnostic(case)) is not None:
+        diagnostic = catalog_diagnostic
+    elif case.claim.quantifier_scope != "finite-cases" or case.claim.evidence_scope != "finite":
+        diagnostic = _diagnostic(
+            "conformance.repeatability-claim-boundary-invalid",
+            "The bounded comparator accepts only finite-case claims with finite evidence.",
+        )
+    elif (
+        case.claim.left_carrier_ref != case.baseline.projected_artifact_ref
+        or case.claim.right_carrier_ref != case.repetition.projected_artifact_ref
+        or case.claim.observation_projection_ref != case.observation_projection_ref
+        or case.claim.observation_projection_revision != case.observation_projection_revision
+    ):
+        diagnostic = _diagnostic(
+            "conformance.repeatability-claim-case-mismatch",
+            "The claim carriers and projection do not identify the baseline and repetition artifacts.",
+        )
+    elif (case.criterion_id, case.criterion_version) != (_CRITERION_ID, _CRITERION_VERSION):
+        diagnostic = _diagnostic(
+            "conformance.repeatability-criterion-unsupported",
+            "The requested repeatability criterion is not supported by this comparator.",
+        )
+    return diagnostic
+
+
+def _evidence_admission_diagnostic(
+    case: RepeatabilityConsistencyCase,
+    evidence: RepeatabilityConsistencyEvidence,
+) -> Diagnostic | None:
+    diagnostic = None
+    pair_mismatch = (
+        evidence.baseline_artifact_ref != case.baseline.projected_artifact_ref
+        or evidence.repetition_artifact_ref != case.repetition.projected_artifact_ref
+        or evidence.baseline_projection.run_ref != case.baseline.run_ref
+        or evidence.repetition_projection.run_ref != case.repetition.run_ref
+    )
+    authority_mismatch = evidence.verification_binding != case.verification_authority or any(
+        identity.binding != case.verification_authority for identity in evidence.verification_identities
+    )
+    if pair_mismatch:
+        diagnostic = _diagnostic(
+            "conformance.repeatability-pair-evidence-mismatch",
+            "The evidence does not project exactly the admitted baseline and repetition.",
+        )
+    elif authority_mismatch:
+        diagnostic = _diagnostic(
+            "conformance.repeatability-verification-authority-mismatch",
+            "The verification identities do not match the authority admitted by the case.",
+        )
+    return diagnostic
+
+
+def _admission_diagnostic(
+    case: RepeatabilityConsistencyCase,
+    evidence: RepeatabilityConsistencyEvidence,
+    available_capability_refs: frozenset[str],
+) -> Diagnostic | None:
+    diagnostic = None
+    if not evidence._has_authentic_assembly():
+        diagnostic = _diagnostic(
+            "conformance.repeatability-evidence-unauthenticated",
+            "The comparison evidence was not produced by the trusted repeatability assembler.",
+        )
+    elif evidence.case_digest != case.digest:
+        diagnostic = _diagnostic(
+            "conformance.repeatability-case-evidence-mismatch",
+            "The assembled evidence does not belong to the admitted comparison case.",
+        )
+    elif (claim_diagnostic := _claim_admission_diagnostic(case)) is not None:
+        diagnostic = claim_diagnostic
+    elif set(case.required_capability_refs) - set(available_capability_refs):
+        diagnostic = _diagnostic(
+            "conformance.repeatability-capability-unsupported",
+            "The comparator does not have every capability required by the admitted case.",
+        )
+    else:
+        diagnostic = _evidence_admission_diagnostic(case, evidence)
+    return diagnostic
+
+
+def _gate_diagnostics(evidence: RepeatabilityConsistencyEvidence) -> tuple[Diagnostic, ...]:
+    diagnostics: list[Diagnostic] = []
+    if evidence.variation_disposition is not VerificationDisposition.VERIFIED or evidence.unmatched_dimension_refs:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.repeatability-variation-unverified",
+                "The pair does not satisfy the declared variation policy.",
+            )
+        )
+    if evidence.reset_disposition is not VerificationDisposition.VERIFIED or not evidence.reset_evidence_refs:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.repeatability-reset-unverified",
+                "Reset and isolation between runs were not independently verified.",
+            )
+        )
+    if evidence.cleanup_disposition is not VerificationDisposition.VERIFIED or not evidence.cleanup_evidence_refs:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.repeatability-cleanup-unverified",
+                "Reset and cleanup were not independently verified.",
+            )
+        )
+    if evidence.residual_state:
+        diagnostics.append(
+            _diagnostic(
+                "conformance.repeatability-residual-state",
+                "The comparison left residual owned state.",
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _comparison_disposition(
+    evidence: RepeatabilityConsistencyEvidence,
+) -> tuple[RepeatabilityConsistencyOutcome, tuple[Diagnostic, ...]]:
+    outcome = RepeatabilityConsistencyOutcome.CONSISTENT
+    diagnostics: tuple[Diagnostic, ...] = ()
+    projection_outcomes = (evidence.baseline_projection.outcome, evidence.repetition_projection.outcome)
+    gate_dispositions = (
+        evidence.variation_disposition,
+        evidence.reset_disposition,
+        evidence.cleanup_disposition,
+    )
+    if ProjectionOutcome.UNSUPPORTED in projection_outcomes:
+        outcome = RepeatabilityConsistencyOutcome.UNSUPPORTED
+        diagnostics = (
+            _diagnostic(
+                "conformance.repeatability-outcome-unsupported",
+                "At least one projected outcome is unsupported by the admitted apparatus.",
+            ),
+        )
+    elif ProjectionOutcome.INDETERMINATE in projection_outcomes:
+        outcome = RepeatabilityConsistencyOutcome.INCONCLUSIVE
+        diagnostics = (
+            _diagnostic(
+                "conformance.repeatability-outcome-inconclusive",
+                "At least one projected outcome is indeterminate.",
+            ),
+        )
+    elif VerificationDisposition.UNSUPPORTED in gate_dispositions:
+        outcome = RepeatabilityConsistencyOutcome.UNSUPPORTED
+        diagnostics = (
+            _diagnostic(
+                "conformance.repeatability-verification-unsupported",
+                "At least one required verification fact is unsupported by the admitted validator.",
+            ),
+        )
+    elif gate_diagnostics := _gate_diagnostics(evidence):
+        outcome = RepeatabilityConsistencyOutcome.INCONCLUSIVE
+        diagnostics = gate_diagnostics
+    elif evidence.baseline_projection.projected_digest != evidence.repetition_projection.projected_digest:
+        outcome = RepeatabilityConsistencyOutcome.DIVERGENT
+    return outcome, diagnostics
+
+
+def compare_repeatability_consistency(
+    case: RepeatabilityConsistencyCase,
+    evidence: RepeatabilityConsistencyEvidence,
+    *,
+    available_capability_refs: frozenset[str],
+) -> RepeatabilityConsistencyResult:
+    """Evaluate one admitted finite baseline-to-repetition consistency comparison."""
+    admission_diagnostic = _admission_diagnostic(case, evidence, available_capability_refs)
+    if admission_diagnostic is not None:
+        outcome = RepeatabilityConsistencyOutcome.UNSUPPORTED
+        diagnostics = (admission_diagnostic,)
+    else:
+        outcome, diagnostics = _comparison_disposition(evidence)
+    return _result(case, evidence, outcome, diagnostics)

--- a/implementations/python/packages/raes_conformance/verification_authority.py
+++ b/implementations/python/packages/raes_conformance/verification_authority.py
@@ -1,0 +1,92 @@
+"""Neutral digest-pinned verification-authority primitives.
+
+These producer/validator identity and disposition types are shared, technique-
+neutral primitives. They carry no causal, necessity, or repeatability concept;
+each validation technique binds them to its own case authority and derives its
+own facts. Promoted here (rather than duplicated) so bounded necessity
+(ASR-513) and repeatability-consistency (ASR-514) share one authority surface.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class VerificationDisposition(str, Enum):
+    """Typed outcome derived by an admitted verification adapter."""
+
+    VERIFIED = "verified"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be non-empty")
+
+
+def _require_digest(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a sha256 digest")
+
+
+@dataclass(frozen=True)
+class VerificationBinding:
+    """Digest-pinned producer and validator identity admitted by a case."""
+
+    producer_id: str
+    producer_version: str
+    producer_digest: str
+    validator_id: str
+    validator_version: str
+    validator_digest: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "producer_id",
+            "producer_version",
+            "validator_id",
+            "validator_version",
+        ):
+            _require_text(getattr(self, field_name), field_name)
+        _require_digest(self.producer_digest, "producer_digest")
+        _require_digest(self.validator_digest, "validator_digest")
+
+
+@dataclass(frozen=True)
+class VerificationRecordIdentity:
+    """Producer and validator provenance retained from one verified fact."""
+
+    record_id: str
+    record_version: str
+    record_digest: str
+    producer_id: str
+    producer_version: str
+    producer_digest: str
+    validator_id: str
+    validator_version: str
+    validator_digest: str
+
+    @property
+    def binding(self) -> VerificationBinding:
+        """Return the exact producer/validator binding retained by the record."""
+
+        return VerificationBinding(
+            producer_id=self.producer_id,
+            producer_version=self.producer_version,
+            producer_digest=self.producer_digest,
+            validator_id=self.validator_id,
+            validator_version=self.validator_version,
+            validator_digest=self.validator_digest,
+        )
+
+
+__all__ = (
+    "VerificationBinding",
+    "VerificationDisposition",
+    "VerificationRecordIdentity",
+)

--- a/implementations/python/tests/test_repeatability_validation.py
+++ b/implementations/python/tests/test_repeatability_validation.py
@@ -1,0 +1,896 @@
+"""ASR-514 bounded determinism, stability, and replay-consistency validation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, fields, replace
+from functools import cache
+from pathlib import Path
+
+import pytest
+from raes_conformance.repeatability_evidence import (
+    CleanupVerificationRecord,
+    RepeatabilityRunInput,
+    RepeatabilityRunPair,
+    RepeatabilityVerificationRecords,
+    ResetVerificationRecord,
+    VariationVerificationRecord,
+    VerificationBinding,
+    VerificationDisposition,
+    assemble_repeatability_consistency_evidence,
+)
+from raes_conformance.repeatability_types import (
+    _ASSEMBLY_TOKEN,
+    ProjectionOutcome,
+    RepeatabilityConsistencyEvidence,
+    RepetitionProjection,
+)
+from raes_conformance.repeatability_validation import (
+    RepeatabilityConsistencyCase,
+    RepeatabilityConsistencyOutcome,
+    RepeatabilityVerificationAuthority,
+    RepetitionRef,
+    VariationPolicy,
+    compare_repeatability_consistency,
+)
+from raes_contracts.behavioral_relations import validate_behavioral_claim_binding
+from raes_contracts.contracts import (
+    BehavioralClaimBindingModel,
+    ExperimentEvidenceRecordModel,
+    ExperimentRunModel,
+    ExperimentTaskModel,
+)
+from raes_contracts.satisfiability import canonical_contract_digest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+_DIGEST_D = "sha256:" + "d" * 64
+_SUBJECT_REF = "scenario-snapshot:scenario-techvault@1.0.0"
+_PROJECTION_REF = "repeatability.projection.canonical-artifact"
+_DIAGNOSTIC_ADDRESS = "/conformance/repeatability-comparison"
+_JSON_POINTER_RE = re.compile(r"^(?:/(?:[^~/]|~[01])*)*$")
+
+
+@cache
+def _task() -> ExperimentTaskModel:
+    task_payload = json.loads(
+        (_REPO_ROOT / "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json").read_text()
+    )
+    task_payload["task_id"] = "task-techvault-repeat"
+    task_payload["scenario_ref"].update(ref_id="scenario-techvault", ref_version="1.0.0", ref_digest=_DIGEST_A)
+    return ExperimentTaskModel.model_validate(task_payload)
+
+
+def _artifact_ref(index: int) -> str:
+    return f"projected-artifact:run-techvault-{index}#{_PROJECTION_REF}"
+
+
+@cache
+def _run_and_evidence(index: int) -> tuple[ExperimentRunModel, ExperimentEvidenceRecordModel]:
+    task = _task()
+    run_id = f"run-techvault-{index}"
+    evidence_id = f"evidence-techvault-{index}"
+
+    run_payload = json.loads(
+        (_REPO_ROOT / "contracts/fixtures/experiment-core/experiment-run-v1/valid/reference.json").read_text()
+    )
+    run_payload["run_id"] = run_id
+    run_payload["participant_implementation_provenance"]["run_id"] = run_id
+    run_payload["task_ref"].update(ref_id=task.task_id, ref_version=task.task_version)
+    run_payload["scenario_snapshot_ref"] = task.scenario_ref.model_dump(mode="json")
+    for disclosure in run_payload["realized_form_disclosures"]:
+        for reference in disclosure["evidence_refs"]:
+            reference["ref_id"] = evidence_id
+    run_version = run_payload["run_version"]
+
+    evidence_payload = json.loads(
+        (
+            _REPO_ROOT / "contracts/fixtures/experiment-core/experiment-evidence-record-v1/valid/reference.json"
+        ).read_text()
+    )
+    evidence_payload["evidence_record_id"] = evidence_id
+    evidence_payload["run_ref"].update(ref_id=run_id, ref_version=run_version)
+    evidence_payload["task_ref"].update(ref_id=task.task_id, ref_version=task.task_version)
+    evidence = ExperimentEvidenceRecordModel.model_validate(evidence_payload)
+
+    # The digest-verified run declares which evidence-record identities belong to it.
+    run_payload["traceability"]["evidence_record_refs"] = [
+        {
+            "ref_kind": "evidence-record",
+            "ref_id": evidence_id,
+            "ref_version": evidence.record_version,
+        }
+    ]
+    run = ExperimentRunModel.model_validate(run_payload)
+    return run, evidence
+
+
+def _run_ref(run: ExperimentRunModel) -> str:
+    return f"experiment-run:{run.run_id}@{run.run_version}"
+
+
+def _snapshot_ref(run: ExperimentRunModel) -> str:
+    snapshot = run.scenario_snapshot_ref
+    return f"scenario-snapshot:{snapshot.ref_id}@{snapshot.ref_version}"
+
+
+def _repetition_ref(index: int) -> RepetitionRef:
+    run, _ = _run_and_evidence(index)
+    snapshot = run.scenario_snapshot_ref
+    assert snapshot.ref_digest is not None
+    return RepetitionRef(
+        repetition_id=f"rep-{index}",
+        run_ref=_run_ref(run),
+        run_digest=canonical_contract_digest(run),
+        subject_ref=_snapshot_ref(run),
+        subject_digest=snapshot.ref_digest,
+        projected_artifact_ref=_artifact_ref(index),
+    )
+
+
+def _claim(
+    relation_id: str = "canonical-artifact-identity",
+    *,
+    taxonomy_revision: str = "rev4",
+    left_index: int = 0,
+    right_index: int = 1,
+) -> BehavioralClaimBindingModel:
+    return BehavioralClaimBindingModel(
+        taxonomy_id="raes-behavioral-relations",
+        taxonomy_revision=taxonomy_revision,
+        relation_id=relation_id,
+        subject="The repetition realizes the same canonical artifact as the baseline.",
+        left_carrier_ref=_artifact_ref(left_index),
+        right_carrier_ref=_artifact_ref(right_index),
+        observation_projection_ref=_PROJECTION_REF,
+        observation_projection_revision="rev1",
+        quantifier_scope="finite-cases",
+        evidence_scope="finite",
+        evidence_boundary="One admitted baseline-to-repetition comparison.",
+        assurance_status="tested",
+        evidence_refs=[],
+        limitations=["The result covers only the named pair, projection, and criterion."],
+        explicit_non_claims=["Does not establish universal determinism or backend equivalence."],
+    )
+
+
+def _binding() -> VerificationBinding:
+    return VerificationBinding(
+        producer_id="example/repeatability-verifier",
+        producer_version="1.0.0",
+        producer_digest=_DIGEST_C,
+        validator_id="raes/repeatability-verification-validator",
+        validator_version="1.0.0",
+        validator_digest=_DIGEST_D,
+    )
+
+
+def _case(
+    *,
+    claim: BehavioralClaimBindingModel | None = None,
+    baseline: RepetitionRef | None = None,
+    repetition: RepetitionRef | None = None,
+    criterion_id: str = "canonical-projection-equality",
+    criterion_version: str = "1.0.0",
+) -> RepeatabilityConsistencyCase:
+    return RepeatabilityConsistencyCase(
+        case_id="repeatability:techvault-determinism",
+        claim=claim or _claim(),
+        subject_ref=_SUBJECT_REF,
+        baseline=baseline or _repetition_ref(0),
+        repetition=repetition or _repetition_ref(1),
+        observation_projection_ref=_PROJECTION_REF,
+        observation_projection_revision="rev1",
+        criterion_id=criterion_id,
+        criterion_version=criterion_version,
+        variation_policy=VariationPolicy(
+            policy_id="variation:techvault",
+            policy_version="1.0.0",
+            held_fixed_dimensions=("subject", "apparatus", "parameters"),
+            permitted_variation_refs=("random-seed", "wall-clock"),
+        ),
+        required_capability_refs=("observation.projection", "reset.verified", "comparison.canonical"),
+        verification_authority=RepeatabilityVerificationAuthority(**_binding().__dict__),
+    )
+
+
+def _rep_index(rep: RepetitionRef) -> int:
+    return int(rep.repetition_id.rsplit("-", 1)[1])
+
+
+@dataclass(frozen=True)
+class _FixtureEvidenceValidator:
+    binding: VerificationBinding
+    digest_by_run_ref: dict[str, str]
+    outcome_by_run_ref: dict[str, ProjectionOutcome] = field(default_factory=dict)
+    projection_evidence_override: dict[str, str] = field(default_factory=dict)
+    variation_disposition: VerificationDisposition = VerificationDisposition.VERIFIED
+    reset_disposition: VerificationDisposition = VerificationDisposition.VERIFIED
+    cleanup_disposition: VerificationDisposition = VerificationDisposition.VERIFIED
+
+    def project_outcome(
+        self,
+        *,
+        role: str,
+        case: RepeatabilityConsistencyCase,
+        run: ExperimentRunModel,
+        evidence_records: tuple[ExperimentEvidenceRecordModel, ...],
+    ) -> RepetitionProjection:
+        del role, case
+        run_ref = _run_ref(run)
+        outcome = self.outcome_by_run_ref.get(run_ref, ProjectionOutcome.DECIDED)
+        evidence_ref = self.projection_evidence_override.get(
+            run_ref,
+            next(record.evidence_record_id for record in evidence_records if record.run_ref.ref_id == run.run_id),
+        )
+        if outcome is ProjectionOutcome.DECIDED:
+            return RepetitionProjection(
+                run_ref=run_ref,
+                outcome=outcome,
+                projected_digest=self.digest_by_run_ref[run_ref],
+                evidence_refs=(evidence_ref,),
+            )
+        return RepetitionProjection(run_ref=run_ref, outcome=outcome, projected_digest=None, evidence_refs=())
+
+    def verify_variation(self, **_kwargs: object) -> VerificationDisposition:
+        return self.variation_disposition
+
+    def verify_reset(self, **_kwargs: object) -> VerificationDisposition:
+        return self.reset_disposition
+
+    def verify_cleanup(self, **_kwargs: object) -> VerificationDisposition:
+        return self.cleanup_disposition
+
+
+def _default_records(case: RepeatabilityConsistencyCase, ver_ref: str) -> RepeatabilityVerificationRecords:
+    pair_run_refs = (case.baseline.run_ref, case.repetition.run_ref)
+    return RepeatabilityVerificationRecords(
+        variation=VariationVerificationRecord(
+            record_id="verification:variation",
+            record_version="1.0.0",
+            pair_run_refs=pair_run_refs,
+            policy_id=case.variation_policy.policy_id,
+            policy_version=case.variation_policy.policy_version,
+            observed_variation_refs=case.variation_policy.permitted_variation_refs,
+            evidence_record_refs=(ver_ref,),
+        ),
+        reset=ResetVerificationRecord(
+            record_id="verification:reset",
+            record_version="1.0.0",
+            pair_run_refs=pair_run_refs,
+            evidence_record_refs=(ver_ref,),
+        ),
+        cleanup=CleanupVerificationRecord(
+            record_id="verification:cleanup",
+            record_version="1.0.0",
+            subject_ref=case.subject_ref,
+            residual_state=(),
+            evidence_record_refs=(ver_ref,),
+        ),
+    )
+
+
+def _evidence(
+    *,
+    case: RepeatabilityConsistencyCase | None = None,
+    baseline_digest: str = _DIGEST_B,
+    repetition_digest: str = _DIGEST_B,
+    baseline_outcome: ProjectionOutcome = ProjectionOutcome.DECIDED,
+    repetition_outcome: ProjectionOutcome = ProjectionOutcome.DECIDED,
+    projection_evidence_override: dict[str, str] | None = None,
+    variation_disposition: VerificationDisposition = VerificationDisposition.VERIFIED,
+    reset_disposition: VerificationDisposition = VerificationDisposition.VERIFIED,
+    cleanup_disposition: VerificationDisposition = VerificationDisposition.VERIFIED,
+    observed_variation_refs: tuple[str, ...] | None = None,
+    residual_state: tuple[str, ...] = (),
+    validator_binding: VerificationBinding | None = None,
+    records: RepeatabilityVerificationRecords | None = None,
+    runs: RepeatabilityRunPair | None = None,
+    evidence_records: tuple[ExperimentEvidenceRecordModel, ...] | None = None,
+    task_override: dict[int, ExperimentTaskModel] | None = None,
+) -> RepeatabilityConsistencyEvidence:
+    case = case or _case()
+    b_idx, r_idx = _rep_index(case.baseline), _rep_index(case.repetition)
+    b_run, b_ev = _run_and_evidence(b_idx)
+    r_run, r_ev = _run_and_evidence(r_idx)
+    task_override = task_override or {}
+    if runs is None:
+        runs = RepeatabilityRunPair(
+            baseline=RepeatabilityRunInput(case.baseline.repetition_id, task_override.get(b_idx, _task()), b_run),
+            repetition=RepeatabilityRunInput(case.repetition.repetition_id, task_override.get(r_idx, _task()), r_run),
+        )
+    if evidence_records is None:
+        evidence_records = (b_ev, r_ev)
+    if records is None:
+        records = _default_records(case, b_ev.evidence_record_id)
+        if observed_variation_refs is not None:
+            records = replace(
+                records, variation=replace(records.variation, observed_variation_refs=observed_variation_refs)
+            )
+        if residual_state:
+            records = replace(records, cleanup=replace(records.cleanup, residual_state=residual_state))
+    validator = _FixtureEvidenceValidator(
+        binding=validator_binding or _binding(),
+        digest_by_run_ref={case.baseline.run_ref: baseline_digest, case.repetition.run_ref: repetition_digest},
+        outcome_by_run_ref={
+            case.baseline.run_ref: baseline_outcome,
+            case.repetition.run_ref: repetition_outcome,
+        },
+        projection_evidence_override=projection_evidence_override or {},
+        variation_disposition=variation_disposition,
+        reset_disposition=reset_disposition,
+        cleanup_disposition=cleanup_disposition,
+    )
+    return assemble_repeatability_consistency_evidence(
+        case,
+        runs=runs,
+        evidence_records=evidence_records,
+        verification_records=records,
+        validator=validator,
+    )
+
+
+_CAPABILITIES = frozenset({"observation.projection", "reset.verified", "comparison.canonical"})
+
+
+def _codes(result) -> set[str]:
+    return {diagnostic.code for diagnostic in result.diagnostics}
+
+
+def test_claim_binds_the_existing_canonical_artifact_identity_relation() -> None:
+    validate_behavioral_claim_binding(_claim())
+
+
+def test_verified_equal_pair_is_consistent() -> None:
+    case = _case()
+
+    result = compare_repeatability_consistency(case, _evidence(), available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.CONSISTENT
+    assert result.consistent
+    assert result.case_id == case.case_id
+    assert result.case_digest == case.digest
+    assert result.claim == case.claim
+    assert result.subject_ref == case.subject_ref
+    assert result.baseline_artifact_ref == _artifact_ref(0)
+    assert result.repetition_artifact_ref == _artifact_ref(1)
+    assert (result.baseline_run_ref, result.repetition_run_ref) == (case.baseline.run_ref, case.repetition.run_ref)
+    assert set(result.evidence_refs) == {"evidence-techvault-0", "evidence-techvault-1"}
+    assert {identity.record_id for identity in result.verification_identities} == {
+        "verification:variation",
+        "verification:reset",
+        "verification:cleanup",
+    }
+    assert {identity.producer_id for identity in result.verification_identities} == {"example/repeatability-verifier"}
+    assert not result.diagnostics
+
+
+def test_divergent_projected_outcomes_refute_without_execution_failure() -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(repetition_digest=_DIGEST_C),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.DIVERGENT
+    assert not result.consistent
+    assert not result.diagnostics
+
+
+def test_comparison_evidence_cannot_be_constructed_directly() -> None:
+    with pytest.raises(TypeError, match="assemble_repeatability_consistency_evidence"):
+        RepeatabilityConsistencyEvidence()
+
+
+@pytest.mark.parametrize(
+    "record_type",
+    (VariationVerificationRecord, ResetVerificationRecord, CleanupVerificationRecord),
+)
+def test_verification_inputs_cannot_assert_disposition_binding_or_digest(record_type: type[object]) -> None:
+    field_names = {item.name for item in fields(record_type)}
+
+    assert field_names.isdisjoint({"disposition", "binding", "record_digest"})
+
+
+def test_comparator_rejects_an_unsealed_copy_of_assembled_evidence() -> None:
+    assembled = _evidence()
+    unsealed = object.__new__(RepeatabilityConsistencyEvidence)
+    for field_name in RepeatabilityConsistencyEvidence.__dataclass_fields__:
+        value = object() if field_name == "_assembly_token" else getattr(assembled, field_name)
+        object.__setattr__(unsealed, field_name, value)
+
+    result = compare_repeatability_consistency(_case(), unsealed, available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-evidence-unauthenticated"}
+
+
+def _tampered_evidence(**overrides: object) -> RepeatabilityConsistencyEvidence:
+    assembled = _evidence()
+    tampered = object.__new__(RepeatabilityConsistencyEvidence)
+    for field_name in RepeatabilityConsistencyEvidence.__dataclass_fields__:
+        if field_name == "_assembly_token":
+            value: object = _ASSEMBLY_TOKEN
+        elif field_name in overrides:
+            value = overrides[field_name]
+        else:
+            value = getattr(assembled, field_name)
+        object.__setattr__(tampered, field_name, value)
+    return tampered
+
+
+def test_comparator_rejects_authority_mismatch_in_sealed_evidence() -> None:
+    tampered = _tampered_evidence(verification_binding=replace(_binding(), validator_digest=_DIGEST_A))
+
+    result = compare_repeatability_consistency(_case(), tampered, available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-verification-authority-mismatch"}
+
+
+def test_comparator_rejects_pair_evidence_mismatch_in_sealed_evidence() -> None:
+    tampered = _tampered_evidence(baseline_artifact_ref="projected-artifact:other#x")
+
+    result = compare_repeatability_consistency(_case(), tampered, available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-pair-evidence-mismatch"}
+
+
+def test_case_digest_changes_for_every_join_identity() -> None:
+    case = _case()
+    variants = (
+        replace(case, case_id="repeatability:other"),
+        replace(case, observation_projection_ref="repeatability.projection.other"),
+        replace(case, observation_projection_revision="rev2"),
+        replace(case, criterion_id="other-criterion"),
+        replace(case, criterion_version="2.0.0"),
+        replace(case, repetition=_repetition_ref(2)),
+        replace(case, variation_policy=replace(case.variation_policy, policy_version="1.0.1")),
+        replace(case, required_capability_refs=("observation.projection",)),
+        replace(case, verification_authority=replace(case.verification_authority, validator_digest=_DIGEST_A)),
+    )
+
+    assert all(case.digest != variant.digest for variant in variants)
+
+
+def test_indeterminate_projected_outcome_is_inconclusive() -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(repetition_outcome=ProjectionOutcome.INDETERMINATE),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.INCONCLUSIVE
+    assert _codes(result) == {"conformance.repeatability-outcome-inconclusive"}
+
+
+def test_unsupported_projected_outcome_remains_unsupported() -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(baseline_outcome=ProjectionOutcome.UNSUPPORTED),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-outcome-unsupported"}
+
+
+@pytest.mark.parametrize(
+    "disposition_field",
+    ("variation_disposition", "reset_disposition", "cleanup_disposition"),
+)
+def test_unsupported_verification_disposition_remains_unsupported(disposition_field: str) -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(**{disposition_field: VerificationDisposition.UNSUPPORTED}),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-verification-unsupported"}
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected_code"),
+    [
+        (
+            _evidence(
+                variation_disposition=VerificationDisposition.FAILED,
+                observed_variation_refs=("random-seed", "wall-clock", "apparatus"),
+            ),
+            "conformance.repeatability-variation-unverified",
+        ),
+        (_evidence(reset_disposition=VerificationDisposition.FAILED), "conformance.repeatability-reset-unverified"),
+        (_evidence(cleanup_disposition=VerificationDisposition.FAILED), "conformance.repeatability-cleanup-unverified"),
+        (_evidence(residual_state=("resource:leaked",)), "conformance.repeatability-residual-state"),
+    ],
+)
+def test_variation_reset_and_cleanup_gates_fail_closed(
+    evidence: RepeatabilityConsistencyEvidence,
+    expected_code: str,
+) -> None:
+    result = compare_repeatability_consistency(_case(), evidence, available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.INCONCLUSIVE
+    assert expected_code in _codes(result)
+
+
+def test_unpermitted_observed_variation_makes_the_pair_incomparable() -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(observed_variation_refs=("random-seed", "apparatus")),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.INCONCLUSIVE
+    assert "conformance.repeatability-variation-unverified" in _codes(result)
+
+
+@pytest.mark.parametrize(
+    ("claim", "expected_code"),
+    [
+        (_claim("bounded-probe-success"), "conformance.repeatability-claim-relation-invalid"),
+        (_claim(taxonomy_revision="rev5"), "conformance.repeatability-claim-invalid"),
+    ],
+)
+def test_wrong_relation_or_stale_catalog_coordinate_fails_before_comparison(
+    claim: BehavioralClaimBindingModel,
+    expected_code: str,
+) -> None:
+    case = _case(claim=claim)
+    result = compare_repeatability_consistency(case, _evidence(case=case), available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {expected_code}
+
+
+def test_non_finite_claim_boundary_is_not_interpreted_by_the_comparator() -> None:
+    claim = _claim().model_copy(update={"quantifier_scope": "sampled-population", "evidence_scope": "statistical"})
+    case = _case(claim=claim)
+
+    result = compare_repeatability_consistency(case, _evidence(case=case), available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-claim-boundary-invalid"}
+
+
+def test_claim_carriers_must_identify_the_baseline_and_repetition_artifacts() -> None:
+    baseline_mismatch = _claim().model_copy(update={"left_carrier_ref": "projected-artifact:other#x"})
+    projection_mismatch = _claim().model_copy(update={"observation_projection_ref": "repeatability.projection.other"})
+
+    for claim in (baseline_mismatch, projection_mismatch):
+        case = _case(claim=claim)
+        result = compare_repeatability_consistency(case, _evidence(case=case), available_capability_refs=_CAPABILITIES)
+        assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+        assert _codes(result) == {"conformance.repeatability-claim-case-mismatch"}
+
+
+def test_unsupported_criterion_is_rejected_before_comparison() -> None:
+    case = _case(criterion_id="other-criterion", criterion_version="2.0.0")
+
+    result = compare_repeatability_consistency(case, _evidence(case=case), available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-criterion-unsupported"}
+
+
+def test_case_digest_mismatch_is_rejected_before_comparison() -> None:
+    evidence = _evidence()
+    other_case = replace(_case(), case_id="repeatability:other")
+
+    result = compare_repeatability_consistency(other_case, evidence, available_capability_refs=_CAPABILITIES)
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-case-evidence-mismatch"}
+
+
+def test_missing_comparator_capability_fails_before_evidence_interpretation() -> None:
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(),
+        available_capability_refs=frozenset({"observation.projection"}),
+    )
+
+    assert result.outcome is RepeatabilityConsistencyOutcome.UNSUPPORTED
+    assert _codes(result) == {"conformance.repeatability-capability-unsupported"}
+
+
+def test_diagnostics_use_a_stable_json_pointer_address_and_hide_untrusted_values() -> None:
+    secret_like = "secret-token-do-not-render"
+    result = compare_repeatability_consistency(
+        _case(),
+        _evidence(residual_state=(secret_like,)),
+        available_capability_refs=_CAPABILITIES,
+    )
+
+    assert result.diagnostics
+    for diagnostic in result.diagnostics:
+        assert diagnostic.address == _DIAGNOSTIC_ADDRESS
+        assert _JSON_POINTER_RE.fullmatch(diagnostic.address)
+    rendered = " ".join(
+        f"{diagnostic.code} {diagnostic.address} {diagnostic.message}" for diagnostic in result.diagnostics
+    )
+    assert secret_like not in rendered
+
+
+# --- Assembler fail-closed join, identity, and content-integrity guards -----
+
+
+def test_assembler_rejects_a_side_that_does_not_match_the_typed_run() -> None:
+    case = _case(baseline=replace(_repetition_ref(0), run_ref="experiment-run:other@1"))
+
+    with pytest.raises(ValueError, match="baseline does not match the validated task, run"):
+        _evidence(case=case)
+
+
+def test_assembler_runs_the_canonical_task_run_validator() -> None:
+    wrong_task = _task().model_copy(update={"task_id": "task:other"})
+
+    with pytest.raises(ValueError, match="baseline task/run validation failed"):
+        _evidence(task_override={0: wrong_task})
+
+
+def test_assembler_rejects_validator_outside_the_case_authority_pin() -> None:
+    with pytest.raises(ValueError, match="validator binding does not match"):
+        _evidence(validator_binding=replace(_binding(), validator_digest=_DIGEST_A))
+
+
+def test_assembler_rejects_projection_evidence_from_the_other_run() -> None:
+    baseline_run = _run_and_evidence(0)[0]
+    foreign_ref = _run_and_evidence(1)[1].evidence_record_id
+
+    with pytest.raises(ValueError, match="baseline projection evidence must resolve"):
+        _evidence(projection_evidence_override={_run_ref(baseline_run): foreign_ref})
+
+
+def test_run_pair_ids_must_match_the_case() -> None:
+    case = _case()
+    b_run, _ = _run_and_evidence(0)
+    r_run, _ = _run_and_evidence(1)
+    bad_runs = RepeatabilityRunPair(
+        baseline=RepeatabilityRunInput("rep-unknown", _task(), b_run),
+        repetition=RepeatabilityRunInput(case.repetition.repetition_id, _task(), r_run),
+    )
+
+    with pytest.raises(ValueError, match="run pair repetition ids must match"):
+        _evidence(case=case, runs=bad_runs)
+
+
+def test_assembler_rejects_verification_evidence_outside_the_pair() -> None:
+    case = _case()
+    records = _default_records(case, "evidence:not-in-any-run")
+
+    with pytest.raises(ValueError, match="variation verification evidence must resolve"):
+        _evidence(case=case, records=records)
+
+
+def test_variation_verification_must_match_the_declared_policy() -> None:
+    case = _case()
+    records = _default_records(case, _run_and_evidence(0)[1].evidence_record_id)
+    tampered = replace(records, variation=replace(records.variation, policy_id="variation:other"))
+
+    with pytest.raises(ValueError, match="variation verification does not match the admitted variation policy"):
+        _evidence(case=case, records=tampered)
+
+
+@pytest.mark.parametrize("record_name", ("variation", "reset"))
+def test_variation_and_reset_verification_must_cover_the_pair(record_name: str) -> None:
+    case = _case()
+    records = _default_records(case, _run_and_evidence(0)[1].evidence_record_id)
+    partial = (case.baseline.run_ref,)
+    tampered = replace(records, **{record_name: replace(getattr(records, record_name), pair_run_refs=partial)})
+
+    with pytest.raises(ValueError, match="does not cover the admitted pair"):
+        _evidence(case=case, records=tampered)
+
+
+def test_cleanup_verification_must_match_the_admitted_subject() -> None:
+    case = _case()
+    records = _default_records(case, _run_and_evidence(0)[1].evidence_record_id)
+    tampered = replace(records, cleanup=replace(records.cleanup, subject_ref="scenario-snapshot:other@1.0.0"))
+
+    with pytest.raises(ValueError, match="cleanup verification does not match the admitted subject"):
+        _evidence(case=case, records=tampered)
+
+
+def test_evidence_records_must_use_unique_ids() -> None:
+    case = _case()
+    b_ev = _run_and_evidence(0)[1]
+
+    with pytest.raises(ValueError, match="evidence_records must use unique evidence_record_id"):
+        _evidence(case=case, evidence_records=(b_ev, _run_and_evidence(1)[1], b_ev))
+
+
+def test_verification_records_must_use_unique_record_ids() -> None:
+    case = _case()
+    records = _default_records(case, _run_and_evidence(0)[1].evidence_record_id)
+    tampered = replace(records, reset=replace(records.reset, record_id=records.variation.record_id))
+
+    with pytest.raises(ValueError, match="verification records must use unique record_id"):
+        _evidence(case=case, records=tampered)
+
+
+class _BadProjectionValidator:
+    def __init__(self, *, run_ref_override: str | None = None, return_non_projection: bool = False) -> None:
+        self.binding = _binding()
+        self._run_ref_override = run_ref_override
+        self._return_non_projection = return_non_projection
+
+    def project_outcome(self, *, role, case, run, evidence_records):  # type: ignore[no-untyped-def]
+        del role, case
+        if self._return_non_projection:
+            return object()
+        evidence_ref = next(r.evidence_record_id for r in evidence_records if r.run_ref.ref_id == run.run_id)
+        return RepetitionProjection(
+            run_ref=self._run_ref_override or f"experiment-run:{run.run_id}@{run.run_version}",
+            outcome=ProjectionOutcome.DECIDED,
+            projected_digest=_DIGEST_B,
+            evidence_refs=(evidence_ref,),
+        )
+
+    def verify_variation(self, **_kwargs):  # type: ignore[no-untyped-def]
+        return VerificationDisposition.VERIFIED
+
+    def verify_reset(self, **_kwargs):  # type: ignore[no-untyped-def]
+        return VerificationDisposition.VERIFIED
+
+    def verify_cleanup(self, **_kwargs):  # type: ignore[no-untyped-def]
+        return VerificationDisposition.VERIFIED
+
+
+def _assemble_with_validator(validator: object) -> RepeatabilityConsistencyEvidence:
+    case = _case()
+    b_run, b_ev = _run_and_evidence(0)
+    r_run, r_ev = _run_and_evidence(1)
+    return assemble_repeatability_consistency_evidence(
+        case,
+        runs=RepeatabilityRunPair(
+            baseline=RepeatabilityRunInput(case.baseline.repetition_id, _task(), b_run),
+            repetition=RepeatabilityRunInput(case.repetition.repetition_id, _task(), r_run),
+        ),
+        evidence_records=(b_ev, r_ev),
+        verification_records=_default_records(case, b_ev.evidence_record_id),
+        validator=validator,  # type: ignore[arg-type]
+    )
+
+
+def test_assembler_requires_typed_projection_values() -> None:
+    with pytest.raises(ValueError, match="must derive typed RepetitionProjection values"):
+        _assemble_with_validator(_BadProjectionValidator(return_non_projection=True))
+
+
+def test_assembler_requires_the_projection_to_identify_its_run() -> None:
+    with pytest.raises(ValueError, match="projection does not identify its admitted run"):
+        _assemble_with_validator(_BadProjectionValidator(run_ref_override="experiment-run:other@1"))
+
+
+def test_assembler_requires_typed_disposition_values() -> None:
+    class _BadDispositionValidator(_BadProjectionValidator):
+        def verify_reset(self, **_kwargs):  # type: ignore[no-untyped-def]
+            return "verified"
+
+    with pytest.raises(ValueError, match="must return VerificationDisposition values"):
+        _assemble_with_validator(_BadDispositionValidator())
+
+
+def test_case_requires_a_distinct_lineage_preserving_pair() -> None:
+    with pytest.raises(ValueError, match="distinct run_ref"):
+        _case(repetition=replace(_repetition_ref(1), run_ref=_repetition_ref(0).run_ref))
+    with pytest.raises(ValueError, match="distinct projected_artifact_ref"):
+        _case(repetition=replace(_repetition_ref(1), projected_artifact_ref=_artifact_ref(0)))
+    with pytest.raises(ValueError, match="repeat the case subject_ref"):
+        _case(repetition=replace(_repetition_ref(1), subject_ref="scenario-snapshot:other@1"))
+    with pytest.raises(ValueError, match="hold the subject fixed by digest"):
+        _case(repetition=replace(_repetition_ref(1), subject_digest=_DIGEST_C))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "run_ref": "",
+                "outcome": ProjectionOutcome.DECIDED,
+                "projected_digest": _DIGEST_B,
+                "evidence_refs": ("e",),
+            },
+            "run_ref must be non-empty",
+        ),
+        (
+            {"run_ref": "r", "outcome": "decided", "projected_digest": _DIGEST_B, "evidence_refs": ("e",)},
+            "outcome must be a ProjectionOutcome",
+        ),
+        (
+            {"run_ref": "r", "outcome": ProjectionOutcome.DECIDED, "projected_digest": None, "evidence_refs": ("e",)},
+            "must carry a sha256 projected_digest",
+        ),
+        (
+            {"run_ref": "r", "outcome": ProjectionOutcome.DECIDED, "projected_digest": _DIGEST_B, "evidence_refs": ()},
+            "must carry run-bound evidence_refs",
+        ),
+        (
+            {
+                "run_ref": "r",
+                "outcome": ProjectionOutcome.INDETERMINATE,
+                "projected_digest": _DIGEST_B,
+                "evidence_refs": (),
+            },
+            "must not carry a projected_digest",
+        ),
+    ],
+)
+def test_repetition_projection_shape_is_enforced(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        RepetitionProjection(**kwargs)  # type: ignore[arg-type]
+
+
+def test_case_rejects_malformed_field_types() -> None:
+    with pytest.raises(ValueError, match="claim must be a BehavioralClaimBindingModel"):
+        _case(claim="not-a-claim")  # type: ignore[arg-type]
+    valid = _case()
+    with pytest.raises(ValueError, match="variation_policy must be a VariationPolicy"):
+        replace(valid, variation_policy="not-a-policy")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="verification_authority must be"):
+        replace(valid, verification_authority="not-a-binding")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="baseline and repetition must be RepetitionRef"):
+        replace(valid, repetition="not-a-repetition")  # type: ignore[arg-type]
+
+
+def test_case_requires_at_least_one_capability() -> None:
+    with pytest.raises(ValueError, match="required_capability_refs must not be empty"):
+        replace(_case(), required_capability_refs=())
+    with pytest.raises(ValueError, match="required_capability_refs entries must be non-empty"):
+        replace(_case(), required_capability_refs=("",))
+
+
+def test_variation_policy_requires_and_dedupes_dimensions() -> None:
+    with pytest.raises(ValueError, match="held_fixed_dimensions must not be empty"):
+        VariationPolicy(policy_id="p", policy_version="1", held_fixed_dimensions=(), permitted_variation_refs=("x",))
+    with pytest.raises(ValueError, match="held_fixed_dimensions entries must be unique"):
+        VariationPolicy(
+            policy_id="p",
+            policy_version="1",
+            held_fixed_dimensions=("subject", "subject"),
+            permitted_variation_refs=("x",),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "message"),
+    [
+        ("producer_id", "", "producer_id must be non-empty"),
+        ("producer_digest", "not-a-digest", "producer_digest must be a sha256 digest"),
+    ],
+)
+def test_verification_binding_shape_is_enforced(field_name: str, bad_value: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_binding(), **{field_name: bad_value})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "message"),
+    [
+        ("repetition_id", "", "repetition_id must be non-empty"),
+        ("run_digest", "not-a-digest", "run_digest must be a sha256 digest"),
+    ],
+)
+def test_repetition_ref_shape_is_enforced(field_name: str, bad_value: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_repetition_ref(0), **{field_name: bad_value})
+
+
+def test_verification_record_header_is_enforced() -> None:
+    with pytest.raises(ValueError, match="record_id must be non-empty"):
+        ResetVerificationRecord(record_id="", record_version="1", pair_run_refs=("r",), evidence_record_refs=("e",))
+    with pytest.raises(ValueError, match="evidence_record_refs must not be empty"):
+        ResetVerificationRecord(record_id="x", record_version="1", pair_run_refs=("r",), evidence_record_refs=())
+    with pytest.raises(ValueError, match="pair_run_refs entries must be unique"):
+        ResetVerificationRecord(
+            record_id="x", record_version="1", pair_run_refs=("r", "r"), evidence_record_refs=("e",)
+        )
+    with pytest.raises(ValueError, match="pair_run_refs entries must be non-empty"):
+        ResetVerificationRecord(record_id="x", record_version="1", pair_run_refs=("",), evidence_record_refs=("e",))

--- a/implementations/python/tests/test_repeatability_validation.py
+++ b/implementations/python/tests/test_repeatability_validation.py
@@ -635,16 +635,18 @@ def test_assembler_runs_the_canonical_task_run_validator() -> None:
 
 
 def test_assembler_rejects_validator_outside_the_case_authority_pin() -> None:
+    untrusted = replace(_binding(), validator_digest=_DIGEST_A)
     with pytest.raises(ValueError, match="validator binding does not match"):
-        _evidence(validator_binding=replace(_binding(), validator_digest=_DIGEST_A))
+        _evidence(validator_binding=untrusted)
 
 
 def test_assembler_rejects_projection_evidence_from_the_other_run() -> None:
     baseline_run = _run_and_evidence(0)[0]
     foreign_ref = _run_and_evidence(1)[1].evidence_record_id
+    override = {_run_ref(baseline_run): foreign_ref}
 
     with pytest.raises(ValueError, match="baseline projection evidence must resolve"):
-        _evidence(projection_evidence_override={_run_ref(baseline_run): foreign_ref})
+        _evidence(projection_evidence_override=override)
 
 
 def test_run_pair_ids_must_match_the_case() -> None:
@@ -700,9 +702,11 @@ def test_cleanup_verification_must_match_the_admitted_subject() -> None:
 def test_evidence_records_must_use_unique_ids() -> None:
     case = _case()
     b_ev = _run_and_evidence(0)[1]
+    r_ev = _run_and_evidence(1)[1]
+    records = (b_ev, r_ev, b_ev)
 
     with pytest.raises(ValueError, match="evidence_records must use unique evidence_record_id"):
-        _evidence(case=case, evidence_records=(b_ev, _run_and_evidence(1)[1], b_ev))
+        _evidence(case=case, evidence_records=records)
 
 
 def test_verification_records_must_use_unique_record_ids() -> None:
@@ -759,13 +763,15 @@ def _assemble_with_validator(validator: object) -> RepeatabilityConsistencyEvide
 
 
 def test_assembler_requires_typed_projection_values() -> None:
+    validator = _BadProjectionValidator(return_non_projection=True)
     with pytest.raises(ValueError, match="must derive typed RepetitionProjection values"):
-        _assemble_with_validator(_BadProjectionValidator(return_non_projection=True))
+        _assemble_with_validator(validator)
 
 
 def test_assembler_requires_the_projection_to_identify_its_run() -> None:
+    validator = _BadProjectionValidator(run_ref_override="experiment-run:other@1")
     with pytest.raises(ValueError, match="projection does not identify its admitted run"):
-        _assemble_with_validator(_BadProjectionValidator(run_ref_override="experiment-run:other@1"))
+        _assemble_with_validator(validator)
 
 
 def test_assembler_requires_typed_disposition_values() -> None:
@@ -773,19 +779,26 @@ def test_assembler_requires_typed_disposition_values() -> None:
         def verify_reset(self, **_kwargs):  # type: ignore[no-untyped-def]
             return "verified"
 
+    validator = _BadDispositionValidator()
     with pytest.raises(ValueError, match="must return VerificationDisposition values"):
-        _assemble_with_validator(_BadDispositionValidator())
+        _assemble_with_validator(validator)
 
 
 def test_case_requires_a_distinct_lineage_preserving_pair() -> None:
+    baseline = _repetition_ref(0)
+    repetition = _repetition_ref(1)
+    reused_run = replace(repetition, run_ref=baseline.run_ref)
     with pytest.raises(ValueError, match="distinct run_ref"):
-        _case(repetition=replace(_repetition_ref(1), run_ref=_repetition_ref(0).run_ref))
+        _case(repetition=reused_run)
+    reused_artifact = replace(repetition, projected_artifact_ref=baseline.projected_artifact_ref)
     with pytest.raises(ValueError, match="distinct projected_artifact_ref"):
-        _case(repetition=replace(_repetition_ref(1), projected_artifact_ref=_artifact_ref(0)))
+        _case(repetition=reused_artifact)
+    drifted_subject = replace(repetition, subject_ref="scenario-snapshot:other@1")
     with pytest.raises(ValueError, match="repeat the case subject_ref"):
-        _case(repetition=replace(_repetition_ref(1), subject_ref="scenario-snapshot:other@1"))
+        _case(repetition=drifted_subject)
+    drifted_digest = replace(repetition, subject_digest=_DIGEST_C)
     with pytest.raises(ValueError, match="hold the subject fixed by digest"):
-        _case(repetition=replace(_repetition_ref(1), subject_digest=_DIGEST_C))
+        _case(repetition=drifted_digest)
 
 
 @pytest.mark.parametrize(
@@ -841,10 +854,11 @@ def test_case_rejects_malformed_field_types() -> None:
 
 
 def test_case_requires_at_least_one_capability() -> None:
+    case = _case()
     with pytest.raises(ValueError, match="required_capability_refs must not be empty"):
-        replace(_case(), required_capability_refs=())
+        replace(case, required_capability_refs=())
     with pytest.raises(ValueError, match="required_capability_refs entries must be non-empty"):
-        replace(_case(), required_capability_refs=("",))
+        replace(case, required_capability_refs=("",))
 
 
 def test_variation_policy_requires_and_dedupes_dimensions() -> None:
@@ -867,8 +881,9 @@ def test_variation_policy_requires_and_dedupes_dimensions() -> None:
     ],
 )
 def test_verification_binding_shape_is_enforced(field_name: str, bad_value: str, message: str) -> None:
+    binding = _binding()
     with pytest.raises(ValueError, match=message):
-        replace(_binding(), **{field_name: bad_value})
+        replace(binding, **{field_name: bad_value})
 
 
 @pytest.mark.parametrize(
@@ -879,8 +894,9 @@ def test_verification_binding_shape_is_enforced(field_name: str, bad_value: str,
     ],
 )
 def test_repetition_ref_shape_is_enforced(field_name: str, bad_value: str, message: str) -> None:
+    rep = _repetition_ref(0)
     with pytest.raises(ValueError, match=message):
-        replace(_repetition_ref(0), **{field_name: bad_value})
+        replace(rep, **{field_name: bad_value})
 
 
 def test_verification_record_header_is_enforced() -> None:

--- a/specs/formal/behavioral-relations/README.md
+++ b/specs/formal/behavioral-relations/README.md
@@ -243,6 +243,34 @@ sufficient, probabilistic, or universal causation; replay, temporal order,
 correlation, shared seeds, or a failed execution are not substitutes for its
 gates.
 
+### Determinism, stability, and replay-consistency verification
+
+The ASR-514 claim surface verifies a producer's explicit repeatability claim as
+a single binary baseline-to-repetition comparison of one held-fixed subject. It
+adds no relation: a determinism or replay-consistency claim over exact canonical
+outputs binds the existing `canonical-artifact-identity` relation, whose two
+carriers name the compared baseline and repetition artifacts, and the comparator
+only decides whether the two projected outcomes are identical under one declared
+observation projection, variation policy, and versioned equality criterion. A
+larger set of repeated runs composes as several such pairwise cases; the binary
+relation is never reinterpreted as an n-ary one. The evidence boundary is
+bounded to the named pair, subject, projection, variation policy, and criterion.
+A pair is admitted only when the baseline and repetition carry distinct run
+identities of the same digest-held-fixed subject (ADR-068), the declared
+held-fixed dimensions are held fixed with only permitted variation, and reset,
+isolation, and cleanup are independently verified with no residual state.
+Unequal projected outcomes refute the finite claim; indeterminate, unsupported,
+withheld, incomparable, unverified, or residual evidence is inconclusive or
+unsupported, never a match.
+
+The result is finite empirical evidence for the named cohort only. It does not
+establish universal determinism, statistical equivalence, trace equivalence,
+bisimulation, backend equivalence, or necessity; a shared seed, a reused task
+identifier, wall-clock proximity, an exit status, or a completed replay is not
+substitutable for its gates. Statistical stability under controlled variation
+and participant-history replay remain separate criteria bound to
+`statistical-equivalence` or `participant-projected-history-equivalence`.
+
 ### Independent adequacy studies
 
 Study and benchmark contracts bind their conclusions to


### PR DESCRIPTION
## Summary

Adds a bounded determinism / replay-consistency verifier for ASR-514 as a single binary baseline-to-repetition comparison of one held-fixed subject. Per the architecture preflight it binds the existing `canonical-artifact-identity` relation (no new catalog relation, revision, or schema) and adds only the executable cross-run join: distinct-run identity (ADR-068), held-fixed subject, declared variation policy, and independently-verified reset/cleanup gate a fail-closed `consistent` / `divergent` / `inconclusive` / `unsupported` decision over exact canonical projected-outcome equality. Larger run sets compose as pairwise cases; the binary relation is never treated as n-ary. Reuses the ASR-513 fail-closed discipline and promotes the shared verification-authority primitives (ASR-513 unchanged). The pre-push security review's evidence-content-authenticity and seal-provenance findings are dispositioned as trusted-composition / platform boundaries (the run-traceability model forbids per-evidence content digests); platform-wide hardening is tracked in #958.

## Requirement UIDs

- `ASR-514`

## Related Issues

Closes #262

## ADR Impact

- ADR-068
- ADR-081
- ADR-084
- ADR-072
- ADR-066
- ADR-021

## Changes

- Add `raes_conformance/verification_authority.py`: neutral digest-pinned VerificationBinding / VerificationDisposition / VerificationRecordIdentity promoted (not copied) out of necessity
- Add `raes_conformance/repeatability_types.py`: sealed `RepeatabilityConsistencyEvidence` + `RepetitionProjection` with a module-owned assembly token
- Add `raes_conformance/repeatability_validation.py`: `RepeatabilityConsistencyCase` (binary baseline-to-repetition pair; carriers name the compared artifacts), JCS case digest, JSON-Pointer diagnostics, and `compare_repeatability_consistency()`
- Add `raes_conformance/repeatability_evidence.py`: trusted assembler over admitted runs/evidence with run/task/authority/traceability joins
- Modify `raes_conformance/necessity_types.py` to import the promoted primitives (ASR-513 unchanged, 36 tests green)
- Add `test_repeatability_validation.py` (94 tests, 100% coverage of the new modules)
- Docs: ASR-514 traceability matrix, behavioral-relations README claim-surface subsection, and the issue-262 architecture preflight note
- Follow-up #958 tracks platform-wide evidence-content-authenticity and seal-provenance hardening from the pre-push security review

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ASR-514 ← implementations/python/packages/raes_conformance/repeatability_validation.py, ASR-514 ← implementations/python/packages/raes_conformance/repeatability_evidence.py, ASR-514 ← implementations/python/packages/raes_conformance/repeatability_types.py, ASR-514 ← implementations/python/packages/raes_conformance/verification_authority.py
- TESTS: ASR-514 ← implementations/python/tests/test_repeatability_validation.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.