### PR TITLE
ci: let the docker integration lane fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,15 @@ jobs:
       - name: Test exact interpreter and clean distribution
         run: uv tool run --from 'nox[uv]==2026.4.10' nox -f noxfile.py -s python-compatibility
 
-  # Opt-in, non-blocking, runtime-gated container integration tests (RUN-314).
-  # Kept out of the hermetic `verify` graph; the `docker` marker tests self-skip
-  # when no runtime is present, and this whole job never fails the build.
+  # Runtime-gated container integration tests (RUN-314). Kept out of the
+  # hermetic `verify` graph; the probe step skips the session when no container
+  # runtime exists (so forks and constrained runners stay green), but when a
+  # runtime is present -- as on every GitHub-hosted runner -- a failing docker
+  # integration session fails the build. The reference OCI driver's real
+  # container IO is exercised only here, so a non-gating lane would leave it
+  # unguarded.
   integration-docker:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Plain-language summary

- **Problem:** `integration-docker` ran with `continue-on-error: true`, so a genuine failure in the container integration session never failed the build — even though GitHub-hosted runners always have docker. The reference OCI driver's real container IO (`_default_runner`, deliberately excluded from hermetic coverage) was exercised only by a lane that could not gate: a closed blind spot around the only code that touches a real runtime.
- **Fix:** Remove the blanket pass. The existing runtime probe still skips the session on runners without a container runtime (forks/constrained runners stay green); where a runtime exists, a failing session now fails CI.

## Verification

- Behavioral change is CI-only; the docker session itself is unchanged and green on recent dev runs. This PR's own `integration-docker` check demonstrates the gating path live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)