### PR TITLE
fix(runtime): synchronize operational summary reads

### DIFF
--- a/implementations/python/packages/raes_runtime/control_plane.py
+++ b/implementations/python/packages/raes_runtime/control_plane.py
@@ -120,6 +120,7 @@ class RuntimeControlPlane(WorkflowControlMixin, ParticipantControlMixin, Partici
         self._store = store or InMemoryControlPlaneStore(initial_snapshot)
         self._snapshot = initial_snapshot if initial_snapshot is not None else self._store.load_snapshot()
         self._operations: dict[str, ControlPlaneOperationRecord] = self._store.load_records()
+        self._operation_lock = RLock()
         self._behavior_specifications = dict(behavior_specifications or {})
         self._crossing_policy_resolver = crossing_policy_resolver
         self._information_state_context_resolver = information_state_context_resolver
@@ -150,7 +151,8 @@ class RuntimeControlPlane(WorkflowControlMixin, ParticipantControlMixin, Partici
         """Return a compact operational view over existing control-plane carriers."""
 
         audit_events = self._store.read_audit()
-        operation_records = list(self._operations.values())
+        with self._operation_lock:
+            operation_records = list(self._operations.values())
         return operational_apparatus_summary(
             target_name=self._target.name,
             snapshot=self._snapshot,
@@ -289,7 +291,8 @@ class RuntimeControlPlane(WorkflowControlMixin, ParticipantControlMixin, Partici
         )
 
     def get_operation(self, operation_id: str) -> OperationStatus | None:
-        record = self._operations.get(operation_id)
+        with self._operation_lock:
+            record = self._operations.get(operation_id)
         return None if record is None else record.status
 
     def get_snapshot(self) -> RuntimeSnapshotEnvelope:
@@ -388,9 +391,11 @@ class RuntimeControlPlane(WorkflowControlMixin, ParticipantControlMixin, Partici
             return None
         if record.request_fingerprint and request_fingerprint and record.request_fingerprint != request_fingerprint:
             raise ValueError("Idempotency-Key was reused with a different request body.")
-        self._operations[record.receipt.operation_id] = record
+        with self._operation_lock:
+            self._operations[record.receipt.operation_id] = record
         return record.receipt
 
     def _persist_record(self, record: ControlPlaneOperationRecord) -> None:
-        self._operations[record.receipt.operation_id] = record
+        with self._operation_lock:
+            self._operations[record.receipt.operation_id] = record
         self._store.save_record(record)

--- a/implementations/python/tests/test_runtime_control_plane_api.py
+++ b/implementations/python/tests/test_runtime_control_plane_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import textwrap
 from collections.abc import Coroutine
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Event
 from typing import Any, TypeVar
@@ -446,6 +447,46 @@ def test_control_plane_api_operational_apparatus_summary_requires_read_role():
     assert response.status_code == 401
     assert control_plane.audit_log()
     assert control_plane.audit_log()[-1].allowed is False
+
+
+def test_operational_apparatus_summary_snapshots_operations_safely_during_mutation() -> None:
+    target = create_stub_target()
+    control_plane = RuntimeControlPlane(target)
+    control_plane._persist_record(_participant_operation_record("existing", "participant.alice"))
+    iteration_started = Event()
+    mutation_completed = Event()
+
+    class PausingOperationRecords(dict[str, ControlPlaneOperationRecord]):
+        def values(self):  # type: ignore[override]
+            live_values = super().values()
+
+            def iter_values():
+                iterator = iter(live_values)
+                yield next(iterator)
+                iteration_started.set()
+                mutation_completed.wait(timeout=2)
+                yield from iterator
+
+            return iter_values()
+
+        def __setitem__(self, key: str, value: ControlPlaneOperationRecord) -> None:
+            super().__setitem__(key, value)
+            mutation_completed.set()
+
+    control_plane._operations = PausingOperationRecords(control_plane._operations)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        summary = executor.submit(control_plane.operational_apparatus_summary)
+        assert iteration_started.wait(timeout=2)
+        persistence = executor.submit(
+            control_plane._persist_record,
+            _participant_operation_record("concurrent", "participant.bob"),
+        )
+        result = summary.result(timeout=3)
+        persistence.result(timeout=3)
+
+    assert result["operations"]["total"] == 1
+    assert control_plane.get_operation("concurrent") is not None
 
 
 def test_control_plane_api_rejects_unauthenticated_mutations():


### PR DESCRIPTION
## Summary

Prevent concurrent control-plane operation updates from invalidating operational-summary iteration.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1093

## ADR Impact

- ADR-021

## Changes

- Guard operation-record snapshots, lookups, and updates with the control plane's internal synchronization boundary.
- Add a deterministic concurrency regression test covering summary reads during record persistence.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

The runtime control-plane API test module and the repository completion and policy gates pass.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: Issue #1093 ← implementations/python/packages/raes_runtime/control_plane.py
- TESTS: Issue #1093 ← implementations/python/tests/test_runtime_control_plane_api.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.