### PR TITLE
fix: apply backend protocol Any-signature policy to every protocol module

### DIFF
--- a/implementations/python/tests/test_repo_policy_tools.py
+++ b/implementations/python/tests/test_repo_policy_tools.py
@@ -817,6 +817,57 @@ def test_module_boundaries_reject_backend_protocol_any_signatures(tmp_path: Path
     assert [f.rule_id for f in failures] == ["backend-protocol-untyped-contract"]
 
 
+def test_module_boundaries_reject_backend_protocol_any_signatures_outside_protocols_module(
+    tmp_path: Path,
+) -> None:
+    # ADR-036 requires the Any-signature ban package-wide, not only in protocols.py.
+    repo_root = setup_policy_repo(tmp_path)
+    rel = "implementations/python/packages/raes_backend_protocols/participant_reset.py"
+    write_text(
+        repo_root / rel,
+        "from typing import Any, Protocol\n\n"
+        "class ParticipantReset(Protocol):\n"
+        "    def reset(self, request: Any) -> Any: ...\n",
+    )
+
+    failures = evaluate_repo_policy(repo_root, [rel], check_set="file-local", structural_runner=structural_runner_stub)
+
+    assert [f.rule_id for f in failures] == ["backend-protocol-untyped-contract"]
+
+
+def test_module_boundaries_allow_typed_backend_protocol_outside_protocols_module(
+    tmp_path: Path,
+) -> None:
+    repo_root = setup_policy_repo(tmp_path)
+    rel = "implementations/python/packages/raes_backend_protocols/participant_reset.py"
+    write_text(
+        repo_root / rel,
+        "from typing import Protocol\n\n"
+        "class ParticipantReset(Protocol):\n"
+        "    def reset(self, request: str) -> bool: ...\n",
+    )
+
+    failures = evaluate_repo_policy(repo_root, [rel], check_set="file-local", structural_runner=structural_runner_stub)
+
+    assert failures == []
+
+
+def test_module_boundaries_allow_structural_backend_protocol_attributes_outside_protocols_module(
+    tmp_path: Path,
+) -> None:
+    # Non-method structural protocol attributes are not signatures and must not be flagged.
+    repo_root = setup_policy_repo(tmp_path)
+    rel = "implementations/python/packages/raes_backend_protocols/participant_resource_admission.py"
+    write_text(
+        repo_root / rel,
+        "from typing import Any, Protocol\n\nclass ParticipantResourceAdmission(Protocol):\n    limit: Any\n",
+    )
+
+    failures = evaluate_repo_policy(repo_root, [rel], check_set="file-local", structural_runner=structural_runner_stub)
+
+    assert failures == []
+
+
 def test_module_boundaries_config_is_required(tmp_path: Path) -> None:
     repo_root = setup_policy_repo(tmp_path)
     policy = _load_test_policy(repo_root)

--- a/tools/policy/repo_policy.py
+++ b/tools/policy/repo_policy.py
@@ -678,7 +678,7 @@ def _check_module_boundaries(
                 continue
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel_path)
             failures.extend(_check_module_imports(rel_path, rule, known_modules, tree))
-            if rule["id"] == "raes_backend_protocols" and rel_path.endswith("protocols.py"):
+            if rule["id"] == "raes_backend_protocols":
                 failures.extend(_check_backend_protocol_contract_annotations(rel_path, tree))
     return failures
 


### PR DESCRIPTION
## Summary

Hardens the repository-policy backend-protocol `Any`-signature check to run for every module under `raes_backend_protocols`, not only `protocols.py`, closing enforcement drift against ADR-036's package-wide wording. The current tree is already typed correctly; this prevents regressions in newer protocol modules (e.g. `participant_reset.py`, `capability_admission.py`).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1035

## ADR Impact

- ADR-036
- ADR-021

## Changes

- `tools/policy/repo_policy.py`: drop the `protocols.py` filename filter so `_check_backend_protocol_contract_annotations` applies to every candidate module under the `raes_backend_protocols` rule root; the existing recursive `*.py` traversal covers new and nested modules automatically.
- The AST checker is unchanged: it still flags only `Any` in `Protocol` method signatures, preserves non-method structural protocol attributes, keeps the `backend-protocol-untyped-contract` rule id, and emits one failure per offending method.
- Package-wide processor/runtime import rejection (`_check_module_imports`) is unaffected.
- Tests: add a reject case for an `Any` signature in a non-`protocols.py` module, a pass case for a typed protocol in such a module, and a pass case for an attribute-only structural protocol.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Full `verify` suite (unit/integration/contracts/static/proof/docs lanes) and `make policy` pass; the real full-tree `check_repo_policy.py` scan stays green because no existing `Protocol` method uses `Any`.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-036 ← tools/policy/repo_policy.py
- TESTS: ADR-036 ← implementations/python/tests/test_repo_policy_tools.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Not updated (authorized): gc_documentation_coverage flagged docs/DEVELOPMENT_WORKFLOW.md (surface_class policy), but that doc does not enumerate individual policy checks and ADR-036 already records the package-wide invariant this change enforces; no documentation surface has a natural home for this internal enforcement-drift fix.