### PR TITLE
fix(conformance): keep the default adapter probe envelope-neutral

### DIFF
--- a/implementations/python/packages/raes_conformance/conformance/target_probes.py
+++ b/implementations/python/packages/raes_conformance/conformance/target_probes.py
@@ -39,7 +39,13 @@ from raes_conformance.conformance.semantics import _semantic_diagnostics
 from raes_conformance.conformance.validators import _validate_payload
 
 # Default reference scenario the target-conformance adapter probe drives when the
-# caller supplies none. Backend-neutral: a single generic linux vm node.
+# caller supplies none. Backend-neutral: a single generic compute node with no
+# authored OS identity — an authored ``os`` becomes an exact SEM-218
+# realization requirement demanding corroboration no hermetic in-process
+# backend declares, which is what regressed this probe when authored OS
+# identity started carrying through realization. Leaving it unset keeps the
+# probe admissible on every declared envelope, mirroring
+# ``examples/scenarios/cross-backend-minimal.sdl.yaml``.
 #
 # Issue #663 makes this a *default*, not a universal assumption. A fixed-topology
 # emulation or bounded simulation backend that cannot realize this generic
@@ -55,7 +61,6 @@ _DEFAULT_CONFORMANCE_SCENARIO = dedent(
     nodes:
       vm:
         type: compute
-        os: linux
         resources: {ram: 1 gib, cpu: 1}
         conditions: {health: ops}
         roles: {ops: operator}

--- a/implementations/python/tests/test_reference_backend_conformance.py
+++ b/implementations/python/tests/test_reference_backend_conformance.py
@@ -20,6 +20,29 @@ def test_reference_target_requires_opacity_probe_for_positive_declaration():
     assert not report.unsupported_capability_gaps
 
 
+def test_adapter_probes_pass_for_every_hermetic_backend():
+    """The provisioning/snapshot adapter probes must stay envelope-neutral.
+
+    An authored ``os`` in the default probe scenario becomes an exact SEM-218
+    realization requirement no hermetic in-process backend can corroborate,
+    which silently failed these probes for every honest backend when authored
+    OS identity started carrying through realization. Pinning them keeps the
+    default probe admissible on every declared envelope (issue #663's runner
+    parameter stays the escape hatch for bounded backends).
+    """
+
+    from raes_backend_stubs.stubs import create_stub_target
+
+    for target in (create_reference_backend_target(), create_stub_target()):
+        report = run_target_conformance(target)
+        cases = {case.name: case for case in report.cases}
+        for name in ("target-provisioning", "target-snapshot"):
+            assert cases[name].passed, (
+                f"{name} must pass for an honest hermetic backend; "
+                f"diagnostics: {[diag.message for diag in cases[name].diagnostics]}"
+            )
+
+
 def test_reference_target_drives_full_participant_probe_case_set():
     report = run_target_conformance(create_reference_backend_target())
 


### PR DESCRIPTION
## Plain-language summary

- **Context:** RUN-314 (#197) requires the released conformance harness to be invocable by an independently installed backend without private knowledge; the #1150 falsification matrix noted `run_target_conformance` with default arguments fails even the honest reference backend.
- **Problem:** Since authored OS identity started carrying through realization (#1141), the default probe scenario's `os: linux` demands exact SEM-218 os-family corroboration that no hermetic in-process backend declares — so `target-provisioning` and `target-snapshot` silently fail for **every** honest backend (reference and stub alike), and nothing pinned them.
- **Fix:** Drop the authored OS from the default probe scenario (mirroring the canonical `cross-backend-minimal` decision that leaving `os` unset keeps a scenario admissible on more than one envelope) and pin both adapter probes passing for every hermetic backend.

## Issue mapping

- Advances #197 (RUN-314) — specifically the "released conformance harness invocable by a downstream package" criterion.
- Follows through on the residue of #663 recorded in #1150's module docstring; #663's `reference_scenario=` runner parameter remains the escape hatch for bounded/fixed-topology backends.

## Summary

- `raes_conformance/conformance/target_probes.py`: the default conformance scenario no longer authors `os: linux`; the comment records why (an authored OS is an exact realization requirement, not adapter mechanics — the SEM-218 probes own that concern).
- `tests/test_reference_backend_conformance.py`: new `test_adapter_probes_pass_for_every_hermetic_backend` pins `target-provisioning` and `target-snapshot` passing for the reference and stub targets, so the probe cannot silently regress again.
- The pinned fail-closed posture is untouched: `report.passed` stays `False` for the reference target (opacity and constructive-envelope probes still report `unsupported`), exactly as `test_reference_target_requires_opacity_probe_for_positive_declaration` requires.

## Compatibility

- No SDL field, schema, portable contract, or CLI changes. The default probe scenario is a harness input, not a published contract; callers who supplied their own `reference_scenario` are unaffected.

## Verification

- Reference and stub targets both pass `target-provisioning` and `target-snapshot`; full report posture unchanged.
- `nox -s tests`: 7,012 passed; coverage gate green.
- Ruff format and lint clean; `tools/check_repo_policy.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
