### PR TITLE
test(mcp): drive MCP tool calls through asyncio.run

### DIFF
--- a/implementations/python/tests/test_mcp_server.py
+++ b/implementations/python/tests/test_mcp_server.py
@@ -31,7 +31,7 @@ def _text(result) -> str:
 
 def _call(server, tool: str, args: dict | None = None) -> str:
     """Synchronously call a tool and return its text."""
-    return asyncio.get_event_loop().run_until_complete(_async_call(server, tool, args or {}))
+    return asyncio.run(_async_call(server, tool, args or {}))
 
 
 async def _async_call(server, tool: str, args: dict) -> str:
@@ -897,7 +897,7 @@ class TestServerConstruction:
         # Using the real registration surface (rather than a hand-copied
         # literal) means a drift between what the server exposes and what
         # raes_tool_surface advertises cannot pass silently.
-        registered = asyncio.get_event_loop().run_until_complete(server.list_tools())
+        registered = asyncio.run(server.list_tools())
         registered_names = {tool.name for tool in registered}
         assert registered_names, "server registered no tools"
 


### PR DESCRIPTION
## Plain-language summary

- **Context:** The MCP tests need to run asynchronous tool calls on every supported Python version.
- **Problem:** They relied on an implicitly created event loop, behavior removed in Python 3.14, so otherwise valid MCP tests failed before exercising the server.
- **Fix:** Run each asynchronous test call through `asyncio.run()`, which creates and closes the loop explicitly.

## Related issues

Closes #1117

Required by the broader interpreter qualification in #1097.

---

## What breaks

`tests/test_mcp_server.py` fails entirely — all 85 tests — on Python 3.14. It passes today only because CI pins 3.12, where the same call is merely deprecated.

## Concretely

The module drives its async MCP calls from synchronous test code like this:

```python
return asyncio.get_event_loop().run_until_complete(_async_call(server, tool, args or {}))
```

Calling `asyncio.get_event_loop()` with no running loop has emitted a DeprecationWarning since 3.12. In 3.14 it raises:

```
RuntimeError: There is no current event loop in thread 'MainThread'
```

So the file is one interpreter bump away from taking out the whole MCP test module, and it currently adds a DeprecationWarning to every run of the suite.

I hit this for real: running the full gate on a Linux host where `uv` selected 3.14 rather than the pinned 3.12, ~20 of these failed before I noticed the interpreter mismatch.

## The fix

`asyncio.run(...)`, which is the supported way to drive a coroutine from sync code. Two call sites. Tests only — no package code changes.

## How I know

I reproduced 3.14's behaviour on 3.12 by promoting the warning to an error, since it is the same call that hard-fails there:

```shell
pytest tests/test_mcp_server.py -W error::DeprecationWarning
```

- before: `DeprecationWarning: There is no current event loop` errors the module
- after: 85 passed

Full hermetic suite green. The suite's warning count drops by one, because this was the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)