### PR TITLE
fix(processor): enforce evaluator capability admission (#1036)

### DIFF
--- a/docs/decisions/issue-1036-evaluator-capability-admission-remediation.md
+++ b/docs/decisions/issue-1036-evaluator-capability-admission-remediation.md
@@ -1,0 +1,104 @@
+# Issue 1036 Evaluator Capability Admission Remediation
+
+Date: 2026-08-11
+
+Issue: #1036. Requirement: API-413.
+
+This note records the narrow remediation for evaluator capability admission. It
+does not add predicate families, evidence-channel kinds, truth outcomes, or an
+SDL time-domain field.
+
+## Gap Claim
+
+Planner admission checked only evaluation sections and objective support. A
+backend could therefore declare a narrow proposition evaluator and still admit
+compiled propositions outside its predicate, quantifier, evidence-channel, or
+time-domain surface. Runtime refusal remained conformant, but the plan falsely
+suggested that the target could realize the scoring chain.
+
+## Existing Surface Audit
+
+- `EvaluatorCapabilities` already requires proposition evaluators to declare
+  predicate families, quantifiers, all portable truth outcomes, evidence
+  channels, time domains, and binding-provenance preservation.
+- The compiler already emitted predicate kind, evaluation basis, and evidence
+  requirement ids, but not quantifier or resolved channel kind.
+- Authored `EvidenceRequirement.channel_refs` are opaque references, not
+  evidence-channel kinds. Treating their identifiers as kinds would create a
+  second, unsound resolution rule.
+- An observed decided `PropositionTruthResultModel` requires governed temporal
+  context. The current v1 evaluator manifests declare `scenario_time`; SDL does
+  not yet carry a per-proposition evaluator time-domain requirement.
+- The capability constructor already closes truth outcomes and provenance, so
+  duplicating those invariant checks in the planner would add no scenario-
+  dependent admission information.
+
+## Lineage And Precedent
+
+ADR-079 and
+`specs/formal/objectives/proposition-and-assertion-semantics.md` require
+unsupported evaluator semantics to be reported rather than weakened. The
+provisioner and orchestrator planner gates already compare compiled, typed
+requirements with manifest capability sets. This remediation follows that
+boundary: compiler projection owns scenario requirements; planner admission
+owns target comparison.
+
+## Literature And Practice
+
+The repository's issue-725 review grounds proposition evaluation in runtime
+verification and W3C PROV: a monitor may decide only the predicate and evidence
+semantics it actually implements, and provenance does not substitute for that
+capability. Capability negotiation must therefore compare requested semantics
+before execution rather than infer support from a coarse subsystem flag.
+
+## Alternatives Considered
+
+1. **Do nothing and rely on runtime `unsupported`.** Rejected because the
+   planner would continue approving a known mismatch.
+2. **Parse generic `PropositionRuntime.spec` dictionaries in the planner.**
+   Rejected because it duplicates compiler interpretation and leaves channel
+   references unresolved.
+3. **Treat `channel_refs` as channel kinds.** Rejected because reference
+   identity and modality are different contracts.
+4. **Add a new SDL proposition time-domain field now.** Rejected as an
+   unrequested language/schema change requiring a new governed profile.
+5. **Compile a small typed capability projection and compare it in the
+   planner.** Chosen because it reuses incumbent models and keeps the gate
+   deterministic and backend-neutral.
+
+## Chosen Architecture
+
+`PropositionRuntime` carries the proposition quantifier, distinct evidence
+channel kinds, unresolved evidence requirement ids, and the required evaluator
+time domain. Compilation obtains channel kinds only from explicit
+`EvidenceRequirement.channel` values. A cited requirement without an explicit
+kind fails closed at planner admission.
+
+For the existing v1 observed-truth contract, compilation projects
+`scenario_time`; declared-state propositions carry no temporal requirement.
+This binds the incumbent reference/stub manifest declaration without inventing
+wall-clock semantics. A future authored per-proposition domain requires a
+separate SDL/profile decision and will replace this v1 projection explicitly.
+
+Fine-grained diagnostics run only when the evaluator admits the proposition
+section; an unsupported section remains the controlling failure and is not
+expanded into misleading per-field failures.
+
+## Documentation Defense
+
+The normative proposition specification now names the exact admission
+comparison and the v1 temporal projection. API-413 traces the compiler,
+planner, decision, and tests. No published wire schema changes because the new
+fields are processor-internal compiled metadata.
+
+## Verification Plan
+
+- Compile an observed numeric/`any`/`log` proposition and prove that a
+  Boolean/`all`/`api_response`/non-scenario-time evaluator receives four stable
+  diagnostics.
+- Prove the compiler projection retains the exact quantifier, channel, and
+  time domain used by admission.
+- Prove an opaque channel reference fails closed even when every other
+  evaluator capability matches.
+- Run the complete planner tests, policy checks, lint, and repository
+  completion verification.

--- a/docs/requirements/API-413/requirement.md
+++ b/docs/requirements/API-413/requirement.md
@@ -6,7 +6,7 @@ type: INTERFACE
 priority: MUST
 wave: 2
 created_at: 2026-04-05T00:54:58.521004Z
-updated_at: 2026-04-12T03:13:42.645239Z
+updated_at: 2026-08-11T00:00:00Z
 ---
 
 # API-413 — Realization Support And Disclosure Declarations
@@ -17,7 +17,7 @@ Processor and backend manifest surfaces shall declare the concern domains in whi
 
 ## Rationale
 
-Current state: implemented. Processor and backend v2 manifest surfaces publish realization_support declarations over the shared authority stack. Backend manifests are now v2-only, and backend conformance fails when declared contract support does not cover the contracts required by the inferred runtime capability profile.
+Current state: implemented. Processor and backend v2 manifest surfaces publish realization_support declarations over the shared authority stack. Backend manifests are now v2-only, and backend conformance fails when declared contract support does not cover the contracts required by the inferred runtime capability profile. Evaluator proposition declarations are binding at planner admission: compiled predicate, quantifier, evidence-channel, and v1 time-domain requirements must fit the target manifest.
 
 ## Traceability
 
@@ -30,3 +30,8 @@ Current state: implemented. Processor and backend v2 manifest surfaces publish r
 - TESTS → TEST `implementations/python/tests/test_processor_manifest.py` (Processor Manifest Realization Support Tests)
 - TESTS → TEST `implementations/python/tests/test_runtime_contracts.py` (Shared Manifest Schema Tests)
 - TESTS → TEST `implementations/python/tests/test_runtime_conformance.py` (Backend Conformance Runtime Tests)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_processor/compiler/evaluation.py` (Typed evaluator capability requirement projection)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_processor/planner/manifest_validation.py` (Fail-closed evaluator proposition admission)
+- IMPLEMENTS → DOCUMENTATION `docs/decisions/issue-1036-evaluator-capability-admission-remediation.md` (Issue 1036 remediation decision)
+- IMPLEMENTS → GITHUB_ISSUE `1036` (Fine-grained evaluator capability admission)
+- TESTS → TEST `implementations/python/tests/test_runtime_planner.py` (Evaluator capability admission regression tests)

--- a/implementations/python/packages/raes_processor/compiler/evaluation.py
+++ b/implementations/python/packages/raes_processor/compiler/evaluation.py
@@ -15,14 +15,40 @@ from .alias_index import _runtime_addressable_ref_index, _runtime_addresses_for_
 from .ref_resolution import _evaluation_contracts
 from .support import _dedupe, _dump
 
+_OBSERVED_PROPOSITION_TIME_DOMAIN = "scenario_time"
+
+
+def _evidence_capability_projection(
+    scenario: InstantiatedScenario,
+    evidence_requirement_refs: list[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Project channel kinds without treating opaque channel refs as kinds."""
+
+    channels: set[str] = set()
+    unresolved: list[str] = []
+    for ref in evidence_requirement_refs:
+        requirement = scenario.evidence_requirements[ref]
+        channel = requirement.channel
+        if channel is None:
+            unresolved.append(ref)
+            continue
+        channels.add(str(getattr(channel, "value", channel)))
+    return tuple(sorted(channels)), tuple(unresolved)
+
 
 def _compile_propositions(
     scenario: InstantiatedScenario,
 ) -> dict[str, PropositionRuntime]:
     address_index = _runtime_addressable_ref_index(scenario)
-    return {
-        _proposition_address(name): PropositionRuntime(
-            address=_proposition_address(name),
+    propositions: dict[str, PropositionRuntime] = {}
+    for name, proposition in scenario.propositions.items():
+        channels, unresolved_channels = _evidence_capability_projection(
+            scenario,
+            proposition.evidence_requirements,
+        )
+        address = _proposition_address(name)
+        propositions[address] = PropositionRuntime(
+            address=address,
             name=name,
             spec=_dump(proposition),
             subject_addresses=_runtime_addresses_for_refs(
@@ -30,11 +56,16 @@ def _compile_propositions(
                 addressable_ref_index=address_index,
             ),
             predicate_kind=proposition.predicate.kind,
+            quantifier=proposition.quantifier.value,
             evaluation_basis=proposition.basis.value,
             evidence_requirement_refs=tuple(proposition.evidence_requirements),
+            evidence_channels=channels,
+            unresolved_evidence_channel_refs=unresolved_channels,
+            required_time_domain=(
+                _OBSERVED_PROPOSITION_TIME_DOMAIN if proposition.basis.value == "observed_state" else ""
+            ),
         )
-        for name, proposition in scenario.propositions.items()
-    }
+    return propositions
 
 
 def _compile_assertions(

--- a/implementations/python/packages/raes_processor/models/resources.py
+++ b/implementations/python/packages/raes_processor/models/resources.py
@@ -82,8 +82,12 @@ class PropositionRuntime(ResolvedResource):
 
     subject_addresses: tuple[str, ...] = ()
     predicate_kind: str = ""
+    quantifier: str = ""
     evaluation_basis: str = ""
     evidence_requirement_refs: tuple[str, ...] = ()
+    evidence_channels: tuple[str, ...] = ()
+    unresolved_evidence_channel_refs: tuple[str, ...] = ()
+    required_time_domain: str = ""
 
 
 @dataclass(frozen=True)

--- a/implementations/python/packages/raes_processor/planner/manifest_validation.py
+++ b/implementations/python/packages/raes_processor/planner/manifest_validation.py
@@ -1,8 +1,13 @@
 """Backend-manifest capability validation for compiled runtime models."""
 
-from raes_backend_protocols.capabilities import BackendManifest, OrchestratorCapabilities, ProvisionerCapabilities
+from raes_backend_protocols.capabilities import (
+    BackendManifest,
+    EvaluatorCapabilities,
+    OrchestratorCapabilities,
+    ProvisionerCapabilities,
+)
 
-from ..models import Diagnostic, RuntimeModel
+from ..models import Diagnostic, PropositionRuntime, RuntimeModel
 from .capability_domains import (
     _account_features,
     _resource_count_upper_bound,
@@ -310,6 +315,82 @@ def _validate_orchestration_support(model: RuntimeModel, manifest: BackendManife
     return diagnostics
 
 
+def _evaluator_section_support(
+    evaluation_sections: dict[str, bool], supported_sections: frozenset[str]
+) -> list[Diagnostic]:
+    return [
+        Diagnostic(
+            code="evaluator.unsupported-section",
+            domain="evaluation",
+            address=f"evaluation.{section}",
+            message=f"Evaluator does not support '{section}'.",
+        )
+        for section, used in evaluation_sections.items()
+        if used and section not in supported_sections
+    ]
+
+
+def _proposition_evaluator_support(
+    proposition: PropositionRuntime, evaluator: EvaluatorCapabilities
+) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    if proposition.predicate_kind not in evaluator.supported_predicate_families:
+        diagnostics.append(
+            Diagnostic(
+                code="evaluator.unsupported-predicate-family",
+                domain="evaluation",
+                address=proposition.address,
+                message=f"Evaluator does not support proposition predicate family '{proposition.predicate_kind}'.",
+            )
+        )
+    if proposition.quantifier not in evaluator.supported_quantifiers:
+        diagnostics.append(
+            Diagnostic(
+                code="evaluator.unsupported-quantifier",
+                domain="evaluation",
+                address=proposition.address,
+                message=f"Evaluator does not support proposition quantifier '{proposition.quantifier}'.",
+            )
+        )
+    if proposition.unresolved_evidence_channel_refs:
+        diagnostics.append(
+            Diagnostic(
+                code="evaluator.evidence-channel-unresolved",
+                domain="evaluation",
+                address=proposition.address,
+                message="Evaluator admission requires every cited evidence requirement to declare a channel kind.",
+            )
+        )
+    for channel in proposition.evidence_channels:
+        if channel in evaluator.supported_evidence_channels:
+            continue
+        diagnostics.append(
+            Diagnostic(
+                code="evaluator.unsupported-evidence-channel",
+                domain="evaluation",
+                address=proposition.address,
+                message=f"Evaluator does not support evidence channel '{channel}'.",
+            )
+        )
+    if proposition.required_time_domain and proposition.required_time_domain not in evaluator.supported_time_domains:
+        diagnostics.append(
+            Diagnostic(
+                code="evaluator.unsupported-time-domain",
+                domain="evaluation",
+                address=proposition.address,
+                message=f"Evaluator does not support proposition time domain '{proposition.required_time_domain}'.",
+            )
+        )
+    return diagnostics
+
+
+def _evaluator_proposition_support(model: RuntimeModel, evaluator: EvaluatorCapabilities) -> list[Diagnostic]:
+    diagnostics: list[Diagnostic] = []
+    for proposition in model.propositions.values():
+        diagnostics.extend(_proposition_evaluator_support(proposition, evaluator))
+    return diagnostics
+
+
 def _validate_evaluation_support(model: RuntimeModel, manifest: BackendManifest) -> list[Diagnostic]:
     evaluation_sections = {
         "conditions": bool(model.condition_bindings),
@@ -332,18 +413,8 @@ def _validate_evaluation_support(model: RuntimeModel, manifest: BackendManifest)
 
     evaluator = manifest.evaluator
     assert evaluator is not None
-    diagnostics: list[Diagnostic] = []
     supported_sections = manifest.evaluator_supported_sections
-    for section, used in evaluation_sections.items():
-        if used and section not in supported_sections:
-            diagnostics.append(
-                Diagnostic(
-                    code="evaluator.unsupported-section",
-                    domain="evaluation",
-                    address=f"evaluation.{section}",
-                    message=f"Evaluator does not support '{section}'.",
-                )
-            )
+    diagnostics = _evaluator_section_support(evaluation_sections, supported_sections)
     if model.objectives and not manifest.supports_objectives:
         diagnostics.append(
             Diagnostic(
@@ -354,63 +425,7 @@ def _validate_evaluation_support(model: RuntimeModel, manifest: BackendManifest)
             )
         )
     if "propositions" in supported_sections:
-        for proposition in model.propositions.values():
-            if proposition.predicate_kind not in evaluator.supported_predicate_families:
-                diagnostics.append(
-                    Diagnostic(
-                        code="evaluator.unsupported-predicate-family",
-                        domain="evaluation",
-                        address=proposition.address,
-                        message=(
-                            f"Evaluator does not support proposition predicate family '{proposition.predicate_kind}'."
-                        ),
-                    )
-                )
-            if proposition.quantifier not in evaluator.supported_quantifiers:
-                diagnostics.append(
-                    Diagnostic(
-                        code="evaluator.unsupported-quantifier",
-                        domain="evaluation",
-                        address=proposition.address,
-                        message=f"Evaluator does not support proposition quantifier '{proposition.quantifier}'.",
-                    )
-                )
-            if proposition.unresolved_evidence_channel_refs:
-                diagnostics.append(
-                    Diagnostic(
-                        code="evaluator.evidence-channel-unresolved",
-                        domain="evaluation",
-                        address=proposition.address,
-                        message=(
-                            "Evaluator admission requires every cited evidence requirement to declare a channel kind."
-                        ),
-                    )
-                )
-            for channel in proposition.evidence_channels:
-                if channel in evaluator.supported_evidence_channels:
-                    continue
-                diagnostics.append(
-                    Diagnostic(
-                        code="evaluator.unsupported-evidence-channel",
-                        domain="evaluation",
-                        address=proposition.address,
-                        message=f"Evaluator does not support evidence channel '{channel}'.",
-                    )
-                )
-            if (
-                proposition.required_time_domain
-                and proposition.required_time_domain not in evaluator.supported_time_domains
-            ):
-                diagnostics.append(
-                    Diagnostic(
-                        code="evaluator.unsupported-time-domain",
-                        domain="evaluation",
-                        address=proposition.address,
-                        message=(
-                            f"Evaluator does not support proposition time domain '{proposition.required_time_domain}'."
-                        ),
-                    )
-                )
+        diagnostics.extend(_evaluator_proposition_support(model, evaluator))
     return diagnostics
 
 

--- a/implementations/python/packages/raes_processor/planner/manifest_validation.py
+++ b/implementations/python/packages/raes_processor/planner/manifest_validation.py
@@ -330,6 +330,8 @@ def _validate_evaluation_support(model: RuntimeModel, manifest: BackendManifest)
             )
         ]
 
+    evaluator = manifest.evaluator
+    assert evaluator is not None
     diagnostics: list[Diagnostic] = []
     supported_sections = manifest.evaluator_supported_sections
     for section, used in evaluation_sections.items():
@@ -351,6 +353,64 @@ def _validate_evaluation_support(model: RuntimeModel, manifest: BackendManifest)
                 message="Evaluator does not support objectives.",
             )
         )
+    if "propositions" in supported_sections:
+        for proposition in model.propositions.values():
+            if proposition.predicate_kind not in evaluator.supported_predicate_families:
+                diagnostics.append(
+                    Diagnostic(
+                        code="evaluator.unsupported-predicate-family",
+                        domain="evaluation",
+                        address=proposition.address,
+                        message=(
+                            f"Evaluator does not support proposition predicate family '{proposition.predicate_kind}'."
+                        ),
+                    )
+                )
+            if proposition.quantifier not in evaluator.supported_quantifiers:
+                diagnostics.append(
+                    Diagnostic(
+                        code="evaluator.unsupported-quantifier",
+                        domain="evaluation",
+                        address=proposition.address,
+                        message=f"Evaluator does not support proposition quantifier '{proposition.quantifier}'.",
+                    )
+                )
+            if proposition.unresolved_evidence_channel_refs:
+                diagnostics.append(
+                    Diagnostic(
+                        code="evaluator.evidence-channel-unresolved",
+                        domain="evaluation",
+                        address=proposition.address,
+                        message=(
+                            "Evaluator admission requires every cited evidence requirement to declare a channel kind."
+                        ),
+                    )
+                )
+            for channel in proposition.evidence_channels:
+                if channel in evaluator.supported_evidence_channels:
+                    continue
+                diagnostics.append(
+                    Diagnostic(
+                        code="evaluator.unsupported-evidence-channel",
+                        domain="evaluation",
+                        address=proposition.address,
+                        message=f"Evaluator does not support evidence channel '{channel}'.",
+                    )
+                )
+            if (
+                proposition.required_time_domain
+                and proposition.required_time_domain not in evaluator.supported_time_domains
+            ):
+                diagnostics.append(
+                    Diagnostic(
+                        code="evaluator.unsupported-time-domain",
+                        domain="evaluation",
+                        address=proposition.address,
+                        message=(
+                            f"Evaluator does not support proposition time domain '{proposition.required_time_domain}'."
+                        ),
+                    )
+                )
     return diagnostics
 
 

--- a/implementations/python/tests/test_runtime_planner.py
+++ b/implementations/python/tests/test_runtime_planner.py
@@ -1107,6 +1107,133 @@ workflows:
         assert "evaluator.objectives-unsupported" in codes
         assert not execution_plan.is_valid
 
+    def test_evaluator_admission_enforces_compiled_proposition_capabilities(self):
+        limited = _limited_backend_manifest(
+            provisioner=ProvisionerCapabilities(
+                name="limited-provisioner",
+                supported_node_types=frozenset({"compute"}),
+                supported_os_families=frozenset({"linux"}),
+            ),
+            evaluator=EvaluatorCapabilities(
+                name="boolean-api-evaluator",
+                supported_sections=frozenset({"propositions", "assertions"}),
+                supported_predicate_families=frozenset({"boolean"}),
+                supported_quantifiers=frozenset({"all"}),
+                supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
+                supported_evidence_channels=frozenset({"api_response"}),
+                supported_time_domains=frozenset({"wall_clock_time"}),
+                preserves_binding_provenance=True,
+            ),
+        )
+        model = compile_runtime_model(
+            _scenario("""
+name: evaluator-capability-mismatch
+nodes:
+  vm: {type: compute, os: linux, resources: {ram: 1 gib, cpu: 1}}
+evidence_requirements:
+  runtime-log:
+    source_refs: [nodes.vm]
+    scope: evaluator admission test
+    boundary_kind: assertion_evaluation
+    channel: log
+    sensitivity: plain
+    redaction: redact_secrets
+    integrity: checksum
+    retention: run_lifetime
+    loss_disclosure: required
+propositions:
+  load:
+    description: The runtime load equals the expected value.
+    subjects: [nodes.vm]
+    basis: observed_state
+    quantifier: any
+    predicate:
+      kind: number
+      property: runtime.load
+      semantic_ref: urn:raes:observed-property:runtime.load
+      expected: 1
+      unit: count
+      unit_semantic_ref: urn:raes:unit:count
+    evidence_requirements: [runtime-log]
+assertions:
+  load: {proposition: load, role: postcondition}
+""")
+        )
+
+        proposition = model.propositions["evaluation.proposition.load"]
+        execution_plan = plan(model, limited)
+        codes = {diagnostic.code for diagnostic in execution_plan.diagnostics}
+
+        assert proposition.quantifier == "any"
+        assert proposition.evidence_channels == ("log",)
+        assert proposition.required_time_domain == "scenario_time"
+        assert {
+            "evaluator.unsupported-predicate-family",
+            "evaluator.unsupported-quantifier",
+            "evaluator.unsupported-evidence-channel",
+            "evaluator.unsupported-time-domain",
+        } <= codes
+        assert not execution_plan.is_valid
+
+    def test_evaluator_admission_rejects_opaque_evidence_channel_refs(self):
+        evaluator = EvaluatorCapabilities(
+            name="complete-evaluator",
+            supported_sections=frozenset({"propositions", "assertions"}),
+            supported_predicate_families=frozenset({"boolean"}),
+            supported_quantifiers=frozenset({"all"}),
+            supported_truth_outcomes=frozenset({"true", "false", "unknown", "unsupported"}),
+            supported_evidence_channels=frozenset({"log"}),
+            supported_time_domains=frozenset({"scenario_time"}),
+            preserves_binding_provenance=True,
+        )
+        manifest = _limited_backend_manifest(
+            provisioner=ProvisionerCapabilities(
+                name="limited-provisioner",
+                supported_node_types=frozenset({"compute"}),
+                supported_os_families=frozenset({"linux"}),
+            ),
+            evaluator=evaluator,
+        )
+        model = compile_runtime_model(
+            _scenario("""
+name: unresolved-evidence-channel
+nodes:
+  vm: {type: compute, os: linux, resources: {ram: 1 gib, cpu: 1}}
+evidence_requirements:
+  opaque-capture:
+    source_refs: [nodes.vm]
+    scope: evaluator admission test
+    boundary_kind: assertion_evaluation
+    channel_refs: [nodes.vm]
+    sensitivity: plain
+    redaction: redact_secrets
+    integrity: checksum
+    retention: run_lifetime
+    loss_disclosure: required
+propositions:
+  healthy:
+    description: The observed runtime is healthy.
+    subjects: [nodes.vm]
+    basis: observed_state
+    predicate:
+      kind: boolean
+      property: runtime.healthy
+      semantic_ref: urn:raes:observed-property:runtime.healthy
+      expected: true
+    evidence_requirements: [opaque-capture]
+assertions:
+  healthy: {proposition: healthy, role: postcondition}
+""")
+        )
+
+        execution_plan = plan(model, manifest)
+
+        assert model.propositions["evaluation.proposition.healthy"].unresolved_evidence_channel_refs == (
+            "opaque-capture",
+        )
+        assert "evaluator.evidence-channel-unresolved" in {diagnostic.code for diagnostic in execution_plan.diagnostics}
+        assert not execution_plan.is_valid
+
     def test_acl_capability_validation_covers_node_attached_rules(self):
         limited = _limited_backend_manifest(
             name="limited",

--- a/specs/formal/objectives/proposition-and-assertion-semantics.md
+++ b/specs/formal/objectives/proposition-and-assertion-semantics.md
@@ -164,6 +164,20 @@ portable outcomes, evidence channels, time domains, and binding-provenance
 preservation. Admission reports unsupported instead of substituting a weaker
 predicate or clock.
 
+Planner admission compares every compiled proposition's predicate family and
+quantifier with the evaluator declaration. For each cited evidence requirement,
+it compares the explicit `channel` kind with `supported_evidence_channels`.
+An evidence requirement that supplies only opaque `channel_refs` or a boundary
+kind does not establish a channel kind and fails evaluator admission; the
+planner MUST NOT infer modality from a reference name.
+
+The current v1 runtime projection requires `scenario_time` for observed-state
+proposition evaluation and no evaluator time domain for declared-state
+propositions. The planner compares that requirement with
+`supported_time_domains`. This projection does not establish a wall clock or
+clock authority. A future authored per-proposition time domain requires a new
+governed language/profile revision rather than a backend-local inference.
+
 A runtime truth result is admitted only if its proposition and assertion
 addresses resolve to semantic entries in the same snapshot, the proposition
 entry has the same evaluation basis, and the assertion entry has the same


### PR DESCRIPTION
## Plain-language summary

- **Context:** OpenRAE compiles each scenario into requirements that an evaluator must be able to check.
- **Problem:** The planner could admit an evaluator even when its declaration did not cover the scenario predicate, quantifier, evidence channel, or scenario-time requirement. The mismatch appeared too late, after planning had already treated the evaluator as usable.
- **Fix:** Carry those requirements into the compiled model and reject an incompatible evaluator before execution, with a clear diagnostic naming the unsupported capability.

## Summary

Fail planner admission when an evaluator's declared proposition capabilities do not cover the compiled scenario requirements. The compiler now carries a typed capability projection into the runtime model, and the planner compares predicate family, quantifier, explicit evidence-channel kind, and the v1 observed-state time domain before execution.

Opaque `channel_refs` remain references rather than inferred modality: a proposition that cites an evidence requirement without an explicit channel kind fails closed with a stable diagnostic.

## Related issues

Closes #1036

## Changes

- project proposition quantifier, evidence-channel kinds, unresolved channel references, and v1 time-domain requirements into `PropositionRuntime`
- enforce the evaluator declaration with stable, address-scoped planner diagnostics
- document the architecture, rejected alternatives, lineage, evidence boundary, and API-413 traceability
- add regression coverage for a four-dimensional capability mismatch and an opaque evidence-channel reference

## Test plan

- [x] New focused regressions on CPython 3.14.4 free-threaded: 2 passed
- [x] Complete runtime planner suite on CPython 3.14.4 free-threaded: 38 passed
- [x] Changed executable-line coverage: 100% (38/38, `diff-cover` against `origin/dev`)
- [x] Every branch introduced by this patch exercised in both directions under branch coverage
- [x] Ruff format and lint pass
- [x] Repository policy checks pass; Ground Control requirement lookup skipped cleanly when its service was unavailable
- [x] Public docs build passes with warnings treated as errors
- [ ] Canonical `nox -s verify`: attempted; this macOS worktree lacks `/usr/bin/busybox` (18 unrelated libvirt failures; 6,397 tests passed and 1 skipped on Python 3.12) and the pinned offline Isabelle acquisition

## Checklist

- [x] Code follows the project coding standards
- [x] Classified FM1: fail-closed static semantic admission over typed compiled requirements
- [x] No published contract schema changed; regeneration is not applicable
- [x] PR title is a Conventional Commit
- [x] Architectural and formal-semantics documentation updated

## Notes for review

- This draft is based directly on `dev` commit `3d6e369b` (merged PR #1082) and uses the current `compute` kind rather than the retired realization substrate value.
- The change is limited to evaluator capability admission. It contains no expanded-parent satisfiability or solver changes.
- The temporal rule is deliberately bounded: v1 observed-state propositions require `scenario_time`; this does not introduce a wall-clock claim or a new SDL time-domain field.