### PR TITLE
perf(processor): materialize explicitness once per compile

### DIFF
--- a/docs/decisions/issue-1099-run-313-compiler-explicitness-performance-preflight.md
+++ b/docs/decisions/issue-1099-run-313-compiler-explicitness-performance-preflight.md
@@ -1,0 +1,126 @@
+# Issue 1099 RUN-313 Compiler Explicitness Performance Preflight
+
+Date: 2026-08-11
+
+Issue: #1099.
+
+Requirement: RUN-313.
+
+This note records the measured performance boundary and semantic guardrails for
+materializing SEM-218 explicitness once during realization compilation. It does
+not change explicitness classification, instantiation provenance, public SDL or
+processor contracts, schemas, CLI startup, manifests, or backend behavior.
+
+## Measured Gap
+
+The representative input is
+`examples/scenarios/hospital-ransomware-surgery-day.sdl.yaml`, a 33,774-byte
+shipped scenario already used by the pipeline-determinism suite. On
+`origin/dev` at `5c210d520e884cca0c08ad201b033fae920ce0c2`, realization compilation
+enumerated 185 registered concerns. Each call to
+`_compiled_registered_realization()` evaluated
+`InstantiatedScenario.explicitness`, reconstructing all 1,461 path-keyed
+records from instantiation provenance.
+
+The prior audit measured about 148 ms for compilation and 233 ms for the full
+parse/instantiate/compile/plan pipeline. A fresh Python 3.13.5 run on the
+implementation host was slower in absolute terms: after three warmups, the
+median of 15 runs was 347 ms for compilation and 549 ms for the full pipeline.
+Across 25 runs, 185 isolated explicitness reconstructions took a median 207 ms.
+The exact latency is host- and load-dependent; the 185 full reconstructions are
+the portable defect signal.
+
+## Binding Sources And Existing Surfaces
+
+- RUN-313 and the issue #196 preflight keep the repository reference processor
+  on the existing parse, instantiate, compile, and plan seams.
+- SEM-218 issues #72, #489, and #490 define classifier, instantiation, compiler,
+  and planner fidelity. Issues #760 and #767 preserve provenance and establish
+  the path-keyed instantiated mapping as the downstream contract.
+- Issue #985 expanded the registered realization concern surface; the compiler
+  must continue to enumerate that registry in stable order.
+- `InstantiatedScenario.explicitness` is a public convenience projection. Its
+  fresh-return behavior and caller mutation isolation are not changed here.
+- `_compile_realization()` owns one ordered realization-lowering pass and is the
+  narrow lifetime for a pass-local snapshot.
+- The compiler-package preflight for issue #41 already directs domain compilers
+  to consume explicit prerequisite mappings and semantic analyses.
+
+LLVM's official New Pass Manager documentation describes analysis managers
+caching analysis results for reuse within compiler pipelines:
+<https://llvm.org/docs/NewPassManager.html>. Python's `property` documentation
+specifies getter invocation on attribute access and supplies no implicit
+memoization: <https://docs.python.org/3/library/functions.html#property>.
+
+## Chosen Boundary
+
+`_compile_realization()` evaluates `scenario.explicitness` once before concern
+enumeration and passes the resulting mapping to
+`_compiled_registered_realization()`. The helper treats the mapping as
+read-only. For `E` explicitness records and `C` registered concerns, this makes
+the mapping work O(E + C) for the pass instead of O(E * C).
+
+The snapshot lifetime is exactly one realization compile. It is not stored on
+the scenario, shared across compile calls, placed in global state, or exposed
+as a new public cache. This avoids mutation/invalidation questions and ensures
+each separately admitted compile observes its own provenance.
+
+## Semantic Invariants
+
+- Admission, declaration-index construction, domain analysis, compiler order,
+  registry order, diagnostic order, and `RuntimeModel` construction do not
+  change.
+- Every lookup uses the same `ExplicitnessRecord` values that the pre-change
+  helper obtained from a freshly reconstructed but semantically identical map.
+- Exact, constrained, open, provenance, designation, governing scope,
+  delegation, verification, and planner behavior remain unchanged.
+- No schema, serialized payload, public signature, manifest, CLI, runtime, or
+  backend surface changes.
+- The optimization adds no environment input, filesystem or network access,
+  logging, persistence, secret handling, or new error path.
+
+## Alternatives Rejected
+
+- Leaving the repeated reconstruction in place preserves output but makes the
+  reference processor scale with the product of two independently growing
+  collections.
+- Caching on `InstantiatedScenario` broadens lifetime and changes a public
+  projection's isolation contract.
+- Returning provenance records directly changes downstream types.
+- A reduced or second explicitness index risks semantic drift from the
+  canonical SEM-218 projection.
+
+## Verification Boundary
+
+Correctness is defended by a property test that compares complete
+`RuntimeModel` values and execution plans against a reference path which
+reconstructs explicitness for every concern. A separate complex-scenario test
+patches the property getter and requires exactly one access per compile. The
+call-count assertion is deterministic and fails if the nested reconstruction
+returns; CI does not enforce a wall-clock threshold.
+
+Existing SEM-218 fidelity, pipeline determinism, repository policy,
+requirement-governance, and canonical verification suites remain required. A
+same-host paired run supplied the following supporting evidence:
+
+| Path | Repeated reconstruction | Pass-local snapshot | Median reduction |
+| --- | ---: | ---: | ---: |
+| Compile | 149.549 ms | 10.213 ms | 93.2% |
+| Parse / instantiate / compile / plan | 240.079 ms | 99.707 ms | 58.5% |
+
+The Python 3.13.5 measurement alternated the two modes over 15 paired runs
+after two warmups. Both modes used the same helper wrapper: the reference mode
+requested a fresh `scenario.explicitness` mapping for every concern, while the
+optimized mode used the mapping passed by the realization coordinator. The
+reference mode conservatively also paid for the coordinator's unused initial
+snapshot; its 149.549 ms compile median nevertheless agrees with the independent
+148 ms pre-change audit. Latency remains supporting evidence rather than the
+regression oracle.
+
+## Non-Goals
+
+- Caching other scenario projections or compiler analyses.
+- Optimizing schema-bundle construction or CLI startup.
+- Changing the realization registry or adding realization concerns.
+- Changing SDL, SEM-218, runtime, planner, backend, or conformance semantics.
+- Adding a general compiler cache, benchmark framework, or performance SLA.

