### PR TITLE
ci: analyze tools/ in sonarcloud and wire its coverage

### DIFF
--- a/implementations/python/pyproject.toml
+++ b/implementations/python/pyproject.toml
@@ -135,6 +135,12 @@ source = [
     "raes_processor",
     "raes_runtime",
     "raes",
+    # Repo CI tooling (issue #54): the `tools/` tree lives at the repo root and
+    # is imported as the top-level `tools` package via pytest's `pythonpath`
+    # (`../..`). Coverage matches source packages by module name, so its
+    # `tools.*` modules are measured even though pytest runs from
+    # `implementations/python/`.
+    "tools",
 ]
 
 [tool.coverage.report]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,16 +13,28 @@ sonar.qualitygate.wait=true
 sonar.qualitygate.timeout=600
 
 # Source and test directories
-sonar.sources=implementations/python/packages
+#
+# `tools/` (issue #54) is real production code — the ADR-015 policy gates,
+# contract-schema generator/checker, requirement-governance enforcer, and the
+# rest of the repo's CI tooling — exercised by `implementations/python/tests`.
+# It is analyzed alongside the packages so SonarCloud sees it.
+sonar.sources=implementations/python/packages,tools
 sonar.tests=implementations/python/tests
 
 # Exclusions
+#
+# `tools/real-daemon/evidence/**` holds generated hardware-certification run
+# records (timestamped JSON captured by the smoke scripts), not hand-written
+# source — keep it out of analysis now that `tools/` is a source root (issue
+# #54). The policy config (YAML/JSON/Rego) under `tools/policy/` is
+# hand-authored governance data and stays analyzed.
 sonar.exclusions=\
   **/__pycache__/**,\
   **/.venv/**,\
   **/build/**,\
   **/dist/**,\
-  **/*.egg-info/**
+  **/*.egg-info/**,\
+  tools/real-daemon/evidence/**
 
 # Copy/paste (CPD) exclusions (RUN-314).
 #
@@ -43,7 +55,11 @@ sonar.cpd.exclusions=\
   implementations/python/packages/raes_reference_backend/participant_runtime.py
 
 # Python
-sonar.python.version=3.12
+#
+# Match the project's declared support: `requires-python = ">=3.11"` and Ruff
+# `target-version = "py311"`. Telling SonarCloud the code targets 3.11–3.12
+# (not 3.12 only) keeps its rules aligned with the lint contract (issue #54).
+sonar.python.version=3.11, 3.12
 
 # Rule/profile alignment
 #

--- a/tools/policy/historical_identity_records.json
+++ b/tools/policy/historical_identity_records.json
@@ -24,7 +24,7 @@
       "binding_class": "external-service-project-key",
       "rationale": "Retains the existing service-owned SonarCloud project designation without treating it as current RAES product identity.",
       "occurrences": 2,
-      "content_sha256": "df85536b996b633de8f1400941ce9a8b47e72c22bfe1cb5736e520a02d0fe361"
+      "content_sha256": "bcb2fa9327da30146ede9dba4f6294e0ed94c9e86287a8b278d7be2508c806f0"
     }
   ],
   "records": [


### PR DESCRIPTION
## Summary

Completes the SonarCloud setup (issue #54): adds the repo-root `tools/` tree to `sonar.sources` so its CI tooling (ADR-015 policy gates, contract-schema generator/checker, requirement-governance enforcer, and the rest) gets static analysis, and adds `tools` to the coverage run source so `coverage.xml` reports its line data. Coverage matches source packages by module name, so the `tools.*` modules imported by the tooling tests are measured even though pytest runs from `implementations/python/`; the resulting absolute `tools/...` paths resolve on CI the same way the existing package paths already do. Also excludes the generated `tools/real-daemon/evidence/**` records from analysis, aligns `sonar.python.version` with the declared 3.11+ support (requires-python + Ruff target-version), and re-pins the `sonar-project.properties` identity-cutover digest. Full hermetic suite passes with total coverage at 91% (floor is 50%); the new-code coverage gate that blocks PRs is unaffected.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #54

## ADR Impact

- No ADR required

## Changes

- sonar-project.properties: add `tools` to `sonar.sources`; exclude the generated `tools/real-daemon/evidence/**` certification records; set `sonar.python.version=3.11, 3.12` to match the project's declared 3.11+ support.
- implementations/python/pyproject.toml: add `tools` to `[tool.coverage.run].source` so `coverage.xml` carries `tools/...` line data.
- tools/policy/historical_identity_records.json: re-pin the `sonar-project.properties` content digest for the identity-cutover operational-binding check (mechanical consequence of editing that file).
- Decision — coverage dip: with `tools/` measured, the full-suite total is 91% locally (floor 50%), so the overall figure is accepted as-is with no pre-work tests required; the new-code coverage condition that actually gates PRs is unaffected.
- Decision — branch protection: recommend making the CI `sonar` job a required status check on `main`/`dev` (repo-admin setting; it already reports skipped-as-pass for forked/Dependabot runs). Requires admin action outside this PR.
- Decision — SonarCloud PR check: keep the CI `sonar` job as the PR-visible quality-gate signal; installing the SonarCloud GitHub App is optional (org-admin) and not required for gating. Recorded as the accepted posture.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Full hermetic `pytest` suite (6030 passed, 1 skipped) under coverage with `tools/` in scope; `coverage report --fail-under=50 --format=total` → 91%. `nox -s policy -- --skip-requirement` green (requirement governance skipped for the UID-less branch, identity-cutover passes after the digest re-pin). Verified locally that the generated `coverage.xml` carries `tools/...` file entries. SonarCloud attachment of `tools/` coverage and the gate result are verified post-scan on this PR (Step Q11).

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Not updated (authorized): CI/quality-gate configuration; no documentation surface describes sonar.sources / coverage internals. The edited config files carry inline rationale comments.