### PR TITLE
test: add property/differential coverage for FM2/FM3 result-contract domains

### DIFF
--- a/implementations/python/tests/test_experiment_core_properties.py
+++ b/implementations/python/tests/test_experiment_core_properties.py
@@ -1,0 +1,68 @@
+"""Property-based coverage for the experiment-core contract boundary (FM2).
+
+Delivers the ``property_based_or_differential_tests`` artifact kind for the
+``experiment-core`` formal-spec subsystem (``specs/formal/experiment-core``,
+FM2) recorded in ``specs/formal/assurance-fulfillment.yaml`` (issue #521). The
+existing ``test_runtime_contracts.py`` coverage of the EXP-701..705 contracts is
+example-based; this file adds property-based coverage of one of the
+cross-artifact semantic-graph constraints standard JSON Schema cannot portably
+enforce (README "Separation" invariant 6): every ``metric_definitions`` object
+key MUST equal its embedded ``metric_id``.
+
+The property is exercised as a metamorphic mutation of a *published valid
+fixture*: across the space of alternative identifiers, breaking the key/id
+correspondence is always rejected, while a *consistent* rename of both the key
+and the embedded id is always accepted. The unmutated fixture is the positive
+anchor.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+from raes_contracts.contracts import ExperimentTaskModel
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VALID_TASK = json.loads(
+    (_REPO_ROOT / "contracts/fixtures/experiment-core/experiment-task-v1/valid/reference.json").read_text()
+)
+_METRIC_KEY = next(iter(_VALID_TASK["evaluation_protocol"]["metric_definitions"]))
+
+# Alternative identifiers that are guaranteed distinct from the fixture's metric
+# key (the ``metric-`` prefix cannot collide with ``foothold-achieved``) and are
+# valid NonEmptyString values, so the only invariant a mismatch can trip is the
+# key/metric_id correspondence itself.
+_ALT_SUFFIXES = st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=20)
+
+
+def test_reference_task_fixture_validates() -> None:
+    ExperimentTaskModel.model_validate(copy.deepcopy(_VALID_TASK))
+
+
+class TestMetricDefinitionKeyInvariant:
+    @given(_ALT_SUFFIXES)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    def test_embedded_metric_id_must_match_its_key(self, suffix: str) -> None:
+        alternate_id = f"metric-{suffix}"
+        payload = copy.deepcopy(_VALID_TASK)
+        payload["evaluation_protocol"]["metric_definitions"][_METRIC_KEY]["metric_id"] = alternate_id
+        with pytest.raises(ValidationError) as exc_info:
+            ExperimentTaskModel.model_validate(payload)
+        assert "metric_definitions keys must match embedded metric_id" in str(exc_info.value)
+
+    @given(_ALT_SUFFIXES)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    def test_consistent_key_and_id_rename_preserves_validity(self, suffix: str) -> None:
+        alternate_id = f"metric-{suffix}"
+        payload = copy.deepcopy(_VALID_TASK)
+        definitions = payload["evaluation_protocol"]["metric_definitions"]
+        definition = definitions.pop(_METRIC_KEY)
+        definition["metric_id"] = alternate_id
+        definitions[alternate_id] = definition
+        ExperimentTaskModel.model_validate(payload)

--- a/implementations/python/tests/test_runtime_result_envelope_properties.py
+++ b/implementations/python/tests/test_runtime_result_envelope_properties.py
@@ -1,0 +1,286 @@
+"""Property-based coverage for the portable runtime result/evaluator envelopes (FM2).
+
+Delivers the ``property_based_or_differential_tests`` artifact kind for the
+``runtime-contracts`` formal-spec subsystem (``specs/formal/runtime-contracts``,
+FM2) recorded in ``specs/formal/assurance-fulfillment.yaml`` (issue #521). Where
+``test_workflow_semantics_properties.py`` covers the workflow *rules*, this file
+covers the portable *typed envelopes* the runtime-contracts domain owns:
+
+* the typed workflow execution envelope and step execution state
+  (``raes_contracts.workflow``), and
+* the typed evaluator result envelope (``raes_contracts.evaluation``).
+
+For each envelope the properties are the same shape: any legally constructed
+value survives a ``to_payload`` -> ``from_payload`` round-trip unchanged
+(structure-preservation), while targeted illegal states are rejected at
+construction, and the evaluator contract validator flags exactly the
+capability mismatches its rules describe. The round-trip and rejection
+guarantees hold across the generated space, not for a single fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from raes_contracts.evaluation import (
+    EvaluationExecutionState,
+    EvaluationResultContract,
+    EvaluationResultStatus,
+    validate_evaluation_result,
+)
+from raes_contracts.workflow import (
+    WorkflowCompensationStatus,
+    WorkflowExecutionState,
+    WorkflowStatus,
+    WorkflowStepExecutionState,
+    WorkflowStepLifecycle,
+    WorkflowStepOutcome,
+)
+
+_TIMESTAMP = "2020-01-01T00:00:00Z"
+_TERMINAL_STATUSES = (
+    WorkflowStatus.SUCCEEDED,
+    WorkflowStatus.FAILED,
+    WorkflowStatus.CANCELLED,
+    WorkflowStatus.TIMED_OUT,
+)
+_NON_TERMINAL_STATUSES = (WorkflowStatus.PENDING, WorkflowStatus.RUNNING)
+
+# --------------------------------------------------------------------------- #
+# Typed workflow step execution state                                         #
+# --------------------------------------------------------------------------- #
+
+
+@st.composite
+def _legal_workflow_step_state(draw):
+    lifecycle = draw(st.sampled_from(list(WorkflowStepLifecycle)))
+    if lifecycle == WorkflowStepLifecycle.PENDING:
+        return WorkflowStepExecutionState(lifecycle=lifecycle, outcome=None, attempts=0)
+    if lifecycle == WorkflowStepLifecycle.RUNNING:
+        return WorkflowStepExecutionState(
+            lifecycle=lifecycle,
+            outcome=None,
+            attempts=draw(st.integers(min_value=0, max_value=5)),
+        )
+    outcome = draw(st.sampled_from([None, *list(WorkflowStepOutcome)]))
+    return WorkflowStepExecutionState(
+        lifecycle=lifecycle,
+        outcome=outcome,
+        attempts=draw(st.integers(min_value=0, max_value=5)),
+    )
+
+
+class TestWorkflowStepEnvelope:
+    @given(_legal_workflow_step_state())
+    @settings(deadline=None)
+    def test_payload_round_trip_is_identity(self, state):
+        assert WorkflowStepExecutionState.from_payload(state.to_payload()) == state
+
+    def test_pending_step_with_attempts_is_rejected(self):
+        with pytest.raises(ValueError, match="pending workflow steps must report 0 attempts"):
+            WorkflowStepExecutionState(lifecycle=WorkflowStepLifecycle.PENDING, attempts=1)
+
+    def test_non_completed_step_with_outcome_is_rejected(self):
+        with pytest.raises(ValueError, match="non-completed workflow steps may not report an outcome"):
+            WorkflowStepExecutionState(
+                lifecycle=WorkflowStepLifecycle.RUNNING,
+                outcome=WorkflowStepOutcome.SUCCEEDED,
+                attempts=1,
+            )
+
+    def test_negative_attempts_are_rejected(self):
+        with pytest.raises(ValueError, match="attempts must be >= 0"):
+            WorkflowStepExecutionState(lifecycle=WorkflowStepLifecycle.RUNNING, attempts=-1)
+
+
+# --------------------------------------------------------------------------- #
+# Typed workflow execution envelope                                           #
+# --------------------------------------------------------------------------- #
+
+
+@st.composite
+def _legal_workflow_execution_state(draw):
+    status = draw(st.sampled_from(list(WorkflowStatus)))
+    steps = {
+        f"step-{index}": draw(_legal_workflow_step_state())
+        for index in range(draw(st.integers(min_value=0, max_value=3)))
+    }
+    if status in _NON_TERMINAL_STATUSES:
+        return WorkflowExecutionState(
+            workflow_status=status,
+            run_id="run-1",
+            started_at=_TIMESTAMP,
+            updated_at=_TIMESTAMP,
+            terminal_reason=None,
+            compensation_status=WorkflowCompensationStatus.NOT_REQUIRED,
+            steps=steps,
+        )
+    compensation_status = draw(st.sampled_from(list(WorkflowCompensationStatus)))
+    started_at: str | None = None
+    updated_at: str | None = None
+    failures: list[dict[str, str]] = []
+    if compensation_status != WorkflowCompensationStatus.NOT_REQUIRED:
+        started_at = _TIMESTAMP
+        updated_at = draw(st.sampled_from([None, _TIMESTAMP]))
+        failures = draw(st.sampled_from([[], [{"step": "step-0", "reason": "boom"}]]))
+    return WorkflowExecutionState(
+        workflow_status=status,
+        run_id="run-1",
+        started_at=_TIMESTAMP,
+        updated_at=_TIMESTAMP,
+        terminal_reason="terminal",
+        compensation_status=compensation_status,
+        compensation_started_at=started_at,
+        compensation_updated_at=updated_at,
+        compensation_failures=failures,
+        steps=steps,
+    )
+
+
+class TestWorkflowExecutionEnvelope:
+    @given(_legal_workflow_execution_state())
+    @settings(deadline=None)
+    def test_payload_round_trip_is_identity(self, state):
+        assert WorkflowExecutionState.from_payload(state.to_payload()) == state
+
+    def test_terminal_status_requires_terminal_reason(self):
+        with pytest.raises(ValueError, match="terminal workflow statuses must include terminal_reason"):
+            WorkflowExecutionState(
+                workflow_status=WorkflowStatus.SUCCEEDED,
+                run_id="run-1",
+                started_at=_TIMESTAMP,
+                updated_at=_TIMESTAMP,
+                terminal_reason=None,
+            )
+
+    def test_non_terminal_status_forbids_terminal_reason(self):
+        with pytest.raises(ValueError, match="non-terminal workflow statuses may not include terminal_reason"):
+            WorkflowExecutionState(
+                workflow_status=WorkflowStatus.RUNNING,
+                run_id="run-1",
+                started_at=_TIMESTAMP,
+                updated_at=_TIMESTAMP,
+                terminal_reason="early",
+            )
+
+    def test_non_terminal_status_forbids_compensation_activity(self):
+        with pytest.raises(ValueError, match="non-terminal workflow statuses may not report compensation activity"):
+            WorkflowExecutionState(
+                workflow_status=WorkflowStatus.RUNNING,
+                run_id="run-1",
+                started_at=_TIMESTAMP,
+                updated_at=_TIMESTAMP,
+                compensation_status=WorkflowCompensationStatus.RUNNING,
+                compensation_started_at=_TIMESTAMP,
+            )
+
+    def test_not_required_compensation_forbids_timestamps(self):
+        with pytest.raises(ValueError, match="compensation_status=not_required may not report compensation timestamps"):
+            WorkflowExecutionState(
+                workflow_status=WorkflowStatus.SUCCEEDED,
+                run_id="run-1",
+                started_at=_TIMESTAMP,
+                updated_at=_TIMESTAMP,
+                terminal_reason="terminal",
+                compensation_status=WorkflowCompensationStatus.NOT_REQUIRED,
+                compensation_started_at=_TIMESTAMP,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Typed evaluator result envelope                                             #
+# --------------------------------------------------------------------------- #
+
+_NON_RESULT_EVALUATION_STATUSES = (
+    EvaluationResultStatus.PENDING,
+    EvaluationResultStatus.RUNNING,
+    EvaluationResultStatus.FAILED,
+)
+
+
+@st.composite
+def _legal_evaluation_state(draw):
+    status = draw(st.sampled_from(list(EvaluationResultStatus)))
+    passed: bool | None = None
+    score: int | None = None
+    max_score: int | None = None
+    if status == EvaluationResultStatus.READY:
+        report = draw(st.sampled_from(("passed", "score", "both")))
+        if report in ("passed", "both"):
+            passed = draw(st.booleans())
+        if report in ("score", "both"):
+            max_score = draw(st.integers(min_value=0, max_value=100))
+            score = draw(st.integers(min_value=0, max_value=max_score))
+    return EvaluationExecutionState(
+        resource_type="goal",
+        run_id="run-1",
+        status=status,
+        observed_at=_TIMESTAMP,
+        updated_at=_TIMESTAMP,
+        passed=passed,
+        score=score,
+        max_score=max_score,
+    )
+
+
+class TestEvaluationResultEnvelope:
+    @given(_legal_evaluation_state())
+    @settings(deadline=None)
+    def test_payload_round_trip_is_identity(self, state):
+        assert EvaluationExecutionState.from_payload(state.to_payload()) == state
+
+    @given(_legal_evaluation_state())
+    @settings(deadline=None)
+    def test_capability_matched_contract_reports_no_violations(self, state):
+        # A contract whose declared capabilities match what the state reports
+        # must accept the state with zero violations across the generated space.
+        contract = EvaluationResultContract(
+            state_schema_version=state.state_schema_version,
+            resource_type=state.resource_type,
+            supports_passed=state.passed is not None,
+            supports_score=state.score is not None,
+            fixed_max_score=state.max_score if state.score is not None else None,
+        )
+        assert validate_evaluation_result(contract, state) == []
+
+    def test_reporting_passed_without_capability_is_flagged(self):
+        state = EvaluationExecutionState(
+            resource_type="goal",
+            run_id="run-1",
+            status=EvaluationResultStatus.READY,
+            observed_at=_TIMESTAMP,
+            updated_at=_TIMESTAMP,
+            passed=True,
+        )
+        contract = EvaluationResultContract(resource_type="goal", supports_passed=False)
+        assert any("may not report 'passed'" in violation for violation in validate_evaluation_result(contract, state))
+
+    def test_reporting_score_without_capability_is_flagged(self):
+        state = EvaluationExecutionState(
+            resource_type="goal",
+            run_id="run-1",
+            status=EvaluationResultStatus.READY,
+            observed_at=_TIMESTAMP,
+            updated_at=_TIMESTAMP,
+            score=3,
+            max_score=5,
+        )
+        contract = EvaluationResultContract(resource_type="goal", supports_score=False)
+        assert any(
+            "may not report score fields" in violation for violation in validate_evaluation_result(contract, state)
+        )
+
+    def test_resource_type_mismatch_is_flagged(self):
+        state = EvaluationExecutionState(
+            resource_type="goal",
+            run_id="run-1",
+            status=EvaluationResultStatus.PENDING,
+            observed_at=_TIMESTAMP,
+            updated_at=_TIMESTAMP,
+        )
+        contract = EvaluationResultContract(resource_type="metric")
+        assert any(
+            "does not match compiled contract" in violation
+            for violation in validate_evaluation_result(contract, state)
+        )

--- a/implementations/python/tests/test_runtime_result_envelope_properties.py
+++ b/implementations/python/tests/test_runtime_result_envelope_properties.py
@@ -281,6 +281,5 @@ class TestEvaluationResultEnvelope:
         )
         contract = EvaluationResultContract(resource_type="metric")
         assert any(
-            "does not match compiled contract" in violation
-            for violation in validate_evaluation_result(contract, state)
+            "does not match compiled contract" in violation for violation in validate_evaluation_result(contract, state)
         )

--- a/implementations/python/tests/test_workflow_semantics_properties.py
+++ b/implementations/python/tests/test_workflow_semantics_properties.py
@@ -177,9 +177,7 @@ class TestStepResultContract:
         contract, lifecycle, outcome, attempts = payload
         assert validate_workflow_step_result(
             contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts
-        ) == validate_workflow_step_result_contract(
-            contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts
-        )
+        ) == validate_workflow_step_result_contract(contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts)
 
     @given(st.sampled_from(_NON_OBSERVABLE_STEP_TYPES), st.integers(max_value=-1))
     @settings(deadline=None)

