### PR TITLE
feat: add planned resource payload accessors

### DIFF
--- a/docs/decisions/issue-713-planned-resource-payload-accessors-preflight.md
+++ b/docs/decisions/issue-713-planned-resource-payload-accessors-preflight.md
@@ -1,0 +1,137 @@
+# Issue 713 PlannedResource Payload Accessors Preflight
+
+Date: 2026-08-01
+
+Requirement: none. GitHub issue #713 is the authoritative contract.
+
+This note records the boundary for a public Python convenience API over
+`PlannedResource.payload`. It is guidance only: it does not add a portable
+semantic, schema, fixture, profile, backend capability, or production-backend
+claim, and it is not an implementation plan.
+
+No ADR is needed. ADR-009, ADR-036, and ADR-063 already establish normative
+authority, package ownership, and the repository-owned reference-backend
+boundary.
+
+## Binding Sources
+
+- `raes_contracts.planning.PlannedResource`, `ProvisioningPlan`,
+  `RuntimeDomain`, `ChangeAction`, and `require_plan_operation_identity()` are
+  the neutral planning DTO and shape authority.
+- `raes_processor.models.runtime_model.resource_payload()` is the compiler-side
+  producer of the stable planner payload; it is not a backend reader API.
+- `raes_reference_backend.realization` and `raes_backend_libvirt.realization`
+  are the two consumer migrations. Their pure interpretation and existing
+  package-local `Diagnostic` behavior remain authoritative for realization
+  failure reporting.
+- `raes_backend_libvirt._payload` is the immediate duplication to retire or
+  reduce to backend-only concerns. `capability_envelope_diagnostics()` remains
+  the backend capability gate, not an accessor responsibility.
+- `provider_resource_name()` is the incumbent backend-native name normalizer.
+  `Diagnostic`, `Severity`, `RuntimeSnapshot`, `ApplyResult`, and the runtime
+  backend-call gates remain the public error and persistence envelopes.
+- ADR-009/019/061 and the corpus/publication checks govern normative artifacts;
+  ADR-036 and `tools/policy/adr_policy.yaml` govern this import direction.
+
+## Decision And Guardrails
+
+Place one small, public, dependency-free accessor surface alongside
+`PlannedResource` in `raes_contracts.planning` (or a directly public
+`raes_contracts.planning` submodule re-exported there). It accepts only a
+`PlannedResource`; it must not import a backend, processor implementation,
+runtime, schema model, or provider naming helper.
+
+The surface is a **total read/normalization convenience API**, not validation.
+It must provide mapping-shaped access to the top-level payload and the node
+`spec`, `infrastructure`, `resources`, and `source` surfaces, plus a stable
+authored-name fallback. A missing optional subtree, a non-mapping payload, a
+non-provisioning resource, or a non-node resource must produce the documented
+safe empty/absent result for the relevant accessor; it must not throw, coerce,
+guess, mutate the payload, or leak its contents. Source should retain its
+existing string-or-mapping distinction rather than inventing an image/source
+DTO. The name accessor may fall back to the stable planned address; a backend
+that needs a provider-safe runtime name continues to apply
+`provider_resource_name()` at its own boundary.
+
+Use one consistent absent-result convention across all accessors (for example,
+`None` for an unavailable scalar/subtree and an empty mapping only where the
+API explicitly promises a mapping). Document the resource/domain precondition
+and the absent-result behavior. Do not make `None` mean a malformed plan is
+valid: realization collectors must retain their existing resource-type/domain
+checks and their distinct `invalid-payload` versus `unsupported-resource`
+diagnostics before using node-specific reads.
+
+The helper must expose existing payload projections only. It must not validate
+SDL meaning, enforce capability allowlists, resolve network or placement
+references, convert RAM/CPU units, normalize service entries, choose an image,
+or supply defaults with operational meaning. Those decisions stay respectively
+with the parser/compiler/planner, `capability_envelope_diagnostics()`, and the
+backend realization/driver layers.
+
+Migrate both realization modules for every covered node read. Do not leave
+parallel local traversal helpers for source, resources, infrastructure/spec, or
+authored name. Shared generic access does not require migrating backend-only
+placement, account, feature, ACL, cloud-init, or capability-envelope traversal
+in this issue; those must continue to use their current local validation until
+they have an equally clear shared contract.
+
+## Cross-Cutting And Security Gates
+
+| Layer | Required treatment |
+| --- | --- |
+| SDL, schemas, and compiler | No new input path or schema. Existing closed SDL/Pydantic validation and `resource_payload()` remain the sole producer/validator of plan payload meaning. |
+| Plan DTO shape | Keep `PlannedResource` address/dependency checks and plan-domain admission unchanged. The accessor handles hostile or hand-built payload shapes defensively without changing DTO validation. |
+| Capability and realization | Keep `ProvisionerCapabilities`, capability-envelope diagnostics, supported-resource checks, and pure realization diagnostics in the backends. The helper neither authorizes nor realizes anything. |
+| Runtime/error envelope | Do not add exceptions, logs, or diagnostics in `raes_contracts`. Existing package-local `Diagnostic` codes and runtime `_call_backend_apply()`/snapshot validation continue to envelope failures. |
+| Secrets and observability | The helper performs no IO, parsing of environment/config, logging, persistence, subprocess invocation, or serialization. Callers must not include returned payload values in diagnostic messages; existing redaction tests remain relevant. |
+| Host/OS exposure | None: this layer must never reach driver configuration, libvirt, OCI, filesystem, process argv, or environment. Provider-safe naming remains in the backend protocol boundary. |
+| Packaging and policy | Keep the public API within the already packaged `raes_contracts` root and the ADR-036-approved dependency direction. Run repository policy, requirement governance with the existing requirement-free setting, and hermetic verification. |
+
+## Evidence Required From The Implementation
+
+Add focused contract tests for valid node source/resources/infrastructure/name
+reads; omitted optional fields; non-mapping payloads; and wrong resource type
+or runtime domain. Include the fallback-name and string-versus-mapping-source
+cases. Keep the existing reference and libvirt realization tests as migration
+evidence: malformed payloads must still yield their existing redacted backend
+diagnostic codes, and valid plans must preserve current realization output.
+
+## Extensibility Boundary
+
+The seam is a small family of `PlannedResource`-only accessors, with explicit
+resource/domain applicability rather than a generic dotted-path evaluator or a
+backend parameter. The next reasonable addition (for example node services or
+network infrastructure) can add one named accessor with the same absent-result
+contract. It must not require re-editing schemas, planner payload production,
+runtime control, or either driver. If a later use needs semantic validation or a
+typed portable value, that is a separate contract-evolution decision rather
+than a widening of this convenience layer.
+
+## Gotchas And Anti-Patterns
+
+Avoid:
+
+- a second payload schema, Pydantic model, source/image DTO, exception class,
+  validation profile, diagnostic code set, or backend capability registry;
+- a `dict`/deep-copy/serialization conversion that changes identity, accepts
+  arbitrary mapping-like objects inconsistently, or makes the accessor a
+  persistence boundary;
+- treating wrong resource/domain or malformed payload as a valid empty node in
+  backend control flow; retain the collectors' diagnostic gates;
+- provider name sanitization, network/placement resolution, resource sizing,
+  default-image selection, or cloud-init policy in `raes_contracts`;
+- importing `raes_backend_*`, `raes_processor`, `raes_runtime`, or the legacy
+  `raes.*` compatibility tree from the shared helper;
+- exposing raw payloads or source/build data through logs, diagnostics,
+  snapshots, control-plane records, or error messages.
+
+## Non-Goals
+
+- Changing normative portable semantics, schemas, fixtures, profiles, or
+  conformance claims.
+- Making the reference or libvirt backend a production backend, transferring
+  ownership to LilRAE/BigRAE, or changing ADR-063's boundary.
+- Refactoring all payload traversal across every backend concern, redesigning
+  planning DTOs, or changing planner reconciliation.
+- Adding a persistence, configuration, authentication, authorization, logging,
+  IO, driver, or API surface.

--- a/implementations/python/packages/raes_backend_libvirt/realization.py
+++ b/implementations/python/packages/raes_backend_libvirt/realization.py
@@ -149,14 +149,8 @@ def _collect_supported_resources(
     node_resources: list[tuple[PlannedResource, Mapping[str, object]]] = []
     placement_resources: list[tuple[PlannedResource, Mapping[str, object]]] = []
     for resource in sorted(plan.resources.values(), key=lambda item: item.address):
-        if resource.domain != RuntimeDomain.PROVISIONING:
-            continue
-        if resource.resource_type not in SUPPORTED_RESOURCE_TYPES:
-            diagnostics.append(_unsupported_resource(resource))
-            continue
-        payload = planned_resource_payload(resource)
+        payload = _supported_resource_payload(resource, diagnostics)
         if payload is None:
-            diagnostics.append(_invalid_payload(resource))
             continue
         if resource.resource_type == NETWORK_RESOURCE_TYPE:
             network_resources.append((resource, payload))
@@ -167,6 +161,21 @@ def _collect_supported_resources(
         else:
             placement_resources.append((resource, payload))
     return network_resources, node_resources, placement_resources
+
+
+def _supported_resource_payload(
+    resource: PlannedResource,
+    diagnostics: list[Diagnostic],
+) -> Mapping[str, object] | None:
+    if resource.domain != RuntimeDomain.PROVISIONING:
+        return None
+    if resource.resource_type not in SUPPORTED_RESOURCE_TYPES:
+        diagnostics.append(_unsupported_resource(resource))
+        return None
+    payload = planned_resource_payload(resource)
+    if payload is None:
+        diagnostics.append(_invalid_payload(resource))
+    return payload
 
 
 def _network_address_lookup(networks: list[NetworkSpec]) -> dict[str, str]:

--- a/implementations/python/packages/raes_backend_libvirt/realization.py
+++ b/implementations/python/packages/raes_backend_libvirt/realization.py
@@ -189,19 +189,24 @@ def _network_address_lookup(networks: list[NetworkSpec]) -> dict[str, str]:
 
 def _network_spec(resource: PlannedResource) -> NetworkSpec:
     infrastructure = planned_infrastructure_spec(resource) or {}
-    properties = infrastructure.get("properties")
+    raw_properties = infrastructure.get("properties")
+    properties = raw_properties if isinstance(raw_properties, Mapping) else {}
     labels: dict[str, str] = {}
-    if isinstance(properties, Mapping) and isinstance(properties.get("internal"), bool):
-        labels["internal"] = "true" if properties["internal"] else "false"
-    cidr = properties.get("cidr") if isinstance(properties, Mapping) else None
-    gateway = properties.get("gateway") if isinstance(properties, Mapping) else None
+    internal = properties.get("internal")
+    if isinstance(internal, bool):
+        labels["internal"] = str(internal).lower()
     return NetworkSpec(
         address=resource.address,
         name=_resource_name(resource),
-        cidr=cidr if isinstance(cidr, str) and cidr else None,
-        gateway=gateway if isinstance(gateway, str) and gateway else None,
+        cidr=_optional_str(properties.get("cidr")),
+        gateway=_optional_str(properties.get("gateway")),
         labels=labels,
     )
+
+
+def _optional_str(value: object) -> str | None:
+    text = _str(value)
+    return text or None
 
 
 def _node_address_lookup(

--- a/implementations/python/packages/raes_backend_libvirt/realization.py
+++ b/implementations/python/packages/raes_backend_libvirt/realization.py
@@ -25,7 +25,18 @@ from dataclasses import dataclass, field
 from raes_backend_protocols.capabilities import ProvisionerCapabilities
 from raes_backend_protocols.naming import provider_resource_name
 from raes_contracts.diagnostics import Diagnostic, Severity
-from raes_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
+from raes_contracts.planning import (
+    PlannedResource,
+    PlanOperation,
+    ProvisioningPlan,
+    RuntimeDomain,
+    planned_infrastructure_spec,
+    planned_node_resources,
+    planned_node_source,
+    planned_node_spec,
+    planned_resource_authored_name,
+    planned_resource_payload,
+)
 
 from ._payload import (
     ACCOUNT_PLACEMENT_RESOURCE_TYPE,
@@ -100,7 +111,7 @@ def interpret_provisioning_plan(
     diagnostics: list[Diagnostic] = list(capability_envelope_diagnostics(plan, capabilities))
     network_resources, node_resources, placement_resources = _collect_supported_resources(plan, diagnostics)
 
-    networks = [_network_spec(resource, payload) for resource, payload in network_resources]
+    networks = [_network_spec(resource) for resource, _ in network_resources]
     network_lookup = _network_address_lookup(networks)
     cidr_lookup = _network_cidr_lookup(networks)
     node_lookup = _node_address_lookup(node_resources)
@@ -111,13 +122,12 @@ def interpret_provisioning_plan(
     )
     diagnostics.extend(placement_diagnostics)
     acls: dict[str, tuple[NetworkAcl, ...]] = {}
-    for resource, payload in node_resources:
-        node_acls, acl_diagnostics = realize_node_acls(resource, _infrastructure_spec(payload).get("acls"), cidr_lookup)
+    for resource, _payload in node_resources:
+        infrastructure = planned_infrastructure_spec(resource) or {}
+        node_acls, acl_diagnostics = realize_node_acls(resource, infrastructure.get("acls"), cidr_lookup)
         acls[resource.address] = node_acls
         diagnostics.extend(acl_diagnostics)
-    domains = [
-        _domain_spec(resource, payload, network_lookup, cloud_init, acls) for resource, payload in node_resources
-    ]
+    domains = [_domain_spec(resource, network_lookup, cloud_init, acls) for resource, _ in node_resources]
 
     return Realization(
         networks=tuple(sorted(networks, key=lambda spec: spec.address)),
@@ -144,8 +154,8 @@ def _collect_supported_resources(
         if resource.resource_type not in SUPPORTED_RESOURCE_TYPES:
             diagnostics.append(_unsupported_resource(resource))
             continue
-        payload = resource.payload
-        if not isinstance(payload, Mapping):
+        payload = planned_resource_payload(resource)
+        if payload is None:
             diagnostics.append(_invalid_payload(resource))
             continue
         if resource.resource_type == NETWORK_RESOURCE_TYPE:
@@ -168,8 +178,8 @@ def _network_address_lookup(networks: list[NetworkSpec]) -> dict[str, str]:
     return lookup
 
 
-def _network_spec(resource: PlannedResource, payload: Mapping[str, object]) -> NetworkSpec:
-    infrastructure = _infrastructure_spec(payload)
+def _network_spec(resource: PlannedResource) -> NetworkSpec:
+    infrastructure = planned_infrastructure_spec(resource) or {}
     properties = infrastructure.get("properties")
     labels: dict[str, str] = {}
     if isinstance(properties, Mapping) and isinstance(properties.get("internal"), bool):
@@ -178,7 +188,7 @@ def _network_spec(resource: PlannedResource, payload: Mapping[str, object]) -> N
     gateway = properties.get("gateway") if isinstance(properties, Mapping) else None
     return NetworkSpec(
         address=resource.address,
-        name=_resource_name(resource, payload),
+        name=_resource_name(resource),
         cidr=cidr if isinstance(cidr, str) and cidr else None,
         gateway=gateway if isinstance(gateway, str) and gateway else None,
         labels=labels,
@@ -191,8 +201,8 @@ def _node_address_lookup(
     """Map every handle a placement might reference a node by to its address."""
 
     lookup: dict[str, str] = {}
-    for resource, payload in node_resources:
-        name = _resource_name(resource, payload)
+    for resource, _payload in node_resources:
+        name = _resource_name(resource)
         for key in (resource.address, name):
             if key:
                 lookup[key] = resource.address
@@ -333,7 +343,7 @@ def _realize_feature(
     feature_type = _str(template.get("type"))
     source = template.get("source")
     package = _str(source.get("name")) if isinstance(source, Mapping) else ""
-    name = _resource_name(resource, payload)
+    name = _resource_name(resource)
     if feature_type == "service" and package:
         _merge_emit(accumulator, dialect.enable_feature(package))
     else:
@@ -355,7 +365,7 @@ def _content_descriptor(
     location: str | None,
 ) -> CloudInitFile:
     spec = _spec(payload)
-    name = _resource_name(resource, payload)
+    name = _resource_name(resource)
     descriptor = {
         "content": name,
         "type": _str(spec.get("type")),
@@ -371,25 +381,24 @@ def _descriptor_body(descriptor: Mapping[str, object]) -> str:
 
 def _domain_spec(
     resource: PlannedResource,
-    payload: Mapping[str, object],
     network_lookup: dict[str, str],
     cloud_init: dict[str, _CloudInitAccumulator],
     acls: dict[str, tuple[NetworkAcl, ...]],
 ) -> DomainSpec:
-    infrastructure = _infrastructure_spec(payload)
+    infrastructure = planned_infrastructure_spec(resource) or {}
     references = _network_refs(infrastructure)
     network_addresses = tuple(network_lookup.get(ref, ref) for ref in references)
-    resources = _node_resources(payload)
-    name = _resource_name(resource, payload)
+    resources = planned_node_resources(resource) or {}
+    name = _resource_name(resource)
     accumulator = cloud_init.get(resource.address, _CloudInitAccumulator())
     return DomainSpec(
         address=resource.address,
         name=name,
-        image_ref=_image_ref(payload),
+        image_ref=_planned_node_image_ref(resource),
         memory_mib=_memory_mib(resources.get("ram")),
         vcpus=_vcpus(resources.get("cpu")),
         networks=network_addresses,
-        services=_services(payload),
+        services=_planned_node_services(resource),
         cloud_init=accumulator.build(hostname=name),
         network_acls=acls.get(resource.address, ()),
     )
@@ -406,9 +415,17 @@ def _network_cidr_lookup(networks: list[NetworkSpec]) -> dict[str, str]:
     return lookup
 
 
-def _resource_name(resource: PlannedResource, payload: Mapping[str, object]) -> str:
-    name = payload.get("name") or payload.get("node_name")
-    if isinstance(name, str) and name:
+def _resource_name(
+    resource: PlannedResource | PlanOperation,
+    payload: Mapping[str, object] | None = None,
+) -> str:
+    if isinstance(resource, PlannedResource):
+        name = planned_resource_authored_name(resource)
+    else:
+        operation_payload = payload or {}
+        raw_name = operation_payload.get("name") or operation_payload.get("node_name")
+        name = raw_name if isinstance(raw_name, str) and raw_name else None
+    if name is not None:
         return name
     return provider_resource_name(resource.address, prefix="raes")
 
@@ -450,6 +467,15 @@ def _services(payload: Mapping[str, object]) -> tuple[ServiceSpec, ...]:
     return tuple(sorted(services, key=lambda service: (service.protocol, service.port, service.name)))
 
 
+def _planned_node_services(resource: PlannedResource) -> tuple[ServiceSpec, ...]:
+    node = planned_node_spec(resource)
+    raw_services = node.get("services") if node is not None else None
+    if not isinstance(raw_services, list | tuple):
+        return ()
+    services = [service for item in raw_services if (service := _service(item)) is not None]
+    return tuple(sorted(services, key=lambda service: (service.protocol, service.port, service.name)))
+
+
 def _service(raw: object) -> ServiceSpec | None:
     service: ServiceSpec | None = None
     if isinstance(raw, Mapping):
@@ -485,6 +511,17 @@ def _image_ref(payload: Mapping[str, object]) -> str | None:
     node = spec.get("node") if isinstance(spec, Mapping) else None
     source = node.get("source") if isinstance(node, Mapping) else None
     if isinstance(source, str) and source:
+        return source
+    if isinstance(source, Mapping):
+        name = source.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def _planned_node_image_ref(resource: PlannedResource) -> str | None:
+    source = planned_node_source(resource)
+    if isinstance(source, str):
         return source
     if isinstance(source, Mapping):
         name = source.get("name")

--- a/implementations/python/packages/raes_contracts/planning.py
+++ b/implementations/python/packages/raes_contracts/planning.py
@@ -1,7 +1,15 @@
-"""Shared runtime planning contracts."""
+"""Shared runtime planning contracts and safe planned-resource readers.
+
+Backend and provisioner implementations should use the named
+``planned_*`` accessors in this module instead of traversing a
+:class:`PlannedResource` payload directly.  The accessors are total, perform no
+validation or normalization, and return ``None`` when a requested surface is
+missing or does not apply to the resource's domain and type.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -81,6 +89,89 @@ class PlannedResource:
         require_compiled_address(self.address)
         for dependency in (*self.ordering_dependencies, *self.refresh_dependencies):
             require_compiled_address(dependency, field_name="dependency address")
+
+
+def planned_resource_payload(resource: PlannedResource) -> Mapping[str, Any] | None:
+    """Return the resource's mapping payload, or ``None`` when it is malformed.
+
+    The original mapping is returned without copying or mutation.  This reader
+    is domain-neutral; callers should use the narrower provisioning readers
+    below for fields whose meaning depends on a runtime domain or resource type.
+    """
+
+    payload = resource.payload
+    return payload if isinstance(payload, Mapping) else None
+
+
+def planned_resource_authored_name(resource: PlannedResource) -> str | None:
+    """Return the authored top-level resource name, if one is available."""
+
+    payload = planned_resource_payload(resource)
+    if payload is None:
+        return None
+    name = payload.get("name") or payload.get("node_name")
+    return name if isinstance(name, str) and name else None
+
+
+def planned_resource_name(resource: PlannedResource) -> str:
+    """Return the authored resource name or its full canonical address.
+
+    The address is a stable, provider-neutral fallback.  Backends that require
+    provider-safe native names remain responsible for deriving those names from
+    the address.
+    """
+
+    return planned_resource_authored_name(resource) or resource.address
+
+
+def planned_node_spec(resource: PlannedResource) -> Mapping[str, Any] | None:
+    """Return ``spec.node`` for a provisioning node, otherwise ``None``."""
+
+    if resource.domain is not RuntimeDomain.PROVISIONING or resource.resource_type != "node":
+        return None
+    payload = planned_resource_payload(resource)
+    spec = payload.get("spec") if payload is not None else None
+    node = spec.get("node") if isinstance(spec, Mapping) else None
+    return node if isinstance(node, Mapping) else None
+
+
+def planned_node_source(resource: PlannedResource) -> str | Mapping[str, Any] | None:
+    """Return a provisioning node's authored string-or-mapping source.
+
+    Mapping sources retain all source/build inputs and are not collapsed to a
+    backend-specific image name.  Empty strings and unsupported value shapes
+    are treated as absent.
+    """
+
+    node = planned_node_spec(resource)
+    source = node.get("source") if node is not None else None
+    if isinstance(source, str):
+        return source if source else None
+    return source if isinstance(source, Mapping) else None
+
+
+def planned_node_resources(resource: PlannedResource) -> Mapping[str, Any] | None:
+    """Return a provisioning node's authored resources mapping, if present."""
+
+    node = planned_node_spec(resource)
+    resources = node.get("resources") if node is not None else None
+    return resources if isinstance(resources, Mapping) else None
+
+
+def planned_infrastructure_spec(resource: PlannedResource) -> Mapping[str, Any] | None:
+    """Return ``spec.infrastructure`` for a provisioning node or network.
+
+    Infrastructure is intentionally unavailable for other provisioning
+    resource types and for other runtime domains rather than being inferred
+    from a coincidentally similar payload shape.
+    """
+
+    if resource.domain is not RuntimeDomain.PROVISIONING or resource.resource_type not in {"node", "network"}:
+        return None
+    payload = planned_resource_payload(resource)
+    spec = payload.get("spec") if payload is not None else None
+    infrastructure = spec.get("infrastructure") if isinstance(spec, Mapping) else None
+    return infrastructure if isinstance(infrastructure, Mapping) else None
 
 
 @dataclass(frozen=True)
@@ -216,5 +307,12 @@ __all__ = (
     "ProvisionOp",
     "ProvisioningPlan",
     "RuntimeDomain",
+    "planned_infrastructure_spec",
+    "planned_node_resources",
+    "planned_node_source",
+    "planned_node_spec",
+    "planned_resource_authored_name",
+    "planned_resource_name",
+    "planned_resource_payload",
     "require_plan_operation_identity",
 )

--- a/implementations/python/packages/raes_reference_backend/realization.py
+++ b/implementations/python/packages/raes_reference_backend/realization.py
@@ -241,16 +241,13 @@ def _valid_service_port(value: object) -> bool:
 
 def _image_ref(resource: PlannedResource, payload: Mapping[str, object]) -> str:
     source = planned_node_source(resource)
-    if isinstance(source, str):
-        return source
     if isinstance(source, Mapping):
-        name = source.get("name")
-        if isinstance(name, str) and name:
-            return name
-    os_family = payload.get("os_family")
-    if isinstance(os_family, str) and os_family:
-        return f"raes-reference/{os_family}"
-    return "raes-reference/base"
+        source = source.get("name")
+    image_ref = source if isinstance(source, str) and source else None
+    if image_ref is None:
+        os_family = payload.get("os_family")
+        image_ref = f"raes-reference/{os_family}" if isinstance(os_family, str) and os_family else "raes-reference/base"
+    return image_ref
 
 
 def _placement(resource: PlannedResource, payload: Mapping[str, object]) -> PlacementRealization:

--- a/implementations/python/packages/raes_reference_backend/realization.py
+++ b/implementations/python/packages/raes_reference_backend/realization.py
@@ -15,7 +15,16 @@ from dataclasses import dataclass
 
 from raes_backend_protocols.naming import provider_resource_name
 from raes_contracts.diagnostics import Diagnostic, Severity
-from raes_contracts.planning import PlannedResource, ProvisioningPlan, RuntimeDomain
+from raes_contracts.planning import (
+    PlannedResource,
+    ProvisioningPlan,
+    RuntimeDomain,
+    planned_infrastructure_spec,
+    planned_node_source,
+    planned_node_spec,
+    planned_resource_authored_name,
+    planned_resource_payload,
+)
 
 from .driver import ContainerSpec, NetworkSpec, ServiceSpec
 
@@ -75,8 +84,8 @@ def interpret_provisioning_plan(plan: ProvisioningPlan) -> Realization:
         if resource.resource_type not in SUPPORTED_RESOURCE_TYPES:
             diagnostics.append(_unsupported_resource(resource))
             continue
-        payload = resource.payload
-        if not isinstance(payload, Mapping):
+        payload = planned_resource_payload(resource)
+        if payload is None:
             diagnostics.append(_invalid_payload(resource))
             continue
         if resource.resource_type == NETWORK_RESOURCE_TYPE:
@@ -86,7 +95,7 @@ def interpret_provisioning_plan(plan: ProvisioningPlan) -> Realization:
         else:
             placement_resources.append((resource, payload))
 
-    networks = [_network_spec(resource, payload) for resource, payload in network_resources]
+    networks = [_network_spec(resource) for resource, _ in network_resources]
     network_lookup = _network_address_lookup(networks)
     containers: list[ContainerSpec] = []
     for resource, payload in node_resources:
@@ -114,30 +123,22 @@ def _network_address_lookup(networks: list[NetworkSpec]) -> dict[str, str]:
     return lookup
 
 
-def _resource_name(resource: PlannedResource, payload: Mapping[str, object]) -> str:
-    name = payload.get("name") or payload.get("node_name")
-    if isinstance(name, str) and name:
+def _resource_name(resource: PlannedResource) -> str:
+    name = planned_resource_authored_name(resource)
+    if name is not None:
         return name
     return provider_resource_name(resource.address, prefix="raes")
 
 
-def _infrastructure_spec(payload: Mapping[str, object]) -> Mapping[str, object]:
-    spec = payload.get("spec")
-    if not isinstance(spec, Mapping):
-        return {}
-    infrastructure = spec.get("infrastructure")
-    return infrastructure if isinstance(infrastructure, Mapping) else {}
-
-
-def _network_spec(resource: PlannedResource, payload: Mapping[str, object]) -> NetworkSpec:
-    infrastructure = _infrastructure_spec(payload)
+def _network_spec(resource: PlannedResource) -> NetworkSpec:
+    infrastructure = planned_infrastructure_spec(resource) or {}
     properties = infrastructure.get("properties")
     labels: dict[str, str] = {}
     if isinstance(properties, Mapping) and properties.get("internal") is True:
         labels["internal"] = "true"
     return NetworkSpec(
         address=resource.address,
-        name=_resource_name(resource, payload),
+        name=_resource_name(resource),
         labels=labels,
     )
 
@@ -147,7 +148,7 @@ def _container_spec(
     payload: Mapping[str, object],
     network_lookup: dict[str, str],
 ) -> tuple[ContainerSpec, tuple[Diagnostic, ...]]:
-    infrastructure = _infrastructure_spec(payload)
+    infrastructure = planned_infrastructure_spec(resource) or {}
     networks = infrastructure.get("networks")
     references: tuple[str, ...] = ()
     if isinstance(networks, (list, tuple)):
@@ -156,12 +157,12 @@ def _container_spec(
     # resource address; pass unresolved references through unchanged so the
     # contract stays total even when a node names a network not in this plan.
     network_addresses = tuple(network_lookup.get(ref, ref) for ref in references)
-    image_ref = _image_ref(payload)
-    services, diagnostics = _service_specs(resource, payload)
+    image_ref = _image_ref(resource, payload)
+    services, diagnostics = _service_specs(resource)
     return (
         ContainerSpec(
             address=resource.address,
-            name=_resource_name(resource, payload),
+            name=_resource_name(resource),
             image_ref=image_ref,
             networks=network_addresses,
             services=services,
@@ -204,10 +205,8 @@ def _order_containers(containers: list[ContainerSpec]) -> tuple[ContainerSpec, .
 
 def _service_specs(
     resource: PlannedResource,
-    payload: Mapping[str, object],
 ) -> tuple[tuple[ServiceSpec, ...], tuple[Diagnostic, ...]]:
-    spec = payload.get("spec")
-    node = spec.get("node") if isinstance(spec, Mapping) else None
+    node = planned_node_spec(resource)
     raw_services = node.get("services") if isinstance(node, Mapping) else None
     if raw_services is None:
         return (), ()
@@ -240,29 +239,18 @@ def _valid_service_port(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 65535
 
 
-def _image_ref(payload: Mapping[str, object]) -> str:
-    source = _node_source(payload)
-    if source:
-        return source
-    os_family = payload.get("os_family")
-    if isinstance(os_family, str) and os_family:
-        return f"raes-reference/{os_family}"
-    return "raes-reference/base"
-
-
-def _node_source(payload: Mapping[str, object]) -> str | None:
-    """Return the authored container image source for a node, if any."""
-
-    spec = payload.get("spec")
-    node = spec.get("node") if isinstance(spec, Mapping) else None
-    source = node.get("source") if isinstance(node, Mapping) else None
-    if isinstance(source, str) and source:
+def _image_ref(resource: PlannedResource, payload: Mapping[str, object]) -> str:
+    source = planned_node_source(resource)
+    if isinstance(source, str):
         return source
     if isinstance(source, Mapping):
         name = source.get("name")
         if isinstance(name, str) and name:
             return name
-    return None
+    os_family = payload.get("os_family")
+    if isinstance(os_family, str) and os_family:
+        return f"raes-reference/{os_family}"
+    return "raes-reference/base"
 
 
 def _placement(resource: PlannedResource, payload: Mapping[str, object]) -> PlacementRealization:
@@ -271,7 +259,7 @@ def _placement(resource: PlannedResource, payload: Mapping[str, object]) -> Plac
     return PlacementRealization(
         address=resource.address,
         resource_type=resource.resource_type,
-        name=_resource_name(resource, payload),
+        name=_resource_name(resource),
         target_address=target_address,
     )
 

--- a/implementations/python/tests/test_libvirt_backend_realization.py
+++ b/implementations/python/tests/test_libvirt_backend_realization.py
@@ -53,7 +53,11 @@ def _node_os(os_family: str) -> PlannedResource:
             "node_name": "web",
             "os_family": os_family,
             "spec": {
-                "node": {"type": "vm", "source": {"name": "/img/base.qcow2"}, "resources": {"ram": 512, "cpu": 1}},
+                "node": {
+                    "type": "vm",
+                    "source": {"name": "/img/base.qcow2"},
+                    "resources": {"ram": 2_147_483_648, "cpu": 4},
+                },
                 "infrastructure": {"networks": ["lan"]},
             },
         },
@@ -71,7 +75,12 @@ def _domain(realization, address: str = NODE_ADDRESS):
 def test_node_without_placements_gets_hostname_only_cloud_init():
     realization = interpret_provisioning_plan(_plan(_node()))
 
-    cloud_init = _domain(realization).cloud_init
+    domain = _domain(realization)
+    cloud_init = domain.cloud_init
+    assert domain.image_ref == "/img/base.qcow2"
+    assert domain.memory_mib == 2048
+    assert domain.vcpus == 4
+    assert domain.networks == ("lan",)
     assert cloud_init.hostname == "web"
     assert cloud_init.is_empty is False  # hostname is present
     assert cloud_init.users == ()

--- a/implementations/python/tests/test_planned_resource_accessors.py
+++ b/implementations/python/tests/test_planned_resource_accessors.py
@@ -1,0 +1,122 @@
+"""Public payload-accessor tests for planned resources."""
+
+from __future__ import annotations
+
+from raes_contracts.planning import (
+    PlannedResource,
+    RuntimeDomain,
+    planned_infrastructure_spec,
+    planned_node_resources,
+    planned_node_source,
+    planned_node_spec,
+    planned_resource_authored_name,
+    planned_resource_name,
+    planned_resource_payload,
+)
+
+
+def test_node_accessors_preserve_authored_mapping_shapes() -> None:
+    source = {"name": "images/base.qcow2", "build": {"format": "qcow2"}}
+    resources = {"ram": 1_073_741_824, "cpu": 2}
+    infrastructure = {"networks": ["lan"], "properties": {"zone": "test"}}
+    node = {"source": source, "resources": resources}
+    payload = {
+        "name": "web",
+        "spec": {"node": node, "infrastructure": infrastructure},
+    }
+    resource = PlannedResource(
+        address="provision.node.web",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload=payload,
+    )
+
+    assert planned_resource_payload(resource) is payload
+    assert planned_node_spec(resource) is node
+    assert planned_node_source(resource) is source
+    assert planned_node_resources(resource) is resources
+    assert planned_infrastructure_spec(resource) is infrastructure
+    assert planned_resource_authored_name(resource) == "web"
+    assert planned_resource_name(resource) == "web"
+
+
+def test_node_source_preserves_string_shape() -> None:
+    resource = PlannedResource(
+        address="provision.node.web",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload={"spec": {"node": {"source": "registry.example/web:1"}}},
+    )
+
+    assert planned_node_source(resource) == "registry.example/web:1"
+
+
+def test_missing_optional_node_fields_are_absent_and_name_falls_back_to_address() -> None:
+    resource = PlannedResource(
+        address="provision.node.web",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload={},
+    )
+
+    assert planned_node_spec(resource) is None
+    assert planned_node_source(resource) is None
+    assert planned_node_resources(resource) is None
+    assert planned_infrastructure_spec(resource) is None
+    assert planned_resource_authored_name(resource) is None
+    assert planned_resource_name(resource) == resource.address
+
+
+def test_non_mapping_payload_is_safely_absent() -> None:
+    resource = PlannedResource(
+        address="provision.node.web",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload="not-a-mapping",  # type: ignore[arg-type]
+    )
+
+    assert planned_resource_payload(resource) is None
+    assert planned_node_spec(resource) is None
+    assert planned_node_source(resource) is None
+    assert planned_node_resources(resource) is None
+    assert planned_infrastructure_spec(resource) is None
+    assert planned_resource_authored_name(resource) is None
+    assert planned_resource_name(resource) == resource.address
+
+
+def test_node_accessors_reject_unsupported_provisioning_resource_type() -> None:
+    resource = PlannedResource(
+        address="provision.feature-binding.monitoring",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="feature-binding",
+        payload={
+            "spec": {
+                "node": {"source": "should-not-be-read", "resources": {"cpu": 8}},
+                "infrastructure": {"networks": ["should-not-be-read"]},
+            }
+        },
+    )
+
+    assert planned_node_spec(resource) is None
+    assert planned_node_source(resource) is None
+    assert planned_node_resources(resource) is None
+    assert planned_infrastructure_spec(resource) is None
+
+
+def test_provisioning_accessors_reject_wrong_runtime_domain() -> None:
+    resource = PlannedResource(
+        address="orchestration.script.setup",
+        domain=RuntimeDomain.ORCHESTRATION,
+        resource_type="script",
+        payload={
+            "spec": {
+                "node": {"source": "should-not-be-read", "resources": {"cpu": 8}},
+                "infrastructure": {"networks": ["should-not-be-read"]},
+            }
+        },
+    )
+
+    assert planned_node_spec(resource) is None
+    assert planned_node_source(resource) is None
+    assert planned_node_resources(resource) is None
+    assert planned_infrastructure_spec(resource) is None

--- a/implementations/python/tests/test_reference_backend_realization.py
+++ b/implementations/python/tests/test_reference_backend_realization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from raes_backend_protocols.naming import provider_resource_name
 from raes_contracts.planning import (
     ChangeAction,
     PlannedResource,
@@ -73,6 +74,27 @@ def test_interpret_maps_nodes_to_container_specs():
     assert isinstance(realization, Realization)
     assert [spec.address for spec in realization.containers] == ["provision.node.web"]
     assert realization.containers[0].name == "web"
+    assert not realization.diagnostics
+
+
+def test_interpret_uses_node_source_and_preserves_provider_name_fallback() -> None:
+    resource = PlannedResource(
+        address="provision.node.web",
+        domain=RuntimeDomain.PROVISIONING,
+        resource_type="node",
+        payload={
+            "os_family": "linux",
+            "spec": {
+                "node": {"source": {"name": "registry.example/web:1"}},
+                "infrastructure": {},
+            },
+        },
+    )
+
+    realization = interpret_provisioning_plan(_plan(resource))
+
+    assert realization.containers[0].image_ref == "registry.example/web:1"
+    assert realization.containers[0].name == provider_resource_name(resource.address, prefix="raes")
     assert not realization.diagnostics
 
 


### PR DESCRIPTION
## Summary

Add a supported, total Python accessor surface for commonly consumed PlannedResource payload data and migrate the in-repository realization backends to use it without changing normative contracts or backend ownership.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #713

## ADR Impact

- ADR-009
- ADR-021
- ADR-036
- ADR-063

## Changes

- Export named accessors for planned payloads, authored names, node source/resources/spec, and infrastructure with consistent absent-value behavior.
- Migrate reference and libvirt plan realization to the shared accessors while preserving backend diagnostics, conversion rules, and provider-safe naming.
- Document the ownership boundary and add focused accessor plus backend compatibility tests.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Final synchronized tree: 5,936 unit tests passed (1 skipped), 56 integration tests passed (2 skipped), contracts/static/docs/proof lanes passed, and combined coverage was 92%.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #713 ← implementations/python/packages/raes_contracts/planning.py, Issue #713 ← implementations/python/packages/raes_reference_backend/realization.py, Issue #713 ← implementations/python/packages/raes_backend_libvirt/realization.py
- TESTS: Issue #713 ← implementations/python/tests/test_planned_resource_accessors.py, Issue #713 ← implementations/python/tests/test_reference_backend_realization.py, Issue #713 ← implementations/python/tests/test_libvirt_backend_realization.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.