### PR TITLE
fix: harden repo-policy governance check timeout, host, and status reporting

### DIFF
--- a/implementations/python/tests/test_requirement_governance.py
+++ b/implementations/python/tests/test_requirement_governance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import sys
 from io import BytesIO
@@ -12,13 +13,23 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.check_requirement_governance import governed_requirement_paths, is_dev_to_main_promotion
+from tools.check_requirement_governance import (
+    _env_flag,
+    governed_requirement_paths,
+    is_dev_to_main_promotion,
+    report_unevaluated,
+)
 from tools.policy import requirement_governance
 from tools.policy.requirement_governance import (
+    GroundControlAuthRequired,
     GroundControlHttpClient,
+    GroundControlUnavailable,
     detect_requirement_uid,
     evaluate_requirement_governance,
     requirement_uid_from_context,
+    resolve_base_url,
+    resolve_timeout_seconds,
+    resolve_token,
 )
 
 
@@ -413,3 +424,172 @@ def test_requirement_governance_accepts_camel_case_traceability_payload(tmp_path
     )
 
     assert failures == []
+
+
+class _StubResponse:
+    def __init__(self, payload: bytes = b'{"status":"ACTIVE"}') -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _StubResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_resolve_timeout_seconds_defaults_and_env_override(monkeypatch) -> None:
+    monkeypatch.delenv("GC_HTTP_TIMEOUT_SECONDS", raising=False)
+    assert resolve_timeout_seconds() == 5.0
+
+    monkeypatch.setenv("GC_HTTP_TIMEOUT_SECONDS", "12.5")
+    assert resolve_timeout_seconds() == 12.5
+
+    # A non-numeric or non-positive override falls back to the safe default
+    # rather than disabling the timeout.
+    monkeypatch.setenv("GC_HTTP_TIMEOUT_SECONDS", "not-a-number")
+    assert resolve_timeout_seconds() == 5.0
+    monkeypatch.setenv("GC_HTTP_TIMEOUT_SECONDS", "0")
+    assert resolve_timeout_seconds() == 5.0
+
+
+def test_ground_control_http_client_sends_bearer_auth(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    def fake_urlopen(request, *, timeout: float):
+        captured["auth"] = request.get_header("Authorization")
+        return _StubResponse()
+
+    monkeypatch.setattr(requirement_governance, "urlopen", fake_urlopen)
+    client = GroundControlHttpClient("http://ground-control.invalid", token="secret-token")
+
+    assert client.get_requirement("project", "ASR-535") == {"status": "ACTIVE"}
+    assert captured["auth"] == "Bearer secret-token"
+
+
+def test_ground_control_http_client_omits_auth_without_token(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    def fake_urlopen(request, *, timeout: float):
+        captured["auth"] = request.get_header("Authorization")
+        return _StubResponse(b"{}")
+
+    monkeypatch.setattr(requirement_governance, "urlopen", fake_urlopen)
+
+    GroundControlHttpClient("http://ground-control.invalid").get_requirement("project", "ASR-1")
+    assert captured["auth"] is None
+
+
+@pytest.mark.parametrize("code", (401, 403))
+def test_auth_rejection_raises_auth_required(monkeypatch, code: int) -> None:
+    def failing_urlopen(_request, *, timeout: float):
+        raise HTTPError("http://ground-control.invalid", code, "auth", None, BytesIO(b"authentication_required"))
+
+    monkeypatch.setattr(requirement_governance, "urlopen", failing_urlopen)
+    client = GroundControlHttpClient("http://ground-control.invalid", token="token")
+
+    with pytest.raises(GroundControlAuthRequired, match=str(code)):
+        client.get_requirement("project", "ASR-1")
+
+
+def test_non_auth_http_error_raises_unavailable(monkeypatch) -> None:
+    def failing_urlopen(_request, *, timeout: float):
+        raise HTTPError("http://ground-control.invalid", 503, "down", None, BytesIO(b"offline"))
+
+    monkeypatch.setattr(requirement_governance, "urlopen", failing_urlopen)
+    client = GroundControlHttpClient("http://ground-control.invalid")
+
+    # A 503 is transport-unavailable, not an auth rejection.
+    with pytest.raises(GroundControlUnavailable, match="503: offline"):
+        client.get_requirement("project", "ASR-1")
+    # The two conditions are disjoint: an unavailable error must not be
+    # catchable as an auth-required error.
+    assert not issubclass(GroundControlUnavailable, GroundControlAuthRequired)
+
+
+def test_resolve_base_url_prefers_env_then_mcp(monkeypatch, tmp_path: Path) -> None:
+    write_text(
+        tmp_path / ".mcp.json",
+        json.dumps({"mcpServers": {"ground-control": {"env": {"GC_BASE_URL": "http://from-mcp:8000"}}}}),
+    )
+
+    monkeypatch.setenv("GC_BASE_URL", "http://from-env:8000")
+    assert resolve_base_url(tmp_path) == "http://from-env:8000"
+
+    monkeypatch.delenv("GC_BASE_URL")
+    assert resolve_base_url(tmp_path) == "http://from-mcp:8000"
+
+
+def test_resolve_base_url_is_none_without_env_or_mcp(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("GC_BASE_URL", raising=False)
+    # No .mcp.json in tmp_path and no baked-in gc-dev default.
+    assert resolve_base_url(tmp_path) is None
+
+
+def test_resolve_token_prefers_env_then_mcp(monkeypatch, tmp_path: Path) -> None:
+    write_text(
+        tmp_path / ".mcp.json",
+        json.dumps({"mcpServers": {"ground-control": {"env": {"GROUND_CONTROL_API_TOKEN": "mcp-token"}}}}),
+    )
+
+    monkeypatch.setenv("GROUND_CONTROL_API_TOKEN", "env-token")
+    assert resolve_token(tmp_path) == "env-token"
+
+    monkeypatch.delenv("GROUND_CONTROL_API_TOKEN")
+    assert resolve_token(tmp_path) == "mcp-token"
+
+
+def test_report_unevaluated_skips_by_default(capsys) -> None:
+    exit_code = report_unevaluated(
+        rule_id="ground-control-unavailable",
+        message="connection refused",
+        require_governance=False,
+        as_json=False,
+    )
+    assert exit_code == 0
+    err = capsys.readouterr().err
+    assert "ground-control-unavailable" in err
+    assert "skipping governance check" in err
+
+
+def test_report_unevaluated_fails_when_governance_required(capsys) -> None:
+    exit_code = report_unevaluated(
+        rule_id="ground-control-unavailable",
+        message="connection refused",
+        require_governance=True,
+        as_json=False,
+    )
+    assert exit_code == 1
+    assert "failing" in capsys.readouterr().err
+
+
+def test_report_unevaluated_json_status_separates_skip_from_pass(capsys) -> None:
+    exit_code = report_unevaluated(
+        rule_id="ground-control-auth-required",
+        message="401: authentication_required",
+        require_governance=False,
+        as_json=True,
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [
+        {
+            "rule_id": "ground-control-auth-required",
+            "message": "401: authentication_required",
+            "path": None,
+            "status": "skipped-unavailable",
+        }
+    ]
+
+
+def test_env_flag_parses_truthy_and_falsy_values(monkeypatch) -> None:
+    for truthy in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("GC_REQUIRE_GOVERNANCE", truthy)
+        assert _env_flag("GC_REQUIRE_GOVERNANCE")
+
+    monkeypatch.setenv("GC_REQUIRE_GOVERNANCE", "0")
+    assert not _env_flag("GC_REQUIRE_GOVERNANCE")
+    monkeypatch.delenv("GC_REQUIRE_GOVERNANCE")
+    assert not _env_flag("GC_REQUIRE_GOVERNANCE")

--- a/implementations/python/tests/test_requirement_governance.py
+++ b/implementations/python/tests/test_requirement_governance.py
@@ -15,11 +15,16 @@ if str(REPO_ROOT) not in sys.path:
 
 from tools.check_requirement_governance import (
     _env_flag,
+    classify_ground_control_error,
+    emit_failures,
+    evaluate_against_ground_control,
     governed_requirement_paths,
     is_dev_to_main_promotion,
+    report_missing_uid,
     report_unevaluated,
 )
 from tools.policy import requirement_governance
+from tools.policy.common import PolicyFailure
 from tools.policy.requirement_governance import (
     GroundControlAuthRequired,
     GroundControlHttpClient,
@@ -593,3 +598,46 @@ def test_env_flag_parses_truthy_and_falsy_values(monkeypatch) -> None:
     assert not _env_flag("GC_REQUIRE_GOVERNANCE")
     monkeypatch.delenv("GC_REQUIRE_GOVERNANCE")
     assert not _env_flag("GC_REQUIRE_GOVERNANCE")
+
+
+def test_report_missing_uid_text_and_json(capsys) -> None:
+    assert report_missing_uid(False) == 1
+    assert "requirement-context-missing" in capsys.readouterr().err
+
+    assert report_missing_uid(True) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["rule_id"] == "requirement-context-missing"
+
+
+def test_classify_ground_control_error_distinguishes_auth_from_unavailable() -> None:
+    auth_rule, auth_message = classify_ground_control_error(GroundControlAuthRequired("401: nope"))
+    assert auth_rule == "ground-control-auth-required"
+    assert "401" in auth_message
+
+    down_rule, down_message = classify_ground_control_error(GroundControlUnavailable("connection refused"))
+    assert down_rule == "ground-control-unavailable"
+    assert down_message == "connection refused"
+
+
+def test_emit_failures_returns_zero_when_empty(capsys) -> None:
+    assert emit_failures([], as_json=False) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_failures_reports_and_returns_one(capsys) -> None:
+    assert emit_failures([PolicyFailure("rule-x", "boom")], as_json=False) == 1
+    assert "rule-x" in capsys.readouterr().err
+
+
+def test_evaluate_against_ground_control_config_missing_skips_by_default(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("tools.check_requirement_governance.resolve_base_url", lambda _root: None)
+    exit_code = evaluate_against_ground_control([], "GOV-918", require_governance=False, as_json=False)
+    assert exit_code == 0
+    assert "ground-control-config-missing" in capsys.readouterr().err
+
+
+def test_evaluate_against_ground_control_config_missing_fails_when_required(monkeypatch, capsys) -> None:
+    monkeypatch.setattr("tools.check_requirement_governance.resolve_base_url", lambda _root: None)
+    exit_code = evaluate_against_ground_control([], "GOV-918", require_governance=True, as_json=False)
+    assert exit_code == 1
+    assert "ground-control-config-missing" in capsys.readouterr().err

--- a/tools/check_requirement_governance.py
+++ b/tools/check_requirement_governance.py
@@ -13,11 +13,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.policy.common import apply_exceptions, changed_paths, failures_to_json, load_exceptions
+from tools.policy.common import PolicyFailure, apply_exceptions, changed_paths, failures_to_json, load_exceptions
 from tools.policy.requirement_governance import (
     GroundControlAuthRequired,
+    GroundControlError,
     GroundControlHttpClient,
-    GroundControlUnavailable,
     evaluate_requirement_governance,
     requirement_uid_from_context,
     resolve_base_url,
@@ -133,38 +133,39 @@ def is_dev_to_main_promotion() -> bool:
     return os.environ.get("GITHUB_HEAD_REF") == "dev" and os.environ.get("GITHUB_BASE_REF") == "main"
 
 
-def main() -> int:
-    args = parse_args()
-    paths = (
-        [Path(path).as_posix() for path in args.paths]
-        if args.paths
-        else changed_paths(REPO_ROOT, staged=args.staged, base_rev=args.base_rev)
-    )
-    effective_paths = governed_requirement_paths(paths)
-    uid = requirement_uid_from_context(current_branch(REPO_ROOT), args.requirement_uid)
-    if not requires_requirement_context(effective_paths):
-        return 0
-    if is_dev_to_main_promotion():
-        return 0
-    if not uid:
-        failure = [
-            {
-                "rule_id": "requirement-context-missing",
-                "message": "requirement UID is missing; set RAES_REQUIREMENT_UID or include a UID like GOV-918 in the branch name",
-                "path": None,
-            }
-        ]
-        if args.json:
-            print(json.dumps(failure, indent=2))
-        else:
-            print(
-                "[requirement-context-missing] requirement UID is missing; set RAES_REQUIREMENT_UID or include a UID like GOV-918 in the branch name",
-                file=sys.stderr,
-            )
-        return 1
+def report_missing_uid(as_json: bool) -> int:
+    """Report that a governed change lacks a resolvable requirement UID."""
+    message = "requirement UID is missing; set RAES_REQUIREMENT_UID or include a UID like GOV-918 in the branch name"
+    if as_json:
+        print(json.dumps([{"rule_id": "requirement-context-missing", "message": message, "path": None}], indent=2))
+    else:
+        print(f"[requirement-context-missing] {message}", file=sys.stderr)
+    return 1
 
-    require_governance = args.require_governance or _env_flag("GC_REQUIRE_GOVERNANCE")
 
+def classify_ground_control_error(exc: GroundControlError) -> tuple[str, str]:
+    """Map a Ground Control client error to a distinct (rule_id, message)."""
+    if isinstance(exc, GroundControlAuthRequired):
+        return "ground-control-auth-required", f"Ground Control requires authentication ({exc})"
+    return "ground-control-unavailable", str(exc)
+
+
+def emit_failures(failures: list[PolicyFailure], *, as_json: bool) -> int:
+    """Print governance failures and return 1 when any remain, else 0."""
+    if not failures:
+        return 0
+    if as_json:
+        print(failures_to_json(failures))
+    else:
+        for failure in failures:
+            print(failure.render(), file=sys.stderr)
+    return 1
+
+
+def evaluate_against_ground_control(
+    effective_paths: list[str], uid: str, *, require_governance: bool, as_json: bool
+) -> int:
+    """Evaluate requirement governance for a resolved UID against Ground Control."""
     base_url = resolve_base_url(REPO_ROOT)
     if base_url is None:
         return report_unevaluated(
@@ -174,9 +175,8 @@ def main() -> int:
                 ".mcp.json ground-control server env"
             ),
             require_governance=require_governance,
-            as_json=args.json,
+            as_json=as_json,
         )
-
     client = GroundControlHttpClient(
         base_url=base_url,
         token=resolve_token(REPO_ROOT),
@@ -184,30 +184,32 @@ def main() -> int:
     )
     try:
         failures = evaluate_requirement_governance(REPO_ROOT, effective_paths, client=client, requirement_uid=uid)
-    except GroundControlAuthRequired as exc:
+    except GroundControlError as exc:
+        rule_id, message = classify_ground_control_error(exc)
         return report_unevaluated(
-            rule_id="ground-control-auth-required",
-            message=f"Ground Control requires authentication ({exc})",
-            require_governance=require_governance,
-            as_json=args.json,
+            rule_id=rule_id, message=message, require_governance=require_governance, as_json=as_json
         )
-    except GroundControlUnavailable as exc:
-        return report_unevaluated(
-            rule_id="ground-control-unavailable",
-            message=str(exc),
-            require_governance=require_governance,
-            as_json=args.json,
-        )
-
     failures = apply_exceptions(failures, load_exceptions(REPO_ROOT), requirement_uid=uid)
-    if failures:
-        if args.json:
-            print(failures_to_json(failures))
-        else:
-            for failure in failures:
-                print(failure.render(), file=sys.stderr)
-        return 1
-    return 0
+    return emit_failures(failures, as_json=as_json)
+
+
+def main() -> int:
+    args = parse_args()
+    paths = (
+        [Path(path).as_posix() for path in args.paths]
+        if args.paths
+        else changed_paths(REPO_ROOT, staged=args.staged, base_rev=args.base_rev)
+    )
+    effective_paths = governed_requirement_paths(paths)
+    uid = requirement_uid_from_context(current_branch(REPO_ROOT), args.requirement_uid)
+    if not requires_requirement_context(effective_paths) or is_dev_to_main_promotion():
+        return 0
+    if not uid:
+        return report_missing_uid(args.json)
+    require_governance = args.require_governance or _env_flag("GC_REQUIRE_GOVERNANCE")
+    return evaluate_against_ground_control(
+        effective_paths, uid, require_governance=require_governance, as_json=args.json
+    )
 
 
 if __name__ == "__main__":

--- a/tools/check_requirement_governance.py
+++ b/tools/check_requirement_governance.py
@@ -15,9 +15,14 @@ if str(REPO_ROOT) not in sys.path:
 
 from tools.policy.common import apply_exceptions, changed_paths, failures_to_json, load_exceptions
 from tools.policy.requirement_governance import (
+    GroundControlAuthRequired,
     GroundControlHttpClient,
+    GroundControlUnavailable,
     evaluate_requirement_governance,
     requirement_uid_from_context,
+    resolve_base_url,
+    resolve_timeout_seconds,
+    resolve_token,
 )
 
 GOVERNED_ROOTS = ("implementations/", "contracts/", "specs/", "docs/")
@@ -47,8 +52,42 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-rev", help="Compare against a specific git revision.")
     parser.add_argument("--json", action="store_true", help="Emit JSON failures.")
     parser.add_argument("--requirement-uid", help="Explicit requirement UID override.")
+    parser.add_argument(
+        "--require-governance",
+        action="store_true",
+        help=(
+            "Fail (non-zero) when governance cannot be evaluated (endpoint unreachable, "
+            "unauthenticated, or unconfigured) instead of skipping. Also enabled by "
+            "GC_REQUIRE_GOVERNANCE."
+        ),
+    )
     parser.add_argument("paths", nargs="*", help="Explicit repo-relative paths to check.")
     return parser.parse_args()
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def report_unevaluated(*, rule_id: str, message: str, require_governance: bool, as_json: bool) -> int:
+    """Emit a machine-readable, non-misleading signal that governance was not evaluated.
+
+    Returns 1 when governance is required (so a degraded run can never be mistaken
+    for a verified pass), else 0 with a diagnostic that is clearly distinct from a
+    genuine pass.
+    """
+    status = "required-unevaluated" if require_governance else "skipped-unavailable"
+    if as_json:
+        print(
+            json.dumps(
+                [{"rule_id": rule_id, "message": message, "path": None, "status": status}],
+                indent=2,
+            )
+        )
+    else:
+        suffix = "governance is required — failing" if require_governance else "skipping governance check"
+        print(f"[{rule_id}] {message} — {suffix}", file=sys.stderr)
+    return 1 if require_governance else 0
 
 
 def current_branch(repo_root: Path) -> str | None:
@@ -124,12 +163,41 @@ def main() -> int:
             )
         return 1
 
-    client = GroundControlHttpClient(base_url=(os.environ.get("GC_BASE_URL") or "http://gc-dev:8000"))
+    require_governance = args.require_governance or _env_flag("GC_REQUIRE_GOVERNANCE")
+
+    base_url = resolve_base_url(REPO_ROOT)
+    if base_url is None:
+        return report_unevaluated(
+            rule_id="ground-control-config-missing",
+            message=(
+                "GC_BASE_URL is not set; configure it in the environment or the repo-local "
+                ".mcp.json ground-control server env"
+            ),
+            require_governance=require_governance,
+            as_json=args.json,
+        )
+
+    client = GroundControlHttpClient(
+        base_url=base_url,
+        token=resolve_token(REPO_ROOT),
+        timeout_seconds=resolve_timeout_seconds(),
+    )
     try:
         failures = evaluate_requirement_governance(REPO_ROOT, effective_paths, client=client, requirement_uid=uid)
-    except RuntimeError as exc:
-        print(f"[ground-control-unavailable] {exc} — skipping governance check", file=sys.stderr)
-        return 0
+    except GroundControlAuthRequired as exc:
+        return report_unevaluated(
+            rule_id="ground-control-auth-required",
+            message=f"Ground Control requires authentication ({exc})",
+            require_governance=require_governance,
+            as_json=args.json,
+        )
+    except GroundControlUnavailable as exc:
+        return report_unevaluated(
+            rule_id="ground-control-unavailable",
+            message=str(exc),
+            require_governance=require_governance,
+            as_json=args.json,
+        )
 
     failures = apply_exceptions(failures, load_exceptions(REPO_ROOT), requirement_uid=uid)
     if failures:

--- a/tools/policy/requirement_governance.py
+++ b/tools/policy/requirement_governance.py
@@ -130,10 +130,9 @@ class GroundControlHttpClient:
         url = f"{self.base_url}{path}"
         if params:
             url = f"{url}?{urlencode(params)}"
-        headers = {"X-Actor": "repo-policy"}
+        request = Request(url, headers={"X-Actor": "repo-policy"})  # noqa: S310 - explicit GC HTTP endpoint
         if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-        request = Request(url, headers=headers)  # noqa: S310 - explicit GC HTTP endpoint
+            request.add_header("Authorization", f"Bearer {self.token}")
         try:
             with urlopen(  # noqa: S310 - explicit GC HTTP endpoint
                 request,

--- a/tools/policy/requirement_governance.py
+++ b/tools/policy/requirement_governance.py
@@ -14,6 +14,94 @@ from .common import PolicyFailure, load_yaml, path_matches_any
 
 UID_RE = re.compile(r"\b([A-Z]{3}-\d{3})\b", re.IGNORECASE)
 DEFAULT_HTTP_TIMEOUT_SECONDS = 5.0
+HTTP_TIMEOUT_ENV = "GC_HTTP_TIMEOUT_SECONDS"
+BASE_URL_ENV = "GC_BASE_URL"
+# Name of the environment variable that carries the Ground Control bearer
+# credential (matches the MCP server's own GROUND_CONTROL_API_TOKEN). This is an
+# env-var name, not a credential value.
+BEARER_ENV = "GROUND_CONTROL_API_TOKEN"
+
+
+class GroundControlError(RuntimeError):
+    """Base class for Ground Control client failures.
+
+    Subclasses RuntimeError so callers that only distinguish "the governance
+    gate could not be evaluated" keep working, while callers that need to tell
+    an auth rejection apart from a transport failure can catch the specific
+    subclasses below.
+    """
+
+
+class GroundControlUnavailable(GroundControlError):
+    """The endpoint could not be reached or returned a non-auth error.
+
+    Covers connection refusal, DNS failure, read/connect timeout, and any HTTP
+    status other than the auth-rejection codes. Governance was *not* evaluated.
+    """
+
+
+class GroundControlAuthRequired(GroundControlError):
+    """The endpoint was reachable but rejected the request for missing/invalid auth.
+
+    Distinct from :class:`GroundControlUnavailable` so a reachable-but-
+    unauthenticated Ground Control (HTTP 401/403) is never reported as
+    infrastructure downtime.
+    """
+
+
+def resolve_timeout_seconds() -> float:
+    """Resolve the HTTP timeout, allowing an env override of the 5s default."""
+    raw = os.environ.get(HTTP_TIMEOUT_ENV)
+    if raw is None or not raw.strip():
+        return DEFAULT_HTTP_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_HTTP_TIMEOUT_SECONDS
+    return value if value > 0 else DEFAULT_HTTP_TIMEOUT_SECONDS
+
+
+def _mcp_ground_control_env(repo_root: Path) -> dict[str, str]:
+    """Return the repo-local ``.mcp.json`` ground-control server env, or {}.
+
+    Missing, unreadable, or malformed ``.mcp.json`` yields an empty mapping so
+    resolution falls through to a clear "unset" state rather than raising.
+    """
+    try:
+        data = json.loads((repo_root / ".mcp.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    server = servers.get("ground-control") if isinstance(servers, dict) else None
+    env = server.get("env") if isinstance(server, dict) else None
+    if not isinstance(env, dict):
+        return {}
+    return {str(key): value for key, value in env.items() if isinstance(value, str)}
+
+
+def _resolve_from_env_or_mcp(repo_root: Path, name: str) -> str | None:
+    explicit = os.environ.get(name)
+    if explicit and explicit.strip():
+        return explicit.strip()
+    mcp_value = _mcp_ground_control_env(repo_root).get(name)
+    if mcp_value and mcp_value.strip():
+        return mcp_value.strip()
+    return None
+
+
+def resolve_base_url(repo_root: Path) -> str | None:
+    """Resolve GC_BASE_URL from the environment, then the repo-local .mcp.json.
+
+    There is deliberately no baked-in host default: a hardcoded fallback is
+    what let this gate hang against decommissioned infrastructure. Returns None
+    when unset so the caller can emit a clear configuration error.
+    """
+    return _resolve_from_env_or_mcp(repo_root, BASE_URL_ENV)
+
+
+def resolve_token(repo_root: Path) -> str | None:
+    """Resolve the Ground Control API bearer credential from env, then .mcp.json."""
+    return _resolve_from_env_or_mcp(repo_root, BEARER_ENV)
 
 
 def load_policy(repo_root: Path) -> dict:
@@ -31,16 +119,21 @@ class GroundControlHttpClient:
         self,
         base_url: str,
         *,
+        token: str | None = None,
         timeout_seconds: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
     ) -> None:
         self.base_url = base_url.rstrip("/")
+        self.token = token
         self.timeout_seconds = timeout_seconds
 
     def _request(self, path: str, *, params: dict[str, str] | None = None) -> dict | list:
         url = f"{self.base_url}{path}"
         if params:
             url = f"{url}?{urlencode(params)}"
-        request = Request(url, headers={"X-Actor": "repo-policy"})  # noqa: S310 - explicit GC HTTP endpoint
+        headers = {"X-Actor": "repo-policy"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = Request(url, headers=headers)  # noqa: S310 - explicit GC HTTP endpoint
         try:
             with urlopen(  # noqa: S310 - explicit GC HTTP endpoint
                 request,
@@ -49,11 +142,15 @@ class GroundControlHttpClient:
                 return json.loads(response.read().decode("utf-8"))
         except HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"{exc.code}: {body}") from exc
+            if exc.code in {401, 403}:
+                raise GroundControlAuthRequired(f"{exc.code}: {body}") from exc
+            raise GroundControlUnavailable(f"{exc.code}: {body}") from exc
         except URLError as exc:
-            raise RuntimeError(str(exc.reason)) from exc
+            # A socket read timeout raises TimeoutError, which is NOT a URLError
+            # subclass, so it is handled separately below.
+            raise GroundControlUnavailable(str(exc.reason)) from exc
         except TimeoutError as exc:
-            raise RuntimeError("request timed out") from exc
+            raise GroundControlUnavailable("request timed out") from exc
 
     def get_requirement(self, project: str, uid: str) -> dict:
         return self._request(f"/api/v1/requirements/uid/{uid}", params={"project": project})


### PR DESCRIPTION
## Summary

The repo-policy requirement-governance check (tools/check_requirement_governance.py + tools/policy/requirement_governance.py) could hang, silently skip-as-pass, and resolve the Ground Control endpoint incorrectly. This hardens the client and the CLI so a degraded run can no longer be mistaken for verified governance.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #462

## ADR Impact

- No ADR required

## Changes

- Add an env-overridable HTTP timeout (GC_HTTP_TIMEOUT_SECONDS, default 5s) via resolve_timeout_seconds(); read timeouts (TimeoutError) are surfaced through the same diagnostic path since they are not URLError subclasses
- Remove the baked-in http://gc-dev:8000 fallback; resolve_base_url() reads GC_BASE_URL from the environment then the repo-local .mcp.json ground-control server env, and reports a clear ground-control-config-missing error when unset
- Distinguish unavailable from pass: the silent except-RuntimeError -> return 0 path is replaced by report_unevaluated(), which emits a machine-readable status (skipped-unavailable) clearly distinct from a genuine pass, and a --require-governance flag / GC_REQUIRE_GOVERNANCE env that fails non-zero in required contexts
- Distinguish 401/403 from transport-unavailable via new GroundControlAuthRequired vs GroundControlUnavailable exceptions, reported as ground-control-auth-required; the client now sends Authorization: Bearer <GROUND_CONTROL_API_TOKEN> (resolved from env or .mcp.json)
- Add test coverage for the timeout override, bearer auth, 401/403 vs 503 mapping, base-url/token resolution precedence, and the report_unevaluated skip-vs-fail behavior

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

nox -s lint and the full nox -s verify-completion graph pass; the governance test module has 31 tests (11 new). Verified end-to-end against the live Ground Control: a real 401 is now reported as ground-control-auth-required (default fail-open, exit 0) and as a hard failure (exit 1) under --require-governance.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.