--- a/docs/requirements/RUN-313/requirement.md
+++ b/docs/requirements/RUN-313/requirement.md
@@ -22,3 +22,7 @@ Portable semantics and contracts need at least one concrete processor implementa
 ## Traceability
 
 - TESTS → TEST `implementations/python/tests/test_reference_processor.py` (Reference processor end-to-end + manifest-evidence tests)
+- IMPLEMENTS → GITHUB_ISSUE `1099` (Materialize SEM-218 explicitness once per reference-processor compile)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_processor/compiler/realization_requirements.py` (Pass-local explicitness snapshot for realization lowering)
+- DOCUMENTS → DOCUMENTATION `docs/decisions/issue-1099-run-313-compiler-explicitness-performance-preflight.md` (Measured scaling boundary and semantic guardrails)
+- TESTS → TEST `implementations/python/tests/test_issue_1099_compiler_explicitness_performance.py` (Runtime-model and plan equivalence plus deterministic one-build guard)

--- a/implementations/python/packages/raes_processor/compiler/realization_requirements.py
+++ b/implementations/python/packages/raes_processor/compiler/realization_requirements.py
@@ -1,6 +1,8 @@
 """Realization-requirement compilation (SEM-218)."""
 
-from raes.explicitness import ExplicitnessClass, ExplicitnessProvenance
+from collections.abc import Mapping
+
+from raes.explicitness import ExplicitnessClass, ExplicitnessProvenance, ExplicitnessRecord
 from raes.nodes import NodeType
 from raes.realization_designation import RealizationConstraintPosture
 from raes.runtime_resource_limits import (
@@ -285,13 +287,14 @@ def _append_service_materialization_requirements(
 def _compiled_registered_realization(
     scenario: InstantiatedScenario,
     registered: RegisteredRealizationConcern,
+    explicitness: Mapping[str, ExplicitnessRecord],
 ) -> tuple[CompiledRealizationRequirement | None, CompiledRealizationAuthority | None]:
     descriptor = registered.descriptor
     section_name = descriptor.section
     declaration_name = registered.declaration_name
     encoded_name = declaration_name.replace("~", "~0").replace("/", "~1")
     field_pointer = f"/{section_name}/{encoded_name}/{'/'.join(descriptor.authored_path)}"
-    record = scenario.explicitness.get(registered.field_path)
+    record = explicitness.get(registered.field_path)
     declarations = getattr(scenario, section_name)
     authored_value = _nested_authored_value(
         declarations[declaration_name],
@@ -401,21 +404,16 @@ def _compile_realization(
     scenario: InstantiatedScenario,
     domain_analysis: DomainTopologyAnalysis,
 ) -> tuple[tuple[CompiledRealizationRequirement, ...], tuple[CompiledRealizationAuthority, ...]]:
-    """SEM-218 typed compiler emission: lower each authored realization concern
-    into a compiled requirement carrying its classifier explicitness class.
-
-    Explicit leaves always win. Missing admitted concerns are lowered through
-    the typed lexical designation cascade; omitted designation preserves the
-    legacy closed fallback while explicit root delegation remains typed.
-    """
+    """Lower explicit leaves before typed fallbacks; omitted stays closed and explicit root delegation stays typed."""
 
     requirements: list[CompiledRealizationRequirement] = []
     _append_compute_substrate_requirements(requirements, scenario)
     authority: list[CompiledRealizationAuthority] = []
+    explicitness = scenario.explicitness
     for registered in registered_realization_concern_descriptors(
         declaration_names={"nodes": scenario.nodes, "content": scenario.content}
     ):
-        requirement, authority_entry = _compiled_registered_realization(scenario, registered)
+        requirement, authority_entry = _compiled_registered_realization(scenario, registered, explicitness)
         if requirement is not None:
             requirements.append(requirement)
         if authority_entry is not None:

--- a/implementations/python/tests/test_issue_1099_compiler_explicitness_performance.py
+++ b/implementations/python/tests/test_issue_1099_compiler_explicitness_performance.py
@@ -1,0 +1,112 @@
+"""RUN-313 regression guards for issue #1099's realization-pass hotspot."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import raes_processor.compiler.realization_requirements as realization_requirements
+import yaml
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from paths import EXAMPLES_DIR
+from raes import instantiate_scenario, parse_sdl, parse_sdl_file
+from raes.scenario import InstantiatedScenario
+from raes_backend_stubs.stubs import create_stub_manifest
+from raes_processor.compiler import compile_runtime_model
+from raes_processor.planner import plan
+
+
+def _generated_scenario(*, node_count: int, constrained_os: bool, open_default: bool):
+    os_value = "${os_choice}" if constrained_os else "linux"
+    payload: dict[str, object] = {
+        "name": f"run-313-{node_count}-{int(constrained_os)}-{int(open_default)}",
+        "nodes": {
+            f"node-{index}": {
+                "type": "compute",
+                "os": os_value,
+                "resources": {"ram": "1 gib", "cpu": index + 1},
+            }
+            for index in range(node_count)
+        },
+    }
+    if constrained_os:
+        payload["variables"] = {
+            "os_choice": {
+                "type": "string",
+                "default": "linux",
+                "allowed_values": ["linux", "windows"],
+            }
+        }
+    if open_default:
+        payload["realization"] = {"default": "open"}
+    return parse_sdl(yaml.safe_dump(payload, sort_keys=False))
+
+
+def _compile_with_repeated_explicitness_lookup(scenario):
+    """Reference issue #1099's pre-fix per-concern reconstruction behavior."""
+
+    optimized_helper = realization_requirements._compiled_registered_realization
+
+    def repeated_lookup(scenario_arg, registered, _pass_explicitness):
+        return optimized_helper(scenario_arg, registered, scenario_arg.explicitness)
+
+    with patch.object(realization_requirements, "_compiled_registered_realization", repeated_lookup):
+        return compile_runtime_model(scenario)
+
+
+@settings(max_examples=12, deadline=None)
+@given(
+    node_count=st.integers(min_value=1, max_value=5),
+    constrained_os=st.booleans(),
+    open_default=st.booleans(),
+)
+def test_single_snapshot_matches_repeated_lookup_runtime_and_plan(
+    node_count: int,
+    constrained_os: bool,
+    open_default: bool,
+) -> None:
+    """The pass-local snapshot preserves the old lookup semantics end to end."""
+
+    optimized = compile_runtime_model(
+        _generated_scenario(
+            node_count=node_count,
+            constrained_os=constrained_os,
+            open_default=open_default,
+        )
+    )
+    reference = _compile_with_repeated_explicitness_lookup(
+        _generated_scenario(
+            node_count=node_count,
+            constrained_os=constrained_os,
+            open_default=open_default,
+        )
+    )
+
+    assert len(optimized.realization_authority) >= node_count * 2
+    assert optimized == reference
+    manifest = create_stub_manifest()
+    assert plan(optimized, manifest) == plan(reference, manifest)
+
+
+@pytest.mark.integration
+def test_complex_compile_materializes_instantiated_explicitness_once() -> None:
+    """Guard work count, not machine-dependent wall-clock latency."""
+
+    source = parse_sdl_file(EXAMPLES_DIR / "hospital-ransomware-surgery-day.sdl.yaml")
+    parameters = {name: variable.default for name, variable in source.variables.items() if variable.default is not None}
+    scenario = instantiate_scenario(source, parameters=parameters)
+    original_getter = InstantiatedScenario.explicitness.fget
+    assert original_getter is not None
+    calls = 0
+
+    def counted_explicitness(concrete: InstantiatedScenario):
+        nonlocal calls
+        calls += 1
+        return original_getter(concrete)
+
+    with patch.object(InstantiatedScenario, "explicitness", property(counted_explicitness)):
+        compiled = compile_runtime_model(scenario)
+
+    assert len(compiled.realization_authority) > 100
+    assert calls == 1


### PR DESCRIPTION
## Plain-language summary

- **Context:** Compiling a scenario visits every registered realization concern to build the runtime plan.
- **Problem:** Each visit rebuilt the same full explicitness map. A representative scenario rebuilt it 185 times, adding substantial CPU time without changing the result.
- **Fix:** Build one read-only explicitness map at the start of the compile pass and reuse it for every concern. The produced runtime model and execution plan remain identical.

## Summary

Materialize the SEM-218 explicitness projection once at the realization-pass boundary and reuse that read-only mapping for every registered concern. This removes repeated full-map reconstruction without changing classifier, compiler, planner, schema, or public API semantics.

The deterministic regression changes 185 explicitness-property evaluations to 1 on the shipped hospital scenario. The documented same-host Python 3.13.5 preflight measured a 93.2% compile-time reduction and a 58.5% full parse/instantiate/compile/plan reduction over 15 paired runs; CI guards work count and semantic equivalence, not wall-clock latency.

## Related issues

Closes #1099

## Changes

- Pass one `Mapping[str, ExplicitnessRecord]` snapshot through the existing ordered realization concern loop.
- Differentially compare complete runtime models and plans against the previous repeated-lookup behavior across generated scenarios.
- Assert exactly one explicitness-property read on a complex checked-in scenario.
- Record the RUN-313 performance boundary, alternatives, non-goals, and requirement traceability.
- Use the canonical `type: compute` fixture introduced by #1082.

## Test plan

- [x] Focused realization, SEM-218, #985, #1076, stateful-resource, and pipeline-determinism suite: 102 passed, 9 deselected.
- [x] New complex-scenario integration guard: 1 passed, 1 deselected.
- [x] Branch-instrumented coverage plus `diff-cover`: 100% of 5 changed executable lines; this change introduces no branch sites.
- [x] Final `verify-static-lane -- --include-policy --base-rev origin/dev`: all hygiene, policy, requirement, and Ruff checks passed.
- [x] Canonical verification attempt: integration, contracts, and docs-local lanes passed.
- [ ] Canonical verification is not fully green locally: the unit lane reaches unrelated existing libvirt guest-certification failures (a direct focused reproduction is 17 failed, 5 passed), and participant-opacity proof replay requires the pinned Isabelle archive that is not installed in this worktree. The final static lane passes after keeping the touched compiler module within its 500-line policy cap. The requirement checker also reported the Ground Control service unavailable and used its documented skip path.

## Checklist

- [x] Code follows the project coding standards.
- [x] FM classification is not applicable because processor semantics do not change.
- [x] Published contract schemas are unchanged.
- [x] PR title is a Conventional Commit.
- [x] The focused decision/preflight note and RUN-313 traceability are updated.

## Notes for review

- This is one squashed commit based directly on current `dev` (`3d6e369b`).
- No cache is added to `InstantiatedScenario`; the snapshot lifetime is one admitted compile.
- No performance threshold is added to CI.