### PR TITLE
fix(libvirt): bind reproducible guest operations to fresh evidence

### DIFF
--- a/docs/decisions/issue-1094-libvirt-boot-artifact-reliability.md
+++ b/docs/decisions/issue-1094-libvirt-boot-artifact-reliability.md
@@ -1,0 +1,119 @@
+# Issue 1094 / RUN-314 Libvirt Boot-Artifact Reliability
+
+Date: 2026-08-11
+
+Requirements: RUN-314 and ASR-519. Related work: issues #197, #714, #717,
+and #1116; pull request #1085 first exposed the interface-rendering defect.
+
+## Decision
+
+The repository-owned libvirt appliance builder owns the exact bytes it asks
+libvirt to boot. It therefore encodes the bounded appliance tree directly as
+Linux `newc`, compresses it with a zero gzip timestamp, validates the embedded
+BusyBox executable before native mutation, and caches the selected kernel by
+content digest through atomic replacement.
+
+This changes adapter implementation semantics, not SDL or a normative
+contract. The published realization envelope still selects an x86_64 generated
+appliance. The run evidence continues to bind the actual kernel and initramfs
+digests.
+
+## Gap and owning boundary
+
+The prior implementation delegated `newc` creation to an ambient host `cpio`,
+embedded the host's `/usr/bin/busybox`, retained source filesystem metadata,
+and let `gzip.compress()` record wall-clock time. Identical inputs could
+therefore yield different bytes, while supported development hosts without
+those exact paths failed before the intended tests ran. Separately, the kernel
+cache treated equal `st_mtime_ns` values as content identity, so changed bytes
+with a preserved timestamp could reuse a stale kernel.
+
+These faults belong to the libvirt adapter's boot-artifact boundary. Scenario
+fields, runtime snapshots, or evidence-only changes cannot make the bytes
+deterministic or fresh.
+
+## Canonical initramfs
+
+`raes_backend_libvirt._initramfs.encode_newc()` implements the kernel-documented
+`070701` format:
+
+- member names are sorted by encoded POSIX-relative path;
+- inode numbers are assigned in that order;
+- uid, gid, mtime, device fields, and checksum are zero;
+- generated directory and symlink permissions are fixed, while deliberately
+  assigned regular-file permissions are retained;
+- regular files, directories, and links are encoded without invoking a host
+  command; unsupported special files fail;
+- names and contents are aligned to four bytes and a canonical `TRAILER!!!`
+  entry terminates the archive; and
+- gzip uses `mtime=0` and a platform-neutral header OS byte.
+
+Generated text and executable modes are assigned explicitly. The completed
+compressed artifact is fsynced in a sibling temporary file and atomically
+replaces its target. This makes repeated builds byte-identical for the same
+domain and BusyBox bytes; it does not claim that externally selected kernel or
+BusyBox inputs are identical across hosts.
+
+## Executable discovery and typed preflight
+
+Both appliance builders accept an absolute `busybox_path`. When it is omitted,
+they discover `busybox` on an optionally injected search path. Before a
+libvirt connection is opened or a network is defined, preflight requires:
+
+- a resolvable regular file with read and execute permission;
+- a structurally valid ELF executable for the x86_64 appliance target; and
+- no `PT_INTERP` program header, because the generated root has no dynamic
+  loader or shared libraries.
+
+The typed `InitramfsPreflight` result distinguishes missing, relative,
+non-regular, non-executable, non-ELF, wrong-architecture, and dynamically linked
+inputs. The driver maps any non-ready result to the stable redacted diagnostic
+`libvirt-backend.techvault-native.initramfs-toolchain-unavailable`. A missing
+or unreadable kernel similarly returns
+`libvirt-backend.techvault-native.kernel-unavailable`. Neither diagnostic
+contains a host path or raw exception.
+
+An injected custom `InitramfsBuilder` may own a different hermetic toolchain and
+omit the optional BusyBox preflight method. Its completed artifact is still
+hashed and read back through the incumbent evidence path.
+
+## Kernel cache
+
+`copy_kernel_for_libvirt()` compares SHA-256 content, never timestamps. Equal
+content reuses the existing inode after restoring its disclosed readable mode.
+Changed content is copied to a sibling temporary file, hashed while copying,
+fsynced, compared with the source digest to detect a concurrent source change,
+chmodded, and atomically replaced. Failure leaves a prior complete target in
+place and removes the incomplete temporary file.
+
+This is a content-integrity cache, not a trust policy for choosing a kernel.
+Configuration and operator controls still own which external kernel and static
+BusyBox bytes are supplied.
+
+## Rejected alternatives
+
+1. Document Ubuntu-only `/usr/bin/busybox` and `cpio` prerequisites: rejected
+   because archive metadata and gzip time would remain nondeterministic.
+2. Add flags to host `cpio`: rejected because implementations differ and an
+   ambient path-list protocol is unnecessary for this bounded tree.
+3. Compare kernel mtime plus size: rejected because mutable metadata is not
+   content identity.
+4. Write cache targets directly: rejected because interruption can expose a
+   partial boot artifact.
+
+## Evidence and verification
+
+The tests parse `newc` entries and verify order, modes, links, fixed metadata,
+alignment, and trailer; compare repeated TechVault and guest-certified builds;
+exercise injected, discovered, missing, dynamic, malformed, and wrong-target
+executables; reproduce same-mtime kernel substitution; and prove atomic failure
+preserves the old target. The changed artifact modules have 100% focused branch
+coverage. Issue #1116's structural MAC/IP/CIDR validation is shared by both
+init scripts, with no unrelated `.DS_Store` artifact.
+
+Primary format references:
+
+- Linux initramfs buffer format: <https://www.kernel.org/doc/html/latest/driver-api/early-userspace/buffer-format.html>
+- Python gzip timestamp control: <https://docs.python.org/3/library/gzip.html#gzip.compress>
+- OCI digest identity: <https://github.com/opencontainers/image-spec/blob/main/descriptor.md>
+- Reproducible archive practice: <https://reproducible-builds.org/docs/archives/>

--- a/docs/decisions/issue-1095-libvirt-guest-evidence-freshness.md
+++ b/docs/decisions/issue-1095-libvirt-guest-evidence-freshness.md
@@ -1,0 +1,120 @@
+# Issue 1095 / ASR-519 Libvirt Guest-Evidence Freshness
+
+Date: 2026-08-11
+
+Requirements: ASR-519 and RUN-314. This implements the freshness and resource
+evidence guardrails recorded for issue #715.
+
+## Decision
+
+Every guest-certified `realize()` attempt starts with empty operation-scoped
+guest evidence. After admission and boot-input preflight, the driver obtains a
+new challenge, rejects any challenge already used by that driver instance,
+removes each prior fact-channel object, and only then opens libvirt. A report is
+accepted only when its returned challenge equals the current operation's value.
+
+Guest memory remains an exact observed integer. A configurable and explicitly
+published one-sided tolerance is applied only when appraising that integer
+against requested memory; no boolean “corroborated” observation replaces the
+measurement.
+
+## Freshness lifecycle
+
+The old driver generated one challenge in `__post_init__` and reused it for all
+later operations. Its stable file-backed serial path could also contain a prior
+completed report. The transport could return that terminal report immediately,
+allowing old evidence to reach validation and making retry behavior depend on
+stale local state.
+
+The operation lifecycle is now:
+
+1. clear `challenge`, `last_guest_observations`, `last_guest_facts`, and
+   `last_guest_binding` at the beginning of every attempt, including attempts
+   rejected by admission or boot-input preflight;
+2. after those gates, request a challenge from the injected factory and require
+   a 16–64-character lowercase hexadecimal token that has not been used by this
+   driver instance;
+3. remove a prior regular, link, FIFO, socket, or broken-link fact channel for
+   every admitted domain; reject a directory or any unlink failure;
+4. pass the current challenge through the disclosed kernel-command-line
+   mechanism, boot, and validate the returned report in the existing staged
+   order; and
+5. publish facts and binding only after every daemon and guest comparison
+   succeeds. Rollback and destroy remove the fact channel and clear published
+   guest evidence.
+
+Preparation failure returns
+`libvirt-backend.guest.freshness-preflight-failed` before native mutation. A
+stale or cross-operation report that appears after channel clearing fails the
+existing `libvirt-backend.guest.challenge-mismatch` gate. A deterministic
+challenge factory remains injectable for hermetic tests, but repeated output is
+rejected rather than silently weakening production freshness.
+
+The challenge proves report recency relative to this driver operation. It is
+not a secret, a guest identity credential, a measured-boot attestation, or proof
+against a malicious guest that can read its own command line.
+
+## Exact memory evidence and appraisal
+
+The old observer reduced `/proc/meminfo` to
+`guest-memory-corroborated: true` whenever the value was between one half and
+all of requested memory. A 128 MiB definition could therefore accept a 64 MiB
+guest report while discarding the exact measurement from the claim-bearing
+observation set.
+
+The observer now emits `guest-memory-mib` with the exact parsed integer. The
+expected value remains the exact requested MiB value. `GuestObservationConfig`
+declares `memory_tolerance_mib` (default 16 MiB), and comparison accepts only:
+
+```text
+max(0, requested_mib - memory_tolerance_mib)
+    <= observed_mib
+    <= requested_mib
+```
+
+The allowance is one-sided because Linux `MemTotal` may exclude small reserved
+regions from memory assigned by the hypervisor; an observed value above the
+definition is not explained by that effect. The exact integer remains in both
+`RealizationObservation` and bounded per-domain facts. The evidence report and
+driver binding publish `memory_tolerance_mib`, so reviewers can separate
+measurement from appraisal. Negative, boolean, or non-integer tolerances fail
+configuration construction.
+
+Changing the default tolerance or probe method changes comparison semantics and
+must be reviewed together with the probe-policy identity. It must never rewrite
+the recorded measurement.
+
+## Evidence boundaries and alternatives
+
+The existing source layers remain distinct: daemon XML proves the exact memory
+definition; `/proc/meminfo` is a guest observation; the tolerance comparison is
+an appraisal. Neither source upgrades the other.
+
+Rejected alternatives:
+
+1. retain one process-lifetime challenge: it cannot distinguish retry reports;
+2. rely only on file mtime or truncate the old channel: timestamps are mutable,
+   and an old writer can retain an open inode;
+3. accept the first completed report and wait for later evidence only on parse
+   failure: a stale report must fail closed, not race the new boot;
+4. retain a boolean memory result: it destroys the evidence needed to audit the
+   tolerance; and
+5. accept a percentage or half-memory heuristic: it is overly permissive at
+   larger sizes and was not disclosed in the evidence binding.
+
+## Verification
+
+Hermetic tests cover two successful operations with distinct challenges,
+repeated and stale challenge rejection, pre-existing channel removal, channel
+directory and unlink failures, factory failure, clearing evidence before a
+failed new attempt, exact memory retention, the 16 MiB boundary, values below
+and above the permitted range, injected tolerance, invalid tolerance, and
+evidence-report disclosure. The guest freshness and observation modules have
+100% focused branch coverage; the opt-in real-libvirt proof remains the native
+certification gate.
+
+Related evidence guidance:
+
+- RFC 9334 attestation freshness model: <https://www.rfc-editor.org/rfc/rfc9334.html>
+- libvirt domain memory definition: <https://libvirt.org/formatdomain.html#memory-allocation>
+- Linux `/proc/meminfo`: <https://docs.kernel.org/filesystems/proc.html#meminfo>

--- a/docs/decisions/issue-1105-libvirt-guest-service-protocol.md
+++ b/docs/decisions/issue-1105-libvirt-guest-service-protocol.md
@@ -1,0 +1,35 @@
+# Issue 1105 / RUN-314 Guest Service Protocol Certification
+
+Date: 2026-08-11
+
+Issue: #1105. Requirements: RUN-314 and ASR-519. Related: #714 and #717.
+
+## Decision
+
+Guest-certified libvirt realization admits only TCP service placements until a
+native UDP implementation and probe are available. Admission rejects every
+other protocol before native mutation. The admitted `tcp` value is then carried
+through the runtime-domain projection, deterministic guest artifact, listener
+startup and inspection, line-oriented guest fact, parsed observation, and
+plan-derived expected projection.
+
+Certification compares name, protocol, port, listener state, and process state.
+Missing or different protocol evidence is a mismatch; a TCP listener cannot
+stand in for requested UDP behavior. This keeps the implementation honest while
+preserving the incumbent default-TCP authoring behavior.
+
+## Nonclaims and Alternatives
+
+This change does not implement or claim UDP service realization. Treating a
+generic `netstat` port match as protocol evidence was rejected because TCP and
+UDP can share a port. Inferring protocol solely from the plan was rejected
+because certification must bind the plan to an independently reported guest
+fact.
+
+## Verification
+
+Tests cover UDP admission rejection, default and explicit TCP admission,
+protocol-preserving runtime projection and boot payload, strict guest-fact
+parsing, TCP-specific listener inspection, exact observation matching, and
+wrong or missing protocol evidence. The focused guest-certified, TechVault
+honesty, and native prerequisite suites remain required.

--- a/docs/requirements/ASR-519/requirement.md
+++ b/docs/requirements/ASR-519/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: MUST
 wave: 3
 created_at: 2026-04-05T00:55:45.357920Z
-updated_at: 2026-06-15T02:32:29.792706Z
+updated_at: 2026-08-11T00:00:00Z
 ---
 
 # ASR-519 — Realization Honesty And Disclosure Conformance
@@ -61,3 +61,17 @@ Current state: identified gap. Honest portability needs executable checks agains
 - TESTS → TEST `implementations/python/tests/test_libvirt_conformance.py` (ASR-519 libvirt conformance mode tests)
 - TESTS → TEST `implementations/python/tests/test_libvirt_participant_runtime.py` (ASR-519 libvirt realization observation tests)
 - TESTS → TEST `implementations/python/tests/test_realization_envelope_relation.py` (ASR-519 envelope probe relation tests)
+- IMPLEMENTS → GITHUB_ISSUE `1116` (Root-run libvirt init-script interface validation)
+- IMPLEMENTS → GITHUB_ISSUE `1094` (Deterministic, preflighted, content-identified boot artifacts)
+- IMPLEMENTS → GITHUB_ISSUE `1095` (Fresh operation-bound guest facts and exact memory evidence)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/guest_certified_driver.py` (Per-operation freshness lifecycle)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/guest_observation.py` (Exact memory observation and explicit tolerance appraisal)
+- IMPLEMENTS → DOCUMENTATION `docs/decisions/issue-1094-libvirt-boot-artifact-reliability.md` (Boot-artifact evidence reliability)
+- IMPLEMENTS → DOCUMENTATION `docs/decisions/issue-1095-libvirt-guest-evidence-freshness.md` (Freshness and memory evidence architecture)
+- TESTS → TEST `implementations/python/tests/test_libvirt_boot_artifacts.py` (Artifact identity and preflight falsification)
+- TESTS → TEST `implementations/python/tests/test_libvirt_backend_guest_certified.py` (Freshness, stale-fact, exact-memory, and evidence-binding falsification)
+- TESTS → TEST `implementations/python/tests/test_libvirt_guest_appliance_init_script.py` (Shared root-run interface injection regressions)
+- DOCUMENTS → GITHUB_ISSUE `1105` (Guest service protocol honesty defect)
+- DOCUMENTS → DOCUMENTATION `docs/decisions/issue-1105-libvirt-guest-service-protocol.md` (Protocol evidence boundary)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/guest_observation.py` (Protocol-bound expected and observed service evidence)
+- TESTS → TEST `implementations/python/tests/test_libvirt_backend_guest_certified.py` (Wrong-protocol evidence rejection)

--- a/docs/requirements/RUN-314/requirement.md
+++ b/docs/requirements/RUN-314/requirement.md
@@ -6,7 +6,7 @@ type: FUNCTIONAL
 priority: MUST
 wave: 2
 created_at: 2026-04-05T01:46:39.033909Z
-updated_at: 2026-06-20T18:06:59.002481Z
+updated_at: 2026-08-11T00:00:00Z
 ---
 
 # RUN-314 — Reference Emulation Backend
@@ -26,3 +26,14 @@ The ecosystem needs at least one concrete infrastructure-backed backend so its p
 - TESTS → TEST `implementations/python/tests/test_reference_backend_provenance.py` (SEM-218 realization provenance)
 - TESTS → TEST `implementations/python/tests/test_reference_backend_oci_driver.py` (OCI driver security + realization)
 - TESTS → TEST `implementations/python/tests/test_reference_backend_registry.py` (Target shape/contract + registry registration)
+- DOCUMENTS → GITHUB_ISSUE `197` (RUN-314 reference-emulation backend root)
+- IMPLEMENTS → GITHUB_ISSUE `1094` (Deterministic and cache-safe libvirt boot artifacts)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/_initramfs.py` (Repository-owned newc, toolchain preflight, and atomic artifact helpers)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/techvault_appliance.py` (Deterministic TechVault appliance and digest kernel cache)
+- IMPLEMENTS → DOCUMENTATION `docs/decisions/issue-1094-libvirt-boot-artifact-reliability.md` (Boot-artifact reliability architecture)
+- TESTS → TEST `implementations/python/tests/test_libvirt_boot_artifacts.py` (Determinism, preflight, newc, and atomic cache regressions)
+- DOCUMENTS → GITHUB_ISSUE `1105` (Guest-certified service protocol binding)
+- DOCUMENTS → DOCUMENTATION `docs/decisions/issue-1105-libvirt-guest-service-protocol.md` (TCP-only admission and evidence decision)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/techvault_concerns.py` (Fail-closed service protocol admission)
+- IMPLEMENTS → CODE_FILE `implementations/python/packages/raes_backend_libvirt/guest_appliance.py` (Protocol-bound guest listener and facts)
+- TESTS → TEST `implementations/python/tests/test_libvirt_backend_guest_certified.py` (Service protocol certification regressions)

--- a/implementations/python/packages/raes_backend_libvirt/_initramfs.py
+++ b/implementations/python/packages/raes_backend_libvirt/_initramfs.py
@@ -1,0 +1,285 @@
+"""Deterministic initramfs encoding and BusyBox toolchain preflight."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+import shutil
+import stat
+import struct
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+_NEWC_MAGIC = b"070701"
+_NEWC_TRAILER = "TRAILER!!!"
+_ELF_MACHINE_X86_64 = 62
+_PT_INTERP = 3
+
+
+class InitramfsPreflightCode(str, Enum):
+    """Stable outcomes for an appliance executable preflight."""
+
+    READY = "ready"
+    NOT_FOUND = "not-found"
+    NOT_ABSOLUTE = "not-absolute"
+    NOT_REGULAR = "not-regular"
+    NOT_EXECUTABLE = "not-executable"
+    NOT_ELF = "not-elf"
+    WRONG_ARCHITECTURE = "wrong-architecture"
+    NOT_STATIC = "not-static"
+
+
+@dataclass(frozen=True)
+class InitramfsPreflight:
+    """Typed result of resolving the executable embedded in an initramfs."""
+
+    code: InitramfsPreflightCode
+    executable: Path | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.code is InitramfsPreflightCode.READY
+
+    def require_executable(self) -> Path:
+        if not self.ready or self.executable is None:
+            raise InitramfsToolchainError(self)
+        return self.executable
+
+
+class InitramfsToolchainError(RuntimeError):
+    """Raised when a builder is invoked after a failed typed preflight."""
+
+    def __init__(self, preflight: InitramfsPreflight) -> None:
+        self.preflight = preflight
+        super().__init__(f"initramfs toolchain preflight failed: {preflight.code.value}")
+
+
+def resolve_static_busybox(
+    configured: Path | None,
+    *,
+    search_path: str | None = None,
+    expected_elf_machine: int = _ELF_MACHINE_X86_64,
+) -> InitramfsPreflight:
+    """Resolve an injected or PATH-discovered static target BusyBox executable."""
+
+    if configured is None:
+        discovered = shutil.which("busybox", path=search_path)
+        if discovered is None:
+            return InitramfsPreflight(InitramfsPreflightCode.NOT_FOUND)
+        candidate = Path(discovered)
+    else:
+        candidate = Path(configured)
+        if not candidate.is_absolute():
+            return InitramfsPreflight(InitramfsPreflightCode.NOT_ABSOLUTE)
+    try:
+        candidate = candidate.resolve(strict=True)
+    except OSError:
+        return InitramfsPreflight(InitramfsPreflightCode.NOT_FOUND)
+    if not candidate.is_file():
+        return InitramfsPreflight(InitramfsPreflightCode.NOT_REGULAR)
+    if not os.access(candidate, os.R_OK | os.X_OK):
+        return InitramfsPreflight(InitramfsPreflightCode.NOT_EXECUTABLE)
+    elf_code = _static_elf_preflight(candidate, expected_machine=expected_elf_machine)
+    if elf_code is not InitramfsPreflightCode.READY:
+        return InitramfsPreflight(elf_code)
+    return InitramfsPreflight(InitramfsPreflightCode.READY, candidate)
+
+
+def builder_preflight(builder: object) -> InitramfsPreflight:
+    """Run an optional typed preflight, preserving injected custom builders."""
+
+    preflight = getattr(builder, "preflight", None)
+    if not callable(preflight):
+        return InitramfsPreflight(InitramfsPreflightCode.READY)
+    result = preflight()
+    if not isinstance(result, InitramfsPreflight):
+        raise TypeError("initramfs builder preflight must return InitramfsPreflight")
+    return result
+
+
+def encode_newc(root: Path) -> bytes:
+    """Encode ``root`` as canonical Linux ``newc`` without host archive tools."""
+
+    root = Path(root)
+    if not root.is_dir():
+        raise ValueError("initramfs root must be a directory")
+    archive = bytearray()
+    paths = sorted(root.rglob("*"), key=lambda path: os.fsencode(path.relative_to(root).as_posix()))
+    for inode, path in enumerate(paths, start=1):
+        relative = path.relative_to(root).as_posix()
+        metadata = path.lstat()
+        mode = stat.S_IFMT(metadata.st_mode) | stat.S_IMODE(metadata.st_mode)
+        if stat.S_ISREG(mode):
+            payload = path.read_bytes()
+        elif stat.S_ISLNK(mode):
+            mode = stat.S_IFLNK | 0o777
+            payload = os.fsencode(os.readlink(path))
+        elif stat.S_ISDIR(mode):
+            mode = stat.S_IFDIR | 0o755
+            payload = b""
+        else:
+            raise ValueError(f"unsupported initramfs member type: {relative!r}")
+        _append_newc_entry(archive, relative, payload, inode=inode, mode=mode)
+    _append_newc_entry(archive, _NEWC_TRAILER, b"", inode=len(paths) + 1, mode=0)
+    return bytes(archive)
+
+
+def deterministic_gzip(payload: bytes, *, compresslevel: int = 6) -> bytes:
+    """Return gzip bytes with a fixed timestamp and platform-neutral OS byte."""
+
+    compressed = bytearray(gzip.compress(payload, compresslevel=compresslevel, mtime=0))
+    compressed[9] = 255
+    return bytes(compressed)
+
+
+def atomic_write(path: Path, payload: bytes, *, mode: int) -> Path:
+    """Durably stage ``payload`` beside ``path`` and atomically replace it."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def atomic_copy_by_digest(source: Path, target: Path, *, mode: int) -> Path:
+    """Reuse equal content or atomically replace ``target`` from ``source``."""
+
+    source = Path(source)
+    target = Path(target)
+    source_digest = _file_digest(source)
+    if target.exists() and not target.is_symlink() and target.is_file():
+        if _file_digest(target) == source_digest:
+            os.chmod(target, mode)
+            return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    temporary = Path(temporary_name)
+    staged_digest = hashlib.sha256()
+    try:
+        with source.open("rb") as input_stream, os.fdopen(descriptor, "wb") as output_stream:
+            while chunk := input_stream.read(1024 * 1024):
+                output_stream.write(chunk)
+                staged_digest.update(chunk)
+            output_stream.flush()
+            os.fsync(output_stream.fileno())
+        if staged_digest.hexdigest() != source_digest:
+            raise RuntimeError("kernel source changed while staging the libvirt cache")
+        os.chmod(temporary, mode)
+        os.replace(temporary, target)
+        _fsync_directory(target.parent)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return target
+
+
+def _static_elf_preflight(path: Path, *, expected_machine: int) -> InitramfsPreflightCode:
+    try:
+        with path.open("rb") as stream:
+            header = stream.read(64)
+            if len(header) < 52 or header[:4] != b"\x7fELF" or header[6] != 1:
+                return InitramfsPreflightCode.NOT_ELF
+            elf_class = header[4]
+            byte_order = header[5]
+            if elf_class not in {1, 2} or byte_order not in {1, 2}:
+                return InitramfsPreflightCode.NOT_ELF
+            endian = "<" if byte_order == 1 else ">"
+            machine = struct.unpack_from(f"{endian}H", header, 18)[0]
+            if machine != expected_machine:
+                return InitramfsPreflightCode.WRONG_ARCHITECTURE
+            if elf_class == 1:
+                phoff = struct.unpack_from(f"{endian}I", header, 28)[0]
+                phentsize = struct.unpack_from(f"{endian}H", header, 42)[0]
+                phnum = struct.unpack_from(f"{endian}H", header, 44)[0]
+                minimum_entry_size = 32
+            else:
+                phoff = struct.unpack_from(f"{endian}Q", header, 32)[0]
+                phentsize = struct.unpack_from(f"{endian}H", header, 54)[0]
+                phnum = struct.unpack_from(f"{endian}H", header, 56)[0]
+                minimum_entry_size = 56
+            if phnum < 1 or phnum > 1024 or phentsize < minimum_entry_size:
+                return InitramfsPreflightCode.NOT_ELF
+            stream.seek(phoff)
+            for _ in range(phnum):
+                entry = stream.read(phentsize)
+                if len(entry) != phentsize:
+                    return InitramfsPreflightCode.NOT_ELF
+                if struct.unpack_from(f"{endian}I", entry)[0] == _PT_INTERP:
+                    return InitramfsPreflightCode.NOT_STATIC
+    except OSError:
+        return InitramfsPreflightCode.NOT_FOUND
+    return InitramfsPreflightCode.READY
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _append_newc_entry(archive: bytearray, name: str, payload: bytes, *, inode: int, mode: int) -> None:
+    encoded_name = os.fsencode(name)
+    fields = (
+        inode,
+        mode,
+        0,  # uid
+        0,  # gid
+        2 if stat.S_ISDIR(mode) else 1,
+        0,  # mtime
+        len(payload),
+        0,  # devmajor
+        0,  # devminor
+        0,  # rdevmajor
+        0,  # rdevminor
+        len(encoded_name) + 1,
+        0,  # check
+    )
+    archive.extend(_NEWC_MAGIC)
+    archive.extend("".join(f"{value:08x}" for value in fields).encode("ascii"))
+    archive.extend(encoded_name)
+    archive.append(0)
+    _align_four(archive)
+    archive.extend(payload)
+    _align_four(archive)
+
+
+def _align_four(payload: bytearray) -> None:
+    payload.extend(b"\0" * (-len(payload) % 4))
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "InitramfsPreflight",
+    "InitramfsPreflightCode",
+    "InitramfsToolchainError",
+    "atomic_copy_by_digest",
+    "atomic_write",
+    "builder_preflight",
+    "deterministic_gzip",
+    "encode_newc",
+    "resolve_static_busybox",
+]

--- a/implementations/python/packages/raes_backend_libvirt/_initramfs.py
+++ b/implementations/python/packages/raes_backend_libvirt/_initramfs.py
@@ -12,6 +12,7 @@ import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import BinaryIO
 
 _NEWC_MAGIC = b"070701"
 _NEWC_TRAILER = "TRAILER!!!"
@@ -57,6 +58,15 @@ class InitramfsToolchainError(RuntimeError):
         super().__init__(f"initramfs toolchain preflight failed: {preflight.code.value}")
 
 