--- a/implementations/python/tests/test_workflow_semantics_properties.py
+++ b/implementations/python/tests/test_workflow_semantics_properties.py
@@ -1,0 +1,217 @@
+"""Property-based and differential coverage for workflow control semantics (FM3).
+
+Delivers the ``property_based_or_differential_tests`` artifact kind for the
+``workflows`` formal-spec subsystem (``specs/formal/workflows``, FM3) recorded in
+``specs/formal/assurance-fulfillment.yaml`` (issue #521). It exercises the pure
+workflow state-machine / result-envelope rules in ``raes.semantics.workflow``
+that validation, compilation, and runtime all share:
+
+* ``branch_closure`` -- the join-ownership / branch-convergence graph semantics
+  (only the owning parallel's branch closure, up to but excluding the join),
+  checked *differentially* against an independent fix-point reachability oracle
+  plus the structural invariants the closure must satisfy for any graph.
+* ``validate_workflow_step_result`` -- the per-step lifecycle/outcome/attempt
+  contract, checked over a generated legal-state space (must accept) and
+  targeted illegal mutations (must reject), and cross-checked against the
+  compiled ``raes_contracts`` wrapper surface.
+
+These are FM2/FM3 semantic properties, not example fixtures: the assertions hold
+across the generated space rather than for a hand-picked case.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from raes.semantics.workflow import (
+    branch_closure,
+    validate_workflow_step_result,
+    workflow_step_semantic_contract,
+)
+from raes_contracts.workflow import validate_workflow_step_result_contract
+
+# --------------------------------------------------------------------------- #
+# branch_closure: workflow-graph state-machine semantics                      #
+# --------------------------------------------------------------------------- #
+
+_NODE_NAMES = tuple(f"s{index}" for index in range(6))
+
+
+@st.composite
+def _graph_with_join(draw):
+    """Draw an arbitrary directed step graph plus a join step and branch entries."""
+    nodes = draw(st.lists(st.sampled_from(_NODE_NAMES), min_size=1, max_size=6, unique=True))
+    graph: dict[str, tuple[str, ...]] = {}
+    for node in nodes:
+        successors = draw(st.lists(st.sampled_from(nodes), max_size=3, unique=True))
+        graph[node] = tuple(successors)
+    join_step = draw(st.sampled_from(nodes))
+    branches = draw(st.lists(st.sampled_from(nodes), min_size=1, max_size=len(nodes), unique=True))
+    return graph, tuple(branches), join_step
+
+
+def _reference_branch_closure(
+    graph: Mapping[str, tuple[str, ...]],
+    branches: tuple[str, ...],
+    join_step: str,
+) -> frozenset[str]:
+    """Independent fix-point reachability oracle for :func:`branch_closure`.
+
+    Deliberately formulated as a monotone fix-point rather than the production
+    DFS so agreement between the two is a genuine differential signal, not a
+    restatement of the same traversal.
+    """
+    reachable = {node for node in branches if node != join_step}
+    changed = True
+    while changed:
+        changed = False
+        for node in list(reachable):
+            for successor in graph.get(node, ()):
+                if successor != join_step and successor not in reachable:
+                    reachable.add(successor)
+                    changed = True
+    return frozenset(reachable)
+
+
+class TestBranchClosureSemantics:
+    @given(_graph_with_join())
+    @settings(deadline=None)
+    def test_matches_independent_reachability_oracle(self, payload):
+        graph, branches, join_step = payload
+        assert branch_closure(graph, branches=branches, join_step=join_step) == _reference_branch_closure(
+            graph, branches, join_step
+        )
+
+    @given(_graph_with_join())
+    @settings(deadline=None)
+    def test_join_is_never_in_the_closure(self, payload):
+        graph, branches, join_step = payload
+        assert join_step not in branch_closure(graph, branches=branches, join_step=join_step)
+
+    @given(_graph_with_join())
+    @settings(deadline=None)
+    def test_closure_is_closed_under_successors_except_join(self, payload):
+        # Branch convergence: every successor of a closure node either is the
+        # join (the single convergence point) or is itself inside the closure.
+        graph, branches, join_step = payload
+        closure = branch_closure(graph, branches=branches, join_step=join_step)
+        for node in closure:
+            for successor in graph.get(node, ()):
+                assert successor == join_step or successor in closure
+
+    @given(_graph_with_join(), st.lists(st.sampled_from(_NODE_NAMES), max_size=6, unique=True))
+    @settings(deadline=None)
+    def test_widening_branch_entries_grows_closure_monotonically(self, payload, extra):
+        graph, branches, join_step = payload
+        base = branch_closure(graph, branches=branches, join_step=join_step)
+        widened = branch_closure(graph, branches=tuple({*branches, *extra}), join_step=join_step)
+        assert base <= widened
+
+
+# --------------------------------------------------------------------------- #
+# validate_workflow_step_result: per-step result-envelope contract            #
+# --------------------------------------------------------------------------- #
+
+_OBSERVABLE_STEP_TYPES = ("objective", "retry", "parallel", "call")
+_NON_OBSERVABLE_STEP_TYPES = ("end", "decision", "join", "start", "scaffold")
+_ALL_STEP_TYPES = _OBSERVABLE_STEP_TYPES + _NON_OBSERVABLE_STEP_TYPES
+_LIFECYCLES = ("pending", "running", "completed")
+
+
+@st.composite
+def _legal_step_state(draw):
+    """Draw a (contract, lifecycle, outcome, attempts) tuple guaranteed legal."""
+    step_type = draw(st.sampled_from(_ALL_STEP_TYPES))
+    contract = workflow_step_semantic_contract(step_type)
+    lifecycle = draw(st.sampled_from(_LIFECYCLES))
+    outcome: str | None = None
+    if lifecycle == "pending":
+        attempts = 0
+    elif lifecycle == "running":
+        lower = 1 if contract.state_observable else 0
+        upper = contract.fixed_attempts if contract.fixed_attempts is not None else 5
+        attempts = draw(st.integers(min_value=lower, max_value=upper))
+    else:  # completed
+        if contract.state_observable:
+            outcome = draw(st.sampled_from(contract.observable_outcomes))
+        if contract.fixed_attempts is not None:
+            attempts = contract.fixed_attempts
+        else:
+            attempts = draw(st.integers(min_value=0, max_value=5))
+    return contract, lifecycle, outcome, attempts
+
+
+@st.composite
+def _arbitrary_step_state(draw):
+    """Draw an unconstrained step state -- most are illegal in some way."""
+    step_type = draw(st.sampled_from(_ALL_STEP_TYPES))
+    contract = workflow_step_semantic_contract(step_type)
+    lifecycle = draw(st.sampled_from((*_LIFECYCLES, "bogus")))
+    outcome = draw(st.sampled_from((None, "succeeded", "failed", "exhausted", "weird")))
+    attempts = draw(st.integers(min_value=-2, max_value=6))
+    return contract, lifecycle, outcome, attempts
+
+
+class TestStepResultContract:
+    @given(_legal_step_state())
+    @settings(deadline=None)
+    def test_legal_states_report_no_violations(self, payload):
+        contract, lifecycle, outcome, attempts = payload
+        assert validate_workflow_step_result(contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts) == ()
+
+    @given(_arbitrary_step_state())
+    @settings(deadline=None)
+    def test_validation_is_deterministic(self, payload):
+        contract, lifecycle, outcome, attempts = payload
+        first = validate_workflow_step_result(contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts)
+        second = validate_workflow_step_result(contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts)
+        assert first == second
+
+    @given(_arbitrary_step_state())
+    @settings(deadline=None)
+    def test_semantics_and_compiled_contract_wrapper_agree(self, payload):
+        # Differential: the raes.semantics rule and the raes_contracts compiled
+        # wrapper are two public surfaces that must stay in lock-step.
+        contract, lifecycle, outcome, attempts = payload
+        assert validate_workflow_step_result(
+            contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts
+        ) == validate_workflow_step_result_contract(
+            contract, lifecycle=lifecycle, outcome=outcome, attempts=attempts
+        )
+
+    @given(st.sampled_from(_NON_OBSERVABLE_STEP_TYPES), st.integers(max_value=-1))
+    @settings(deadline=None)
+    def test_negative_attempts_are_rejected(self, step_type, attempts):
+        contract = workflow_step_semantic_contract(step_type)
+        errors = validate_workflow_step_result(contract, lifecycle="completed", outcome=None, attempts=attempts)
+        assert any("attempts must be >= 0" in error for error in errors)
+
+    @given(st.sampled_from(_ALL_STEP_TYPES), st.integers(min_value=1, max_value=9))
+    @settings(deadline=None)
+    def test_pending_steps_must_report_zero_attempts(self, step_type, attempts):
+        contract = workflow_step_semantic_contract(step_type)
+        errors = validate_workflow_step_result(contract, lifecycle="pending", outcome=None, attempts=attempts)
+        assert any("pending steps must report 0 attempts" in error for error in errors)
+
+    @given(
+        st.sampled_from(("pending", "running")),
+        st.sampled_from(("succeeded", "failed", "exhausted")),
+    )
+    @settings(deadline=None)
+    def test_non_completed_steps_may_not_report_an_outcome(self, lifecycle, outcome):
+        contract = workflow_step_semantic_contract("retry")
+        errors = validate_workflow_step_result(contract, lifecycle=lifecycle, outcome=outcome, attempts=1)
+        assert any("non-completed steps may not report an outcome" in error for error in errors)
+
+    def test_invalid_outcome_for_step_type_is_rejected(self):
+        # 'exhausted' is legal for 'retry' but not for 'objective'.
+        contract = workflow_step_semantic_contract("objective")
+        errors = validate_workflow_step_result(contract, lifecycle="completed", outcome="exhausted", attempts=1)
+        assert any("is invalid for step type 'objective'" in error for error in errors)
+
+    def test_unknown_lifecycle_is_rejected(self):
+        contract = workflow_step_semantic_contract("objective")
+        errors = validate_workflow_step_result(contract, lifecycle="paused", outcome=None, attempts=0)
+        assert any("lifecycle 'paused' is invalid" in error for error in errors)

--- a/specs/formal/assurance-fulfillment.yaml
+++ b/specs/formal/assurance-fulfillment.yaml
@@ -136,14 +136,9 @@ entries:
         path: implementations/python/tests/test_runtime_models.py
       - kind: typed_ir_or_contract_coverage
         path: contracts/schemas/control-plane/workflow-result-envelope-v1.json
-    waived_artifacts:
       - kind: property_based_or_differential_tests
-        date: 2026-06-13
-        tracking:
-          - "#521"
-        rationale: >-
-          No property-based or differential test yet exercises the workflow
-          state-machine / result-envelope semantics; tracked for delivery.
+        path: implementations/python/tests/test_workflow_semantics_properties.py
+    waived_artifacts: []
 
   - subsystem: planner
     delivered_artifacts:
@@ -189,15 +184,9 @@ entries:
         path: implementations/python/tests/test_runtime_contracts.py
       - kind: typed_ir_or_contract_coverage
         path: contracts/schemas/experiment-core/experiment-task-v1.json
-    waived_artifacts:
       - kind: property_based_or_differential_tests
-        date: 2026-06-13
-        tracking:
-          - "#521"
-        rationale: >-
-          Contract validation in test_runtime_contracts.py is example-based; no
-          property-based or differential coverage of the EXP-701-705 contracts
-          yet; tracked for delivery.
+        path: implementations/python/tests/test_experiment_core_properties.py
+    waived_artifacts: []
 
   - subsystem: scenario-variation-trial-realization
     # Executable SCE-002 coverage: #786/#787 deliver family/selection authoring,
@@ -297,14 +286,9 @@ entries:
         path: implementations/python/tests/test_runtime_contracts.py
       - kind: typed_ir_or_contract_coverage
         path: contracts/schemas/control-plane/workflow-result-envelope-v1.json
-    waived_artifacts:
       - kind: property_based_or_differential_tests
-        date: 2026-06-13
-        tracking:
-          - "#521"
-        rationale: >-
-          Portable result/evaluator envelope validation is example-based; no
-          property-based or differential coverage yet; tracked for delivery.
+        path: implementations/python/tests/test_runtime_result_envelope_properties.py
+    waived_artifacts: []
 
   - subsystem: participant-runtime
     # Design coverage only (RUN-305-308): the README is the documented invariant


### PR DESCRIPTION
## Summary

Closes the three tracked `property_based_or_differential_tests` waivers in `specs/formal/assurance-fulfillment.yaml` (issue #521) by delivering genuine property-based and differential coverage for the FM2/FM3 formal result-contract domains, then flipping each subsystem's `waived_artifacts` entry to `delivered_artifacts`. `nox -s policy` (check_assurance_policy) confirms the gaps are closed.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #521

## ADR Impact

- No ADR required

## Changes

- workflows (FM3): new test_workflow_semantics_properties.py exercises raes.semantics.workflow — branch_closure graph semantics differentially against an independent fix-point reachability oracle plus join-ownership/branch-convergence invariants, and validate_workflow_step_result over a generated legal-state space (accepts) and targeted illegal mutations (rejects), cross-checked against the compiled raes_contracts wrapper
- runtime-contracts (FM2): new test_runtime_result_envelope_properties.py exercises the portable typed envelopes — to_payload/from_payload round-trip and invariant enforcement for WorkflowExecutionState/WorkflowStepExecutionState and EvaluationExecutionState, plus evaluator-contract capability-mismatch checks via validate_evaluation_result
- experiment-core (FM2): new test_experiment_core_properties.py exercises the metric-definition-key == embedded metric_id semantic-graph invariant as a metamorphic mutation of the published valid experiment-task-v1 fixture
- flipped the workflows, experiment-core, and runtime-contracts waived_artifacts entries to delivered_artifacts in specs/formal/assurance-fulfillment.yaml, pointing each at its new test file

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

All 29 new property tests pass (.venv pytest). Full `nox -s policy -- --skip-requirement` passes (governance skipped as CI does for this UID-less requirement-free branch); full test collection is clean (no import/collection errors); test_assurance_policy.py + the 3 new files: 134 passed. check_assurance_policy.py passes with no remaining #521 waivers.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: implementations/python/tests/test_workflow_semantics_properties.py, implementations/python/tests/test_runtime_result_envelope_properties.py, implementations/python/tests/test_experiment_core_properties.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed