### PR TITLE
fix(processor): fail loudly on z3 unknown in the satisfiability solver

### DIFF
--- a/implementations/python/packages/raes_processor/satisfiability/_solver.py
+++ b/implementations/python/packages/raes_processor/satisfiability/_solver.py
@@ -22,19 +22,32 @@ class SolverResult:
 def solve_model(model: NormalizedConstraintModel) -> SolverResult:
     """Solve one normalized model and select deterministic portable evidence."""
 
+    _require_unique_clause_ids(model)
     all_clause_ids = tuple(clause.clause_id for clause in model.clauses)
-    status = _check(model, all_clause_ids, {})
-    if status == z3.sat:
+    # ``_check`` fails loudly on ``z3.unknown``, so a non-satisfiable decision
+    # here is decisively unsatisfiable rather than an incomplete timeout.
+    if _check(model, all_clause_ids, {}) == z3.sat:
         return SolverResult(
             outcome=SatisfiabilityOutcome.SATISFIABLE,
             assignment=_select_witness(model, all_clause_ids),
         )
-    if status == z3.unsat:
-        return SolverResult(
-            outcome=SatisfiabilityOutcome.UNSATISFIABLE,
-            core=_reduce_unsat_core(model, all_clause_ids),
-        )
-    raise SolverOperationalError("solver returned an incomplete result")
+    return SolverResult(
+        outcome=SatisfiabilityOutcome.UNSATISFIABLE,
+        core=_reduce_unsat_core(model, all_clause_ids),
+    )
+
+
+def _require_unique_clause_ids(model: NormalizedConstraintModel) -> None:
+    """Reject collapsed clause identity before it can corrupt tracked evidence.
+
+    ``_check`` tracks each clause by a name derived from its id; duplicate ids
+    collapse in the lookup table while z3 rejects the repeated assumption, so the
+    invariant is enforced explicitly at the solver boundary rather than silently.
+    """
+
+    clause_ids = [clause.clause_id for clause in model.clauses]
+    if len(set(clause_ids)) != len(clause_ids):
+        raise SolverOperationalError("normalized model contains duplicate clause ids")
 
 
 def _select_witness(
@@ -93,11 +106,20 @@ def _check(
             for index, value in enumerate(symbol.domain)
             if any(_scalar_equal(value, allowed) for allowed in clause.allowed_values)
         ]
-        expression = z3.Or(*(variables[symbol.symbol_id] == index for index in indexes))
+        # An empty allowed set is an unsatisfiable membership; assert false
+        # explicitly instead of depending on a zero-argument ``z3.Or``.
+        expression = (
+            z3.Or(*(variables[symbol.symbol_id] == index for index in indexes)) if indexes else z3.BoolVal(False)
+        )
         solver.assert_and_track(expression, z3.Bool(_z3_name(clause_id)))
     for symbol_id, index in fixed.items():
         solver.add(variables[symbol_id] == index)
-    return solver.check()
+    result = solver.check()
+    if result == z3.unknown:
+        # A per-call timeout returns unknown; treating it as a decisive answer
+        # would silently break unsat-core minimality or witness canonicality.
+        raise SolverOperationalError(f"solver returned unknown: {solver.reason_unknown()}")
+    return result
 
 
 def _scalar_equal(left: object, right: object) -> bool:

--- a/implementations/python/tests/test_scenario_satisfiability.py
+++ b/implementations/python/tests/test_scenario_satisfiability.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+import z3
 from pydantic import ValidationError
 from raes_contracts.satisfiability import (
     SatisfiabilityOutcome,
@@ -14,9 +15,11 @@ from raes_contracts.satisfiability import (
 )
 from raes_processor.satisfiability import (
     SatisfiabilityEvidenceError,
+    SatisfiabilityOperationalError,
     analyze_scenario_file,
     replay_satisfiability_evidence,
 )
+from raes_processor.satisfiability._solver import SolverOperationalError, solve_model
 
 _SATISFIABLE = """\
 name: satisfiable-control
@@ -61,6 +64,21 @@ nodes:
     resources:
       ram: 1 gib
       cpu: ${cpu_count}
+"""
+
+_EMPTY_TARGET_DOMAIN = """\
+name: empty-target-domain
+variables:
+  copies:
+    type: integer
+    allowed_values: [0]
+    required: true
+nodes:
+  target:
+    type: vm
+infrastructure:
+  target:
+    count: ${copies}
 """
 
 
@@ -313,3 +331,69 @@ def test_published_valid_and_invalid_fixtures_enforce_outcome_joins() -> None:
         ScenarioSatisfiabilityEvidenceModel.model_validate_json(invalid_payload)
 
     assert "outcome must select exactly one matching payload" in str(exc_info.value)
+
+
+def _force_unknown_on_call(monkeypatch: pytest.MonkeyPatch, target_call: int) -> None:
+    """Make the ``target_call``-th z3 check report ``unknown`` (a timeout proxy)."""
+
+    original = z3.Solver.check
+    state = {"calls": 0}
+
+    def patched(self: z3.Solver, *assumptions: object) -> z3.CheckSatResult:
+        state["calls"] += 1
+        if state["calls"] == target_call:
+            return z3.unknown
+        return original(self, *assumptions)
+
+    monkeypatch.setattr(z3.Solver, "check", patched)
+
+
+def test_unknown_during_core_reduction_fails_loudly_without_forging_minimality(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write(tmp_path, "unsatisfiable.sdl.yaml", _UNSATISFIABLE)
+    # Call one is the decisive UNSAT check; call two is the first deletion probe,
+    # where an undetected timeout would silently retain a droppable clause and
+    # publish a core claiming subset-minimality it never established.
+    _force_unknown_on_call(monkeypatch, target_call=2)
+
+    with pytest.raises(SatisfiabilityOperationalError):
+        analyze_scenario_file(source)
+
+
+def test_unknown_during_witness_selection_fails_loudly_without_forging_canonicality(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _write(tmp_path, "satisfiable.sdl.yaml", _SATISFIABLE)
+    # Call one decides SAT; call two probes the canonical first domain value,
+    # where an undetected timeout would skip it and forge a non-lexicographic
+    # witness while still claiming canonical-lexicographic selection.
+    _force_unknown_on_call(monkeypatch, target_call=2)
+
+    with pytest.raises(SatisfiabilityOperationalError):
+        analyze_scenario_file(source)
+
+
+def test_duplicate_clause_ids_rejected_at_solver_boundary(tmp_path: Path) -> None:
+    source = _write(tmp_path, "satisfiable.sdl.yaml", _SATISFIABLE)
+    model = analyze_scenario_file(source).normalized_model
+    # ``model_copy`` bypasses contract validation to inject a collapsed clause
+    # id; the solver must reject it rather than track the assumption twice.
+    duplicated = model.model_copy(update={"clauses": model.clauses + (model.clauses[0],)})
+
+    with pytest.raises(SolverOperationalError, match="duplicate clause ids"):
+        solve_model(duplicated)
+
+
+def test_empty_target_domain_is_unsatisfiable(tmp_path: Path) -> None:
+    source = _write(tmp_path, "empty-target-domain.sdl.yaml", _EMPTY_TARGET_DOMAIN)
+
+    evidence = analyze_scenario_file(source)
+
+    assert evidence.outcome is SatisfiabilityOutcome.UNSATISFIABLE
+    assert evidence.unsat_core is not None
+    # The count target admits only values >= 1, so a {0} domain produces an empty
+    # membership clause that must resolve to false, not a bare zero-argument Or.
+    assert any(clause.allowed_values == () for clause in evidence.normalized_model.clauses)


### PR DESCRIPTION
## Related issues

Closes #1114

Related to #826 and #1108.

---

## What breaks

The satisfiability analyzer could publish a result that **claims more than it actually established**, and the overclaim only surfaced later as an unexplained replay failure.

Each solver call has a 5-second timeout, so z3 can answer "I don't know" (`unknown`) rather than yes or no. The code treated that non-answer as a definite answer.

## Concretely

Analyzing a scenario emits a `ScenarioSatisfiabilityEvidence` record. That record is labelled with the profile it was produced under:

- `core_reduction: "sorted-deletion-subset-minimal/v1"` — asserts the unsatisfiable core is subset-minimal
- `witness_selection: "canonical-lexicographic/v1"` — asserts the witness is the canonical first choice

Under load, a single probe times out. Because `unknown` is not `unsat`, the core-reduction loop keeps a clause it would otherwise have removed; because `unknown` is not `sat`, the witness loop skips a value it would otherwise have chosen. The emitted record is structurally valid and still carries both labels — but neither property was checked. Nobody sees an error.

The failure shows up much later, somewhere else: `replay_satisfiability_evidence` re-derives the result, gets the correct core or witness, compares digests, and disagrees. The published evidence looks corrupt for no visible reason.

For a project whose premise is that a specification plus its evidence is the reproducible unit of exchange, silently emitting evidence that overstates what was proven is the worst available outcome.

## Why it happens

In `raes_processor/satisfiability/_solver.py`, `_check` returns z3's raw result, and both callers compare against one outcome only:

- `_reduce_unsat_core` keeps any clause whose removal is `!= z3.unsat`
- `_select_witness` skips any value that is `!= z3.sat`

`unknown` falls into the same branch as a decisive answer in both.

## The fix

`_check` now raises `SolverOperationalError` on `unknown`, carrying z3's own `reason_unknown()`. This is the single seam every caller shares, so no path can forge minimality or canonicality. The service boundary already converts that into the typed `SatisfiabilityOperationalError("the pinned solver did not complete")`, so no new error style is introduced — a timeout becomes a diagnosable operational failure instead of quiet bad evidence.

Two smaller issues in the same file:
- A clause whose allowed values do not intersect its symbol domain produced a zero-argument `z3.Or()`. In the pinned z3 that happens to assert as unsatisfiable, but it is undocumented edge behaviour; the empty case is now stated explicitly as `BoolVal(False)`.
- Duplicate clause ids were silently collapsed by an id-to-clause dict while z3 rejected the repeated tracked assumption with an opaque `Z3Exception`. They are now refused at the model boundary with a clear message.

The governed `z3-solver==4.16.0.0` pin is untouched, and nothing under `contracts/schemas/` or `specs/` changes.

## How I know

4 new tests. A helper forces the Nth solver call to return `unknown` and leaves the rest real:

- timeout during core reduction → operational error, and **no** evidence claiming minimality is emitted
- timeout during witness selection → operational error
- duplicate clause ids → refused at the boundary (previously leaked a raw `Z3Exception`)
- empty allowed-value set → unsatisfiable, locking the semantics the explicit guard now states

The first three fail against the current code. The fourth passes before and after by design — it pins existing behaviour rather than demonstrating the bug, and is called out as such.

Full `nox -s verify` green on Ubuntu 22.04 / Python 3.12, all six lanes, 91% total coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