+@dataclass(frozen=True)
+class _ElfProgramHeaders:
+    offset: int
+    entry_size: int
+    count: int
+    minimum_entry_size: int
+    byte_order: str
+
+
 def resolve_static_busybox(
     configured: Path | None,
     *,
@@ -65,27 +75,42 @@ def resolve_static_busybox(
 ) -> InitramfsPreflight:
     """Resolve an injected or PATH-discovered static target BusyBox executable."""
 
+    candidate, code = _busybox_candidate(configured, search_path=search_path)
+    if candidate is not None:
+        try:
+            candidate = candidate.resolve(strict=True)
+        except OSError:
+            code = InitramfsPreflightCode.NOT_FOUND
+        else:
+            code = _busybox_file_preflight(candidate, expected_elf_machine=expected_elf_machine)
+    executable = candidate if code is InitramfsPreflightCode.READY else None
+    assert code is not None
+    return InitramfsPreflight(code, executable)
+
+
+def _busybox_candidate(
+    configured: Path | None, *, search_path: str | None
+) -> tuple[Path | None, InitramfsPreflightCode | None]:
     if configured is None:
         discovered = shutil.which("busybox", path=search_path)
-        if discovered is None:
-            return InitramfsPreflight(InitramfsPreflightCode.NOT_FOUND)
-        candidate = Path(discovered)
+        candidate = Path(discovered) if discovered is not None else None
+        code = None if candidate is not None else InitramfsPreflightCode.NOT_FOUND
     else:
         candidate = Path(configured)
-        if not candidate.is_absolute():
-            return InitramfsPreflight(InitramfsPreflightCode.NOT_ABSOLUTE)
-    try:
-        candidate = candidate.resolve(strict=True)
-    except OSError:
-        return InitramfsPreflight(InitramfsPreflightCode.NOT_FOUND)
+        code = None if candidate.is_absolute() else InitramfsPreflightCode.NOT_ABSOLUTE
+        if code is not None:
+            candidate = None
+    return candidate, code
+
+
+def _busybox_file_preflight(candidate: Path, *, expected_elf_machine: int) -> InitramfsPreflightCode:
     if not candidate.is_file():
-        return InitramfsPreflight(InitramfsPreflightCode.NOT_REGULAR)
-    if not os.access(candidate, os.R_OK | os.X_OK):
-        return InitramfsPreflight(InitramfsPreflightCode.NOT_EXECUTABLE)
-    elf_code = _static_elf_preflight(candidate, expected_machine=expected_elf_machine)
-    if elf_code is not InitramfsPreflightCode.READY:
-        return InitramfsPreflight(elf_code)
-    return InitramfsPreflight(InitramfsPreflightCode.READY, candidate)
+        code = InitramfsPreflightCode.NOT_REGULAR
+    elif not os.access(candidate, os.R_OK | os.X_OK):
+        code = InitramfsPreflightCode.NOT_EXECUTABLE
+    else:
+        code = _static_elf_preflight(candidate, expected_machine=expected_elf_machine)
+    return code
 
 
 def builder_preflight(builder: object) -> InitramfsPreflight:
@@ -192,38 +217,71 @@ def _static_elf_preflight(path: Path, *, expected_machine: int) -> InitramfsPref
     try:
         with path.open("rb") as stream:
             header = stream.read(64)
-            if len(header) < 52 or header[:4] != b"\x7fELF" or header[6] != 1:
-                return InitramfsPreflightCode.NOT_ELF
-            elf_class = header[4]
-            byte_order = header[5]
-            if elf_class not in {1, 2} or byte_order not in {1, 2}:
-                return InitramfsPreflightCode.NOT_ELF
+            layout, code = _elf_program_headers(header, expected_machine=expected_machine)
+            if layout is not None:
+                code = _program_header_preflight(stream, layout)
+    except OSError:
+        code = InitramfsPreflightCode.NOT_FOUND
+    assert code is not None
+    return code
+
+
+def _elf_program_headers(
+    header: bytes, *, expected_machine: int
+) -> tuple[_ElfProgramHeaders | None, InitramfsPreflightCode | None]:
+    layout = None
+    code = None
+    if len(header) < 52 or header[:4] != b"\x7fELF" or header[6] != 1:
+        code = InitramfsPreflightCode.NOT_ELF
+    else:
+        elf_class = header[4]
+        byte_order = header[5]
+        if elf_class not in {1, 2} or byte_order not in {1, 2} or (elf_class == 2 and len(header) < 58):
+            code = InitramfsPreflightCode.NOT_ELF
+        else:
             endian = "<" if byte_order == 1 else ">"
             machine = struct.unpack_from(f"{endian}H", header, 18)[0]
             if machine != expected_machine:
-                return InitramfsPreflightCode.WRONG_ARCHITECTURE
-            if elf_class == 1:
-                phoff = struct.unpack_from(f"{endian}I", header, 28)[0]
-                phentsize = struct.unpack_from(f"{endian}H", header, 42)[0]
-                phnum = struct.unpack_from(f"{endian}H", header, 44)[0]
-                minimum_entry_size = 32
+                code = InitramfsPreflightCode.WRONG_ARCHITECTURE
             else:
-                phoff = struct.unpack_from(f"{endian}Q", header, 32)[0]
-                phentsize = struct.unpack_from(f"{endian}H", header, 54)[0]
-                phnum = struct.unpack_from(f"{endian}H", header, 56)[0]
-                minimum_entry_size = 56
-            if phnum < 1 or phnum > 1024 or phentsize < minimum_entry_size:
-                return InitramfsPreflightCode.NOT_ELF
-            stream.seek(phoff)
-            for _ in range(phnum):
-                entry = stream.read(phentsize)
-                if len(entry) != phentsize:
-                    return InitramfsPreflightCode.NOT_ELF
-                if struct.unpack_from(f"{endian}I", entry)[0] == _PT_INTERP:
-                    return InitramfsPreflightCode.NOT_STATIC
-    except OSError:
-        return InitramfsPreflightCode.NOT_FOUND
-    return InitramfsPreflightCode.READY
+                layout = _program_header_layout(header, elf_class=elf_class, byte_order=endian)
+    return layout, code
+
+
+def _program_header_layout(header: bytes, *, elf_class: int, byte_order: str) -> _ElfProgramHeaders:
+    if elf_class == 1:
+        offset = struct.unpack_from(f"{byte_order}I", header, 28)[0]
+        entry_size = struct.unpack_from(f"{byte_order}H", header, 42)[0]
+        count = struct.unpack_from(f"{byte_order}H", header, 44)[0]
+        minimum_entry_size = 32
+    else:
+        offset = struct.unpack_from(f"{byte_order}Q", header, 32)[0]
+        entry_size = struct.unpack_from(f"{byte_order}H", header, 54)[0]
+        count = struct.unpack_from(f"{byte_order}H", header, 56)[0]
+        minimum_entry_size = 56
+    return _ElfProgramHeaders(
+        offset=offset,
+        entry_size=entry_size,
+        count=count,
+        minimum_entry_size=minimum_entry_size,
+        byte_order=byte_order,
+    )
+
+
+def _program_header_preflight(stream: BinaryIO, layout: _ElfProgramHeaders) -> InitramfsPreflightCode:
+    if layout.count < 1 or layout.count > 1024 or layout.entry_size < layout.minimum_entry_size:
+        return InitramfsPreflightCode.NOT_ELF
+    stream.seek(layout.offset)
+    code = InitramfsPreflightCode.READY
+    for _ in range(layout.count):
+        entry = stream.read(layout.entry_size)
+        if len(entry) != layout.entry_size:
+            code = InitramfsPreflightCode.NOT_ELF
+            break
+        if struct.unpack_from(f"{layout.byte_order}I", entry)[0] == _PT_INTERP:
+            code = InitramfsPreflightCode.NOT_STATIC
+            break
+    return code
 
 
 def _file_digest(path: Path) -> str:

--- a/implementations/python/packages/raes_backend_libvirt/_techvault_native_ops.py
+++ b/implementations/python/packages/raes_backend_libvirt/_techvault_native_ops.py
@@ -22,10 +22,13 @@ from .techvault_lifecycle import (
 
 _DOMAIN = "runtime"
 _CODE_OPERATION_FAILED = "libvirt-backend.techvault-native.operation-failed"
+_CODE_KERNEL_UNAVAILABLE = "libvirt-backend.techvault-native.kernel-unavailable"
+_CODE_GUEST_FRESHNESS_UNAVAILABLE = "libvirt-backend.guest.freshness-preflight-failed"
 _CODE_OWNERSHIP_CONFLICT = "libvirt-backend.techvault-native.ownership-conflict"
 _CODE_READBACK_FAILED = "libvirt-backend.techvault-native.readback-failed"
 _CODE_RESIDUAL_STATE = "libvirt-backend.techvault-native.residual-state"
 _CODE_UNAVAILABLE = "libvirt-backend.techvault-native.unavailable"
+_CODE_TOOLCHAIN_UNAVAILABLE = "libvirt-backend.techvault-native.initramfs-toolchain-unavailable"
 _DEFAULT_CONNECTION_URI = "qemu:///system"
 
 
@@ -64,6 +67,13 @@ def _artifact_token(address: str) -> str:
 
 
 _MESSAGES = {
+    _CODE_GUEST_FRESHNESS_UNAVAILABLE: (
+        "A fresh guest challenge and empty fact channel could not be established before native mutation."
+    ),
+    _CODE_KERNEL_UNAVAILABLE: "The configured kernel is not a readable regular file; refusing native mutation.",
+    _CODE_TOOLCHAIN_UNAVAILABLE: (
+        "The injected or discovered initramfs executable failed static target-toolchain preflight."
+    ),
     _CODE_UNAVAILABLE: "Libvirt connection is unavailable for native TechVault realization.",
     _CODE_RESIDUAL_STATE: "TechVault rollback could not verify cleanup for '{address}'; residual state may remain.",
     _CODE_OWNERSHIP_CONFLICT: "Native object for '{address}' is not owned by that RAES address; refusing mutation.",

--- a/implementations/python/packages/raes_backend_libvirt/guest_appliance.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_appliance.py
@@ -23,6 +23,7 @@ from ._initramfs import InitramfsPreflight, atomic_write, deterministic_gzip, re
 from .techvault_appliance import _cpio_newc, _interface_case_lines, _shell_quote
 
 _BOOT_ARTIFACT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+_PRIVATE_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR
 
 _APPLETS = (
     "sh", "mount", "mdev", "ip", "ifconfig", "sleep", "cat", "hostname", "printf", "echo",
@@ -130,7 +131,7 @@ def _write_placement_specs(guest_dir: Path, files_dir: Path, domain: Mapping[str
 
 def _write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
-    os.chmod(path, 0o644)
+    os.chmod(path, _PRIVATE_FILE_MODE)
 
 
 def _init_script(domain: Mapping[str, object]) -> str:

--- a/implementations/python/packages/raes_backend_libvirt/guest_appliance.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_appliance.py
@@ -10,16 +10,19 @@ image bytes (and therefore their digest) are independent of the challenge.
 
 from __future__ import annotations
 
-import gzip
 import json
 import os
 import shutil
+import stat
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from .techvault_appliance import _cpio_newc, _shell_quote
+from ._initramfs import InitramfsPreflight, atomic_write, deterministic_gzip, resolve_static_busybox
+from .techvault_appliance import _cpio_newc, _interface_case_lines, _shell_quote
+
+_BOOT_ARTIFACT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
 _APPLETS = (
     "sh", "mount", "mdev", "ip", "ifconfig", "sleep", "cat", "hostname", "printf", "echo",
@@ -42,16 +45,21 @@ _SKIP_IF_NO_NAME = '  [ -n "$name" ] || continue'
 class GuestObservingInitramfsBuilder:
     """Build a guest-observing appliance that certifies concerns from inside."""
 
-    busybox_path: Path = Path("/usr/bin/busybox")
+    busybox_path: Path | None = None
+    search_path: str | None = None
+
+    def preflight(self) -> InitramfsPreflight:
+        """Resolve and validate the static target BusyBox before mutation."""
+
+        return resolve_static_busybox(self.busybox_path, search_path=self.search_path)
 
     def build(self, *, domain: Mapping[str, object], target: Path) -> Path:
+        busybox_path = self.preflight().require_executable()
         with tempfile.TemporaryDirectory(prefix="raes-guest-initramfs-") as tmp:
             root = Path(tmp)
-            _write_guest_root(root, self.busybox_path, domain)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            payload = _cpio_newc(root)
-            target.write_bytes(gzip.compress(payload, compresslevel=6))
-        return target
+            _write_guest_root(root, busybox_path, domain)
+            payload = deterministic_gzip(_cpio_newc(root), compresslevel=6)
+            return atomic_write(target, payload, mode=_BOOT_ARTIFACT_MODE)
 
 
 def _write_guest_root(root: Path, busybox_path: Path, domain: Mapping[str, object]) -> None:
@@ -70,16 +78,17 @@ def _write_guest_root(root: Path, busybox_path: Path, domain: Mapping[str, objec
         root / "home",
     ):
         directory.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(busybox_path, bin_dir / "busybox")
+    shutil.copyfile(busybox_path, bin_dir / "busybox")
     for applet in _APPLETS:
         (bin_dir / applet).symlink_to("busybox")
-    (etc_dir / "passwd").write_text(_ROOT_ACCOUNT_LINE, encoding="utf-8")
-    (etc_dir / "group").write_text(_ROOT_GROUP_LINE, encoding="utf-8")
-    (etc_dir / "shadow").write_text(_ROOT_SHADOW_LINE, encoding="utf-8")
+    _write_text(etc_dir / "passwd", _ROOT_ACCOUNT_LINE)
+    _write_text(etc_dir / "group", _ROOT_GROUP_LINE)
+    _write_text(etc_dir / "shadow", _ROOT_SHADOW_LINE)
     _write_placement_specs(guest_dir, files_dir, domain)
-    (guest_dir / "domain.json").write_text(json.dumps(domain, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    (root / "init").write_text(_init_script(domain), encoding="utf-8")
-    os.chmod(root / "init", 0o700)
+    _write_text(guest_dir / "domain.json", json.dumps(domain, indent=2, sort_keys=True) + "\n")
+    init_path = root / "init"
+    _write_text(init_path, _init_script(domain))
+    os.chmod(init_path, 0o700)
     os.chmod(bin_dir / "busybox", 0o700)
 
 
@@ -101,16 +110,27 @@ def _write_placement_specs(guest_dir: Path, files_dir: Path, domain: Mapping[str
     for index, item in enumerate(_as_sequence(domain.get("content"))):
         if not isinstance(item, Mapping):
             continue
-        (files_dir / str(index)).write_text(str(item.get("content", "")), encoding="utf-8")
+        _write_text(files_dir / str(index), str(item.get("content", "")))
         content_lines.append("|".join((str(item.get("path", "")), str(item.get("mode", "0644")), str(index))))
     services = [
-        "|".join((str(item.get("name", "")), str(item.get("port", ""))))
+        "|".join(
+            (
+                str(item.get("name", "")),
+                str(item.get("protocol", "")),
+                str(item.get("port", "")),
+            )
+        )
         for item in _as_sequence(domain.get("services"))
         if isinstance(item, Mapping)
     ]
-    (guest_dir / "accounts").write_text("\n".join(accounts) + ("\n" if accounts else ""), encoding="utf-8")
-    (guest_dir / "content").write_text("\n".join(content_lines) + ("\n" if content_lines else ""), encoding="utf-8")
-    (guest_dir / "services").write_text("\n".join(services) + ("\n" if services else ""), encoding="utf-8")
+    _write_text(guest_dir / "accounts", "\n".join(accounts) + ("\n" if accounts else ""))
+    _write_text(guest_dir / "content", "\n".join(content_lines) + ("\n" if content_lines else ""))
+    _write_text(guest_dir / "services", "\n".join(services) + ("\n" if services else ""))
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    os.chmod(path, 0o644)
 
 
 def _init_script(domain: Mapping[str, object]) -> str:
@@ -132,13 +152,7 @@ def _init_script(domain: Mapping[str, object]) -> str:
     for interface in _as_sequence(domain.get("interfaces")):
         if not isinstance(interface, Mapping):
             continue
-        lines.extend(
-            [
-                f"    {interface.get('mac')})",
-                f'      ip addr add {interface.get("ip")}/{interface.get("cidr_prefix")} dev "$iface"',
-                "      ;;",
-            ]
-        )
+        lines.extend(_interface_case_lines(interface))
     lines.extend(["  esac", "done"])
     lines.extend(_REALIZE_SNIPPET)
     lines.append("sleep 1")
@@ -185,8 +199,9 @@ _REALIZE_SNIPPET = [
     "done < /etc/raes/guest/content",
     "fi",
     "if [ -f /etc/raes/guest/services ]; then",
-    "while IFS='|' read name port; do",
+    "while IFS='|' read name protocol port; do",
     _SKIP_IF_NO_NAME,
+    '  [ "$protocol" = tcp ] || continue',
     '  ( while true; do echo raes-guest-service | nc -l -p "$port" >/dev/null 2>&1 || sleep 1; done ) &',
     "  echo $! > /run/raes-svc-$name.pid",
     "done < /etc/raes/guest/services",
@@ -232,11 +247,11 @@ _REPORT_SNIPPET = [
     "done < /etc/raes/guest/accounts",
     "fi",
     "if [ -f /etc/raes/guest/services ]; then",
-    "while IFS='|' read name port; do",
+    "while IFS='|' read name protocol port; do",
     _SKIP_IF_NO_NAME,
-    '  lis=0; netstat -ln 2>/dev/null | grep -q ":$port " && lis=1',
+    '  lis=0; [ "$protocol" = tcp ] && netstat -lnt 2>/dev/null | grep -q ":$port " && lis=1',
     '  pid=0; [ -f "/run/raes-svc-$name.pid" ] && kill -0 "$(cat /run/raes-svc-$name.pid)" 2>/dev/null && pid=1',
-    '  echo "service $name $port $lis $pid"',
+    '  echo "service $name $protocol $port $lis $pid"',
     "done < /etc/raes/guest/services",
     "fi",
     "echo 'init complete'",

--- a/implementations/python/packages/raes_backend_libvirt/guest_certified_driver.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_certified_driver.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import re
 import secrets
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -22,6 +22,7 @@ from typing import ClassVar
 
 from raes_contracts.diagnostics import Diagnostic
 
+from ._techvault_native_ops import _CODE_GUEST_FRESHNESS_UNAVAILABLE, _diagnostic
 from .driver import DomainSpec, NetworkSpec, RealizationObservation
 from .drivers.libvirt import _raes_uuid
 from .guest_appliance import GuestObservingInitramfsBuilder
@@ -36,6 +37,10 @@ from .techvault_native import DriverResult, TechVaultNativeLibvirtDriver, _artif
 _SAFE_CHALLENGE_RE = re.compile(r"^[a-f0-9]{16,64}$")
 
 
+def _fresh_challenge() -> str:
+    return secrets.token_hex(16)
+
+
 @dataclass
 class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
     """Realize TechVault domains and certify concerns from inside the guest."""
@@ -45,17 +50,17 @@ class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
     initramfs_builder: InitramfsBuilder = field(default_factory=GuestObservingInitramfsBuilder)
     guest_transport: GuestFactTransport = field(default_factory=FileSerialGuestFactTransport)
     guest_config: GuestObservationConfig = field(default_factory=GuestObservationConfig)
-    challenge: str | None = None
+    challenge_factory: Callable[[], str] = field(default=_fresh_challenge, repr=False)
+    challenge: str | None = field(default=None, init=False)
     last_guest_observations: tuple[RealizationObservation, ...] = ()
     last_guest_facts: dict[str, object] = field(default_factory=dict)
     last_guest_binding: dict[str, object] = field(default_factory=dict)
+    _used_challenges: set[str] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if self.challenge is None:
-            self.challenge = secrets.token_hex(16)
-        elif not _SAFE_CHALLENGE_RE.match(self.challenge):
-            raise ValueError("guest-certified challenge must be a lowercase hex token")
+        if not callable(self.challenge_factory):
+            raise ValueError("guest-certified challenge_factory must be callable")
 
     def _admission_diagnostics(
         self,
@@ -84,6 +89,44 @@ class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
             name_prefix=self.name_prefix,
             include_placements=True,
         )
+
+    def _prepare_operation(self, matrix: Mapping[str, object]) -> list[Diagnostic]:
+        """Rotate freshness state and remove every prior fact before libvirt I/O."""
+
+        self._begin_operation()
+        try:
+            candidate = self.challenge_factory()
+        except Exception:
+            return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+        if (
+            not isinstance(candidate, str)
+            or not _SAFE_CHALLENGE_RE.match(candidate)
+            or candidate in self._used_challenges
+        ):
+            return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+        for domain in matrix.get("domains", ()):
+            if not isinstance(domain, Mapping):
+                continue
+            channel = self._fact_channel_path(str(domain.get("address", "")))
+            try:
+                channel.parent.mkdir(parents=True, exist_ok=True)
+                if channel.is_symlink() or (channel.exists() and not channel.is_dir()):
+                    channel.unlink()
+                elif channel.exists():
+                    return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+            except OSError:
+                return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+        self.challenge = candidate
+        self._used_challenges.add(candidate)
+        return []
+
+    def _begin_operation(self) -> None:
+        """Prevent prior guest evidence from surviving into a new attempt."""
+
+        self.challenge = None
+        self.last_guest_observations = ()
+        self.last_guest_facts = {}
+        self.last_guest_binding = {}
 
     def _render_domain_xml(self, domain: Mapping[str, object], *, kernel: Path, initrd: Path) -> str:
         address = str(domain.get("address", ""))
@@ -146,6 +189,7 @@ class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
         return {
             "challenge": self.challenge,
             "probe_policy": self.guest_config.probe_policy,
+            "memory_tolerance_mib": self.guest_config.memory_tolerance_mib,
             "correlations": correlations,
         }
 

--- a/implementations/python/packages/raes_backend_libvirt/guest_certified_driver.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_certified_driver.py
@@ -35,6 +35,7 @@ from .techvault_matrix import native_matrix as _native_matrix
 from .techvault_native import DriverResult, TechVaultNativeLibvirtDriver, _artifact_token
 
 _SAFE_CHALLENGE_RE = re.compile(r"^[a-f0-9]{16,64}$")
+_GUEST_FACTS_ADDRESS = "runtime.libvirt.guest-facts"
 
 
 def _fresh_challenge() -> str:
@@ -94,16 +95,27 @@ class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
         """Rotate freshness state and remove every prior fact before libvirt I/O."""
 
         self._begin_operation()
+        diagnostics: list[Diagnostic] = []
         try:
             candidate = self.challenge_factory()
         except Exception:
-            return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+            candidate = None
         if (
             not isinstance(candidate, str)
             or not _SAFE_CHALLENGE_RE.match(candidate)
             or candidate in self._used_challenges
         ):
-            return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+            diagnostics.append(_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, _GUEST_FACTS_ADDRESS))
+        else:
+            diagnostics.extend(self._clear_prior_fact_channels(matrix))
+        if not diagnostics:
+            assert isinstance(candidate, str)
+            self.challenge = candidate
+            self._used_challenges.add(candidate)
+        return diagnostics
+
+    def _clear_prior_fact_channels(self, matrix: Mapping[str, object]) -> list[Diagnostic]:
+        diagnostics: list[Diagnostic] = []
         for domain in matrix.get("domains", ()):
             if not isinstance(domain, Mapping):
                 continue
@@ -113,12 +125,12 @@ class GuestCertifiedLibvirtDriver(TechVaultNativeLibvirtDriver):
                 if channel.is_symlink() or (channel.exists() and not channel.is_dir()):
                     channel.unlink()
                 elif channel.exists():
-                    return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
+                    diagnostics.append(_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, _GUEST_FACTS_ADDRESS))
+                    break
             except OSError:
-                return [_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, "runtime.libvirt.guest-facts")]
-        self.challenge = candidate
-        self._used_challenges.add(candidate)
-        return []
+                diagnostics.append(_diagnostic(_CODE_GUEST_FRESHNESS_UNAVAILABLE, _GUEST_FACTS_ADDRESS))
+                break
+        return diagnostics
 
     def _begin_operation(self) -> None:
         """Prevent prior guest evidence from surviving into a new attempt."""

--- a/implementations/python/packages/raes_backend_libvirt/guest_observation.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_observation.py
@@ -62,6 +62,15 @@ class GuestObservationConfig:
 
     probe_policy: str = "serial-fact-channel/v1"
     transport_deadline_seconds: float = 120.0
+    memory_tolerance_mib: int = 16
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.memory_tolerance_mib, bool)
+            or not isinstance(self.memory_tolerance_mib, int)
+            or self.memory_tolerance_mib < 0
+        ):
+            raise ValueError("guest memory tolerance must be a non-negative integer")
 
 
 @dataclass(frozen=True)
@@ -110,7 +119,13 @@ def observe_guest(
         facts_by_address[address] = _bounded_facts(parsed)
     if not diagnostics:
         expected = expected_guest_observations(domains)
-        diagnostics.extend(guest_observation_diagnostics(expected=expected, observations=tuple(observations)))
+        diagnostics.extend(
+            guest_observation_diagnostics(
+                expected=expected,
+                observations=tuple(observations),
+                memory_tolerance_mib=config.memory_tolerance_mib,
+            )
+        )
     return _GuestOutcome(tuple(observations), tuple(diagnostics), facts_by_address)
 
 
@@ -157,15 +172,13 @@ def _domain_observations(
     domain: Mapping[str, object], parsed: Mapping[str, object]
 ) -> tuple[RealizationObservation, ...]:
     address = str(domain.get("address", ""))
-    requested_memory = _as_int(domain.get("memory_mib"))
     guest_memory = _as_int(parsed.get("memory_mib"))
-    corroborated = requested_memory > 0 and requested_memory // 2 <= guest_memory <= requested_memory
     return (
         guest_observation(
             address, "guest-architecture", RealizationConcern.ARCHITECTURE, str(parsed.get("architecture") or "")
         ),
         guest_observation(address, "guest-vcpus", RealizationConcern.RESOURCE_ALLOCATION, _as_int(parsed.get("vcpus"))),
-        guest_observation(address, "guest-memory-corroborated", RealizationConcern.RESOURCE_ALLOCATION, corroborated),
+        guest_observation(address, "guest-memory-mib", RealizationConcern.RESOURCE_ALLOCATION, guest_memory),
         guest_observation(address, "guest-network", RealizationConcern.NETWORK, _observed_network(parsed)),
         guest_observation(address, "guest-content", RealizationConcern.CONTENT_PLACEMENT, _observed_content(parsed)),
         guest_observation(address, "guest-account", RealizationConcern.ACCOUNT_PLACEMENT, _observed_accounts(parsed)),
@@ -181,7 +194,9 @@ def expected_guest_observations(domains: Sequence[Mapping[str, object]]) -> dict
         address = str(domain.get("address", ""))
         expected[(address, "guest-architecture", RealizationConcern.ARCHITECTURE)] = "x86_64"
         expected[(address, "guest-vcpus", RealizationConcern.RESOURCE_ALLOCATION)] = _as_int(domain.get("vcpus"))
-        expected[(address, "guest-memory-corroborated", RealizationConcern.RESOURCE_ALLOCATION)] = True
+        expected[(address, "guest-memory-mib", RealizationConcern.RESOURCE_ALLOCATION)] = _as_int(
+            domain.get("memory_mib")
+        )
         expected[(address, "guest-network", RealizationConcern.NETWORK)] = _expected_network(domain)
         expected[(address, "guest-content", RealizationConcern.CONTENT_PLACEMENT)] = _expected_content(domain)
         expected[(address, "guest-account", RealizationConcern.ACCOUNT_PLACEMENT)] = _expected_accounts(domain)
@@ -193,8 +208,9 @@ def guest_observation_diagnostics(
     *,
     expected: Mapping[_Key, object],
     observations: tuple[RealizationObservation, ...],
+    memory_tolerance_mib: int = 0,
 ) -> list[Diagnostic]:
-    """Require exactly one matching guest-observed fact per expected concern field."""
+    """Compare exact facts, applying only the disclosed one-sided memory tolerance."""
 
     observed: dict[_Key, list[RealizationObservation]] = {}
     for item in observations:
@@ -205,15 +221,30 @@ def guest_observation_diagnostics(
         candidates = observed.get(key, [])
         if not candidates or any(item.source is not ObservationStrength.GUEST_OBSERVED for item in candidates):
             missing.add(key[0])
-        elif (
-            len(candidates) != 1
-            or type(candidates[0].value) is not type(expected_value)
-            or candidates[0].value != expected_value
+        elif len(candidates) != 1 or not _observation_matches(
+            key,
+            candidates[0].value,
+            expected_value,
+            memory_tolerance_mib=memory_tolerance_mib,
         ):
             mismatched.add(key[0])
     diagnostics = [_diagnostic(_CODE_OBSERVATION_MISSING, address) for address in sorted(missing)]
     diagnostics.extend(_diagnostic(_CODE_OBSERVATION_MISMATCH, address) for address in sorted(mismatched - missing))
     return diagnostics
+
+
+def _observation_matches(
+    key: _Key,
+    observed: object,
+    expected: object,
+    *,
+    memory_tolerance_mib: int,
+) -> bool:
+    if type(observed) is not type(expected):
+        return False
+    if key[1] == "guest-memory-mib" and isinstance(observed, int) and isinstance(expected, int):
+        return max(0, expected - memory_tolerance_mib) <= observed <= expected
+    return observed == expected
 
 
 def correlation_digest(native_identity: str) -> str:
@@ -254,7 +285,8 @@ def _observed_accounts(parsed: Mapping[str, object]) -> tuple[str, ...]:
 def _observed_services(parsed: Mapping[str, object]) -> tuple[str, ...]:
     return tuple(
         sorted(
-            f"{item.get('name')}|{item.get('port')}|{_flag(item.get('listening'))}|{_flag(item.get('pid_present'))}"
+            f"{item.get('name')}|{item.get('protocol')}|{item.get('port')}|"
+            f"{_flag(item.get('listening'))}|{_flag(item.get('pid_present'))}"
             for item in as_sequence(parsed.get("services"))
             if isinstance(item, Mapping)
         )
@@ -299,7 +331,7 @@ def _expected_accounts(domain: Mapping[str, object]) -> tuple[str, ...]:
 def _expected_services(domain: Mapping[str, object]) -> tuple[str, ...]:
     return tuple(
         sorted(
-            f"{item.get('name')}|{item.get('port')}|1|1"
+            f"{item.get('name')}|{item.get('protocol')}|{item.get('port')}|1|1"
             for item in as_sequence(domain.get("services"))
             if isinstance(item, Mapping)
         )

--- a/implementations/python/packages/raes_backend_libvirt/guest_transport.py
+++ b/implementations/python/packages/raes_backend_libvirt/guest_transport.py
@@ -189,9 +189,10 @@ def _account_entry(fields: list[str]) -> dict[str, object]:
 def _service_entry(fields: list[str]) -> dict[str, object]:
     return {
         "name": fields[0],
-        "port": _to_int(fields[1]),
-        "listening": fields[2] == "1",
-        "pid_present": fields[3] == "1",
+        "protocol": fields[1],
+        "port": _to_int(fields[2]),
+        "listening": fields[3] == "1",
+        "pid_present": fields[4] == "1",
     }
 
 
@@ -203,7 +204,7 @@ _LINE_HANDLERS = {
     "iface": _append("interfaces", 3, _iface_entry),
     "content": _append("content", 3, _content_entry),
     "account": _append("accounts", 5, _account_entry),
-    "service": _append("services", 4, _service_entry),
+    "service": _append("services", 5, _service_entry),
 }
 
 

--- a/implementations/python/packages/raes_backend_libvirt/techvault_appliance.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_appliance.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
-import gzip
+import ipaddress
 import json
 import os
+import re
 import shutil
 import stat
-import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+
+from ._initramfs import (
+    InitramfsPreflight,
+    atomic_copy_by_digest,
+    atomic_write,
+    deterministic_gzip,
+    encode_newc,
+    resolve_static_busybox,
+)
+
+_LIBVIRT_BOOT_ARTIFACT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
 
 class InitramfsBuilder(Protocol):
@@ -27,29 +38,27 @@ class InitramfsBuilder(Protocol):
 class BusyboxInitramfsBuilder:
     """Build the generated BusyBox appliance used by native live validation."""
 
-    busybox_path: Path = Path("/usr/bin/busybox")
+    busybox_path: Path | None = None
+    search_path: str | None = None
+
+    def preflight(self) -> InitramfsPreflight:
+        """Resolve and validate the static target BusyBox before mutation."""
+
+        return resolve_static_busybox(self.busybox_path, search_path=self.search_path)
 
     def build(self, *, domain: Mapping[str, object], target: Path) -> Path:
+        busybox_path = self.preflight().require_executable()
         with tempfile.TemporaryDirectory(prefix="raes-initramfs-") as tmp:
             root = Path(tmp)
-            _write_appliance_root(root, self.busybox_path, domain)
-            target.parent.mkdir(parents=True, exist_ok=True)
-            payload = _cpio_newc(root)
-            target.write_bytes(gzip.compress(payload, compresslevel=6))
-        return target
-
-
-_LIBVIRT_BOOT_ARTIFACT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+            _write_appliance_root(root, busybox_path, domain)
+            payload = deterministic_gzip(_cpio_newc(root), compresslevel=6)
+            return atomic_write(target, payload, mode=_LIBVIRT_BOOT_ARTIFACT_MODE)
 
 
 def copy_kernel_for_libvirt(source: Path, target: Path) -> Path:
-    """Copy ``source`` to a libvirt-readable run-local kernel path."""
+    """Digest-validate and atomically cache a libvirt-readable kernel."""
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    if not target.exists() or source.stat().st_mtime_ns != target.stat().st_mtime_ns:
-        shutil.copy2(source, target)
-    make_libvirt_readable(target)
-    return target
+    return atomic_copy_by_digest(source, target, mode=_LIBVIRT_BOOT_ARTIFACT_MODE)
 
 
 def make_libvirt_readable(path: Path) -> None:
@@ -63,12 +72,15 @@ def _write_appliance_root(root: Path, busybox_path: Path, domain: Mapping[str, o
     etc_dir = root / "etc" / "raes"
     for directory in (bin_dir, etc_dir, root / "proc", root / "sys", root / "dev", root / "tmp", root / "run"):
         directory.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(busybox_path, bin_dir / "busybox")
+    shutil.copyfile(busybox_path, bin_dir / "busybox")
     for applet in ("sh", "mount", "mdev", "ip", "ifconfig", "sleep", "cat", "hostname", "printf"):
         (bin_dir / applet).symlink_to("busybox")
-    (etc_dir / "domain.json").write_text(json.dumps(domain, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    (root / "init").write_text(_init_script(domain), encoding="utf-8")
-    os.chmod(root / "init", 0o700)
+    domain_path = etc_dir / "domain.json"
+    domain_path.write_text(json.dumps(domain, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    init_path = root / "init"
+    init_path.write_text(_init_script(domain), encoding="utf-8")
+    os.chmod(domain_path, 0o644)
+    os.chmod(init_path, 0o700)
     os.chmod(bin_dir / "busybox", 0o700)
 
 
@@ -91,37 +103,61 @@ def _init_script(domain: Mapping[str, object]) -> str:
     for interface in _as_sequence(domain.get("interfaces")):
         if not isinstance(interface, Mapping):
             continue
-        lines.extend(
-            [
-                f"    {interface.get('mac')})",
-                f'      ip addr add {interface.get("ip")}/{interface.get("cidr_prefix")} dev "$iface"',
-                "      ;;",
-            ]
-        )
+        lines.extend(_interface_case_lines(interface))
     lines.extend(["  esac", "done"])
     lines.extend(["while true; do sleep 3600; done", ""])
     return "\n".join(lines)
 
 
 def _cpio_newc(root: Path) -> bytes:
-    proc = subprocess.run(
-        ["cpio", "-o", "-H", "newc", "--quiet"],
-        input=("\n".join(_cpio_paths(root)) + "\n").encode(),
-        cwd=root,
-        capture_output=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError("cpio failed while building native TechVault initramfs")
-    return proc.stdout
-
-
-def _cpio_paths(root: Path) -> list[str]:
-    return [str(path.relative_to(root)) for path in sorted(root.rglob("*"))]
+    return encode_newc(root)
 
 
 def _as_sequence(value: object) -> Sequence[object]:
     return value if isinstance(value, list | tuple) else ()
+
+
+_MAC_RE = re.compile(r"\A[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}\Z")
+
+
+def _interface_case_lines(interface: Mapping[str, object]) -> list[str]:
+    """Render one structurally validated, shell-safe interface case arm."""
+
+    mac = _validated_mac(interface.get("mac"))
+    address = _validated_interface_address(interface.get("ip"), interface.get("cidr_prefix"))
+    return [
+        f"    {_shell_quote(mac)})",
+        f'      ip addr add {_shell_quote(address)} dev "$iface"',
+        "      ;;",
+    ]
+
+
+def _validated_mac(value: object) -> str:
+    if isinstance(value, str) and _MAC_RE.match(value):
+        return value
+    raise ValueError(f"interface mac is not a MAC address: {value!r}")
+
+
+def _validated_interface_address(ip: object, cidr_prefix: object) -> str:
+    if not isinstance(ip, str):
+        raise ValueError(f"interface ip is not an IP address: {ip!r}")
+    try:
+        parsed = ipaddress.ip_address(ip)
+    except ValueError as error:
+        raise ValueError(f"interface ip is not an IP address: {ip!r}") from error
+    return f"{ip}/{_validated_cidr_prefix(cidr_prefix, parsed.max_prefixlen)}"
+
+
+def _validated_cidr_prefix(value: object, max_prefix: int) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"interface cidr_prefix is not an integer: {value!r}")
+    if isinstance(value, str) and value.isdecimal():
+        value = int(value)
+    if not isinstance(value, int):
+        raise ValueError(f"interface cidr_prefix is not an integer: {value!r}")
+    if not 0 <= value <= max_prefix:
+        raise ValueError(f"interface cidr_prefix is out of range 0..{max_prefix}: {value!r}")
+    return value
 
 
 def _shell_quote(value: str) -> str:

--- a/implementations/python/packages/raes_backend_libvirt/techvault_concerns.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_concerns.py
@@ -159,14 +159,17 @@ def _guest_placement_bounds_diagnostics(spec: DomainSpec) -> list[Diagnostic]:
 
 
 def _guest_service_bounds_diagnostics(spec: DomainSpec) -> list[Diagnostic]:
-    invalid = any(not _SAFE_TOKEN_RE.match(service.name) or not 1 <= service.port <= 65535 for service in spec.services)
+    invalid = any(
+        not _SAFE_TOKEN_RE.match(service.name) or not 1 <= service.port <= 65535 or service.protocol.lower() != "tcp"
+        for service in spec.services
+    )
     if not invalid:
         return []
     return [
         _diagnostic(
             _CODE_SERVICE_UNSUPPORTED,
             spec.address,
-            "Guest-certified services require a libvirt-safe name and a valid port.",
+            "Guest-certified services require a libvirt-safe name, a valid port, and protocol tcp.",
         )
     ]
 

--- a/implementations/python/packages/raes_backend_libvirt/techvault_matrix.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_matrix.py
@@ -137,7 +137,9 @@ def domain_placements(spec: DomainSpec) -> dict[str, object]:
         {"path": item.path, "content": item.content, "mode": item.permissions}
         for item in (cloud_init.write_files if cloud_init is not None else ())
     ]
-    services = [{"name": service.name, "port": service.port} for service in spec.services]
+    services = [
+        {"name": service.name, "protocol": service.protocol.lower(), "port": service.port} for service in spec.services
+    ]
     return {"accounts": accounts, "content": content, "services": services}
 
 

--- a/implementations/python/packages/raes_backend_libvirt/techvault_native/_driver.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_native/_driver.py
@@ -114,29 +114,32 @@ class TechVaultNativeLibvirtDriver:
     ) -> DriverResult:
         self._begin_operation()
         envelope = load_libvirt_realization_envelope(self.driver_mode)
-        spec_diagnostics = self._admission_diagnostics(networks, domains, envelope)
-        if spec_diagnostics:
-            return DriverResult(diagnostics=tuple(spec_diagnostics))
-        artifact_diagnostics = self._artifact_preflight_diagnostics(domains)
-        if artifact_diagnostics:
-            return DriverResult(diagnostics=tuple(artifact_diagnostics))
-        matrix = self._build_matrix(networks, domains)
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-        preparation_diagnostics = self._prepare_operation(matrix)
-        if preparation_diagnostics:
-            return DriverResult(diagnostics=tuple(preparation_diagnostics))
-        try:
-            connection = self._conn()
-        except Exception:
-            return DriverResult(diagnostics=(_diagnostic(_CODE_UNAVAILABLE, _CONNECTION_ADDRESS),))
-        return self._realize_matrix(
-            connection,
-            matrix,
-            networks=networks,
-            domains=domains,
-            envelope_digest=envelope.digest,
-            configuration_digest=envelope.configuration.configuration_digest,
-        )
+        diagnostics = self._admission_diagnostics(networks, domains, envelope)
+        if not diagnostics:
+            diagnostics = self._artifact_preflight_diagnostics(domains)
+        if diagnostics:
+            result = DriverResult(diagnostics=tuple(diagnostics))
+        else:
+            matrix = self._build_matrix(networks, domains)
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            diagnostics = self._prepare_operation(matrix)
+            if diagnostics:
+                result = DriverResult(diagnostics=tuple(diagnostics))
+            else:
+                try:
+                    connection = self._conn()
+                except Exception:
+                    result = DriverResult(diagnostics=(_diagnostic(_CODE_UNAVAILABLE, _CONNECTION_ADDRESS),))
+                else:
+                    result = self._realize_matrix(
+                        connection,
+                        matrix,
+                        networks=networks,
+                        domains=domains,
+                        envelope_digest=envelope.digest,
+                        configuration_digest=envelope.configuration.configuration_digest,
+                    )
+        return result
 
     def _realize_matrix(
         self,

--- a/implementations/python/packages/raes_backend_libvirt/techvault_native/_driver.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_native/_driver.py
@@ -13,7 +13,6 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, cast
-from urllib.parse import urlsplit
 
 from raes_contracts.diagnostics import Diagnostic
 
@@ -63,9 +62,6 @@ from ..techvault_matrix import (
 from ..techvault_matrix import (
     native_matrix as _native_matrix,
 )
-from ..techvault_matrix import (
-    safe_name as _safe_name,
-)
 from ..techvault_observation import (
     canonical_digest,
     file_digest,
@@ -74,6 +70,7 @@ from ..techvault_observation import (
     substrate_observation,
 )
 from ._define import define_domain, define_domains, define_network, define_networks
+from ._preflight import artifact_preflight_diagnostics, validate_driver_configuration
 
 _CONNECTION_ADDRESS = "runtime.libvirt.connection"
 
@@ -96,8 +93,12 @@ class TechVaultNativeLibvirtDriver:
     last_snapshot: dict[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        self._validate_connection_uri()
-        self._validate_appliance_flags()
+        validate_driver_configuration(
+            connection_uri=self.connection_uri,
+            name_prefix=self.name_prefix,
+            define_only=self.define_only,
+            clean_existing=self.clean_existing,
+        )
         self.state_dir = Path(self.state_dir)
         self.kernel_path = Path(self.kernel_path) if self.kernel_path is not None else _default_kernel_path()
         self.connector = self.connector or _default_connector
@@ -105,36 +106,25 @@ class TechVaultNativeLibvirtDriver:
         self._realized: set[str] = set()
         self._artifacts: dict[str, tuple[Path, ...]] = {}
 
-    def _validate_connection_uri(self) -> None:
-        if not self.connection_uri or not self.connection_uri.strip():
-            raise ValueError("TechVaultNativeLibvirtDriver connection_uri must be non-empty.")
-        parsed_uri = urlsplit(self.connection_uri)
-        if parsed_uri.username is not None or parsed_uri.password is not None:
-            raise ValueError("TechVaultNativeLibvirtDriver connection URI must not carry credentials.")
-
-    def _validate_appliance_flags(self) -> None:
-        if not self.name_prefix or not self.name_prefix.strip():
-            raise ValueError("TechVaultNativeLibvirtDriver name_prefix must be non-empty.")
-        if self.define_only:
-            raise ValueError("TechVaultNativeLibvirtDriver define-only mode cannot make realization claims.")
-        if self.clean_existing:
-            raise ValueError("TechVaultNativeLibvirtDriver refuses unsafe prefix-wide cleanup.")
-        safe_prefix = _safe_name(self.name_prefix, fallback="raes-techvault", prefix="")
-        if safe_prefix != self.name_prefix:
-            raise ValueError("TechVaultNativeLibvirtDriver name_prefix must already be libvirt-safe.")
-
     def realize(
         self,
         *,
         networks: tuple[NetworkSpec, ...],
         domains: tuple[DomainSpec, ...],
     ) -> DriverResult:
+        self._begin_operation()
         envelope = load_libvirt_realization_envelope(self.driver_mode)
         spec_diagnostics = self._admission_diagnostics(networks, domains, envelope)
         if spec_diagnostics:
             return DriverResult(diagnostics=tuple(spec_diagnostics))
+        artifact_diagnostics = self._artifact_preflight_diagnostics(domains)
+        if artifact_diagnostics:
+            return DriverResult(diagnostics=tuple(artifact_diagnostics))
         matrix = self._build_matrix(networks, domains)
         self.state_dir.mkdir(parents=True, exist_ok=True)
+        preparation_diagnostics = self._prepare_operation(matrix)
+        if preparation_diagnostics:
+            return DriverResult(diagnostics=tuple(preparation_diagnostics))
         try:
             connection = self._conn()
         except Exception:
@@ -246,6 +236,24 @@ class TechVaultNativeLibvirtDriver:
         domains: tuple[DomainSpec, ...],
     ) -> dict[str, object]:
         return _native_matrix(networks=networks, domains=domains, name_prefix=self.name_prefix)
+
+    def _artifact_preflight_diagnostics(self, domains: tuple[DomainSpec, ...]) -> list[Diagnostic]:
+        return artifact_preflight_diagnostics(
+            domains=domains,
+            kernel_path=self.kernel_path,
+            initramfs_builder=self.initramfs_builder,
+        )
+
+    @staticmethod
+    def _begin_operation() -> None:
+        """Clear operation-scoped subclass evidence before any admission gate."""
+
+    @staticmethod
+    def _prepare_operation(matrix: Mapping[str, object]) -> list[Diagnostic]:
+        """Prepare operation-scoped evidence state before opening libvirt."""
+
+        del matrix
+        return []
 
     # Base extension hooks need no instance state; the guest-certified subclass overrides them.
     @staticmethod

--- a/implementations/python/packages/raes_backend_libvirt/techvault_native/_preflight.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_native/_preflight.py
@@ -1,0 +1,65 @@
+"""Boot-input admission for native TechVault domain operations."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from raes_contracts.diagnostics import Diagnostic
+
+from .._initramfs import builder_preflight
+from .._techvault_native_ops import (
+    _CODE_KERNEL_UNAVAILABLE,
+    _CODE_TOOLCHAIN_UNAVAILABLE,
+    _diagnostic,
+)
+from ..driver import DomainSpec
+from ..techvault_appliance import InitramfsBuilder
+from ..techvault_matrix import safe_name
+
+
+def validate_driver_configuration(
+    *,
+    connection_uri: str,
+    name_prefix: str,
+    define_only: bool,
+    clean_existing: bool,
+) -> None:
+    """Reject ambiguous or claim-incompatible native driver configuration."""
+
+    if not connection_uri or not connection_uri.strip():
+        raise ValueError("TechVaultNativeLibvirtDriver connection_uri must be non-empty.")
+    parsed_uri = urlsplit(connection_uri)
+    if parsed_uri.username is not None or parsed_uri.password is not None:
+        raise ValueError("TechVaultNativeLibvirtDriver connection URI must not carry credentials.")
+    if not name_prefix or not name_prefix.strip():
+        raise ValueError("TechVaultNativeLibvirtDriver name_prefix must be non-empty.")
+    if define_only:
+        raise ValueError("TechVaultNativeLibvirtDriver define-only mode cannot make realization claims.")
+    if clean_existing:
+        raise ValueError("TechVaultNativeLibvirtDriver refuses unsafe prefix-wide cleanup.")
+    if safe_name(name_prefix, fallback="raes-techvault", prefix="") != name_prefix:
+        raise ValueError("TechVaultNativeLibvirtDriver name_prefix must already be libvirt-safe.")
+
+
+def artifact_preflight_diagnostics(
+    *,
+    domains: tuple[DomainSpec, ...],
+    kernel_path: Path | None,
+    initramfs_builder: InitramfsBuilder,
+) -> list[Diagnostic]:
+    """Reject missing boot inputs before opening libvirt or mutating networks."""
+
+    if not domains:
+        return []
+    assert kernel_path is not None
+    if not kernel_path.is_file() or not os.access(kernel_path, os.R_OK):
+        return [_diagnostic(_CODE_KERNEL_UNAVAILABLE, "runtime.libvirt.kernel")]
+    try:
+        toolchain = builder_preflight(initramfs_builder)
+    except Exception:
+        return [_diagnostic(_CODE_TOOLCHAIN_UNAVAILABLE, "runtime.libvirt.initramfs")]
+    if not toolchain.ready:
+        return [_diagnostic(_CODE_TOOLCHAIN_UNAVAILABLE, "runtime.libvirt.initramfs")]
+    return []

--- a/implementations/python/packages/raes_backend_libvirt/techvault_native/_preflight.py
+++ b/implementations/python/packages/raes_backend_libvirt/techvault_native/_preflight.py
@@ -51,15 +51,16 @@ def artifact_preflight_diagnostics(
 ) -> list[Diagnostic]:
     """Reject missing boot inputs before opening libvirt or mutating networks."""
 
-    if not domains:
-        return []
-    assert kernel_path is not None
-    if not kernel_path.is_file() or not os.access(kernel_path, os.R_OK):
-        return [_diagnostic(_CODE_KERNEL_UNAVAILABLE, "runtime.libvirt.kernel")]
-    try:
-        toolchain = builder_preflight(initramfs_builder)
-    except Exception:
-        return [_diagnostic(_CODE_TOOLCHAIN_UNAVAILABLE, "runtime.libvirt.initramfs")]
-    if not toolchain.ready:
-        return [_diagnostic(_CODE_TOOLCHAIN_UNAVAILABLE, "runtime.libvirt.initramfs")]
-    return []
+    diagnostic = None
+    if domains:
+        assert kernel_path is not None
+        if not kernel_path.is_file() or not os.access(kernel_path, os.R_OK):
+            diagnostic = _diagnostic(_CODE_KERNEL_UNAVAILABLE, "runtime.libvirt.kernel")
+        else:
+            try:
+                toolchain = builder_preflight(initramfs_builder)
+            except Exception:
+                toolchain = None
+            if toolchain is None or not toolchain.ready:
+                diagnostic = _diagnostic(_CODE_TOOLCHAIN_UNAVAILABLE, "runtime.libvirt.initramfs")
+    return [diagnostic] if diagnostic is not None else []

--- a/implementations/python/packages/raes_operations/_evidence_run_native.py
+++ b/implementations/python/packages/raes_operations/_evidence_run_native.py
@@ -134,6 +134,7 @@ def _guest_observed_report(
         "observed_at": datetime.now(UTC).isoformat(),
         "certifying": certifying,
         "probe_policy": binding.get("probe_policy") if isinstance(binding, Mapping) else None,
+        "memory_tolerance_mib": binding.get("memory_tolerance_mib") if isinstance(binding, Mapping) else None,
         "challenge": binding.get("challenge") if isinstance(binding, Mapping) else None,
         "domains": domains,
     }

--- a/implementations/python/packages/raes_operations/_evidence_run_realization.py
+++ b/implementations/python/packages/raes_operations/_evidence_run_realization.py
@@ -101,6 +101,9 @@ def _validate_guest_metadata(guest: Mapping[str, Any]) -> list[str]:
         problems.append("guest observation requires a canonical operation reference")
     if not isinstance(guest.get("certifying"), bool):
         problems.append("guest observation requires an explicit certifying flag")
+    tolerance = guest.get("memory_tolerance_mib")
+    if isinstance(tolerance, bool) or not isinstance(tolerance, int) or tolerance < 0:
+        problems.append("guest observation requires an explicit non-negative memory tolerance")
     problems.extend(
         f"guest observation requires a {label}"
         for label, field_name in _GUEST_METADATA_FIELDS

--- a/implementations/python/tests/libvirt_interface_fixtures.py
+++ b/implementations/python/tests/libvirt_interface_fixtures.py
@@ -1,0 +1,29 @@
+"""Shared hostile and valid interface fixtures for guest init scripts."""
+
+from __future__ import annotations
+
+VALID_INTERFACE = {"mac": "52:54:00:00:00:01", "ip": "192.0.2.10", "cidr_prefix": 24}
+
+HOSTILE_INTERFACE_CASES = (
+    ({**VALID_INTERFACE, "mac": "aa:bb:cc:dd:ee:ff) ; rm -rf /outside #"}, "mac is not a MAC"),
+    ({**VALID_INTERFACE, "ip": "192.0.2.10$(touch /pwned)"}, "ip is not an IP"),
+    ({**VALID_INTERFACE, "ip": "`reboot`"}, "ip is not an IP"),
+    ({**VALID_INTERFACE, "cidr_prefix": "24; rm -rf /"}, "cidr_prefix is not an integer"),
+    ({**VALID_INTERFACE, "cidr_prefix": 33}, "cidr_prefix is out of range"),
+    ({**VALID_INTERFACE, "ip": 3221225994}, "ip is not an IP"),
+    ({**VALID_INTERFACE, "ip": None}, "ip is not an IP"),
+    ({**VALID_INTERFACE, "cidr_prefix": True}, "cidr_prefix is not an integer"),
+    ({**VALID_INTERFACE, "cidr_prefix": "²"}, "cidr_prefix is not an integer"),
+    ({**VALID_INTERFACE, "cidr_prefix": 24.5}, "cidr_prefix is not an integer"),
+)
+
+QUOTED_MAC_ARM = "    '52:54:00:00:00:01')"
+QUOTED_ADDRESS_COMMAND = "ip addr add '192.0.2.10/24' dev \"$iface\""
+
+
+def domain_with_interface(**interface: object) -> dict[str, object]:
+    return {"name": "webapp", "interfaces": [interface]}
+
+
+def domain_with_malformed_entry() -> dict[str, object]:
+    return {"name": "webapp", "interfaces": ["not-a-mapping", VALID_INTERFACE]}

--- a/implementations/python/tests/test_libvirt_backend_guest_certified.py
+++ b/implementations/python/tests/test_libvirt_backend_guest_certified.py
@@ -305,15 +305,16 @@ def test_default_challenge_factory_and_invalid_factory_are_explicit(tmp_path: Pa
     )
 
     assert len(driver.challenge_factory()) == 32
+    invalid_driver = {
+        "state_dir": tmp_path / "bad-state",
+        "connection": _FakeConnection(),
+        "kernel_path": tmp_path / "kernel",
+        "initramfs_builder": _FakeBuilder(),
+        "guest_transport": _StubTransport(facts_by_address={}),
+        "challenge_factory": None,
+    }
     with pytest.raises(ValueError, match="must be callable"):
-        GuestCertifiedLibvirtDriver(
-            state_dir=tmp_path / "bad-state",
-            connection=_FakeConnection(),
-            kernel_path=tmp_path / "kernel",
-            initramfs_builder=_FakeBuilder(),
-            guest_transport=_StubTransport(facts_by_address={}),
-            challenge_factory=None,  # type: ignore[arg-type]
-        )
+        GuestCertifiedLibvirtDriver(**invalid_driver)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/tests/test_libvirt_backend_guest_certified.py
+++ b/implementations/python/tests/test_libvirt_backend_guest_certified.py
@@ -15,9 +15,17 @@ from pathlib import Path
 import pytest
 from raes_backend_libvirt.cloudinit import CloudInitFile, CloudInitSpec, CloudInitUser
 from raes_backend_libvirt.driver import DomainSpec, NetworkSpec, ServiceSpec
-from raes_backend_libvirt.guest_appliance import GuestObservingInitramfsBuilder
+from raes_backend_libvirt.guest_appliance import _init_script, _write_placement_specs
 from raes_backend_libvirt.guest_certified_driver import GuestCertifiedLibvirtDriver
-from raes_backend_libvirt.techvault_matrix import mac_address
+from raes_backend_libvirt.guest_observation import (
+    GuestObservationConfig,
+    expected_guest_observations,
+    guest_observation,
+    guest_observation_diagnostics,
+)
+from raes_backend_libvirt.guest_transport import parse_guest_facts
+from raes_backend_libvirt.techvault_matrix import domain_placements, mac_address
+from raes_contracts.realization_envelope import RealizationConcern
 
 _CHALLENGE = "deadbeefcafef00d"
 
@@ -108,7 +116,7 @@ class _GuestFacts:
     interfaces: list[tuple[str, str, int]] = field(default_factory=list)
     content: list[tuple[str, str, str]] = field(default_factory=list)
     accounts: list[tuple[str, int, str, str, int, str]] = field(default_factory=list)
-    services: list[tuple[str, int, int, int]] = field(default_factory=list)
+    services: list[tuple[str, str, int, int, int]] = field(default_factory=list)
     init_complete: bool = True
 
     def render(self) -> str:
@@ -125,7 +133,9 @@ class _GuestFacts:
             f"account {name} {uid} {home} {shell} {dis} {groups}"
             for name, uid, home, shell, dis, groups in self.accounts
         )
-        lines.extend(f"service {name} {port} {lis} {pid}" for name, port, lis, pid in self.services)
+        lines.extend(
+            f"service {name} {protocol} {port} {lis} {pid}" for name, protocol, port, lis, pid in self.services
+        )
         if self.init_complete:
             lines.append("init complete")
         return "\n".join(lines) + "\n"
@@ -171,11 +181,18 @@ def _matching_facts() -> _GuestFacts:
         interfaces=[(mac, "10.9.0.10", 1)],
         content=[("/etc/raes/marker", _sha("hello"), "644")],
         accounts=[("analyst", 1000, "/home/analyst", "/bin/sh", 1, "raes")],
-        services=[("beacon", 9000, 1, 1)],
+        services=[("beacon", "tcp", 9000, 1, 1)],
     )
 
 
-def _driver(tmp_path: Path, connection: _FakeConnection, transport: _StubTransport) -> GuestCertifiedLibvirtDriver:
+def _driver(
+    tmp_path: Path,
+    connection: _FakeConnection,
+    transport: _StubTransport,
+    *,
+    challenge_factory=None,
+    guest_config: GuestObservationConfig | None = None,
+) -> GuestCertifiedLibvirtDriver:
     kernel = tmp_path / "vmlinuz"
     kernel.write_bytes(b"kernel-bytes")
     return GuestCertifiedLibvirtDriver(
@@ -183,9 +200,10 @@ def _driver(tmp_path: Path, connection: _FakeConnection, transport: _StubTranspo
         connection=connection,
         name_prefix="raes-gc",
         kernel_path=kernel,
-        initramfs_builder=GuestObservingInitramfsBuilder(busybox_path=Path("/usr/bin/busybox")),
+        initramfs_builder=_FakeBuilder(),
         guest_transport=transport,
-        challenge=_CHALLENGE,
+        challenge_factory=challenge_factory or (lambda: _CHALLENGE),
+        guest_config=guest_config or GuestObservationConfig(),
     )
 
 
@@ -210,15 +228,92 @@ def test_guest_certified_happy_path_realizes_and_certifies(tmp_path: Path) -> No
     assert {
         "guest-architecture",
         "guest-vcpus",
+        "guest-memory-mib",
         "guest-network",
         "guest-content",
         "guest-account",
         "guest-service",
     } <= guest_fields
     assert driver.last_guest_binding["challenge"] == _CHALLENGE
+    assert driver.last_guest_binding["memory_tolerance_mib"] == 16
     assert "scn.vm" in driver.last_guest_facts
+    memory = next(obs for obs in result.observations if obs.field_path == "guest-memory-mib")
+    assert memory.value == 120
+    service = next(obs for obs in result.observations if obs.field_path == "guest-service")
+    assert service.value == ("beacon|tcp|9000|1|1",)
     # Native objects remain (committed), not rolled back.
     assert all(not native.destroyed for native in connection.domains.values())
+
+
+def test_guest_service_protocol_is_bound_through_projection_artifact_and_facts(tmp_path: Path) -> None:
+    placement = domain_placements(_domain())
+    assert placement["services"] == [{"name": "beacon", "protocol": "tcp", "port": 9000}]
+
+    guest_dir = tmp_path / "guest"
+    files_dir = guest_dir / "files"
+    files_dir.mkdir(parents=True)
+    _write_placement_specs(guest_dir, files_dir, placement)
+    assert (guest_dir / "services").read_text(encoding="utf-8") == "beacon|tcp|9000\n"
+
+    script = _init_script({"name": "vm", "interfaces": [], **placement})
+    assert "read name protocol port" in script
+    assert "netstat -lnt" in script
+    assert 'echo "service $name $protocol $port $lis $pid"' in script
+
+    parsed = parse_guest_facts(_matching_facts().render())
+    assert parsed is not None
+    assert parsed["services"] == [
+        {"name": "beacon", "protocol": "tcp", "port": 9000, "listening": True, "pid_present": True}
+    ]
+
+
+def test_guest_service_fact_without_protocol_is_not_accepted() -> None:
+    text = _matching_facts().render().replace("service beacon tcp 9000 1 1", "service beacon 9000 1 1")
+    parsed = parse_guest_facts(text)
+
+    assert parsed is not None
+    assert parsed["services"] == []
+
+
+def test_udp_guest_service_is_rejected_before_native_mutation(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+    driver = _driver(tmp_path, connection, _StubTransport(facts_by_address={}))
+    domain = DomainSpec(
+        address="scn.vm",
+        name="vm",
+        image_ref=None,
+        memory_mib=128,
+        vcpus=1,
+        networks=("scn.net",),
+        services=(ServiceSpec(name="beacon", protocol="udp", port=9000),),
+    )
+
+    result = driver.realize(networks=(_network(),), domains=(domain,))
+
+    assert _codes(result) == {"libvirt-backend.techvault.service-unsupported"}
+    assert connection.networks == {}
+    assert connection.domains == {}
+
+
+def test_default_challenge_factory_and_invalid_factory_are_explicit(tmp_path: Path) -> None:
+    driver = GuestCertifiedLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=_FakeConnection(),
+        kernel_path=tmp_path / "kernel",
+        initramfs_builder=_FakeBuilder(),
+        guest_transport=_StubTransport(facts_by_address={}),
+    )
+
+    assert len(driver.challenge_factory()) == 32
+    with pytest.raises(ValueError, match="must be callable"):
+        GuestCertifiedLibvirtDriver(
+            state_dir=tmp_path / "bad-state",
+            connection=_FakeConnection(),
+            kernel_path=tmp_path / "kernel",
+            initramfs_builder=_FakeBuilder(),
+            guest_transport=_StubTransport(facts_by_address={}),
+            challenge_factory=None,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize(
@@ -250,6 +345,111 @@ def test_stale_challenge_is_rejected(tmp_path: Path) -> None:
     assert "libvirt-backend.guest.challenge-mismatch" in _codes(result)
 
 
+def test_prior_fact_channel_is_removed_before_native_mutation(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={"scn.vm": _matching_facts().render()})
+    driver = _driver(tmp_path, connection, transport)
+    channel = driver._fact_channel_path("scn.vm")
+    channel.parent.mkdir(parents=True)
+    channel.write_text("stale completed report", encoding="utf-8")
+
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert result.diagnostics == ()
+    assert not channel.exists()
+
+
+def test_each_realize_operation_uses_a_new_challenge(tmp_path: Path) -> None:
+    challenges = iter(("1111111111111111", "2222222222222222"))
+    first_facts = _matching_facts()
+    first_facts.challenge = "1111111111111111"
+    transport = _StubTransport(facts_by_address={"scn.vm": first_facts.render()})
+    driver = _driver(tmp_path, _FakeConnection(), transport, challenge_factory=challenges.__next__)
+
+    first = driver.realize(networks=(_network(),), domains=(_domain(),))
+    first_challenge = driver.challenge
+    assert first.diagnostics == ()
+    assert not driver.destroy(networks=("scn.net",), domains=("scn.vm",)).diagnostics
+    driver.connection = _FakeConnection()
+    second_facts = _matching_facts()
+    second_facts.challenge = "2222222222222222"
+    transport.facts_by_address["scn.vm"] = second_facts.render()
+    second = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert second.diagnostics == ()
+    assert first_challenge == "1111111111111111"
+    assert driver.challenge == "2222222222222222"
+
+
+def test_reused_challenge_is_rejected_before_libvirt_mutation(tmp_path: Path) -> None:
+    transport = _StubTransport(facts_by_address={"scn.vm": _matching_facts().render()})
+    driver = _driver(tmp_path, _FakeConnection(), transport)
+    assert not driver.realize(networks=(_network(),), domains=(_domain(),)).diagnostics
+    assert not driver.destroy(networks=("scn.net",), domains=("scn.vm",)).diagnostics
+    replacement = _FakeConnection()
+    driver.connection = replacement
+
+    second = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert _codes(second) == {"libvirt-backend.guest.freshness-preflight-failed"}
+    assert replacement.networks == {}
+    assert replacement.domains == {}
+
+
+def test_challenge_factory_failure_is_typed_before_libvirt_mutation(tmp_path: Path) -> None:
+    def fail_challenge() -> str:
+        raise RuntimeError("entropy unavailable")
+
+    connection = _FakeConnection()
+    driver = _driver(
+        tmp_path,
+        connection,
+        _StubTransport(facts_by_address={}),
+        challenge_factory=fail_challenge,
+    )
+
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert _codes(result) == {"libvirt-backend.guest.freshness-preflight-failed"}
+    assert connection.networks == {}
+    assert connection.domains == {}
+
+
+def test_fact_channel_directory_and_unlink_failure_fail_preflight(tmp_path: Path, monkeypatch) -> None:
+    connection = _FakeConnection()
+    driver = _driver(tmp_path, connection, _StubTransport(facts_by_address={}))
+    channel = driver._fact_channel_path("scn.vm")
+    channel.mkdir(parents=True)
+
+    directory_result = driver.realize(networks=(_network(),), domains=(_domain(),))
+    assert _codes(directory_result) == {"libvirt-backend.guest.freshness-preflight-failed"}
+    assert connection.networks == {}
+    channel.rmdir()
+    channel.write_text("stale", encoding="utf-8")
+    replacement = _FakeConnection()
+    driver.connection = replacement
+    driver.challenge_factory = lambda: "2222222222222222"
+    original_unlink = Path.unlink
+
+    def fail_channel_unlink(path: Path, *args, **kwargs):
+        if path == channel:
+            raise OSError("blocked")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_channel_unlink)
+    unlink_result = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert _codes(unlink_result) == {"libvirt-backend.guest.freshness-preflight-failed"}
+    assert replacement.networks == {}
+
+
+def test_nonmapping_matrix_entry_is_ignored_during_fact_channel_preparation(tmp_path: Path) -> None:
+    driver = _driver(tmp_path, _FakeConnection(), _StubTransport(facts_by_address={}))
+
+    assert driver._prepare_operation({"domains": ["not-a-mapping"]}) == []
+    assert driver.challenge == _CHALLENGE
+
+
 def test_malformed_report_is_rejected(tmp_path: Path) -> None:
     connection = _FakeConnection()
     transport = _StubTransport(facts_by_address={"scn.vm": "not a fact report"})
@@ -258,7 +458,10 @@ def test_malformed_report_is_rejected(tmp_path: Path) -> None:
     assert "libvirt-backend.guest.observation-malformed" in _codes(result)
 
 
-@pytest.mark.parametrize("mutate", ["ip", "vcpus", "memory", "content", "account", "service", "missing_content"])
+@pytest.mark.parametrize(
+    "mutate",
+    ["ip", "vcpus", "memory", "content", "account", "service", "protocol", "missing_content"],
+)
 def test_concern_mismatches_are_falsified(tmp_path: Path, mutate: str) -> None:
     facts = _matching_facts()
     mac = mac_address("scn.vm", "scn.net")
@@ -273,12 +476,93 @@ def test_concern_mismatches_are_falsified(tmp_path: Path, mutate: str) -> None:
     elif mutate == "account":
         facts.accounts = [("analyst", 1000, "/home/analyst", "/bin/bash", 1, "raes")]
     elif mutate == "service":
-        facts.services = [("beacon", 9000, 0, 1)]
+        facts.services = [("beacon", "tcp", 9000, 0, 1)]
+    elif mutate == "protocol":
+        facts.services = [("beacon", "udp", 9000, 1, 1)]
     elif mutate == "missing_content":
         facts.content = []
     _, connection, result = _realize(tmp_path, facts)
     assert "libvirt-backend.guest.observation-mismatch" in _codes(result)
     assert all(native.destroyed for native in connection.domains.values())
+
+
+@pytest.mark.parametrize(("observed", "passes"), ((112, True), (111, False), (64, False), (129, False)))
+def test_memory_appraisal_uses_disclosed_one_sided_tolerance(tmp_path: Path, observed: int, passes: bool) -> None:
+    facts = _matching_facts()
+    facts.memory_mib = observed
+    _, _, result = _realize(tmp_path, facts)
+
+    assert (result.diagnostics == ()) is passes
+    if not passes:
+        assert "libvirt-backend.guest.observation-mismatch" in _codes(result)
+
+
+def test_memory_tolerance_is_configurable_without_coarsening_evidence(tmp_path: Path) -> None:
+    facts = _matching_facts()
+    connection = _FakeConnection()
+    transport = _StubTransport(facts_by_address={"scn.vm": facts.render()})
+    driver = _driver(
+        tmp_path,
+        connection,
+        transport,
+        guest_config=GuestObservationConfig(memory_tolerance_mib=8),
+    )
+
+    result = driver.realize(networks=(_network(),), domains=(_domain(),))
+
+    assert result.diagnostics == ()
+    memory = next(obs for obs in result.observations if obs.field_path == "guest-memory-mib")
+    assert memory.value == 120
+    assert driver.last_guest_binding["memory_tolerance_mib"] == 8
+
+
+@pytest.mark.parametrize("tolerance", (-1, True, "16"))
+def test_invalid_memory_tolerance_is_rejected(tolerance) -> None:
+    with pytest.raises(ValueError, match="non-negative integer"):
+        GuestObservationConfig(memory_tolerance_mib=tolerance)
+
+
+def test_guest_observation_diagnostics_distinguish_missing_and_wrong_typed_facts() -> None:
+    memory_key = ("scn.vm", "guest-memory-mib", RealizationConcern.RESOURCE_ALLOCATION)
+
+    missing = guest_observation_diagnostics(expected={memory_key: 128}, observations=())
+    wrong_type = guest_observation_diagnostics(
+        expected={memory_key: 128},
+        observations=(guest_observation("scn.vm", "guest-memory-mib", memory_key[2], "128"),),
+    )
+
+    assert [diagnostic.code for diagnostic in missing] == ["libvirt-backend.guest.observation-missing"]
+    assert [diagnostic.code for diagnostic in wrong_type] == ["libvirt-backend.guest.observation-mismatch"]
+
+
+def test_expected_guest_observations_ignore_nonmapping_accounts() -> None:
+    expected = expected_guest_observations(
+        [{"address": "scn.vm", "memory_mib": 128, "vcpus": 1, "accounts": ["not-a-mapping"]}]
+    )
+
+    key = ("scn.vm", "guest-account", RealizationConcern.ACCOUNT_PLACEMENT)
+    assert expected[key] == ()
+
+
+def test_failed_new_attempt_clears_prior_guest_evidence(tmp_path: Path) -> None:
+    driver, _, first = _realize(tmp_path, _matching_facts())
+    assert first.diagnostics == ()
+    invalid = DomainSpec(
+        address="scn.vm",
+        name="vm",
+        image_ref="unsupported.qcow2",
+        memory_mib=128,
+        vcpus=1,
+        networks=("scn.net",),
+    )
+
+    second = driver.realize(networks=(_network(),), domains=(invalid,))
+
+    assert "libvirt-backend.techvault.image-unsupported" in _codes(second)
+    assert driver.challenge is None
+    assert driver.last_guest_observations == ()
+    assert driver.last_guest_facts == {}
+    assert driver.last_guest_binding == {}
 
 
 @pytest.mark.parametrize("second", ["vcpus 9", "vcpus 1", "challenge deadbeefcafef00d"])
@@ -418,7 +702,7 @@ def _guest_matrix(scenario: Path):
         kernel_path=_write_kernel(scenario.parent),
         initramfs_builder=_FakeBuilder(),
         guest_transport=_StubTransport(facts_by_address={}),
-        challenge=_CHALLENGE,
+        challenge_factory=lambda: _CHALLENGE,
     )
     from raes_backend_libvirt import create_libvirt_target
 
@@ -449,7 +733,7 @@ def _guest_factory(tmp_path: Path, transport: _StubTransport):
             kernel_path=_write_kernel(tmp_path),
             initramfs_builder=_FakeBuilder(),
             guest_transport=transport,
-            challenge=_CHALLENGE,
+            challenge_factory=lambda: _CHALLENGE,
         )
 
     return factory
@@ -479,6 +763,7 @@ def test_evidence_run_guest_certified_publishes_bound_observations(tmp_path: Pat
     guest = artifact["realization_facts"]["guest_observed"]
     assert guest["source"] == "guest-observed"
     assert guest["challenge"] == _CHALLENGE
+    assert guest["memory_tolerance_mib"] == 16
     assert guest["operation_ref"].startswith("sha256:")
     # Native-proof boundary: an injected fake driver factory can exercise the
     # orchestration but must be marked non-certifying so its evidence can never be
@@ -531,7 +816,7 @@ def test_evidence_run_guest_certified_residual_probe_artifacts_fail_closed(tmp_p
             kernel_path=_write_kernel(tmp_path),
             initramfs_builder=_FakeBuilder(),
             guest_transport=transport,
-            challenge=_CHALLENGE,
+            challenge_factory=lambda: _CHALLENGE,
         )
 
     report = run_libvirt_evidence_run(

--- a/implementations/python/tests/test_libvirt_backend_guest_certified_real_libvirt.py
+++ b/implementations/python/tests/test_libvirt_backend_guest_certified_real_libvirt.py
@@ -3,20 +3,20 @@
 This is the native-proof gate: it boots the guest-observing appliance through the
 production apply path against an operator-selected real libvirt/QEMU daemon, reads
 concern facts back from inside the guest, and verifies teardown. It is skipped
-unless ``RAES_REAL_LIBVIRT_URI`` is set and the host has libvirt-python, cpio,
-BusyBox, and a readable kernel. Hermetic fake-driver tests cannot satisfy this
-gate.
+unless ``RAES_REAL_LIBVIRT_URI`` is set and the host has libvirt-python, a static
+x86_64 BusyBox on ``PATH``, and a readable kernel. Hermetic fake-driver tests
+cannot satisfy this gate.
 """
 
 from __future__ import annotations
 
 import importlib
 import os
-import shutil
 from pathlib import Path
 
 import pytest
 from paths import EXAMPLES_DIR
+from raes_backend_libvirt._initramfs import resolve_static_busybox
 from raes_operations.libvirt_evidence_run import (
     LibvirtEvidenceRunConfig,
     run_libvirt_evidence_run,
@@ -35,8 +35,8 @@ def test_guest_certified_real_libvirt_readback_and_cleanup(tmp_path):
         libvirt = importlib.import_module("libvirt")
     except ImportError:
         pytest.skip("libvirt-python is unavailable")
-    if shutil.which("cpio") is None or not Path("/usr/bin/busybox").is_file():
-        pytest.skip("cpio and BusyBox are required for guest-observing appliance certification")
+    if not resolve_static_busybox(None).ready:
+        pytest.skip("a static x86_64 BusyBox on PATH is required for guest appliance certification")
     if not tuple(Path("/boot").glob("vmlinuz-*")):
         pytest.skip("a readable host kernel is required for guest-observing appliance certification")
 

--- a/implementations/python/tests/test_libvirt_backend_techvault_native.py
+++ b/implementations/python/tests/test_libvirt_backend_techvault_native.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
-import gzip
 import json
 import xml.etree.ElementTree as ET
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from libvirt_interface_fixtures import (
+    HOSTILE_INTERFACE_CASES,
+    QUOTED_ADDRESS_COMMAND,
+    QUOTED_MAC_ARM,
+    VALID_INTERFACE,
+    domain_with_interface,
+    domain_with_malformed_entry,
+)
 from paths import EXAMPLES_DIR
 from raes import parse_sdl
 from raes_backend_libvirt import create_libvirt_target
 from raes_backend_libvirt.cloudinit import CloudInitSpec, CloudInitUser
 from raes_backend_libvirt.driver import DomainSpec, NetworkAcl, NetworkSpec, ServiceSpec
 from raes_backend_libvirt.envelopes import load_libvirt_realization_envelope
+from raes_backend_libvirt.techvault_appliance import _init_script
 from raes_backend_libvirt.techvault_native import (
     BusyboxInitramfsBuilder,
     ProbeResult,
@@ -237,6 +245,80 @@ def _bounded_specs() -> tuple[NetworkSpec, DomainSpec]:
         networks=(network.address,),
     )
     return network, domain
+
+
+def test_native_driver_rejects_missing_initramfs_toolchain_before_libvirt_io(tmp_path):
+    connection = _FakeConnection()
+    kernel = tmp_path / "vmlinuz"
+    kernel.write_bytes(b"kernel")
+    driver = TechVaultNativeLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=connection,
+        kernel_path=kernel,
+        initramfs_builder=BusyboxInitramfsBuilder(busybox_path=tmp_path / "missing-busybox"),
+    )
+    network, domain = _bounded_specs()
+
+    result = driver.realize(networks=(network,), domains=(domain,))
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "libvirt-backend.techvault-native.initramfs-toolchain-unavailable"
+    ]
+    assert connection.network_xml == []
+    assert connection.domain_xml == []
+    assert not driver.state_dir.exists()
+
+
+def test_native_driver_rejects_missing_kernel_before_libvirt_io(tmp_path):
+    connection = _FakeConnection()
+    driver = TechVaultNativeLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=connection,
+        kernel_path=tmp_path / "missing-kernel",
+        initramfs_builder=_Builder(),
+    )
+    network, domain = _bounded_specs()
+
+    result = driver.realize(networks=(network,), domains=(domain,))
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "libvirt-backend.techvault-native.kernel-unavailable"
+    ]
+    assert connection.network_xml == []
+    assert connection.domain_xml == []
+
+
+def test_native_artifact_preflight_skips_boot_toolchain_for_network_only_plan(tmp_path: Path) -> None:
+    driver = TechVaultNativeLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=_FakeConnection(),
+        kernel_path=None,
+        initramfs_builder=object(),
+    )
+
+    assert driver._artifact_preflight_diagnostics(()) == []
+
+
+def test_native_artifact_preflight_normalizes_builder_exception(tmp_path: Path) -> None:
+    class _ExplodingPreflightBuilder:
+        def preflight(self) -> object:
+            raise RuntimeError("host-specific toolchain detail")
+
+    kernel = tmp_path / "vmlinuz"
+    kernel.write_bytes(b"kernel")
+    driver = TechVaultNativeLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connection=_FakeConnection(),
+        kernel_path=kernel,
+        initramfs_builder=_ExplodingPreflightBuilder(),
+    )
+    _network, domain = _bounded_specs()
+
+    diagnostics = driver._artifact_preflight_diagnostics((domain,))
+
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "libvirt-backend.techvault-native.initramfs-toolchain-unavailable"
+    ]
 
 
 def _submit_native_scenario(path: Path, tmp_path: Path):
@@ -884,6 +966,8 @@ def test_native_driver_refuses_prefix_wide_cleanup(tmp_path):
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     (
+        ({"connection_uri": ""}, "non-empty"),
+        ({"name_prefix": ""}, "non-empty"),
         ({"define_only": True}, "define-only"),
         ({"connection_uri": "qemu+ssh://operator:credential@example/system"}, "credentials"),
         ({"connection_uri": "qemu+ssh://operator@example/system"}, "credentials"),
@@ -920,16 +1004,27 @@ def test_native_driver_derives_provider_name_from_address_not_display_name(tmp_p
     assert "unsafe name" not in connection.domain_xml[0]
 
 
-def test_busybox_initramfs_builder_writes_gzip_cpio(tmp_path):
-    domain = {
-        "name": "webapp",
-        "role": "enterprise",
-        "interfaces": [{"mac": "52:54:00:00:00:01", "ip": "192.0.2.10", "cidr_prefix": 24}],
-        "services": [{"name": "http", "port": 8080, "protocol": "tcp"}],
-    }
+def test_init_script_accepts_a_decimal_string_cidr_prefix():
+    script = _init_script(domain_with_interface(**{**VALID_INTERFACE, "cidr_prefix": "24"}))
 
-    target = BusyboxInitramfsBuilder().build(domain=domain, target=tmp_path / "webapp.cpio.gz")
+    assert QUOTED_ADDRESS_COMMAND in script
 
-    assert target.read_bytes().startswith(b"\x1f\x8b")
-    assert target.stat().st_size > 1000
-    assert b"httpd -p" not in gzip.decompress(target.read_bytes())
+
+def test_init_script_quotes_valid_interface_addressing():
+    script = _init_script(domain_with_interface(**VALID_INTERFACE))
+
+    assert QUOTED_MAC_ARM in script
+    assert QUOTED_ADDRESS_COMMAND in script
+
+
+@pytest.mark.parametrize(("interface", "match"), HOSTILE_INTERFACE_CASES)
+def test_init_script_rejects_hostile_interface_fields_before_scripting(interface, match):
+    with pytest.raises(ValueError, match=match):
+        _init_script(domain_with_interface(**interface))
+
+
+def test_init_script_skips_a_malformed_interface_entry_and_renders_the_rest():
+    script = _init_script(domain_with_malformed_entry())
+
+    assert "not-a-mapping" not in script
+    assert QUOTED_MAC_ARM in script

--- a/implementations/python/tests/test_libvirt_backend_techvault_native.py
+++ b/implementations/python/tests/test_libvirt_backend_techvault_native.py
@@ -321,6 +321,26 @@ def test_native_artifact_preflight_normalizes_builder_exception(tmp_path: Path) 
     ]
 
 
+def test_native_driver_normalizes_connection_failure(tmp_path: Path) -> None:
+    def unavailable_connector(_uri: str) -> object:
+        raise RuntimeError("host-specific connection detail")
+
+    kernel = tmp_path / "vmlinuz"
+    kernel.write_bytes(b"kernel")
+    driver = TechVaultNativeLibvirtDriver(
+        state_dir=tmp_path / "state",
+        connector=unavailable_connector,
+        kernel_path=kernel,
+        initramfs_builder=_Builder(),
+    )
+    network, domain = _bounded_specs()
+
+    result = driver.realize(networks=(network,), domains=(domain,))
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["libvirt-backend.techvault-native.unavailable"]
+    assert result.diagnostics[0].address == "runtime.libvirt.connection"
+
+
 def _submit_native_scenario(path: Path, tmp_path: Path):
     connection = _FakeConnection()
     kernel = tmp_path / "vmlinuz"
@@ -1019,8 +1039,10 @@ def test_init_script_quotes_valid_interface_addressing():
 
 @pytest.mark.parametrize(("interface", "match"), HOSTILE_INTERFACE_CASES)
 def test_init_script_rejects_hostile_interface_fields_before_scripting(interface, match):
+    domain = domain_with_interface(**interface)
+
     with pytest.raises(ValueError, match=match):
-        _init_script(domain_with_interface(**interface))
+        _init_script(domain)
 
 
 def test_init_script_skips_a_malformed_interface_entry_and_renders_the_rest():

--- a/implementations/python/tests/test_libvirt_backend_techvault_real_libvirt.py
+++ b/implementations/python/tests/test_libvirt_backend_techvault_real_libvirt.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import importlib
 import json
 import os
-import shutil
 from pathlib import Path
 
 import pytest
 from paths import EXAMPLES_DIR
+from raes_backend_libvirt._initramfs import resolve_static_busybox
 from raes_operations.techvault_live import TechVaultLiveConfig, validate_techvault_live
 
 
@@ -24,8 +24,8 @@ def test_bounded_techvault_real_libvirt_readback_and_cleanup(tmp_path):
         libvirt = importlib.import_module("libvirt")
     except ImportError:
         pytest.skip("libvirt-python is unavailable")
-    if shutil.which("cpio") is None or not Path("/usr/bin/busybox").is_file():
-        pytest.skip("cpio and static BusyBox are required for native appliance certification")
+    if not resolve_static_busybox(None).ready:
+        pytest.skip("a static x86_64 BusyBox on PATH is required for native appliance certification")
     if not tuple(Path("/boot").glob("vmlinuz-*")):
         pytest.skip("a readable host kernel is required for native appliance certification")
 

--- a/implementations/python/tests/test_libvirt_boot_artifacts.py
+++ b/implementations/python/tests/test_libvirt_boot_artifacts.py
@@ -1,0 +1,297 @@
+"""Deterministic initramfs and content-addressed kernel cache regressions."""
+
+from __future__ import annotations
+
+import gzip
+import os
+import stat
+import struct
+from pathlib import Path
+
+import pytest
+from raes_backend_libvirt import _initramfs
+from raes_backend_libvirt._initramfs import (
+    InitramfsPreflight,
+    InitramfsPreflightCode,
+    InitramfsToolchainError,
+    atomic_write,
+    builder_preflight,
+    encode_newc,
+    resolve_static_busybox,
+)
+from raes_backend_libvirt.guest_appliance import GuestObservingInitramfsBuilder
+from raes_backend_libvirt.techvault_appliance import BusyboxInitramfsBuilder, copy_kernel_for_libvirt
+
+
+def _write_static_elf(path: Path, *, machine: int = 62, interpreter: bool = False) -> Path:
+    identity = b"\x7fELF" + bytes((2, 1, 1, 0)) + b"\0" * 8
+    header = struct.pack(
+        "<HHIQQQIHHHHHH",
+        2,
+        machine,
+        1,
+        0,
+        64,
+        0,
+        0,
+        64,
+        56,
+        1,
+        0,
+        0,
+        0,
+    )
+    program_header = struct.pack("<IIQQQQQQ", 3 if interpreter else 1, 5, 0, 0, 0, 0, 0, 0)
+    path.write_bytes(identity + header + program_header + b"BusyBox" * 256)
+    path.chmod(0o755)
+    return path
+
+
+def _write_static_elf32(path: Path) -> Path:
+    identity = b"\x7fELF" + bytes((1, 1, 1, 0)) + b"\0" * 8
+    header = struct.pack("<HHIIIIIHHHHHH", 2, 62, 1, 0, 52, 0, 0, 52, 32, 1, 0, 0, 0)
+    program_header = struct.pack("<IIIIIIII", 1, 0, 0, 0, 0, 5, 0, 0)
+    path.write_bytes(identity + header + program_header)
+    path.chmod(0o755)
+    return path
+
+
+def _domain() -> dict[str, object]:
+    return {
+        "name": "webapp",
+        "role": "enterprise",
+        "interfaces": [{"mac": "52:54:00:00:00:01", "ip": "192.0.2.10", "cidr_prefix": 24}],
+        "services": [],
+    }
+
+
+def _parse_newc(payload: bytes) -> list[dict[str, object]]:
+    offset = 0
+    entries: list[dict[str, object]] = []
+    while True:
+        assert offset % 4 == 0
+        assert payload[offset : offset + 6] == b"070701"
+        fields = [int(payload[offset + 6 + index * 8 : offset + 14 + index * 8], 16) for index in range(13)]
+        offset += 110
+        name_size = fields[11]
+        name = os.fsdecode(payload[offset : offset + name_size - 1])
+        assert payload[offset + name_size - 1] == 0
+        offset += name_size
+        offset += -offset % 4
+        size = fields[6]
+        content = payload[offset : offset + size]
+        offset += size
+        offset += -offset % 4
+        entries.append(
+            {
+                "name": name,
+                "inode": fields[0],
+                "mode": fields[1],
+                "uid": fields[2],
+                "gid": fields[3],
+                "mtime": fields[5],
+                "devmajor": fields[7],
+                "devminor": fields[8],
+                "content": content,
+            }
+        )
+        if name == "TRAILER!!!":
+            assert payload[offset:] == b""
+            return entries
+
+
+@pytest.mark.parametrize(
+    ("prepare", "expected"),
+    (
+        (lambda path: path, InitramfsPreflightCode.NOT_FOUND),
+        (
+            lambda path: (path.write_text("not elf", encoding="utf-8"), path)[1],
+            InitramfsPreflightCode.NOT_EXECUTABLE,
+        ),
+        (lambda path: _write_static_elf(path, interpreter=True), InitramfsPreflightCode.NOT_STATIC),
+        (lambda path: _write_static_elf(path, machine=183), InitramfsPreflightCode.WRONG_ARCHITECTURE),
+    ),
+)
+def test_static_busybox_preflight_is_typed(tmp_path: Path, prepare, expected: InitramfsPreflightCode) -> None:
+    candidate = prepare(tmp_path / "busybox")
+
+    assert resolve_static_busybox(candidate).code is expected
+
+
+def test_static_busybox_is_injectable_and_path_discoverable(tmp_path: Path) -> None:
+    candidate = _write_static_elf(tmp_path / "busybox")
+
+    injected = resolve_static_busybox(candidate)
+    discovered = resolve_static_busybox(None, search_path=str(tmp_path))
+
+    assert injected.code is InitramfsPreflightCode.READY
+    assert injected.executable == candidate.resolve()
+    assert discovered == injected
+
+
+def test_static_busybox_preflight_covers_discovery_and_file_shapes(tmp_path: Path) -> None:
+    relative = resolve_static_busybox(Path("relative-busybox"))
+    undiscovered = resolve_static_busybox(None, search_path=str(tmp_path / "empty"))
+    directory = tmp_path / "busybox-dir"
+    directory.mkdir()
+    regular_directory = resolve_static_busybox(directory)
+    invalid = tmp_path / "invalid-elf"
+    invalid.write_bytes(b"not an elf" * 8)
+    invalid.chmod(0o755)
+
+    assert relative.code is InitramfsPreflightCode.NOT_ABSOLUTE
+    assert undiscovered.code is InitramfsPreflightCode.NOT_FOUND
+    assert regular_directory.code is InitramfsPreflightCode.NOT_REGULAR
+    assert resolve_static_busybox(invalid).code is InitramfsPreflightCode.NOT_ELF
+    assert resolve_static_busybox(_write_static_elf32(tmp_path / "busybox32")).code is InitramfsPreflightCode.READY
+
+
+def test_failed_preflight_and_invalid_builder_preflight_are_typed() -> None:
+    failure = InitramfsPreflight(InitramfsPreflightCode.NOT_FOUND)
+
+    with pytest.raises(InitramfsToolchainError, match="not-found") as raised:
+        failure.require_executable()
+    with pytest.raises(TypeError, match="InitramfsPreflight"):
+        builder_preflight(type("InvalidBuilder", (), {"preflight": lambda self: "ready"})())
+
+    assert raised.value.preflight is failure
+
+
+@pytest.mark.parametrize("kind", ("invalid-ident", "invalid-class", "missing-program-header", "truncated"))
+def test_malformed_elf_program_tables_are_rejected(tmp_path: Path, kind: str) -> None:
+    path = tmp_path / kind
+    if kind == "invalid-ident":
+        path.write_bytes(b"x" * 64)
+    elif kind == "invalid-class":
+        path.write_bytes(b"\x7fELF" + bytes((0, 1, 1, 0)) + b"\0" * 56)
+    else:
+        identity = b"\x7fELF" + bytes((2, 1, 1, 0)) + b"\0" * 8
+        phnum = 0 if kind == "missing-program-header" else 1
+        header = struct.pack("<HHIQQQIHHHHHH", 2, 62, 1, 0, 64, 0, 0, 64, 56, phnum, 0, 0, 0)
+        path.write_bytes(identity + header)
+    path.chmod(0o755)
+
+    assert resolve_static_busybox(path).code is InitramfsPreflightCode.NOT_ELF
+
+
+def test_static_elf_preflight_maps_open_failure_to_typed_result(tmp_path: Path) -> None:
+    assert _initramfs._static_elf_preflight(tmp_path, expected_machine=62) is InitramfsPreflightCode.NOT_FOUND
+
+
+@pytest.mark.parametrize("builder_type", (BusyboxInitramfsBuilder, GuestObservingInitramfsBuilder))
+def test_initramfs_builds_are_byte_identical_and_have_zero_gzip_mtime(tmp_path: Path, builder_type) -> None:
+    busybox = _write_static_elf(tmp_path / "busybox")
+    builder = builder_type(busybox_path=busybox)
+
+    first = builder.build(domain=_domain(), target=tmp_path / "first.cpio.gz")
+    os.utime(busybox, ns=(9_000_000_000, 9_000_000_000))
+    second = builder.build(domain=_domain(), target=tmp_path / "second.cpio.gz")
+
+    assert first.read_bytes() == second.read_bytes()
+    assert first.read_bytes()[4:8] == b"\0\0\0\0"
+    assert first.read_bytes()[9] == 255
+
+
+def test_repository_newc_encoder_normalizes_metadata_and_links(tmp_path: Path) -> None:
+    busybox = _write_static_elf(tmp_path / "busybox")
+    archive = BusyboxInitramfsBuilder(busybox_path=busybox).build(
+        domain=_domain(), target=tmp_path / "appliance.cpio.gz"
+    )
+
+    entries = _parse_newc(gzip.decompress(archive.read_bytes()))
+    by_name = {str(entry["name"]): entry for entry in entries}
+
+    assert [entry["name"] for entry in entries[:-1]] == sorted(entry["name"] for entry in entries[:-1])
+    assert entries[-1]["name"] == "TRAILER!!!"
+    assert stat.S_IFMT(int(by_name["bin"]["mode"])) == stat.S_IFDIR
+    assert stat.S_IMODE(int(by_name["bin"]["mode"])) == 0o755
+    assert stat.S_IFMT(int(by_name["bin/busybox"]["mode"])) == stat.S_IFREG
+    assert stat.S_IMODE(int(by_name["bin/busybox"]["mode"])) == 0o700
+    assert stat.S_IFMT(int(by_name["bin/sh"]["mode"])) == stat.S_IFLNK
+    assert by_name["bin/sh"]["content"] == b"busybox"
+    assert all(entry[field] == 0 for entry in entries for field in ("uid", "gid", "mtime", "devmajor", "devminor"))
+    assert [entry["inode"] for entry in entries] == list(range(1, len(entries) + 1))
+
+
+def test_guest_initramfs_skips_malformed_content_entries(tmp_path: Path) -> None:
+    busybox = _write_static_elf(tmp_path / "busybox")
+    domain = {**_domain(), "content": ["not-a-mapping", {"path": "/etc/marker", "content": "ok"}]}
+    archive = GuestObservingInitramfsBuilder(busybox_path=busybox).build(
+        domain=domain, target=tmp_path / "guest.cpio.gz"
+    )
+
+    entries = _parse_newc(gzip.decompress(archive.read_bytes()))
+    by_name = {str(entry["name"]): entry for entry in entries}
+
+    assert by_name["etc/raes/guest/files/1"]["content"] == b"ok"
+    assert by_name["etc/raes/guest/content"]["content"] == b"/etc/marker|0644|1\n"
+
+
+def test_newc_encoder_rejects_non_root_and_special_members(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must be a directory"):
+        encode_newc(tmp_path / "missing")
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFO creation is unavailable")
+    os.mkfifo(tmp_path / "unsupported")
+
+    with pytest.raises(ValueError, match="unsupported initramfs member"):
+        encode_newc(tmp_path)
+
+
+def test_atomic_write_failure_removes_staged_file_and_preserves_target(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "artifact"
+    target.write_bytes(b"previous")
+    monkeypatch.setattr(_initramfs.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("blocked")))
+
+    with pytest.raises(OSError, match="blocked"):
+        atomic_write(target, b"replacement", mode=0o644)
+
+    assert target.read_bytes() == b"previous"
+    assert list(tmp_path.glob(".artifact.*")) == []
+
+
+def test_kernel_cache_replaces_same_mtime_different_content_atomically(tmp_path: Path) -> None:
+    source = tmp_path / "source-kernel"
+    target = tmp_path / "cache" / "kernel"
+    source.write_bytes(b"old kernel")
+    copy_kernel_for_libvirt(source, target)
+    original_mtime = source.stat().st_mtime_ns
+    source.write_bytes(b"new kernel")
+    os.utime(source, ns=(original_mtime, original_mtime))
+
+    copy_kernel_for_libvirt(source, target)
+
+    assert target.read_bytes() == b"new kernel"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_kernel_cache_reuses_equal_content_without_replacing_inode(tmp_path: Path) -> None:
+    source = tmp_path / "source-kernel"
+    target = tmp_path / "cache" / "kernel"
+    source.write_bytes(b"same kernel")
+    copy_kernel_for_libvirt(source, target)
+    inode = target.stat().st_ino
+
+    copy_kernel_for_libvirt(source, target)
+
+    assert target.stat().st_ino == inode
+
+
+def test_kernel_cache_failure_preserves_previous_complete_target(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source-kernel"
+    target = tmp_path / "cache" / "kernel"
+    source.write_bytes(b"replacement")
+    target.parent.mkdir()
+    target.write_bytes(b"known good")
+    actual_digest = _initramfs._file_digest
+    monkeypatch.setattr(
+        _initramfs,
+        "_file_digest",
+        lambda path: "stale-source-digest" if Path(path) == source else actual_digest(Path(path)),
+    )
+
+    with pytest.raises(RuntimeError, match="source changed"):
+        copy_kernel_for_libvirt(source, target)
+
+    assert target.read_bytes() == b"known good"
+    assert list(target.parent.glob(f".{target.name}.*")) == []

--- a/implementations/python/tests/test_libvirt_boot_artifacts.py
+++ b/implementations/python/tests/test_libvirt_boot_artifacts.py
@@ -151,19 +151,24 @@ def test_failed_preflight_and_invalid_builder_preflight_are_typed() -> None:
 
     with pytest.raises(InitramfsToolchainError, match="not-found") as raised:
         failure.require_executable()
+    invalid_builder = type("InvalidBuilder", (), {"preflight": lambda self: "ready"})()
     with pytest.raises(TypeError, match="InitramfsPreflight"):
-        builder_preflight(type("InvalidBuilder", (), {"preflight": lambda self: "ready"})())
+        builder_preflight(invalid_builder)
 
     assert raised.value.preflight is failure
 
 
-@pytest.mark.parametrize("kind", ("invalid-ident", "invalid-class", "missing-program-header", "truncated"))
+@pytest.mark.parametrize(
+    "kind", ("invalid-ident", "invalid-class", "truncated-header", "missing-program-header", "truncated")
+)
 def test_malformed_elf_program_tables_are_rejected(tmp_path: Path, kind: str) -> None:
     path = tmp_path / kind
     if kind == "invalid-ident":
         path.write_bytes(b"x" * 64)
     elif kind == "invalid-class":
         path.write_bytes(b"\x7fELF" + bytes((0, 1, 1, 0)) + b"\0" * 56)
+    elif kind == "truncated-header":
+        path.write_bytes(b"\x7fELF" + bytes((2, 1, 1, 0)) + b"\0" * 44)
     else:
         identity = b"\x7fELF" + bytes((2, 1, 1, 0)) + b"\0" * 8
         phnum = 0 if kind == "missing-program-header" else 1
@@ -224,7 +229,9 @@ def test_guest_initramfs_skips_malformed_content_entries(tmp_path: Path) -> None
     by_name = {str(entry["name"]): entry for entry in entries}
 
     assert by_name["etc/raes/guest/files/1"]["content"] == b"ok"
+    assert stat.S_IMODE(int(by_name["etc/raes/guest/files/1"]["mode"])) == 0o600
     assert by_name["etc/raes/guest/content"]["content"] == b"/etc/marker|0644|1\n"
+    assert stat.S_IMODE(int(by_name["etc/raes/guest/content"]["mode"])) == 0o600
 
 
 def test_newc_encoder_rejects_non_root_and_special_members(tmp_path: Path) -> None:

--- a/implementations/python/tests/test_libvirt_evidence_run.py
+++ b/implementations/python/tests/test_libvirt_evidence_run.py
@@ -23,6 +23,7 @@ from raes_contracts.contracts import (
     EvaluationResultStateModel,
     ExperimentRealizedFormDisclosureModel,
 )
+from raes_operations._evidence_run_realization import _validate_guest_metadata
 from raes_operations.libvirt_evidence_run import (
     EVIDENCE_RUN_SCHEMA,
     LibvirtEvidenceRunConfig,
@@ -55,6 +56,22 @@ _REQUIRED_SECTIONS = (
     "redaction_provenance",
     "invariant_ledger_refs",
 )
+
+
+@pytest.mark.parametrize("invalid_tolerance", [True, -1, "16"])
+def test_guest_evidence_requires_explicit_nonnegative_integer_memory_tolerance(invalid_tolerance: object) -> None:
+    problems = _validate_guest_metadata(
+        {
+            "operation_ref": "sha256:" + "0" * 64,
+            "certifying": True,
+            "memory_tolerance_mib": invalid_tolerance,
+            "observed_at": "2026-08-12T00:00:00Z",
+            "probe_policy": "guest-probe/v1",
+            "challenge": "fresh-challenge",
+        }
+    )
+
+    assert problems == ["guest observation requires an explicit non-negative memory tolerance"]
 
 
 # --- fake native libvirt substrate (no daemon) ---------------------------------

--- a/implementations/python/tests/test_libvirt_guest_appliance_init_script.py
+++ b/implementations/python/tests/test_libvirt_guest_appliance_init_script.py
@@ -1,0 +1,40 @@
+"""Guest init scripts must reject hostile interface fields."""
+
+from __future__ import annotations
+
+import pytest
+from libvirt_interface_fixtures import (
+    HOSTILE_INTERFACE_CASES,
+    QUOTED_ADDRESS_COMMAND,
+    QUOTED_MAC_ARM,
+    VALID_INTERFACE,
+    domain_with_interface,
+    domain_with_malformed_entry,
+)
+from raes_backend_libvirt.guest_appliance import _init_script
+
+
+def test_guest_init_script_quotes_valid_interface_addressing():
+    script = _init_script(domain_with_interface(**VALID_INTERFACE))
+
+    assert QUOTED_MAC_ARM in script
+    assert QUOTED_ADDRESS_COMMAND in script
+
+
+@pytest.mark.parametrize(("interface", "match"), HOSTILE_INTERFACE_CASES)
+def test_guest_init_script_rejects_hostile_interface_fields(interface, match):
+    with pytest.raises(ValueError, match=match):
+        _init_script(domain_with_interface(**interface))
+
+
+def test_guest_init_script_quotes_the_hostname():
+    script = _init_script({"name": "web; rm -rf /", "interfaces": []})
+
+    assert "hostname 'web; rm -rf /'" in script
+
+
+def test_guest_init_script_skips_malformed_interface_entries():
+    script = _init_script(domain_with_malformed_entry())
+
+    assert QUOTED_MAC_ARM in script
+    assert "not-a-mapping" not in script

--- a/implementations/python/tests/test_libvirt_guest_appliance_init_script.py
+++ b/implementations/python/tests/test_libvirt_guest_appliance_init_script.py
@@ -23,8 +23,10 @@ def test_guest_init_script_quotes_valid_interface_addressing():
 
 @pytest.mark.parametrize(("interface", "match"), HOSTILE_INTERFACE_CASES)
 def test_guest_init_script_rejects_hostile_interface_fields(interface, match):
+    domain = domain_with_interface(**interface)
+
     with pytest.raises(ValueError, match=match):
-        _init_script(domain_with_interface(**interface))
+        _init_script(domain)
 
 
 def test_guest_init_script_quotes_the_hostname():

--- a/tools/real-daemon/README.md
+++ b/tools/real-daemon/README.md
@@ -66,6 +66,11 @@ inside the guest** (resource allocation, network addressing, file content, and
 service state), freshness-bound to a per-run challenge, then verifies teardown.
 Domain existence alone never satisfies it.
 
+The generated appliance requires a **static x86_64 BusyBox** named `busybox` on
+the command's `PATH` (on Ubuntu, install `busybox-static`) and a readable kernel
+at the configured/default kernel path. The driver validates both before opening
+libvirt. It encodes `newc` itself, so no host `cpio` executable is required.
+
 The reproducible operator/self-hosted command is:
 
 ```sh
@@ -83,7 +88,9 @@ is validated (source separation, binding, redaction) **before** it is written, s
 it contains no host paths, connection URIs, raw domain UUIDs, XML, or secrets; the
 guest report is bound to a redacted control-plane operation reference, the fresh
 challenge, the selected envelope/configuration + appliance digests, and a
-`sha256:` native correlation. The equivalent gate also runs as an opt-in pytest:
+`sha256:` native correlation. The report preserves the exact guest-observed
+memory MiB value and separately discloses the configured one-sided memory
+tolerance (16 MiB by default). The equivalent gate also runs as an opt-in pytest:
 
 ```sh
 RAES_REAL_LIBVIRT_URI=qemu:///system \


### PR DESCRIPTION
## Plain-language summary

- **Context:** The libvirt backend builds a small guest boot environment and then checks evidence from that guest to confirm what actually ran.
- **Problem:** Those boot artifacts could vary with the host or build time, cached kernels could become stale, and a later operation could accidentally accept evidence left by an earlier guest. Memory and network checks also did not preserve enough exact information to justify certification.
- **Fix:** Build deterministic boot artifacts with explicit prerequisite checks, make kernel caching content-aware and atomic, issue a fresh challenge for every guest operation, reject stale evidence, preserve exact memory observations with an explicit tolerance, and bind service evidence to the requested protocol.

## Issues closed

Closes #1094
Closes #1095
Closes #1105
Closes #1116

## What changed

- Replaces host-dependent initramfs assembly with a deterministic repository-owned `newc` writer and fixed gzip metadata.
- Discovers and validates BusyBox explicitly, and fails with typed diagnostics before mutating libvirt state.
- Uses content validation and atomic replacement for the kernel cache.
- Generates a new cryptographic challenge per realization attempt and clears prior fact channels before boot.
- Rejects stale or mismatched guest reports and binds accepted evidence to the current operation.
- Records exact guest memory and applies a documented, configuration-bound tolerance.
- Validates service protocol and hardens generated init-script arguments.

## Verification

- Full Python 3.12 unit suite: **6,490 passed, 1 skipped**.
- Focused libvirt/artifact/evidence suite: **163 passed, 2 deselected**.
- Changed production coverage: **439/439 executable lines** and **114/114 branch exits**.
- Ruff, repository policy, and static checks pass.
- Branch is based on current `dev` at `3d6e369b726607ff657a841c7f1dee0bec655b8f`.

## Scope

This PR is limited to the libvirt boot-artifact and guest-certification boundary. It does not include the separate OCI image-trust security change or the broader runtime scheduler/control-plane work.