### PR TITLE
fix(contracts): admit expanded scenario snapshot parents (#1040)

### DIFF
--- a/docs/decisions/issue-1040-expanded-scenario-parent-remediation.md
+++ b/docs/decisions/issue-1040-expanded-scenario-parent-remediation.md
@@ -1,0 +1,80 @@
+# Issue 1040 Expanded Scenario Parent Remediation
+
+Date: 2026-08-11
+
+Issue: #1040. Requirement: none; the issue acceptance criteria and the
+incumbent associated-artifact contract are authoritative.
+
+## Gap Claim
+
+`parse_sdl_file()` returns a semantically validated `ExpandedScenario` for a
+file-backed module composition, and `canonical_sdl_digest()` accepts that
+authoring phase. Associated-artifact snapshot matching accepted only
+`Scenario`, so an exact expanded semantic parent could never validate.
+
+## Existing Surface Audit
+
+- `Scenario`, `ExpandedScenario`, and `InstantiatedScenario` are closed phase
+  types sharing `ScenarioContent`.
+- Canonical SDL authoring identity accepts validated `Scenario` and
+  `ExpandedScenario`, rejects unvalidated objects, and rejects instantiated
+  artifacts.
+- Generic `scenario` association is intentionally id-only and historically
+  accepts a `Scenario` without consulting canonical identity.
+- Snapshot matching already checks optional version and digest after its
+  overly narrow type test. The manifest schema needs no change.
+- The parser's public return annotation incorrectly hid its expanded return
+  phase even though the runtime behavior and phase tests already expose it.
+
+## Lineage And Precedent
+
+ADR-077 and `specs/supply-chain/associated-artifact-manifests.md` define a
+scenario snapshot as a binding to incumbent canonical SDL identity. ADR-078
+and `raes.canonical` own phase-correct semantic identity. The artifact validator
+must delegate phase admission to that incumbent boundary rather than create a
+narrower authoring-phase list.
+
+## Literature And Practice
+
+The repository's supply-chain lineage separates logical references, canonical
+content identity, byte integrity, and authenticity. This fix preserves that
+separation: it broadens only which canonical authoring phase may supply the
+already-defined snapshot digest.
+
+## Alternatives Considered
+
+1. **Do nothing or require callers to reconstruct `Scenario`.** Rejected
+   because reconstruction discards composition phase identity and encourages
+   mutation of private validation state.
+2. **Accept every `ScenarioContent`.** Rejected because instantiated and
+   unvalidated objects do not have canonical authoring identity.
+3. **Call `canonical_sdl_digest()` and catch every failure.** Rejected because
+   explicit phase/type admission gives a clearer contract and avoids exception
+   control flow.
+4. **Accept validated `Scenario | ExpandedScenario` for snapshots only.**
+   Chosen; it exactly matches canonical authoring identity while preserving
+   generic association behavior.
+
+## Chosen Architecture
+
+For `scenario-snapshot`, the parent matcher requires a semantically validated
+`Scenario` or `ExpandedScenario`, then applies the unchanged id, version, and
+canonical digest comparisons. `InstantiatedScenario` is explicitly outside
+the accepted set. For generic `scenario`, the incumbent `Scenario` id-only rule
+is unchanged. Parser annotations and docstrings now disclose the actual union
+return type.
+
+## Documentation Defense
+
+The normative associated-artifact specification names both accepted authoring
+phases and the validation requirement. No contract schema, canonicalization
+profile, or set-digest projection changes.
+
+## Verification Plan
+
+- Parse a root with a local module import and validate its exact expanded
+  parent id, version, digest, and artifact bytes.
+- Mutate the declared digest and require `associated-artifact.parent-mismatch`.
+- Reject reconstructed unvalidated normalized/expanded objects and an
+  instantiated object as snapshot parents.
+- Lock the legacy generic scenario id-only behavior with a regression test.

--- a/implementations/python/packages/raes/parser.py
+++ b/implementations/python/packages/raes/parser.py
@@ -318,8 +318,8 @@ def parse_sdl(
     source_format: str = SDL_SOURCE_FORMAT,
     migration_policy: SDLMigrationPolicy | str = SDLMigrationPolicy.REJECT,
     limits: SDLParserLimits = DEFAULT_PARSER_LIMITS,
-) -> Scenario:
-    """Parse an SDL YAML string into a validated Scenario.
+) -> Scenario | ExpandedScenario:
+    """Parse SDL YAML into a normalized or expanded authoring object.
 
     Handles SDL documents with ``name`` at the top level. Runs
     structural validation (Pydantic) and semantic validation
@@ -336,7 +336,8 @@ def parse_sdl(
         limits: Source and alias-processing resource limits.
 
     Returns:
-        Validated Scenario object.
+        A ``Scenario``, or ``ExpandedScenario`` when file-backed module imports
+        are present. Unless explicitly skipped, semantic validation has run.
 
     Raises:
         SDLParseError: If YAML parsing fails or the data isn't a dict.
@@ -400,8 +401,8 @@ def parse_sdl(
     return scenario
 
 
-def parse_sdl_file(path: Path, **kwargs: Any) -> Scenario:
-    """Parse an SDL YAML file into a validated Scenario.
+def parse_sdl_file(path: Path, **kwargs: Any) -> Scenario | ExpandedScenario:
+    """Parse an SDL file into a normalized or expanded authoring object.
 
     Convenience wrapper around ``parse_sdl()`` that reads from a file.
     """

--- a/implementations/python/packages/raes_contracts/associated_artifacts.py
+++ b/implementations/python/packages/raes_contracts/associated_artifacts.py
@@ -10,7 +10,7 @@ from typing import BinaryIO, cast
 import rfc8785
 from blake3 import blake3
 from raes import canonical_sdl_digest
-from raes.scenario import Scenario
+from raes.scenario import ExpandedScenario, InstantiatedScenario, Scenario
 
 from .contracts import (
     AssociatedArtifactManifestModel,
@@ -97,11 +97,21 @@ def _diagnostic(code: str, address: str, message: str) -> Diagnostic:
 
 def _scenario_parent_matches(manifest: AssociatedArtifactManifestModel, parent: object) -> bool:
     reference = manifest.parent_ref
-    matches = isinstance(parent, Scenario) and parent.name == reference.ref_id
-    if matches and reference.ref_kind == "scenario-snapshot":
+    if reference.ref_kind == "scenario":
+        # Generic scenario association remains the incumbent id-only contract.
+        return isinstance(parent, Scenario) and parent.name == reference.ref_id
+
+    snapshot_types = (Scenario, ExpandedScenario)
+    matches = (
+        isinstance(parent, snapshot_types)
+        and not isinstance(parent, InstantiatedScenario)
+        and parent.semantic_validated
+        and parent.name == reference.ref_id
+    )
+    if matches:
         matches = reference.ref_version is None or parent.version == reference.ref_version
-        if matches and reference.ref_digest is not None:
-            matches = canonical_sdl_digest(parent).value.casefold() == reference.ref_digest.casefold()
+    if matches and reference.ref_digest is not None:
+        matches = canonical_sdl_digest(parent).value.casefold() == reference.ref_digest.casefold()
     return matches
 
 
@@ -294,6 +304,11 @@ def validate_associated_artifact_manifest(
     limits: AssociatedArtifactValidationLimits | None = None,
 ) -> tuple[Diagnostic, ...]:
     """Validate parent/set identity and every payload through bounded readers.
+
+    Scenario snapshots accept only semantically validated ``Scenario`` or
+    ``ExpandedScenario`` authoring parents. Generic scenario association keeps
+    its id-only ``Scenario`` behavior; instantiated scenarios are never
+    canonical authoring snapshot parents.
 
     The caller acquires and immutably stages payloads. This function performs no
     URI fetching, directory traversal, archive extraction, or ambient lookup.

--- a/implementations/python/tests/test_associated_artifact_manifests.py
+++ b/implementations/python/tests/test_associated_artifact_manifests.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
-from raes import canonical_sdl_digest, parse_sdl
+from raes import canonical_sdl_digest, parse_sdl, parse_sdl_file
+from raes.instantiate import instantiate_scenario
+from raes.scenario import ExpandedScenario, Scenario
 from raes_conformance.conformance import _MODEL_VALIDATORS, _fixture_case_diagnostics
 from raes_contracts.associated_artifacts import (
     AssociatedArtifactValidationLimits,
@@ -362,6 +364,84 @@ def test_snapshot_parent_digest_is_checked_without_changing_sdl_identity() -> No
                 artifact_readers={"operator-guide": BytesIO(PAYLOAD)},
             )
         )
+
+
+def test_snapshot_parent_admits_validated_file_backed_expansion_only(tmp_path: Path) -> None:
+    module = tmp_path / "module.yaml"
+    module.write_text(
+        """\
+name: shared-host
+version: 1.0.0
+module:
+  id: raes/shared-host
+  version: 1.0.0
+  exports: {nodes: [host]}
+nodes:
+  host: {type: compute, os: linux, resources: {ram: 1 gib, cpu: 1}}
+""",
+        encoding="utf-8",
+    )
+    root = tmp_path / "root.yaml"
+    root.write_text(
+        """\
+name: training-range
+version: 1.0.0
+imports:
+  - path: module.yaml
+    namespace: shared
+    version: 1.0.0
+""",
+        encoding="utf-8",
+    )
+    expanded = parse_sdl_file(root)
+    assert isinstance(expanded, ExpandedScenario)
+    parent_ref = {
+        "ref_kind": "scenario-snapshot",
+        "ref_id": expanded.name,
+        "ref_version": expanded.version,
+        "ref_digest": canonical_sdl_digest(expanded).value,
+    }
+    manifest = _manifest(parent_ref=parent_ref)
+
+    assert (
+        validate_associated_artifact_manifest(
+            manifest,
+            parent=expanded,
+            artifact_readers={"operator-guide": BytesIO(PAYLOAD)},
+        )
+        == ()
+    )
+
+    wrong_digest = _manifest(parent_ref={**parent_ref, "ref_digest": "sha256:" + ("0" * 64)})
+    assert "associated-artifact.parent-mismatch" in _codes(
+        validate_associated_artifact_manifest(
+            wrong_digest,
+            parent=expanded,
+            artifact_readers={"operator-guide": BytesIO(PAYLOAD)},
+        )
+    )
+
+    unvalidated_expanded = ExpandedScenario.model_validate(expanded.model_dump(mode="python"))
+    unvalidated_scenario = Scenario.model_validate({"name": expanded.name, "version": expanded.version})
+    instantiated = instantiate_scenario(expanded)
+    for inadmissible_parent in (unvalidated_expanded, unvalidated_scenario, instantiated):
+        assert "associated-artifact.parent-mismatch" in _codes(
+            validate_associated_artifact_manifest(
+                manifest,
+                parent=inadmissible_parent,
+                artifact_readers={"operator-guide": BytesIO(PAYLOAD)},
+            )
+        )
+
+    generic_manifest = _manifest(parent_ref={"ref_kind": "scenario", "ref_id": expanded.name})
+    assert (
+        validate_associated_artifact_manifest(
+            generic_manifest,
+            parent=unvalidated_scenario,
+            artifact_readers={"operator-guide": BytesIO(PAYLOAD)},
+        )
+        == ()
+    )
 
 
 def test_published_schema_and_fixture_corpus_cover_both_attachment_scopes() -> None:

--- a/specs/supply-chain/associated-artifact-manifests.md
+++ b/specs/supply-chain/associated-artifact-manifests.md
@@ -96,6 +96,12 @@ requires `validate_associated_artifact_manifest()` with:
 - the concrete parent artifact; and
 - exactly one concrete byte reader for every artifact id.
 
+A generic `scenario` parent retains the id-only `Scenario` association
+contract. A `scenario-snapshot` concrete parent MUST be a semantically validated
+normalized `Scenario` or composed `ExpandedScenario`, matching the authoring
+phases admitted by `canonical_sdl_digest()`. An unvalidated authoring object or
+an `InstantiatedScenario` MUST NOT satisfy a scenario-snapshot parent reference.
+
 The validator MUST:
 
 1. match parent kind, id, version, and snapshot digest where applicable;


### PR DESCRIPTION
## Plain-language summary

- **Context:** A runtime snapshot can record either an authored scenario or a fully expanded scenario as its parent artifact.
- **Problem:** The contract accepted an authored Scenario parent but rejected a valid, semantically checked ExpandedScenario parent, so a legitimate expansion could not be represented.
- **Fix:** Accept both validated parent forms while continuing to reject unvalidated, instantiated, or otherwise unsafe parent objects.

## Summary

Admit semantically validated `ExpandedScenario` values as canonical `scenario-snapshot` parents for associated-artifact manifests. This keeps generic `scenario` references id-only, rejects unvalidated and instantiated objects, and makes the parser's public return annotation match its existing file-backed expansion behavior.

This is the focused successor for the expanded-scenario parent portion of the earlier aggregate work. It intentionally excludes evaluator and solver changes.

## Related issues

Closes #1040

## Changes

- accept validated `Scenario | ExpandedScenario` parents at the snapshot boundary
- preserve the existing generic `scenario` parent contract
- reject unvalidated authoring objects and `InstantiatedScenario` parents
- document the phase boundary, lineage, alternatives, and validation invariant
- cover exact expanded-parent success, digest mismatch, inadmissible phases, and generic-parent compatibility
- update `parse_sdl()` and `parse_sdl_file()` annotations to disclose their existing expanded return phase

## Test plan

- [x] Focused parser/contracts/phase suite: `140 passed, 1 skipped`
- [x] Associated-artifact branch-coverage run: `20 passed`; changed `_scenario_parent_matches()` is 100% statement and branch covered
- [x] Change-aware pre-commit gate, including Ruff, schema publication, generated-schema drift, contract graph, policy, and the changed test module
- [x] Direct repository-policy and requirement-governance commands (Ground Control was unavailable, so its remote check reported the repository's documented non-gating skip)
- [ ] Canonical `tools/verify_all.py` completed all static, contracts, and docs lanes, but the repository-wide unit lane remains red in unchanged libvirt tests and the local proof lane lacks the pinned Isabelle archive. A representative `libvirt-backend.techvault-native.operation-failed` failure reproduces on exact base `3d6e369b`.

## Checklist

- [x] Code follows the project coding standards
- [x] FM level classified: FM1 static semantic phase-admission rule, with the invariant documented and unit-tested
- [x] No published schema shape changes; generated schema and publication checks pass
- [x] PR title is a Conventional Commit
- [x] Contract and architecture rationale is documented

## Notes for review

The branch is a single commit based directly on `dev` at `3d6e369b726607ff657a841c7f1dee0bec655b8f`. The #1082 compute-kind change required updating the new test fixture from legacy `type: vm` to canonical `type: compute`; no realization semantics are changed here.