### PR TITLE
fix(sdl): reduce content validator complexity

### DIFF
--- a/implementations/python/packages/raes/content.py
+++ b/implementations/python/packages/raes/content.py
@@ -166,6 +166,24 @@ class Content(SDLModel):
     def parse_sensitive(cls, v: bool | str) -> bool | str:
         return parse_bool_or_var(v, field_name="sensitive")
 
+    def _validate_search_index_schema_content(self) -> bool:
+        if not isinstance(
+            self.service_materialization,
+            ServiceSearchIndexSchemaMaterialization,
+        ):
+            return False
+        if self.type != ContentType.DATASET:
+            raise ValueError("Search-index schema materialization requires dataset content")
+        if self.source is not None or self.items:
+            raise ValueError("Search-index schema materialization must not carry source or items")
+        return True
+
+    def _validate_ordinary_dataset_content(self, *, is_search_index_schema: bool) -> None:
+        if self.type != ContentType.DATASET or is_search_index_schema:
+            return
+        if not (self.source or self.items):
+            raise ValueError("Dataset content requires either 'source' or non-empty 'items'")
+
     @model_validator(mode="after")
     def validate_type_requirements(self) -> "Content":
         """Require the minimum anchors needed to describe real content."""
@@ -175,16 +193,10 @@ class Content(SDLModel):
         if self.type == ContentType.FILE and not self.path:
             raise ValueError("File content requires 'path'")
 
-        is_search_index_schema = isinstance(
-            self.service_materialization,
-            ServiceSearchIndexSchemaMaterialization,
+        is_search_index_schema = self._validate_search_index_schema_content()
+        self._validate_ordinary_dataset_content(
+            is_search_index_schema=is_search_index_schema,
         )
-        if is_search_index_schema and self.type != ContentType.DATASET:
-            raise ValueError("Search-index schema materialization requires dataset content")
-        if is_search_index_schema and (self.source is not None or self.items):
-            raise ValueError("Search-index schema materialization must not carry source or items")
-        if self.type == ContentType.DATASET and not is_search_index_schema and not (self.source or self.items):
-            raise ValueError("Dataset content requires either 'source' or non-empty 'items'")
 
         if self.type == ContentType.DIRECTORY and not self.destination:
             raise ValueError("Directory content requires 'destination'")

--- a/implementations/python/tests/test_sdl_models.py
+++ b/implementations/python/tests/test_sdl_models.py
@@ -2337,8 +2337,22 @@ class TestObjective:
 # ---------------------------------------------------------------------------
 
 from raes.accounts import Account, PasswordStrength
-from raes.content import Content, ContentItem, ContentType
+from raes.content import Content, ContentItem, ContentType, ServiceSearchIndexSchemaMaterialization
 from raes.nodes import AssetValue, AssetValueLevel, OSFamily, ServicePort
+
+
+def _search_index_schema_materialization() -> dict[str, object]:
+    return {
+        "interface_profile": "service-search-index-schema",
+        "profile_version": "1",
+        "target_service_ref": "search",
+        "readback_assertion_refs": ["schema-ready"],
+        "evidence_requirement_refs": ["schema-readback"],
+        "observation_boundary_refs": ["participant-view"],
+        "requirements": {
+            "field_semantics": {"key": "exact-token"},
+        },
+    }
 
 
 class TestContent:
@@ -2391,6 +2405,67 @@ class TestContent:
             match="Directory content requires 'destination'",
         ):
             Content(type="directory", target="victim")
+
+    @pytest.mark.parametrize(
+        ("content", "message"),
+        [
+            (
+                {
+                    "type": "file",
+                    "target": "victim",
+                    "path": "/tmp/flag.txt",
+                    "service_materialization": _search_index_schema_materialization(),
+                },
+                "Search-index schema materialization requires dataset content",
+            ),
+            (
+                {
+                    "type": "dataset",
+                    "target": "victim",
+                    "source": {"name": "schema"},
+                    "service_materialization": _search_index_schema_materialization(),
+                },
+                "Search-index schema materialization must not carry source or items",
+            ),
+            (
+                {
+                    "type": "dataset",
+                    "target": "victim",
+                    "items": [{"name": "schema"}],
+                    "service_materialization": _search_index_schema_materialization(),
+                },
+                "Search-index schema materialization must not carry source or items",
+            ),
+            (
+                {
+                    "type": "file",
+                    "path": "/tmp/flag.txt",
+                    "service_materialization": _search_index_schema_materialization(),
+                },
+                "Content requires 'target'",
+            ),
+        ],
+    )
+    def test_search_index_schema_content_shape_rules(
+        self,
+        content: dict[str, object],
+        message: str,
+    ) -> None:
+        with pytest.raises(ValidationError, match=message):
+            Content.model_validate(content)
+
+    def test_search_index_schema_dataset_does_not_require_payload(self) -> None:
+        content = Content.model_validate(
+            {
+                "type": "dataset",
+                "target": "victim",
+                "service_materialization": _search_index_schema_materialization(),
+            }
+        )
+
+        assert isinstance(content.service_materialization, ServiceSearchIndexSchemaMaterialization)
+        assert content.source is None
+        assert content.items == []
 
 
 class TestAccount:


### PR DESCRIPTION
## Summary

Reduce the `Content` model validator complexity that blocks the release Sonar gate while preserving validation behavior and error ordering.

## Related issues

Closes #1027

## Changes

- Extract search-index-schema and ordinary-dataset validation helpers
- Reduce the validator decision complexity from 15 to 6
- Add positive and negative regression coverage for the affected materialization rules

## Test plan

- [x] Relevant tests pass (42 focused tests; 5,827 unit tests; 56 integration tests)
- [x] The canonical verification gate passes
- [x] The docs gate passes; documentation is unchanged

## Checklist

- [x] Code follows the project coding standards
- [x] FM level classified: no semantic change
- [x] Published contract schemas verified unchanged
- [x] PR title is a Conventional Commit
- [x] Architectural docs are not affected

## Notes for review

Requirement: DSL-436